### PR TITLE
[feat] 시스템 관찰 가능성(Observability) 확보 및 장애 자가 진단 알림 기능 도입

### DIFF
--- a/src/main/java/maple/expectation/mornitering/MonitoringAlertService.java
+++ b/src/main/java/maple/expectation/mornitering/MonitoringAlertService.java
@@ -1,0 +1,30 @@
+package maple.expectation.mornitering;
+
+import lombok.RequiredArgsConstructor;
+import maple.expectation.service.v2.alert.DiscordAlertService;
+import maple.expectation.service.v2.cache.LikeBufferStorage;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+@Component
+@RequiredArgsConstructor
+public class MonitoringAlertService {
+    private final LikeBufferStorage likeBufferStorage;
+    private final DiscordAlertService discordAlertService;
+
+    @Scheduled(fixedRate = 5000) // 5초마다 체크
+    public void checkBufferSaturation() {
+        long currentPending = likeBufferStorage.getCache().asMap().values().stream()
+                .mapToLong(AtomicLong::get).sum();
+
+        if (currentPending > 2000) { // 임계치 설정
+            discordAlertService.sendCriticalAlert(
+                "BUFFER SATURATION WARNING",
+                "현재 좋아요 버퍼 잔량이 너무 높습니다: " + currentPending,
+                new RuntimeException("System Load High")
+            );
+        }
+    }
+}

--- a/src/main/java/maple/expectation/scheduler/LikeSyncScheduler.java
+++ b/src/main/java/maple/expectation/scheduler/LikeSyncScheduler.java
@@ -2,11 +2,15 @@ package maple.expectation.scheduler;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import maple.expectation.aop.annotation.ObservedTransaction;
 import maple.expectation.repository.v2.GameCharacterRepository;
 import maple.expectation.service.v2.cache.LikeBufferStorage;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 
 @Slf4j
 @Component
