### PR TITLE
Infra: Docker Compose 도입 및 환경별 프로파일 분리 (#32)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ out/
 
 ### VS Code ###
 .vscode/
+
+# Docker
+.env
+mysql_data/

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv'
     implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'com.github.ben-manes.caffeine:caffeine'
+    implementation 'me.paulschwarz:spring-dotenv:4.0.0'
 
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3.8'
+
+services:
+  db:
+    image: mysql:8.0
+    container_name: maple-mysql
+    restart: always
+    ports:
+      - "3306:3306"
+    environment:
+      # .env 파일에서 값을 읽어옵니다
+      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${DB_SCHEMA_NAME}
+      TZ: ${TZ}
+    command:
+      --character-set-server=utf8mb4
+      --collation-server=utf8mb4_unicode_ci
+      --default-authentication-plugin=mysql_native_password
+    volumes:
+      - ./mysql_data:/var/lib/mysql
+
+volumes:
+  mysql_data:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -4,18 +4,17 @@ spring:
       on-profile: local
 
   datasource:
-    # [Safety] 로컬은 무조건 내 컴퓨터 DB(localhost)
-    url: jdbc:mysql://localhost:3306/maple_expectation?serverTimezone=Asia/Seoul&characterEncoding=UTF-8&rewriteBatchedStatements=true
+    url: jdbc:mysql://localhost:3306/${DB_SCHEMA_NAME}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8&rewriteBatchedStatements=true
     username: root
-    password: 1234 # 로컬은 편의상 하드코딩 (팀 정책에 따라 변경 가능)
+    password: ${DB_ROOT_PASSWORD}
 
     hikari:
-      maximum-pool-size: 10 # 로컬 리소스 절약
+      maximum-pool-size: 10
       minimum-idle: 5
 
   jpa:
     hibernate:
-      ddl-auto: update # 개발 편의를 위해 스키마 자동 변경 허용
+      ddl-auto: update
 
 discord:
   webhook-url: ${DISCORD_WEBHOOK_URL}

--- a/src/test/java/maple/expectation/EnvironmentIntegrationTest.java
+++ b/src/test/java/maple/expectation/EnvironmentIntegrationTest.java
@@ -1,0 +1,40 @@
+package maple.expectation;
+
+import lombok.extern.slf4j.Slf4j; // 1. 롬복 어노테이션 임포트
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+@SpringBootTest
+class EnvironmentIntegrationTest {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Value("${discord.webhook-url}")
+    private String webhookUrl;
+
+    @Test
+    @DisplayName("1. DB 연결이 정상이고 데이터를 읽을 수 있어야 한다")
+    void testDbConnection() {
+        Integer result = jdbcTemplate.queryForObject("SELECT 1", Integer.class);
+        assertThat(result).isEqualTo(1);
+
+        log.info("✅ DB Connection Success! Result: {}", result); 
+    }
+
+    @Test
+    @DisplayName("2. .env에서 로드한 API 키나 설정값이 주입되어야 한다")
+    void testEnvLoading() {
+        assertThat(webhookUrl).isNotNull();
+        assertThat(webhookUrl).isNotEmpty();
+
+        log.info("✅ Env Variable Loaded: {}", webhookUrl);
+    }
+}

--- a/src/test/java/maple/expectation/concurrency/LikeConcurrencyTest.java
+++ b/src/test/java/maple/expectation/concurrency/LikeConcurrencyTest.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 @Slf4j
 @SpringBootTestWithTimeLogging
-@TestPropertySource(properties = "app.optimization.use-compression=false")
 public class LikeConcurrencyTest {
 
     @Autowired

--- a/src/test/java/maple/expectation/performance/ItemEquipmentInsertPerformanceTest.java
+++ b/src/test/java/maple/expectation/performance/ItemEquipmentInsertPerformanceTest.java
@@ -19,7 +19,6 @@ import java.util.Random;
 @Slf4j
 @Transactional
 @SpringBootTestWithTimeLogging
-@TestPropertySource(properties = "app.optimization.use-compression=false")
 class ItemEquipmentInsertPerformanceTest {
 
     @Autowired

--- a/src/test/java/maple/expectation/service/CubeServiceTest.java
+++ b/src/test/java/maple/expectation/service/CubeServiceTest.java
@@ -16,7 +16,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @Slf4j
 @SpringBootTestWithTimeLogging
-@TestPropertySource(properties = "app.optimization.use-compression=false")
 class CubeServiceTest {
 
     @Autowired

--- a/src/test/java/maple/expectation/setup/DataSeedingTest.java
+++ b/src/test/java/maple/expectation/setup/DataSeedingTest.java
@@ -17,7 +17,6 @@ import java.util.Random;
 @Slf4j
 //@Commit
 @SpringBootTestWithTimeLogging
-@TestPropertySource(properties = "app.optimization.use-compression=false")
 public class DataSeedingTest {
 
     @Autowired

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,5 +1,4 @@
 spring:
-  # [중요 1] 테스트는 'H2' 인메모리 DB를 써야 설치 없이 어디서든 돌아갑니다.
   datasource:
     url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1
     driver-class-name: org.h2.Driver
@@ -7,29 +6,29 @@ spring:
     password:
 
     hikari:
-      maximum-pool-size: 5  # 테스트는 혼자 하니까 많이 필요 없음
+      maximum-pool-size: 5
       minimum-idle: 5
 
   jpa:
     hibernate:
-      ddl-auto: create-drop # 테스트 시작할 때 만들고, 끝나면 삭제 (깔끔)
+      ddl-auto: create-drop
     properties:
       hibernate:
-        format_sql: true    # 테스트 때는 쿼리 보는 게 디버깅에 좋음
+        format_sql: true
         show_sql: true
 
 logging:
   level:
     root: info
-    # 테스트 실패 원인 분석을 위해 SQL 로그는 켜두는 게 좋습니다
     org.hibernate.SQL: debug
 
-# [중요 2] 테스트 환경에서는 실제 키 대신 '가짜 값'을 넣습니다.
-# (테스트 코드는 외부 API를 실제로 호출하지 않고 Mocking 하는 것이 원칙이므로)
 nexon:
   api:
     key: "test_dummy_key"
 
-# [추가] 테스트용 가짜 디스코드 웹훅 URL
 discord:
   webhook-url: "https://discord.com/api/webhooks/dummy/test"
+
+app:
+  optimization:
+    use-compression: false


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #32

## 🗣 개요
### 📌 배경
기존 Host OS에 직접 DB를 설치하는 방식은 윈도우/WSL 환경 충돌 시 데이터 유실 위험이 있고, 개발자 간 환경 불일치 문제를 야기했습니다. 이를 해결하기 위해 **Infrastructure as Code (IaC)** 관점에서 DB 실행 환경을 Docker로 격리하고 표준화했습니다.

### 🎯 목적
- `docker-compose up` 명령어 하나로 로컬 DB 환경 즉시 구축
- Local(MySQL)과 Test(H2) 환경의 명확한 분리
- 민감 정보(`.env`)의 코드 베이스 분리를 통한 보안 강화

## 🛠 작업 내용
### 1. Docker Environment 구성
- `docker-compose.yml` 추가: MySQL 8.0 이미지 기반
- `mysql_data` 볼륨 마운트를 통한 컨테이너 재실행 시 데이터 유지 보장
- `.env` 파일을 통한 환경 변수 주입 (DB Password, Schema Name 등)

### 2. Spring Boot Configuration 고도화
- **Profile 분리 전략 적용:**
  - `local`: Docker MySQL 연결 (`ddl-auto: update`, 쿼리 로그 활성화)
  - `test`: H2 In-memory DB 연결 (`ddl-auto: create-drop`, 고속 테스트용)
- **보안 강화:** 소스 코드 내 하드코딩된 Secret들을 환경 변수(`${VARIABLE}`)로 대체

### 3. Git Ignore 최적화
- IDE(IntelliJ, VS Code, STS) 설정 파일 및 OS 시스템 파일 제외
- 보안상 중요한 `.env` 파일 추적 제외

### 4. 테스트 코드 작성 (Unit & Integration)
- **통합 테스트 (`EnvironmentIntegrationTest`):** - `testDbConnection()`: `SELECT 1` 쿼리를 실행하여 DB 커넥션 풀(HikariCP) 정상 동작 확인
  - `testEnvLoading()`: `.env` 또는 시스템 환경 변수에서 설정값이 올바르게 주입되는지 검증 (`@Value` 동작 확인)

## 📸 스크린샷 (선택 사항)
> (테스트 통과 로그 캡처본을 여기에 첨부해 주세요. 예: "✅ DB Connection Success! Result: 1")

## 💬 리뷰 포인트
- 로컬에서 `docker-compose up -d` 실행 시 MySQL이 정상적으로 뜨는지 확인 부탁드립니다.
- 프로젝트 루트에 `.env` 파일을 생성하고 필요한 변수를 넣었을 때, `EnvironmentIntegrationTest`가 통과하는지 확인해 주세요.
- `local` 프로필 실행 시 H2가 아닌 Docker MySQL에 붙는지 로그 확인 부탁드립니다.

## ✅ 체크리스트
- [x] 로컬 환경에서 테스트 코드가 정상적으로 실행되는가?
- [x] `docker-compose` 명령어로 DB가 정상 구동되는가?
- [x] `.env` 파일이 `.gitignore`에 잘 포함되어 커밋되지 않았는가?