### PR TITLE
[feat] 예외 계층 구조 개편 및 Global Exception Handler 구축 (#21)

### DIFF
--- a/src/main/java/maple/expectation/exception/CharacterNotFoundException.java
+++ b/src/main/java/maple/expectation/exception/CharacterNotFoundException.java
@@ -1,12 +1,10 @@
 package maple.expectation.exception;
 
-public class CharacterNotFoundException extends RuntimeException {
+import maple.expectation.global.error.CommonErrorCode;
+import maple.expectation.global.error.exception.ClientBaseException;
 
-    public CharacterNotFoundException() {
-        super();
-    }
-
-    public CharacterNotFoundException(String message) {
-        super(message);
+public class CharacterNotFoundException extends ClientBaseException {
+    public CharacterNotFoundException(String userIgn) {
+        super(CommonErrorCode.CHARACTER_NOT_FOUND, userIgn);
     }
 }

--- a/src/main/java/maple/expectation/exception/CriticalTransactionFailureException.java
+++ b/src/main/java/maple/expectation/exception/CriticalTransactionFailureException.java
@@ -1,14 +1,11 @@
 package maple.expectation.exception;
 
-public class CriticalTransactionFailureException extends RuntimeException /* implements ServerBaseException (예정) */ {
+import maple.expectation.global.error.CommonErrorCode;
+import maple.expectation.global.error.exception.ServerBaseException;
 
-    public CriticalTransactionFailureException(String message) {
-        super(message);
+public class CriticalTransactionFailureException extends ServerBaseException {
+    public CriticalTransactionFailureException(String detail, Throwable cause) {
+        super(CommonErrorCode.DATABASE_TRANSACTION_FAILURE, detail);
+        // 필요 시 별도로 cause를 로깅하거나 상위로 전달 가능
     }
-
-    public CriticalTransactionFailureException(String message, Throwable cause) {
-        super(message, cause);
-    }
-    
-    // Global Exception Handler가 인식할 수 있는 ErrorCode 등을 추가할 수 있습니다.
 }

--- a/src/main/java/maple/expectation/exception/CubeDataInitializationException.java
+++ b/src/main/java/maple/expectation/exception/CubeDataInitializationException.java
@@ -1,18 +1,16 @@
 package maple.expectation.exception;
 
+import maple.expectation.global.error.CommonErrorCode;
+import maple.expectation.global.error.exception.ServerBaseException;
+
 /**
  * 큐브 확률 데이터 초기화(로딩) 실패 시 발생하는 예외
  * - CSV 파일 없음
  * - CSV 파싱 오류
  * - I/O 오류
  */
-public class CubeDataInitializationException extends RuntimeException {
-
-    public CubeDataInitializationException(String message) {
-        super(message);
-    }
-
-    public CubeDataInitializationException(String message, Throwable cause) {
-        super(message, cause);
+public class CubeDataInitializationException extends ServerBaseException {
+    public CubeDataInitializationException(String fileName) {
+        super(CommonErrorCode.DATA_INITIALIZATION_FAILED, fileName);
     }
 }

--- a/src/main/java/maple/expectation/exception/DeveloperNotFoundException.java
+++ b/src/main/java/maple/expectation/exception/DeveloperNotFoundException.java
@@ -1,7 +1,10 @@
 package maple.expectation.exception;
 
-public class DeveloperNotFoundException extends RuntimeException {
-    public DeveloperNotFoundException(String message) {
-        super(message);
+import maple.expectation.global.error.CommonErrorCode;
+import maple.expectation.global.error.exception.ClientBaseException;
+
+public class DeveloperNotFoundException extends ClientBaseException {
+    public DeveloperNotFoundException(String developerId) {
+        super(CommonErrorCode.DEVELOPER_NOT_FOUND, developerId);
     }
 }

--- a/src/main/java/maple/expectation/exception/EquipmentDataProcessingException.java
+++ b/src/main/java/maple/expectation/exception/EquipmentDataProcessingException.java
@@ -1,15 +1,13 @@
 package maple.expectation.exception;
 
+import maple.expectation.global.error.CommonErrorCode;
+import maple.expectation.global.error.exception.ServerBaseException;
+
 /**
  * 장비 데이터 처리(JSON 파싱, 압축, DB 변환) 중 발생하는 예외
  */
-public class EquipmentDataProcessingException extends RuntimeException {
-
-    public EquipmentDataProcessingException(String message) {
-        super(message);
-    }
-
-    public EquipmentDataProcessingException(String message, Throwable cause) {
-        super(message, cause);
+public class EquipmentDataProcessingException extends ServerBaseException {
+    public EquipmentDataProcessingException(String detail) {
+        super(CommonErrorCode.DATA_PROCESSING_ERROR, detail);
     }
 }

--- a/src/main/java/maple/expectation/exception/InsufficientPointException.java
+++ b/src/main/java/maple/expectation/exception/InsufficientPointException.java
@@ -1,7 +1,10 @@
 package maple.expectation.exception;
 
-public class InsufficientPointException extends RuntimeException {
-    public InsufficientPointException(String message) {
-        super(message);
+import maple.expectation.global.error.CommonErrorCode;
+import maple.expectation.global.error.exception.ClientBaseException;
+
+public class InsufficientPointException extends ClientBaseException {
+    public InsufficientPointException(String msg) {
+        super(CommonErrorCode.INSUFFICIENT_POINTS, msg);
     }
 }

--- a/src/main/java/maple/expectation/exception/MapleDataProcessingException.java
+++ b/src/main/java/maple/expectation/exception/MapleDataProcessingException.java
@@ -1,7 +1,10 @@
 package maple.expectation.exception;
 
-public class MapleDataProcessingException extends RuntimeException {
-    public MapleDataProcessingException(String message, Throwable cause) {
-        super(message, cause);
+import maple.expectation.global.error.CommonErrorCode;
+import maple.expectation.global.error.exception.ServerBaseException;
+
+public class MapleDataProcessingException extends ServerBaseException {
+    public MapleDataProcessingException(String detail) {
+        super(CommonErrorCode.DATA_PROCESSING_ERROR, detail);
     }
 }

--- a/src/main/java/maple/expectation/external/impl/RealNexonApiClient.java
+++ b/src/main/java/maple/expectation/external/impl/RealNexonApiClient.java
@@ -1,12 +1,15 @@
 package maple.expectation.external.impl;
 
 import lombok.RequiredArgsConstructor;
+import maple.expectation.exception.CharacterNotFoundException;
 import maple.expectation.external.NexonApiClient;
 import maple.expectation.external.dto.v2.CharacterOcidResponse;
 import maple.expectation.external.dto.v2.EquipmentResponse;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
 
 @Component
 @RequiredArgsConstructor
@@ -26,6 +29,14 @@ public class RealNexonApiClient implements NexonApiClient {
                         .build())
                 .header("x-nxopen-api-key", apiKey)
                 .retrieve()
+                // 4xx 에러 발생 시 처리
+                .onStatus(HttpStatusCode::is4xxClientError, clientResponse -> {
+                    // 넥슨 API가 캐릭터가 없을 때 400을 반환하므로 이를 잡아냄
+                    if (clientResponse.statusCode().value() == 400) {
+                        return Mono.error(new CharacterNotFoundException(characterName));
+                    }
+                    return clientResponse.createException().flatMap(Mono::error);
+                })
                 .bodyToMono(CharacterOcidResponse.class)
                 .block();
     }

--- a/src/main/java/maple/expectation/external/proxy/NexonApiCachingProxy.java
+++ b/src/main/java/maple/expectation/external/proxy/NexonApiCachingProxy.java
@@ -99,7 +99,7 @@ public class NexonApiCachingProxy implements NexonApiClient {
             String json = isGzip(rawData) ? GzipUtils.decompress(rawData) : new String(rawData, StandardCharsets.UTF_8);
             return objectMapper.readValue(json, EquipmentResponse.class);
         } catch (JsonProcessingException e) {
-            throw new EquipmentDataProcessingException("캐시 데이터 파싱 실패", e);
+            throw new EquipmentDataProcessingException("캐시 데이터 파싱 실패");
         }
     }
 
@@ -114,7 +114,7 @@ public class NexonApiCachingProxy implements NexonApiClient {
             entity.updateData(rawData);
             equipmentRepository.saveAndFlush(entity);
         } catch (JsonProcessingException e) {
-            throw new EquipmentDataProcessingException("데이터 직렬화 실패", e);
+            throw new EquipmentDataProcessingException("데이터 직렬화 실패");
         }
     }
 

--- a/src/main/java/maple/expectation/global/error/CommonErrorCode.java
+++ b/src/main/java/maple/expectation/global/error/CommonErrorCode.java
@@ -1,0 +1,25 @@
+package maple.expectation.global.error;
+
+import lombok.Getter;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum CommonErrorCode implements ErrorCode {
+    // === Client Errors (4xx) ===
+    INVALID_INPUT_VALUE("C001", "잘못된 입력값입니다: %s", HttpStatus.BAD_REQUEST),
+    CHARACTER_NOT_FOUND("C002", "존재하지 않는 캐릭터입니다 (IGN: %s)", HttpStatus.NOT_FOUND),
+    INSUFFICIENT_POINTS("C003", "포인트가 부족합니다 (보유: %s, 필요: %s)", HttpStatus.BAD_REQUEST),
+    DEVELOPER_NOT_FOUND("C004", "해당 개발자를 찾을 수 없습니다 (ID: %s)", HttpStatus.NOT_FOUND),
+
+    // === Server Errors (5xx) ===
+    INTERNAL_SERVER_ERROR("S001", "서버 내부 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    DATABASE_TRANSACTION_FAILURE("S002", "치명적인 트랜잭션 오류가 발생했습니다: %s", HttpStatus.INTERNAL_SERVER_ERROR),
+    DATA_INITIALIZATION_FAILED("S003", "데이터 초기화 실패 (대상: %s)", HttpStatus.INTERNAL_SERVER_ERROR),
+    DATA_PROCESSING_ERROR("S004", "데이터 처리 중 오류 발생 (%s)", HttpStatus.INTERNAL_SERVER_ERROR);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus status;
+}

--- a/src/main/java/maple/expectation/global/error/ErrorCode.java
+++ b/src/main/java/maple/expectation/global/error/ErrorCode.java
@@ -1,0 +1,12 @@
+package maple.expectation.global.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    String getCode();
+    String getMessage();
+    HttpStatus getStatus();
+}
+

--- a/src/main/java/maple/expectation/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/maple/expectation/global/error/GlobalExceptionHandler.java
@@ -1,0 +1,36 @@
+package maple.expectation.global.error;
+
+import lombok.extern.slf4j.Slf4j;
+import maple.expectation.global.error.dto.ErrorResponse;
+import maple.expectation.global.error.exception.BaseException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    /**
+     * [1순위 가치] 비즈니스 예외 처리 (동적 메시지 포함)
+     * BaseException 객체를 직접 넘겨서 가공된 메시지(예: IGN 포함)를 활용합니다. [cite: 14, 15]
+     */
+    @ExceptionHandler(BaseException.class)
+    protected ResponseEntity<ErrorResponse> handleBaseException(BaseException e) {
+        log.warn("Business Exception: {} | Message: {}", e.getErrorCode().getCode(), e.getMessage());
+        return ErrorResponse.toResponseEntity(e); // 💡 ErrorCode가 아닌 e 자체를 넘깁니다.
+    }
+
+    /**
+     * [재앙 방지] 예측하지 못한 시스템 예외 처리 [cite: 32, 37]
+     * 시스템 내부의 '약한 고리'에서 터진 재앙을 안전하게 캡슐화합니다. [cite: 40]
+     */
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+        // 실제 운영 환경의 장애 회고록을 위해 스택 트레이스를 상세히 남깁니다. [cite: 34, 36]
+        log.error("Unexpected System Failure: ", e);
+
+        // 500 에러는 보안상 상세 메시지를 숨기고 규격화된 공통 코드를 넘깁니다. [cite: 44]
+        return ErrorResponse.toResponseEntity(CommonErrorCode.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/maple/expectation/global/error/dto/ErrorResponse.java
+++ b/src/main/java/maple/expectation/global/error/dto/ErrorResponse.java
@@ -1,0 +1,44 @@
+package maple.expectation.global.error.dto;
+
+import lombok.Builder;
+import maple.expectation.global.error.ErrorCode;
+import maple.expectation.global.error.exception.BaseException;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDateTime;
+
+public record ErrorResponse(int status, String code, String message, LocalDateTime timestamp) {
+
+    @Builder
+    public ErrorResponse {}
+
+    /**
+     * [방법 1] BaseException을 받는 경우 (비즈니스 예외)
+     * e.getMessage()를 통해 동적으로 가공된 메시지(예: 어떤 유저가 없는지)를 전달합니다. [cite: 11]
+     */
+    public static ResponseEntity<ErrorResponse> toResponseEntity(BaseException e) {
+        return ResponseEntity
+                .status(e.getErrorCode().getStatus())
+                .body(ErrorResponse.builder()
+                        .status(e.getErrorCode().getStatus().value())
+                        .code(e.getErrorCode().getCode())
+                        .message(e.getMessage())
+                        .timestamp(LocalDateTime.now())
+                        .build());
+    }
+
+    /**
+     * [방법 2] ErrorCode를 직접 받는 경우 (예상치 못한 서버 예외)
+     * Enum에 정의된 기본 메시지를 사용하며, 상세한 에러 내용은 보안을 위해 숨깁니다. [cite: 44]
+     */
+    public static ResponseEntity<ErrorResponse> toResponseEntity(ErrorCode errorCode) {
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ErrorResponse.builder()
+                        .status(errorCode.getStatus().value())
+                        .code(errorCode.getCode())
+                        .message(errorCode.getMessage())
+                        .timestamp(LocalDateTime.now())
+                        .build());
+    }
+}

--- a/src/main/java/maple/expectation/global/error/exception/BaseException.java
+++ b/src/main/java/maple/expectation/global/error/exception/BaseException.java
@@ -1,0 +1,24 @@
+package maple.expectation.global.error.exception;
+
+import lombok.Getter;
+import maple.expectation.global.error.ErrorCode;
+
+@Getter
+public abstract class BaseException extends RuntimeException {
+    private final ErrorCode errorCode;
+    private final String message; // 💡 필드 추가
+
+    // 기본 생성자
+    public BaseException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+        this.message = errorCode.getMessage();
+    }
+
+    // 💡 동적 인자를 받는 생성자 (String.format 활용)
+    public BaseException(ErrorCode errorCode, Object... args) {
+        super(String.format(errorCode.getMessage(), args));
+        this.errorCode = errorCode;
+        this.message = String.format(errorCode.getMessage(), args);
+    }
+}

--- a/src/main/java/maple/expectation/global/error/exception/ClientBaseException.java
+++ b/src/main/java/maple/expectation/global/error/exception/ClientBaseException.java
@@ -1,0 +1,21 @@
+package maple.expectation.global.error.exception;
+
+import maple.expectation.global.error.ErrorCode;
+
+/**
+ * ClientBaseException: 사용자의 의도와 다를 때 발생하는 '비즈니스 예외'
+ * 4xx 계열의 에러를 처리하며, 유저에게 구체적인 실패 원인을 전달하는 것이 목적입니다.
+ */
+public abstract class ClientBaseException extends BaseException {
+
+    // 기본 생성자: 고정된 에러 메시지를 사용할 때
+    public ClientBaseException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    // 💡 추가: 동적 인자를 받는 생성자
+    // 이를 통해 "존재하지 않는 캐릭터입니다 (IGN: %s)"와 같은 메시지 완성이 가능해집니다.
+    public ClientBaseException(ErrorCode errorCode, Object... args) {
+        super(errorCode, args);
+    }
+}

--- a/src/main/java/maple/expectation/global/error/exception/ServerBaseException.java
+++ b/src/main/java/maple/expectation/global/error/exception/ServerBaseException.java
@@ -1,0 +1,19 @@
+package maple.expectation.global.error.exception;
+
+import maple.expectation.global.error.ErrorCode;
+
+/**
+ * ServerBaseException: 시스템 내부 오류나 나의 오타로 인해 발생하는 '서버 예외'
+ * 5xx 계열의 에러를 처리하며, 장애 회고를 위한 상세 로그를 남기는 것이 주 목적입니다.
+ */
+public abstract class ServerBaseException extends BaseException {
+
+    public ServerBaseException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    // 서버 측 에러도 구체적인 ID나 파일명 등을 로그에 남기기 위해 추가합니다.
+    public ServerBaseException(ErrorCode errorCode, Object... args) {
+        super(errorCode, args);
+    }
+}

--- a/src/main/java/maple/expectation/parser/EquipmentStreamingParser.java
+++ b/src/main/java/maple/expectation/parser/EquipmentStreamingParser.java
@@ -105,7 +105,7 @@ public class EquipmentStreamingParser {
             return resultList;
 
         } catch (IOException e) {
-            throw new MapleDataProcessingException("큐브 계산 입력값 파싱 실패", e);
+            throw new MapleDataProcessingException("큐브 계산 입력값 파싱 실패");
         }
     }
 
@@ -115,7 +115,7 @@ public class EquipmentStreamingParser {
             objectMapper.writeValue(jsonGenerator, response);
             jsonGenerator.flush();
         } catch (IOException e) {
-            throw new MapleDataProcessingException("JSON 스트리밍 직렬화 실패", e);
+            throw new MapleDataProcessingException("JSON 스트리밍 직렬화 실패");
         }
     }
 

--- a/src/main/java/maple/expectation/provider/EquipmentDataProvider.java
+++ b/src/main/java/maple/expectation/provider/EquipmentDataProvider.java
@@ -58,7 +58,7 @@ public class EquipmentDataProvider {
 
         } catch (JsonProcessingException e) {
             log.error("직렬화 중 오류 발생: {}", response.getDate(), e);
-            throw new EquipmentDataProcessingException("데이터 직렬화 실패", e);
+            throw new EquipmentDataProcessingException("데이터 직렬화 실패");
         }
     }
 }

--- a/src/main/java/maple/expectation/repository/v2/CubeProbabilityRepository.java
+++ b/src/main/java/maple/expectation/repository/v2/CubeProbabilityRepository.java
@@ -60,7 +60,7 @@ public class CubeProbabilityRepository {
 
         } catch (IOException e) {
             log.error("확률 데이터 로딩 중 치명적 오류 발생", e);
-            throw new CubeDataInitializationException("확률 데이터 파싱 중 I/O 오류 발생", e);
+            throw new CubeDataInitializationException("확률 데이터 파싱 중 I/O 오류 발생");
         }
     }
 

--- a/src/main/java/maple/expectation/service/v2/GameCharacterService.java
+++ b/src/main/java/maple/expectation/service/v2/GameCharacterService.java
@@ -76,12 +76,12 @@ public class GameCharacterService {
 
     public GameCharacter getCharacterOrThrow(String userIgn) {
         return gameCharacterRepository.findByUserIgn(userIgn)
-                .orElseThrow(CharacterNotFoundException::new);
+                .orElseThrow(() -> new CharacterNotFoundException(userIgn));
     }
 
     @Transactional
     public GameCharacter getCharacterForUpdate(String userIgn) {
         return gameCharacterRepository.findByUserIgnWithPessimisticLock(userIgn)
-                .orElseThrow(CharacterNotFoundException::new);
+                .orElseThrow(() -> new CharacterNotFoundException(userIgn));
     }
 }

--- a/src/test/java/maple/expectation/global/error/GlobalExceptionHandlerTest.java
+++ b/src/test/java/maple/expectation/global/error/GlobalExceptionHandlerTest.java
@@ -1,0 +1,50 @@
+package maple.expectation.global.error;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class GlobalExceptionHandlerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("존재하지 않는 캐릭터 조회 시 404 에러와 동적 메시지를 반환한다")
+    void handleCharacterNotFoundException() throws Exception {
+        // given: 존재하지 않는 캐릭터 이름
+        String nonExistIgn = "유령캐릭터1234567891234565675688945";
+
+        // when & then: 
+        // 1순위 가치인 '명확한 피드백'이 전달되는지 확인합니다. [cite: 14]
+        mockMvc.perform(get("/api/v1/characters/" + nonExistIgn))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("C002"))
+                .andExpect(jsonPath("$.message").value("존재하지 않는 캐릭터입니다 (IGN: " + nonExistIgn + ")"))
+                .andExpect(jsonPath("$.timestamp").exists());
+    }
+
+    @Test
+    @DisplayName("예측하지 못한 서버 내부 오류 발생 시 500 에러와 공통 메시지를 반환한다")
+    void handleUnexpectedException() throws Exception {
+        // given: 서버 내부에서 오타나 로직 오류가 발생한 상황을 가정 [cite: 35, 37]
+        // (테스트용 엔드포인트에서 의도적으로 RuntimeException을 던지도록 설정 필요)
+
+        // when & then: 
+        // 재앙이 발생해도 시스템 전체 마비를 방지하고 규격화된 응답을 주는지 확인합니다. [cite: 32, 41]
+        mockMvc.perform(get("/api/v1/test/error"))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.code").value("S001"))
+                .andExpect(jsonPath("$.message").value("서버 내부 오류가 발생했습니다."))
+                .andExpect(jsonPath("$.timestamp").exists());
+    }
+}


### PR DESCRIPTION
### 🔗 관련 이슈
* #21

### 📌 Problem Definition (문제 정의)
* 프로젝트 내 커스텀 예외들이 파편화되어 있어 일관된 에러 응답 제공이 어려움.
* 외부 API(넥슨) 호출 시 발생하는 에러(400 Bad Request)가 내부 비즈니스 로직 예외로 전환되지 않아 예외 처리가 파편화됨.

### 🎯 Goal (목표)
* `BaseException` 기반의 단일 예외 계층 구조 구축을 통한 유지보수성 향상.
* 클라이언트에게 `ErrorCode` 기반의 규격화된 JSON 응답(code, message, timestamp) 제공.
* 외부 API 에러를 도메인 예외로 캡슐화하여 서비스 레이어의 순수성 유지.

### 🔍 Workflow (작업 방식)
1. **상위 계층 정의**: `BaseException` 추상 클래스 및 공통 `ErrorCode` Enum 정의.
2. **핸들러 구축**: `@RestControllerAdvice`를 사용하여 전역 예외 처리기 구현.
3. **외부 에러 매핑**: `RealNexonApiClient`에서 `WebClient.onStatus()`를 활용해 외부 400 에러를 `CharacterNotFoundException`으로 변환.
4. **검증**: `MockMvc` 기반 통합 테스트(`GlobalExceptionHandlerTest`)로 최종 응답 규격 확인.

### 🛠️ 해결 (Resolve)
* `CharacterNotFoundException` 등 기존 예외들이 `BaseException`을 상속하도록 리팩토링 완료.
* 외부 API에서 캐릭터 미존재 시 발생하는 400 에러를 시스템 내부 에러 코드 `C002`(404 Not Found)로 일원화하여 응답하도록 처리.

### 📝 Analysis Plan (중점 분석 대상)
* `WebClient`가 비동기 기반임에도 `.block()` 상황에서 `onStatus`가 예외를 정상적으로 전파하여 핸들러가 낚아채는지 여부.
* `GlobalExceptionHandler`에서 `Exception.class`를 통해 잡히는 '예측하지 못한 오류'가 `S001` 규격으로 잘 나가는지 확인.

### ⚖️ Trade-off (트레이드오프)
* **일관성 vs 상세함**: 외부 API의 구체적인 에러 메시지를 그대로 노출하는 대신, 내부 규격으로 마스킹하여 보안성을 높이고 클라이언트의 예외 처리 로직을 단순화함.
* **구조화 vs 복잡도**: 예외 클래스 개수는 늘어날 수 있으나, 전역 핸들러에서 타입 기반으로 명확하게 제어할 수 있는 이점을 택함.

### ✅ Action Items
- [x] 모든 커스텀 예외의 `BaseException` 상속 리팩토링
- [x] `GlobalExceptionHandler` 구현 및 공통 JSON 응답 포맷 적용
- [x] `RealNexonApiClient` 내 에러 변환 로직(`onStatus`) 적용 및 검증

### 🏁 Definition of Done (완료 조건)
- [x] 존재하지 않는 캐릭터 조회 시 404 상태 코드와 `C002` 에러 코드 반환 확인.
- [x] 시스템 내부 오류 발생 시 500 상태 코드와 `S001` 에러 코드 반환 확인.
- [x] 모든 에러 응답에 `timestamp` 필드가 포함됨.

### Why (이 작업이 왜 필요한가)
시스템 규모가 커짐에 따라 에러 처리 로직이 흩어져 있으면 프론트엔드와의 협업 및 디버깅에 큰 비용이 발생합니다. 이번 개편을 통해 **"명확한 피드백 전달"**이라는 제1순위 가치를 실현하고, 외부 의존성(API) 변화에도 흔들리지 않는 견고한 에러 핸들링 구조를 구축하고자 합니다.