@@ -16,19 +20,25 @@ public class LikeSyncScheduler {
     private final LikeBufferStorage likeBufferStorage;
     private final GameCharacterRepository gameCharacterRepository;
 
-    @Scheduled(fixedRate = 3000)
+    @Scheduled(fixedRate = 3000) // 3초마다 실행
     @Transactional
+    @ObservedTransaction("scheduler.like.sync")
     public void syncLikesToDatabase() {
-        likeBufferStorage.getCache().asMap().forEach((userIgn, atomicCount) -> {
+        Map<String, AtomicLong> bufferMap = likeBufferStorage.getCache().asMap();
+
+        if (bufferMap.isEmpty()) return;
+
+        log.debug("[Sync] 데이터 동기화 시작 (대상 유저 수: {})", bufferMap.size());
+
+        bufferMap.forEach((userIgn, atomicCount) -> {
             long countToAdd = atomicCount.getAndSet(0); // 원자적 리셋
 
             if (countToAdd > 0) {
                 try {
                     gameCharacterRepository.incrementLikeCount(userIgn, countToAdd);
-                    log.info("[Sync] {} 님의 좋아요 {}개 DB 반영 완료", userIgn, countToAdd);
                 } catch (Exception e) {
-                    log.error("[Sync Error] {} 반영 실패. 데이터 복구", userIgn);
-                    atomicCount.addAndGet(countToAdd); // 실패 시 복구
+                    log.error("[Sync Error] {} 반영 실패. 데이터 복구 시도", userIgn, e);
+                    atomicCount.addAndGet(countToAdd); // 실패 시 다시 버퍼에 복구
                 }
             }
         });

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,8 @@ spring:
   # 공통 드라이버 설정
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      register-mbeans: true # JMX를 통해 지표 노출 활성화
 
   # 공통 JPA 설정
   jpa:
@@ -22,7 +24,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health, info, prometheus # Prometheus 엔드포인트 활성화
+        include: "health,info,metrics,prometheus"
   endpoint:
     health:
       show-details: always # 서킷 브레이커 상태를 상세히 보기 위해 필수

--- a/src/test/java/maple/expectation/mornitering/MetricTest.java
+++ b/src/test/java/maple/expectation/mornitering/MetricTest.java
@@ -1,0 +1,36 @@
+package maple.expectation.mornitering;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import maple.expectation.service.v2.LikeProcessor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class MetricTest {
+    @Autowired
+    MeterRegistry registry;
+    @Autowired
+    LikeProcessor processor;
+
+    @Test
+    @DisplayName("좋아요 클릭 시 커스텀 Gauge(total_pending) 수치가 증가해야 한다")
+    void like_gauge_increase_test() {
+        // given: 현재 수치 확인
+        double beforeCount = getGaugeValue("like.buffer.total_pending");
+
+        // when: 좋아요 처리
+        processor.processLike("UserA");
+
+        // then: 수치 1 증가 확인
+        double afterCount = getGaugeValue("like.buffer.total_pending");
+        assertThat(afterCount).isEqualTo(beforeCount + 1.0);
+    }
+
+    private double getGaugeValue(String name) {
+        return registry.find(name).gauge().value();
+    }
+}

--- a/src/test/java/maple/expectation/mornitering/MonitoringAlertServiceTest.java
+++ b/src/test/java/maple/expectation/mornitering/MonitoringAlertServiceTest.java
@@ -1,0 +1,73 @@
+package maple.expectation.mornitering;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import maple.expectation.service.v2.alert.DiscordAlertService;
+import maple.expectation.service.v2.cache.LikeBufferStorage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MonitoringAlertServiceTest {
+
+    @Mock
+    private LikeBufferStorage likeBufferStorage;
+
+    @Mock
+    private DiscordAlertService discordAlertService;
+
+    @InjectMocks
+    private MonitoringAlertService monitoringAlertService;
+
+    private Cache<String, AtomicLong> testCache;
+
+    @BeforeEach
+    void setUp() {
+        // 실제 Caffeine 캐시를 생성하여 Mock 동작 설정
+        testCache = Caffeine.newBuilder().build();
+        given(likeBufferStorage.getCache()).willReturn(testCache);
+    }
+
+    @Test
+    @DisplayName("버퍼 잔량이 임계치(2000) 이하일 때는 알림을 보내지 않아야 한다")
+    void underThreshold_NoAlert() {
+        // given: 잔량 1000개 설정
+        testCache.put("UserA", new AtomicLong(1000));
+
+        // when
+        monitoringAlertService.checkBufferSaturation();
+
+        // then: 알림 서비스가 한 번도 호출되지 않았는지 확인
+        verify(discordAlertService, never()).sendCriticalAlert(anyString(), anyString(), any());
+    }
+
+    @Test
+    @DisplayName("버퍼 잔량이 임계치(2000)를 초과하면 디스코드 알림을 발송해야 한다")
+    void overThreshold_SendAlert() {
+        // given: 잔량 2500개 설정 (1500 + 1000)
+        testCache.put("UserA", new AtomicLong(1500));
+        testCache.put("UserB", new AtomicLong(1000));
+
+        // when
+        monitoringAlertService.checkBufferSaturation();
+
+        // then: 알림 서비스가 정확히 1번 호출되었는지 확인
+        verify(discordAlertService, times(1)).sendCriticalAlert(
+                eq("BUFFER SATURATION WARNING"),
+                contains("2500"), // 메시지에 2500이 포함되었는지 확인
+                any()
+        );
+    }
+}


### PR DESCRIPTION
### 🔗 관련 이슈
- #29 

### 📌 Problem Definition (문제 정의)
- **현상:** 외부 부하 테스트(Locust) 결과에만 의존하여 실제 운영 환경에서의 내부 상태(White-box monitoring) 파악이 불가능함.
- **위험:** 응답 지연 발생 시 원인이 CPU 병목인지, DB 커넥션 고갈인지, 특정 로직의 동기화 문제인지 판단할 데이터가 없어 장애 복구 시간(MTTR)이 길어짐.

### 🎯 Goal (목표)
- 시스템의 건강 상태를 대변하는 **4 Golden Signals(Latency, Traffic, Errors, Saturation)** 정의.
- Spring Actuator 및 Custom Metrics를 통해 내부 지표를 외부로 노출하여 데이터 기반 의사결정 체계 구축.

### 🔍 Workflow (작업 방식)
1. **Spring Actuator 도입:** 인프라 및 앱 기본 지표 노출.
2. **커스텀 메트릭 정의:** 비즈니스 핵심 지표(LikeBuffer 잔량 등) 구현.
3. **자가 진단 로직 추가:** 임계치 기반 자동 알림 시스템 구축.
4. **검증:** 엔드포인트 수치 확인 및 단위 테스트 수행.

### 🛠️ 해결 (Resolve)
- **핵심 모니터링 지표 선정:**
  - **Infra:** CPU Usage, JVM Heap Memory, Thread Count.
  - **DB:** HikariCP Active Connections, Wait Time.
  - **App:** LikeBuffer Pending Count, Scheduler Sync Time.
- **자가 진단 시스템:** `MonitoringAlertService`를 통해 버퍼 잔량 2,000개 초과 시 Discord로 즉시 알림 발송.
- **추적성 강화:** `MDCFilter`를 통한 모든 로그/메트릭에 `requestId` 부여.

### 📝 Analysis Plan (중점 분석 대상)
- **지표 수집 부하:** Actuator 수집 행위가 앱 성능에 미치는 영향(1% 미만 권장) 평가.
- **알람 임계치 유효성:** 실제 부하 상황에서 설정한 버퍼 임계치(2,000)가 장애를 적절히 감지하는지 분석.

### ⚖️ Trade-off (트레이드오프)
- **가시성 vs 성능:** 상세한 지표 수집은 분석에 유리하지만 아주 미세한 성능 오버헤드를 발생시킴. 현재는 운영 안정성을 위해 상세 수집을 선택함.
- **Write-Back 지연:** 좋아요 수치를 버퍼링 후 배치 처리하여 DB 부하를 줄였으나, 최대 3초의 데이터 정합성 지연이 발생함 (모니터링으로 해당 지연 시간을 추적하도록 보완).

### ✅ Action Items
- [x] Spring Actuator 의존성 추가 및 노출 설정
- [x] HikariCP 지표 수집 활성화
- [x] LikeBuffer 잔량 추적 Custom Gauge 구현
- [x] 수집 지표 기반 '운영 체크리스트' 작성

### 🏁 Definition of Done (완료 조건)
- `/actuator/metrics` 엔드포인트를 통해 서버 CPU, 메모리, DB 커넥션 상태 실시간 확인 가능.
- `like.buffer.total_pending` 메트릭을 통해 비즈니스 로직 병목 지점 수치화 완료.

### Why Data over Guessing?
"측정할 수 없으면 관리할 수 없고, 관리할 수 없으면 개선할 수 없습니다." 감에 의존하는 튜닝이 아닌, 지표에 근거한 엔지니어링을 위해 본 기능을 최우선으로 도입하였습니다.