### PR TITLE
[Perf] 좋아요 기능 성능 대폭 향상 (Caffeine Cache + Write-Behind 패턴 적용)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,8 @@ dependencies {
 	implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.0'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'com.github.ben-manes.caffeine:caffeine'
 
 	compileOnly 'org.projectlombok:lombok'
 //	runtimeOnly 'com.h2database:h2'

--- a/src/main/java/maple/expectation/ExpectationApplication.java
+++ b/src/main/java/maple/expectation/ExpectationApplication.java
@@ -2,7 +2,9 @@ package maple.expectation;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class ExpectationApplication {
 

--- a/src/main/java/maple/expectation/scheduler/LikeSyncScheduler.java
+++ b/src/main/java/maple/expectation/scheduler/LikeSyncScheduler.java
@@ -1,0 +1,44 @@
+package maple.expectation.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import maple.expectation.repository.v2.GameCharacterRepository;
+import maple.expectation.service.v2.cache.LikeBufferStorage;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LikeSyncScheduler {
+
+    private final LikeBufferStorage likeBufferStorage;
+    private final GameCharacterRepository gameCharacterRepository;
+
+    // 3초마다 실행 (비즈니스 요건에 따라 조절)
+    @Scheduled(fixedRate = 3000)
+    @Transactional
+    public void syncLikesToDatabase() {
+        likeBufferStorage.getCache().asMap().forEach((userIgn, atomicCount) -> {
+            
+            // 핵심: 현재 쌓인 값을 가져오면서 0으로 리셋 (Atomic 연산)
+            // 만약 get() 하고 set(0)을 따로 하면, 그 사이에 들어온 클릭이 사라질 수 있음(Race Condition)
+            long countToAdd = atomicCount.getAndSet(0);
+
+            if (countToAdd > 0) {
+                try {
+                    // DB Bulk Update 실행
+                    gameCharacterRepository.incrementLikeCount(userIgn, countToAdd);
+                    log.info("[Sync] {} 님의 좋아요 {}개 DB 반영 완료", userIgn, countToAdd);
+                } catch (Exception e) {
+                    log.error("[Sync Error] {} 반영 실패. 다시 복구 시도", userIgn);
+                    // 실패 시 다시 캐시에 더해주는 롤백 로직이 필요할 수 있음 (선택 사항)
+                    atomicCount.addAndGet(countToAdd);
+                }
+            }
+        });
+    }
+}

--- a/src/main/java/maple/expectation/service/v2/cache/LikeBufferStorage.java
+++ b/src/main/java/maple/expectation/service/v2/cache/LikeBufferStorage.java
@@ -1,0 +1,30 @@
+package maple.expectation.service.v2.cache;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.stereotype.Component;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Component
+public class LikeBufferStorage {
+
+    // Key: userIgn, Value: 쌓여있는 좋아요 수 (AtomicLong)
+    private final Cache<String, AtomicLong> likeCache;
+
+    public LikeBufferStorage() {
+        this.likeCache = Caffeine.newBuilder()
+                .expireAfterAccess(10, TimeUnit.MINUTES) // 10분간 활동 없으면 제거 (메모리 관리)
+                .build();
+    }
+
+    public AtomicLong getCounter(String userIgn) {
+        // 키가 없으면 0으로 초기화된 AtomicLong 생성 후 반환
+        return likeCache.get(userIgn, key -> new AtomicLong(0));
+    }
+
+    // 스케줄러가 사용할 맵 반환
+    public Cache<String, AtomicLong> getCache() {
+        return likeCache;
+    }
+}


### PR DESCRIPTION
1. 🚀 작업 배경 (Background)
기존 비관적 락(Pessimistic Lock) 방식은 데이터 정합성은 완벽하게 보장했지만, DB 레벨의 직렬화(Serialization)로 인해 동시성 처리에 물리적 한계가 있었습니다.

기존 성능: 100명 동시 요청 시 약 3.2초 소요 (DB 락 대기 시간 발생)

문제점: 트래픽 폭증 시 DB 커넥션 고갈 및 타임아웃 발생 가능성 높음.

따라서, 실시간성을 일부 희생하더라도 **압도적인 처리량(Throughput)**과 **낮은 지연시간(Latency)**을 확보하기 위해 Write-Behind(지연 쓰기) 캐싱 전략을 도입했습니다.

2. 🛠️ 변경 사항 (Changes)
Caffeine Cache 도입: 로컬 인메모리 캐시를 사용하여 DB 접근을 차단했습니다.

AtomicLong 활용: synchronized 키워드 없이 스레드 안전(Thread-Safe)한 카운팅을 구현하여 락 비용을 제거했습니다.

Scheduler 구현: 3초 주기로 메모리에 쌓인 좋아요 수를 DB에 Bulk Update (UPDATE ... SET count = count + :val) 처리합니다.

3. 📊 성능 개선 결과 (Result)
"10배 더 많은 트래픽을 받았음에도, 처리 속도는 80배 이상 빨라졌습니다."

비관적 락 + 인덱스
동시요청수 100명
처리시간 ~3200ms
응답속도 0.03~0.5초
결과 : 정합성 유지

Caffeine Cache (Write-Behind)
동시요청수 1,000명 (10배 증가)
처리시간 : ~37ms
응답속도 : 즉시응답
결과 : 정합성 유지 (Scheduler 동기화 후)

비관적 락
<img width="1212" height="51" alt="image" src="https://github.com/user-attachments/assets/7b0fc631-f64c-4277-bfa1-b261ce76f2c5" />

CaffeinCache + AtomicLong
<img width="1296" height="55" alt="image" src="https://github.com/user-attachments/assets/7ba7c0e1-97fa-4837-b6b1-c249693dcaff" />


4. 💡 아키텍처 변화 (Architecture)
코드 스니펫
`sequenceDiagram
    participant User
    participant Server(Memory)
    participant Scheduler
    participant DB

    Note over User, DB: [기존] 요청마다 DB Lock 대기 (느림)
    
    Note over User, DB: [개선] Write-Behind 전략
    User->>Server(Memory): 좋아요 요청 (1000명)
    Server(Memory)-->>User: 즉시 응답 (0.04ms)
    Note right of Server(Memory): AtomicLong.increment()
    
    loop 3초 주기
        Scheduler->>Server(Memory): 쌓인 데이터 조회 & 초기화
        Server(Memory)->>Scheduler: +1000개 반환
        Scheduler->>DB: UPDATE query (단 1회 실행)
        DB-->>Scheduler: Commit
    end`

5. ⚠️ 트레이드오프 (Trade-offs)
이 방식은 성능을 극대화하는 대신, **데이터 내구성(Durability)**과 **실시간 일관성(Consistency)**을 일부 조정했습니다.

데이터 유실 위험: 서버가 비정상 종료될 경우, 마지막 동기화(최대 3초간) 사이의 데이터가 유실될 수 있습니다. ("좋아요" 기능 특성상 치명적이지 않다고 판단)

Eventual Consistency: 사용자가 좋아요를 눌러도 DB 조회 시점에는 3초