### PR TITLE
[Ops] 서버 재시작 시 데이터 유실 방지를 위한 Graceful Shutdown 구현 (#26)

### DIFF
--- a/src/main/java/maple/expectation/scheduler/LikeSyncScheduler.java
+++ b/src/main/java/maple/expectation/scheduler/LikeSyncScheduler.java
@@ -1,46 +1,35 @@
 package maple.expectation.scheduler;
 
+import jakarta.annotation.PreDestroy;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import maple.expectation.aop.annotation.ObservedTransaction;
-import maple.expectation.repository.v2.GameCharacterRepository;
-import maple.expectation.service.v2.cache.LikeBufferStorage;
+import maple.expectation.service.v2.LikeSyncService;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicLong;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class LikeSyncScheduler {
 
-    private final LikeBufferStorage likeBufferStorage;
-    private final GameCharacterRepository gameCharacterRepository;
+    private final LikeSyncService likeSyncService;
 
-    @Scheduled(fixedRate = 3000) // 3초마다 실행
-    @Transactional
-    @ObservedTransaction("scheduler.like.sync")
-    public void syncLikesToDatabase() {
-        Map<String, AtomicLong> bufferMap = likeBufferStorage.getCache().asMap();
+    /**
+     * 3초마다 주기적으로 동기화 수행
+     */
+    @Scheduled(fixedRate = 3000)
+    public void scheduledSync() {
+        likeSyncService.syncLikesToDatabase();
+    }
 
-        if (bufferMap.isEmpty()) return;
-
-        log.debug("[Sync] 데이터 동기화 시작 (대상 유저 수: {})", bufferMap.size());
-
-        bufferMap.forEach((userIgn, atomicCount) -> {
-            long countToAdd = atomicCount.getAndSet(0); // 원자적 리셋
-
-            if (countToAdd > 0) {
-                try {
-                    gameCharacterRepository.incrementLikeCount(userIgn, countToAdd);
-                } catch (Exception e) {
-                    log.error("[Sync Error] {} 반영 실패. 데이터 복구 시도", userIgn, e);
-                    atomicCount.addAndGet(countToAdd); // 실패 시 다시 버퍼에 복구
-                }
-            }
-        });
+    @PreDestroy
+    public void shutdownSync() {
+        log.warn("⚠️ [Shutdown] 서버 종료 감지: 잔량 좋아요 데이터를 Flush합니다.");
+        try {
+            likeSyncService.syncLikesToDatabase();
+            log.info("✅ [Shutdown] 모든 좋아요 데이터가 안전하게 DB에 동기화되었습니다.");
+        } catch (Exception e) {
+            log.error("❌ [Shutdown Error] 종료 중 동기화 실패!", e);
+        }
     }
 }

--- a/src/main/java/maple/expectation/service/v2/LikeSyncService.java
+++ b/src/main/java/maple/expectation/service/v2/LikeSyncService.java
@@ -1,0 +1,51 @@
+package maple.expectation.service.v2;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import maple.expectation.aop.annotation.ObservedTransaction;
+import maple.expectation.repository.v2.GameCharacterRepository;
+import maple.expectation.service.v2.cache.LikeBufferStorage;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LikeSyncService {
+
+    private final LikeBufferStorage likeBufferStorage;
+    private final GameCharacterRepository gameCharacterRepository;
+
+    @Transactional
+    @ObservedTransaction("scheduler.like.sync")
+    public void syncLikesToDatabase() {
+        Map<String, AtomicLong> bufferMap = likeBufferStorage.getCache().asMap();
+        if (bufferMap.isEmpty()) return;
+
+        log.debug("[Sync] 데이터 동기화 시작 (대상 유저 수: {})", bufferMap.size());
+
+        // 람다 본문을 메서드로 추출하여 가독성 확보
+        bufferMap.forEach(this::syncEachUserLike);
+    }
+
+    private void syncEachUserLike(String userIgn, AtomicLong atomicCount) {
+        long countToAdd = atomicCount.getAndSet(0);
+        
+        // [Guard Clause] 반영할 데이터가 없으면 즉시 리턴 (indent 제거)
+        if (countToAdd <= 0) return;
+
+        try {
+            gameCharacterRepository.incrementLikeCount(userIgn, countToAdd);
+        } catch (Exception e) {
+            rollbackBuffer(userIgn, atomicCount, countToAdd, e);
+        }
+    }
+
+    private void rollbackBuffer(String userIgn, AtomicLong atomicCount, long countToAdd, Exception e) {
+        log.error("[Sync Error] {} 반영 실패. 데이터 복구 시도 (발생 에러: {})", userIgn, e.getMessage());
+        atomicCount.addAndGet(countToAdd); 
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,8 @@ spring:
     name: maple-expectation
   profiles:
     active: local # [Safety Guard] 별도 설정 없으면 무조건 로컬 모드
+  lifecycle:
+    timeout-per-shutdown-phase: 30s
 
   # 공통 드라이버 설정
   datasource:
@@ -78,6 +80,9 @@ logging:
 nexon:
   api:
     key: ${NEXON_API_KEY}
+
+server:
+  shutdown: graceful
 
 # 앱 전용 설정
 app:


### PR DESCRIPTION
## 🔗 관련 이슈
* Resolved #26

## 🗣 개요
`Write-Behind` 패턴의 가장 큰 취약점인 '비정기적 서버 종료 시 데이터 유실' 문제를 해결했습니다. 스프링 부트의 **우아한 종료(Graceful Shutdown)** 기능을 활성화하고, 애플리케이션 수명 주기 훅을 통해 종료 직전 메모리 데이터를 DB로 안전하게 옮기는 로직을 완성했습니다.

## 🛠 작업 내용
### 1. Spring Boot Graceful Shutdown 활성화
- `server.shutdown=graceful` 설정을 통해 프로세스가 종료 신호를 받아도 즉시 죽지 않고, 현재 처리 중인 요청과 내부 정제 로직을 완료할 때까지 대기하도록 설정했습니다. (최대 30초)

### 2. 단일 책임 원칙(SRP) 기반 리팩토링
- 기존 스케줄러에 섞여 있던 동기화 로직을 `LikeSyncService`로 완전히 격리했습니다.
- 이를 통해 '주기적 동기화(Scheduler)'와 '종료 시 동기화(Shutdown Hook)'가 동일한 검증된 비즈니스 로직을 공유하게 되었습니다.

### 3. @PreDestroy 수명 주기 훅 도입
- 애플리케이션 빈(Bean)이 파괴되기 직전 실행되는 `@PreDestroy`를 활용하여, 종료 시점에 버퍼에 남은 잔량 데이터를 DB에 반영하는 `forceFlush` 메커니즘을 구현했습니다.

## 💬 리뷰 포인트
### 🚀 검증 결과 (WSL 환경)
- **SIGTERM 대응 확인**: WSL 터미널에서 `kill -15 [PID]`를 통해 신호를 보냈을 때, 로그에 `⚠️ [Shutdown]` 문구가 찍히며 데이터가 정상적으로 DB에 반영되는 것을 확인했습니다.
- **Exit Code 143**: 프로세스가 신호를 받고 모든 정리 작업을 마친 후 정상 종료 코드(143)를 반환함을 확인했습니다.

### 🛡️ 데이터 안전 장치
- 동기화 실패 시 `AtomicLong.addAndGet()`을 사용하여 버퍼에 데이터를 복구하는 '원자적 롤백' 로직이 종료 시점에도 안정적으로 작동함을 검증했습니다.

## ✅ 체크리스트
- [x] `application.yml`의 인덴트 구조가 정확한가?
- [x] 종료 직전 로그 출력 및 DB 반영이 실제로 일어나는가?
- [x] 스케줄러 주기를 60초로 늘려도 종료 시 데이터가 저장되는가?
- [x] 전체 테스트(`gradlew test`) 통과 여부