### PR TITLE
feat: 장비 데이터 조회 동시성 제어(Lock) 도입 및 V3 성능 최적화

### DIFF
--- a/src/test/java/maple/expectation/provider/EquipmentDataProviderConcurrencyTest.java
+++ b/src/test/java/maple/expectation/provider/EquipmentDataProviderConcurrencyTest.java
@@ -1,0 +1,105 @@
+package maple.expectation.provider;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import maple.expectation.domain.v2.CharacterEquipment;
+import maple.expectation.external.MaplestoryApiClient;
+import maple.expectation.external.dto.v2.EquipmentResponse;
+import maple.expectation.repository.v2.CharacterEquipmentRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EquipmentDataProviderConcurrencyTest {
+
+    @InjectMocks
+    private EquipmentDataProvider provider;
+
+    @Mock
+    private CharacterEquipmentRepository equipmentRepository;
+
+    @Mock
+    private MaplestoryApiClient apiClient;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    @DisplayName("동시에 10명이 같은 유저 조회 시, API 호출은 1회만 발생해야 한다")
+    void concurrencyTest() throws InterruptedException {
+        // Given
+        int threadCount = 10;
+        String targetOcid = "ocid_test_123";
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        // 💡 [핵심 해결책] 실제 DB처럼 동작하도록 'AtomicReference'를 사용하여 상태 구현
+        AtomicReference<CharacterEquipment> mockDb = new AtomicReference<>(null);
+
+        // 1. findById: mockDb에 있는 값을 반환하도록 설정 (동적으로 변함!)
+        lenient().when(equipmentRepository.findById(targetOcid)).thenAnswer(invocation -> {
+            return Optional.ofNullable(mockDb.get());
+        });
+
+        // 2. saveAndFlush: 호출되면 mockDb에 값을 저장 (JPA 동작 흉내)
+        lenient().when(equipmentRepository.saveAndFlush(any())).thenAnswer(invocation -> {
+            CharacterEquipment entity = invocation.getArgument(0);
+
+            // 주의: Unit Test에선 JPA Auditing(@CreatedDate)이 동작 안 하므로 시간 수동 설정 필요
+            // Provider 로직의 isValidCache() 통과를 위해 현재 시간 주입
+            if (entity.getUpdatedAt() == null) {
+                // Entity에 setUpdatedAt이 없다면 Reflection으로 강제 주입
+                // (Entity에 @Setter가 있다면 entity.setUpdatedAt(LocalDateTime.now()) 사용)
+                try {
+                    ReflectionTestUtils.setField(entity, "updatedAt", LocalDateTime.now());
+                } catch (Exception e) {
+                    // 필드명이 다르거나 없는 경우 무시 (혹은 테스트 실패 처리)
+                }
+            }
+
+            mockDb.set(entity); // 가짜 DB 업데이트
+            return entity;
+        });
+
+        // 3. API 호출 Stubbing
+        when(apiClient.getItemDataByOcid(targetOcid)).thenReturn(new EquipmentResponse());
+
+        // 4. @Value 주입
+        ReflectionTestUtils.setField(provider, "USE_COMPRESSION", false);
+
+        // When
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    provider.getRawEquipmentData(targetOcid);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        // Then
+        // 이제 2번째 스레드부터는 mockDb에 저장된 값을 읽어가므로 API를 호출하지 않음!
+        verify(apiClient, times(1)).getItemDataByOcid(targetOcid);
+        verify(equipmentRepository, times(1)).saveAndFlush(any());
+    }
+}


### PR DESCRIPTION
## 🚀 작업 배경 (Background)
기존 장비 조회 로직에서 동일한 유저(OCID)에 대해 다수의 요청이 동시에 들어올 경우, 캐시가 만료되었음에도 불구하고 모든 스레드가 외부 API를 중복 호출하는 **Thundering Herd** 문제가 발생할 우려가 있었습니다.
또한, 대용량 장비 데이터를 처리하는 과정에서 메모리 효율성을 높이고자 V3 스트리밍 방식을 도입했습니다.

## 🔧 주요 변경 사항 (Changes)

### 1. 동시성 제어 (Concurrency Control)
- **`EquipmentDataProvider`**: 
  - `ConcurrentHashMap`과 `ReentrantLock`을 사용하여 사용자(OCID) 단위로 락을 거는 메커니즘을 구현했습니다.
  - **Double-Check Locking**: 락을 획득한 후 한 번 더 DB 캐시를 확인하여, 앞선 스레드가 이미 데이터를 갱신했다면 API 호출 없이 캐시를 반환하도록 최적화했습니다.

### 2. 서비스 로직 리팩토링 (Service Layer)
- **`EquipmentService`**:
  - `calculateTotalExpectation` (V3): `EquipmentStreamingParser`를 사용하여 byte[] 데이터를 객체 변환 없이 바로 파싱하여 메모리 사용량을 줄였습니다.
  - **Exception Handling**: 비즈니스 로직에 혼재되어 있던 `try-catch`를 제거하고, 예외 처리를 전역 핸들러에게 위임하여 가독성을 높였습니다.
  - **Transaction**: 기본 트랜잭션을 `readOnly = true`로 설정하여 성능을 높이고, 쓰기 작업(`fetchFromApiAndSave`)에만 별도 트랜잭션을 적용했습니다.

### 3. 테스트 강화 (Test)
- **동시성 테스트 추가**: `EquipmentDataProviderConcurrencyTest`를 통해 10개의 스레드가 동시에 요청해도 외부 API 호출은 단 1회만 발생하는지 검증했습니다.
- **캐싱 로직 테스트 수정**: `EquipmentServiceTest`에서 Mock 객체 재사용으로 인해 발생하던 Hibernate Update 누락(Dirty Checking) 이슈를 해결하고 테스트 신뢰성을 확보했습니다.

## 📸 결과 (Impact)
- 동시 요청 시 DB 및 외부 API 부하 대폭 감소
- V3 API 도입으로 대용량 데이터 처리 시 응답 속도 및 메모리 효율 개선
- 테스트 커버리지 및 신뢰성 확보

## ✅ 체크리스트
- [x] `./gradlew test` 전체 통과
- [x] 동시성 테스트(`ConcurrencyTest`) 통과 확인