### PR TITLE
[Architecture/Security] 순환 참조 해결 및 관리자 API 보안 격리 (#62)

### DIFF
--- a/src/main/java/maple/expectation/controller/AlertTestController.java
+++ b/src/main/java/maple/expectation/controller/AlertTestController.java
@@ -2,11 +2,13 @@ package maple.expectation.controller;
 
 import lombok.RequiredArgsConstructor;
 import maple.expectation.service.v2.alert.DiscordAlertService;
+import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@Profile("!prod")
 public class AlertTestController {
 
     private final DiscordAlertService alertService;

--- a/src/main/java/maple/expectation/service/v2/alert/DiscordAlertService.java
+++ b/src/main/java/maple/expectation/service/v2/alert/DiscordAlertService.java
@@ -37,16 +37,20 @@ public class DiscordAlertService {
         try {
             String jsonPayload = createDiscordPayload(title, description, e);
 
+            // 💡 보안상 Webhook URL 마스킹 처리 (앞 20자 + ... + 뒤 8자만 노출)
+            String maskedUrl = webhookUrl.substring(0, Math.min(webhookUrl.length(), 20)) + "..." +
+                    webhookUrl.substring(Math.max(0, webhookUrl.length() - 8));
+
             webClient.post()
                     .uri(webhookUrl)
                     .contentType(MediaType.APPLICATION_JSON)
                     .bodyValue(jsonPayload)
                     .retrieve()
-                    // 2xx 응답만 받음 (비동기로 실행하고 결과를 기다리지 않음)
                     .toBodilessEntity()
                     .subscribe(
-                        response -> log.info("Discord Alert Sent successfully to {}", webhookUrl),
-                        error -> log.error("Failed to send Discord Alert. Check Webhook URL: {}", error.getMessage())
+                            // 💡 마스킹된 URL 로그 출력
+                            response -> log.info("Discord Alert Sent successfully to {}", maskedUrl),
+                            error -> log.error("Failed to send Discord Alert. Reason: {}", error.getMessage())
                     );
         } catch (Exception ex) {
             log.error("Failed to create Discord payload or send request.", ex);

--- a/src/main/java/maple/expectation/service/v2/impl/CubeServiceImpl.java
+++ b/src/main/java/maple/expectation/service/v2/impl/CubeServiceImpl.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.Set;
 
 @Slf4j
-@Service
+@Service("cubeServiceImpl")
 @TraceLog
 @RequiredArgsConstructor
 public class CubeServiceImpl implements CubeTrialsProvider {

--- a/src/main/java/maple/expectation/service/v2/proxy/CubeTrialsCachingProxy.java
+++ b/src/main/java/maple/expectation/service/v2/proxy/CubeTrialsCachingProxy.java
@@ -5,6 +5,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import maple.expectation.domain.v2.CubeType;
 import maple.expectation.dto.CubeCalculationInput;
 import maple.expectation.service.v2.CubeTrialsProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
@@ -17,12 +18,11 @@ public class CubeTrialsCachingProxy implements CubeTrialsProvider {
     private final CubeTrialsProvider target; // 실제 계산을 수행할 CubeServiceImpl
     private final Cache<String, Long> trialsCache;
 
-    public CubeTrialsCachingProxy(CubeTrialsProvider cubeServiceImpl) {
+    public CubeTrialsCachingProxy(@Qualifier("cubeServiceImpl") CubeTrialsProvider cubeServiceImpl) {
         this.target = cubeServiceImpl;
-        // Caffeine 캐시 설정
         this.trialsCache = Caffeine.newBuilder()
-                .expireAfterAccess(30, TimeUnit.MINUTES) // 30분간 사용 안하면 제거
-                .maximumSize(10_000) // 최대 1만 건 저장 (메모리 관리)
+                .expireAfterAccess(30, TimeUnit.MINUTES)
+                .maximumSize(10_000)
                 .build();
     }
 


### PR DESCRIPTION
## 🔗 관련 이슈
- #62

## 🗣 개요
시스템 기동 시 발생할 수 있는 DI 순환 참조 결함을 제거하고, 운영 환경에서 관리자 전용 API 및 민감 정보(Webhook URL)가 노출되는 보안 취약점을 개선했습니다.

## 🛠 작업 내용
- **순환 참조 해결**: `CubeTrialsCachingProxy`가 자기 자신을 주입받던 문제를 `@Qualifier("cubeServiceImpl")` 명시를 통해 해결했습니다.
- **환경별 API 격리**: `AlertTestController`에 `@Profile("!prod")`를 적용하여 운영(`prod`) 환경에서는 관리자용 테스트 API 빈이 등록되지 않도록 차단했습니다.
- **보안 강화**: `DiscordAlertService` 로그 출력 시 Webhook URL의 중간 부분을 마스킹 처리하여 민감 정보 유출을 방지했습니다.

## 💬 리뷰 포인트
- `CubeTrialsCachingProxy` 생성자 주입 시 `@Qualifier`가 실제 구현체인 `CubeServiceImpl`을 정확히 지목하고 있는지 확인 부탁드립니다.
- 운영 환경(`prod`) 프로필 적용 시 `/api/admin/**` 경로가 실제로 404를 반환하는지 검증이 완료되었습니다.

## ✅ 체크리스트
- [x] `./gradlew clean test`를 통해 전체 테스트 통과를 확인했는가?
- [x] 애플리케이션 기동 시 `BeanCurrentlyInCreationException`이 발생하지 않는가?
- [x] 로그 출력 시 Webhook URL이 마스킹되어 나타나는가?
- [x] 브랜치 네이밍 규칙 및 커밋 메시지 규칙을 준수하였는가?