### PR TITLE
feat: Guava Striped 기반 LockStrategy 도입 및 핵심 서비스 동시성 제어 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
 
+    implementation 'com.google.guava:guava:33.5.0-jre'
+
     implementation 'io.github.resilience4j:resilience4j-spring-boot3'
     implementation 'io.github.resilience4j:resilience4j-micrometer'
 

--- a/src/main/java/maple/expectation/aop/annotation/Locked.java
+++ b/src/main/java/maple/expectation/aop/annotation/Locked.java
@@ -1,0 +1,15 @@
+package maple.expectation.aop.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Locked {
+    /**
+     * 락 식별자 (SpEL 지원: 예: #userIgn)
+     */
+    String key();
+}

--- a/src/main/java/maple/expectation/aop/aspect/LockAspect.java
+++ b/src/main/java/maple/expectation/aop/aspect/LockAspect.java
@@ -1,0 +1,53 @@
+package maple.expectation.aop.aspect;
+
+import lombok.RequiredArgsConstructor;
+import maple.expectation.aop.annotation.Locked;
+import maple.expectation.global.lock.LockStrategy;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Order(0)
+@Component
+@RequiredArgsConstructor
+public class LockAspect {
+    private final LockStrategy lockStrategy;
+    private final ExpressionParser parser = new SpelExpressionParser();
+
+    @Around("@annotation(locked)")
+    public Object applyLock(ProceedingJoinPoint joinPoint, Locked locked) throws Throwable {
+        String key = getDynamicKey(joinPoint, locked.key());
+
+        // 락 전략을 사용하여 비즈니스 로직(joinPoint.proceed()) 실행
+        return lockStrategy.executeWithLock(key, () -> {
+            try {
+                return joinPoint.proceed();
+            } catch (Throwable e) {
+                if (e instanceof RuntimeException) throw (RuntimeException) e;
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    private String getDynamicKey(ProceedingJoinPoint joinPoint, String keyExpression) {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        StandardEvaluationContext context = new StandardEvaluationContext();
+        
+        String[] parameterNames = signature.getParameterNames();
+        Object[] args = joinPoint.getArgs();
+        
+        for (int i = 0; i < parameterNames.length; i++) {
+            context.setVariable(parameterNames[i], args[i]);
+        }
+        
+        return parser.parseExpression(keyExpression).getValue(context, String.class);
+    }
+}

--- a/src/main/java/maple/expectation/global/lock/GuavaLockStrategy.java
+++ b/src/main/java/maple/expectation/global/lock/GuavaLockStrategy.java
@@ -1,0 +1,22 @@
+package maple.expectation.global.lock;
+
+import com.google.common.util.concurrent.Striped;
+import org.springframework.stereotype.Component;
+import java.util.concurrent.locks.Lock;
+import java.util.function.Supplier;
+
+@Component
+public class GuavaLockStrategy implements LockStrategy {
+    private final Striped<Lock> locks = Striped.lock(128); // 고정된 락 풀 사용
+
+    @Override
+    public <T> T executeWithLock(String key, Supplier<T> task) {
+        Lock lock = locks.get(key);
+        lock.lock();
+        try {
+            return task.get();
+        } finally {
+            lock.unlock();
+        }
+    }
+}

--- a/src/main/java/maple/expectation/global/lock/LockStrategy.java
+++ b/src/main/java/maple/expectation/global/lock/LockStrategy.java
@@ -1,0 +1,7 @@
+package maple.expectation.global.lock;
+
+import java.util.function.Supplier;
+
+public interface LockStrategy {
+    <T> T executeWithLock(String key, Supplier<T> task);
+}

--- a/src/main/java/maple/expectation/service/v2/DonationService.java
+++ b/src/main/java/maple/expectation/service/v2/DonationService.java
@@ -2,9 +2,10 @@ package maple.expectation.service.v2;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import maple.expectation.aop.annotation.Locked; // 1. 어노테이션 추가
 import maple.expectation.aop.annotation.ObservedTransaction;
 import maple.expectation.domain.v2.DonationHistory;
-import maple.expectation.global.error.exception.CriticalTransactionFailureException; // [NEW] 커스텀 예외
+import maple.expectation.global.error.exception.CriticalTransactionFailureException;
 import maple.expectation.global.error.exception.DeveloperNotFoundException;
 import maple.expectation.global.error.exception.InsufficientPointException;
 import maple.expectation.repository.v2.DonationHistoryRepository;
@@ -20,34 +21,38 @@ public class DonationService {
 
     private final MemberRepository memberRepository;
     private final DonationHistoryRepository donationHistoryRepository;
-    private final DiscordAlertService discordAlertService; // [NEW] 주입
+    private final DiscordAlertService discordAlertService;
 
+    /**
+     * 리팩토링 포인트: @Locked 적용
+     * - Key: guestUuid (송금하는 유저별로 락을 걸어 '따닥' 요청 방지)
+     */
     @Transactional
+    @Locked(key = "#guestUuid") // 2. 전략 패턴 기반 락 적용
     @ObservedTransaction("service.v2.DonationService.sendCoffee")
     public void sendCoffee(String guestUuid, Long developerId, Long amount, String requestId) {
         try {
-
-            // 1️⃣ [INFO] 멱등성 방어
+            // 1️⃣ 멱등성 방어 (락 안에서 보호받으므로 훨씬 안전함)
             if (donationHistoryRepository.existsByRequestId(requestId)) {
-                log.info("[Idempotency] 이미 처리된 요청입니다. RequestId={}, Guest={}", requestId, guestUuid);
+                log.info("[Idempotency] 이미 처리된 요청입니다. RequestId={}", requestId);
                 return;
             }
 
-            // 2️⃣ [WARN] 잔액 차감
+            // 2️⃣ 잔액 차감 (Atomic Update 쿼리는 그대로 유지하여 '2중 안전장치' 확보)
             int updatedCount = memberRepository.decreasePoint(guestUuid, amount);
             if (updatedCount == 0) {
-                log.warn("[Donation Failed] 잔액 부족 또는 게스트 없음. Guest={}, Amount={}", guestUuid, amount);
+                log.warn("[Donation Failed] 잔액 부족 또는 게스트 없음. Guest={}", guestUuid);
                 throw new InsufficientPointException("이체 실패: 잔액 부족 또는 유효하지 않은 게스트");
             }
 
-            // 3️⃣ [WARN] 개발자 계정 확인 및 포인트 증가
+            // 3️⃣ 개발자 포인트 증가
             int developerUpdated = memberRepository.increasePoint(developerId, amount);
             if (developerUpdated == 0) {
                 log.warn("[Donation Failed] 존재하지 않는 개발자 ID. DevId={}", developerId);
                 throw new DeveloperNotFoundException("이체 실패: 존재하지 않는 개발자 ID(" + developerId + ")");
             }
 
-            // 4️⃣ [INFO] 이력 저장
+            // 4️⃣ 이력 저장
             DonationHistory history = DonationHistory.builder()
                     .senderUuid(guestUuid)
                     .receiverId(developerId)
@@ -57,24 +62,13 @@ public class DonationService {
 
             donationHistoryRepository.save(history);
 
-            log.info("[Donation Success] 이체 성공. Guest={} -> Dev={}, Amount={}", guestUuid, developerId, amount);
+            log.info("[Donation Success] {} -> {} ({}원)", guestUuid, developerId, amount);
 
         } catch (InsufficientPointException | DeveloperNotFoundException e) {
-            // [Clean Catch 1] 비즈니스 로직상 발생한 "예상된 실패"는 알림 없이 상위로 던짐
             throw e;
-
         } catch (Exception e) {
-            // [Clean Catch 2] 예상치 못한 시스템 장애 (DB 연결 끊김, NPE, 타임아웃 등)
             log.error("💥 Critical Failure in Donation Transaction. RequestId={}", requestId, e);
-
-            // 1. 디스코드 알림 발송 (비동기)
-            discordAlertService.sendCriticalAlert(
-                    "DONATION TRANSACTION FAILED",
-                    "도네이션 트랜잭션 중 치명적인 오류가 발생했습니다.\nRequestId: " + requestId,
-                    e
-            );
-
-            // 2. Global Exception Handler용 커스텀 예외로 감싸서 던짐
+            discordAlertService.sendCriticalAlert("DONATION TRANSACTION FAILED", "RequestId: " + requestId, e);
             throw new CriticalTransactionFailureException("도네이션 시스템 오류 발생", e);
         }
     }

--- a/src/test/java/maple/expectation/service/v2/GameCharacterServiceConcurrencyTest.java
+++ b/src/test/java/maple/expectation/service/v2/GameCharacterServiceConcurrencyTest.java
@@ -1,0 +1,92 @@
+package maple.expectation.service.v2;
+
+import maple.expectation.domain.v2.GameCharacter;
+import maple.expectation.external.NexonApiClient;
+import maple.expectation.external.dto.v2.CharacterOcidResponse;
+import maple.expectation.repository.v2.GameCharacterRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+class GameCharacterServiceConcurrencyTest {
+
+    @Autowired
+    private GameCharacterService gameCharacterService;
+
+    @Autowired
+    private GameCharacterRepository gameCharacterRepository;
+
+    // 넥슨 API 호출 횟수를 감시하기 위해 MockitoBean 사용 (Spring Boot 3.4+)
+    @MockitoBean
+    private NexonApiClient nexonApiClient;
+
+    @AfterEach
+    void tearDown() {
+        gameCharacterRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("신규 캐릭터 조회: 동시에 10명이 같은 이름으로 조회해도 캐릭터는 1개만 생성되어야 한다")
+    void findCharacterConcurrencyTest() throws InterruptedException {
+        // Given
+        int threadCount = 10;
+        String targetName = "신규유저_" + UUID.randomUUID().toString().substring(0, 8);
+        String mockOcid = "mock_ocid_999";
+
+        // API 응답 설정
+        when(nexonApiClient.getOcidByCharacterName(anyString()))
+                .thenReturn(new CharacterOcidResponse(mockOcid));
+
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failCount = new AtomicInteger(0);
+
+        // When
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    gameCharacterService.findCharacterByUserIgn(targetName);
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+                    e.printStackTrace();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executorService.shutdown();
+
+        // Then
+        // 1. 넥슨 API(getOcidByCharacterName) 호출은 전체 스레드 중 딱 1번만 발생해야 함
+        verify(nexonApiClient, times(1)).getOcidByCharacterName(targetName);
+
+        // 2. DB에 저장된 캐릭터도 딱 1개여야 함
+        long dbCount = gameCharacterRepository.findAll().stream()
+                .filter(c -> c.getUserIgn().equals(targetName))
+                .count();
+        assertThat(dbCount).isEqualTo(1);
+
+        // 3. 모든 스레드가 에러 없이 조회를 완료했어야 함
+        assertThat(successCount.get()).isEqualTo(threadCount);
+        assertThat(failCount.get()).isEqualTo(0);
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- 해당 사항 없음

## 🗣 개요
기존 코드베이스의 분산된 동시성 제어 로직(`synchronized`, `intern()`, `ConcurrentHashMap`)을 **전략 패턴(Strategy Pattern)**과 **AOP**를 활용하여 일관성 있는 구조로 리팩토링했습니다. 이를 통해 메모리 누수 위험을 제거하고, 향후 Redis 분산락으로의 확장성을 확보했습니다.

## 🛠 작업 내용
1. **Lock 인프라 구축 (`maple.expectation.global.lock`)**
    - `LockStrategy` 인터페이스 도입으로 락 메커니즘 추상화
    - `GuavaLockStrategy` 구현을 통해 고정된 크기(128개)의 락 풀을 사용하여 메모리 효율성 극대화 (OOM 방지)
2. **선언적 동시성 제어 적용 (`maple.expectation.aop`)**
    - `@Locked` 어노테이션 및 `LockAspect` 구현 (SpEL 지원으로 동적 키 바인딩 가능)
    - 락이 트랜잭션보다 먼저 시작되도록 `@Order` 우선순위 조정
3. **핵심 비즈니스 로직 리팩토링**
    - `GameCharacterService`: `synchronized(intern())` 제거 및 `@Locked` 적용
    - `NexonApiCachingProxy`: 수동으로 관리하던 락 맵을 제거하고 `LockStrategy`로 이관 (메모리 누수 해결)
    - `DonationService`: 송금 정합성 및 멱등성 보장을 위해 `@Locked` 기반의 임계 구역 설정
4. **검증 테스트 추가**
    - `EquipmentDataProviderConcurrencyTest`: 10개 스레드 동시 호출 시 API 1회 호출 검증 성공
    - `DonationTest`: 100개 스레드 동시 송금 시 정합성 유지 및 1회 성공 검증 성공

## 💬 리뷰 포인트
- **Guava Striped Lock**: 128개의 버킷을 사용하는 방식이 현재 트래픽 규모에서 적절한지, 충돌 가능성은 없는지 확인 부탁드립니다.
- **AOP Order**: `LockAspect`가 `@Transactional`보다 바깥쪽에서 동작하도록 설정된 순서가 의도대로 작동하는지 검토 바랍니다.
- **SpEL Parsing**: `@Locked(key = "#userIgn")`와 같이 파라미터 기반의 동적 키 추출 로직이 견고하게 작성되었는지 확인 부탁드립니다.

## ✅ 체크리스트
- [x] 비즈니스 로직에서 저수준 동기화 코드(`synchronized`)를 모두 제거했는가?
- [x] 메모리 누수 위험이 있던 락 맵 구조를 개선했는가?
- [x] 멀티스레드 환경에서의 동시성 테스트가 모두 통과(Green)했는가?
- [x] 향후 Redis 분산락 도입 시 코드 수정 없이 구현체만 교체 가능한 구조인가?