### PR TITLE
최초 캐릭터 생성 시 Race Condition 해결 및 동기화 고도화

### DIFF
--- a/src/main/java/maple/expectation/service/v2/GameCharacterService.java
+++ b/src/main/java/maple/expectation/service/v2/GameCharacterService.java
@@ -13,6 +13,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Slf4j
 @Service
 @TraceLog
@@ -21,10 +23,9 @@ public class GameCharacterService {
 
     private final GameCharacterRepository gameCharacterRepository;
     private final NexonApiClient nexonApiClient;
-    private final LikeProcessor likeProcessor; // @Primary인 BufferedLikeProxy가 주입됨
-    private final DatabaseLikeProcessor databaseLikeProcessor; // 직접 DB 반영용
+    private final LikeProcessor likeProcessor;
+    private final DatabaseLikeProcessor databaseLikeProcessor;
 
-    // 순환 참조 방지를 위해 한 쪽에 @Lazy를 적용합니다.
     public GameCharacterService(
             GameCharacterRepository gameCharacterRepository,
             NexonApiClient nexonApiClient,
@@ -44,45 +45,41 @@ public class GameCharacterService {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public GameCharacter findCharacterByUserIgn(String userIgn) {
         String cleanUserIgn = userIgn.trim();
-        return gameCharacterRepository.findByUserIgn(cleanUserIgn)
-                .orElseGet(() -> {
-                    String ocid = nexonApiClient.getOcidByCharacterName(cleanUserIgn).getOcid();
-                    GameCharacter newChar = new GameCharacter(cleanUserIgn);
-                    newChar.setOcid(ocid);
-                    return gameCharacterRepository.save(newChar);
-                });
+
+        Optional<GameCharacter> firstCheck = gameCharacterRepository.findByUserIgn(cleanUserIgn);
+        if (firstCheck.isPresent()) {
+            return firstCheck.get();
+        }
+
+        synchronized (cleanUserIgn.intern()) {
+            return gameCharacterRepository.findByUserIgn(cleanUserIgn)
+                    .orElseGet(() -> {
+                        log.info("✨ 신규 캐릭터 생성 시도: {}", cleanUserIgn);
+                        String ocid = nexonApiClient.getOcidByCharacterName(cleanUserIgn).getOcid();
+                        GameCharacter newChar = new GameCharacter(cleanUserIgn);
+                        newChar.setOcid(ocid);
+                        return gameCharacterRepository.saveAndFlush(newChar);
+                    });
+        }
     }
 
-    /**
-     * 🚀 [V2용] 기본 프록시(Caffeine 캐시 버퍼) 사용
-     * 처리량(Throughput) 최우선 전략
-     */
     @LogExecutionTime
     public void clickLikeCache(String userIgn) {
         likeProcessor.processLike(userIgn);
     }
 
-    /**
-     * 🔒 [V1용] 비관적 락 강제 사용 (DB 즉시 반영)
-     * 데이터 정합성 최우선 전략
-     */
     @LogExecutionTime
     @Transactional
     public void clickLikePessimistic(String userIgn) {
         databaseLikeProcessor.processLike(userIgn);
     }
 
-    /**
-     * 중앙 집중식 조회 메서드 (프로세서들이 사용)
-     */
     public GameCharacter getCharacterOrThrow(String userIgn) {
         return gameCharacterRepository.findByUserIgn(userIgn)
                 .orElseThrow(CharacterNotFoundException::new);
     }
 
-    /**
-     * 중앙 집중식 비관적 락 조회 메서드 (DatabaseLikeProcessor가 사용)
-     */
+    @Transactional
     public GameCharacter getCharacterForUpdate(String userIgn) {
         return gameCharacterRepository.findByUserIgnWithPessimisticLock(userIgn)
                 .orElseThrow(CharacterNotFoundException::new);


### PR DESCRIPTION
## PR: 최초 캐릭터 생성 시 Race Condition 해결 및 동기화 고도화

### 🔗 관련 이슈
- [Bug/Concurrency] 최초 캐릭터 생성 시 Race Condition으로 인한 Unique 제약 위반 방지 #9

### 📌 Problem Definition (문제 정의)
- 특정 유저가 DB에 존재하지 않을 때, 찰나의 순간에 동일한 `userIgn`으로 여러 요청이 들어오면 중복 `INSERT`가 시도되는 현상 발생.
- Hibernate 세션이 `DataIntegrityViolationException`을 맞으면 오염되어 이후의 재조회 쿼리에서도 `AssertionFailure`가 발생하는 구조적 한계 확인.

### 🎯 Goal (목표)
- 동일 유저에 대한 동시 생성 요청 시 단 하나의 레코드만 생성됨을 보장.
- 락 범위를 최소화하여 기존 유저 조회 성능(Happy Path)에 지장을 주지 않는 구조 설계.
- Hibernate 세션 오염 없이 안전하게 데이터를 반환하도록 개선.

### 🔍 Workflow (작업 방식)
1. **버그 재현:** `CountDownLatch`와 `ExecutorService`를 활용해 100개 쓰레드가 동시에 신규 유저 생성을 시도하는 테스트 작성 (성공: 96, 실패: 4 재현 확인).
2. **패턴 도입:** 락 없이 1차 조회 후, 실패 시에만 동기화 블록에 진입하는 **Double-Checked Locking** 적용.
3. **정밀 락 제어:** `cleanUserIgn.intern()`을 사용하여 전체 서비스가 아닌 **특정 닉네임 값**을 기준으로만 줄을 세우도록 최적화.
4. **검증:** 수정 후 동일 조건 테스트에서 성공 100/100 달성 확인.

### 🛠️ 해결 (Resolve)
- **GameCharacterService.java:**
  - 1차 Read: 락 없이 조회하여 성능 유지.
  - `synchronized(userIgn.intern())`: 동일 닉네임 중복 생성 시도 차단.
  - 2차 Read (Inside Lock): 락 획득 대기 중 생성된 데이터가 있는지 재확인.
  - `saveAndFlush()`: 트랜잭션 종료 전 즉시 반영.

### 📝 Analysis Plan (중점 분석 대상)
- **Lock Precision:** `intern()` 사용 시 JVM PermGen/Metaspace 영역의 메모리 사용량과 락의 세밀함 사이의 트레이드오프 검토 (캐릭터 닉네임 상수는 서비스 규모상 안전하다고 판단).
- **Session Stability:** 예외가 발생하기 전 락에서 차단되므로 Hibernate 세션의 안정성이 획기적으로 향상됨.

### ⚖️ Trade-off (트레이드오프)
- **Pros:** - 기존 유저 조회 시 락 오버헤드가 0에 수렴함.
  - DB 예외 발생 후 복구하는 방식보다 세션 관리가 훨씬 안정적임.
- **Cons:** `String.intern()` 사용으로 인해 아주 미세한 수준의 String Pool 메모리 점유 발생.

### ✅ Action Items
- [x] `findCharacterByUserIgn` 동시성 재현 테스트 코드 작성 (Fail 확인)
- [x] Double-Checked Locking 기반 중복 생성 방지 로직 구현
- [x] 100명 동시 생성 시 100명 전원 성공(1명 생성/99명 조회) 검증 완료
- [x] `@MockitoBean`을 이용한 외부 API 호출 격리 및 테스트 안정화

### 🏁 Definition of Done (완료 조건)
- 100개 쓰레드 동시 요청 시 단 1회의 INSERT 로그와 100회의 성공 응답 확인.
- 로그에 더 이상 `AssertionFailure` 또는 `DataIntegrityViolationException`이 기록되지 않음.

### Why Double-Checked Locking with Intern
애플리케이션 레벨에서 `intern()`을 활용한 동기화는 DB 수준의 무거운 락을 걸지 않고도 특정 리소스(닉네임)에 대한 배타적 접근을 보장합니다. 이는 메이플 시뮬레이터와 같이 특정 캐릭터에 트래픽이 몰릴 수 있는 환경에서 최적의 처리량과 데이터 무결성을 동시에 확보하는 전략입니다.