### PR TITLE
[Stability] LoggingAspect 성능 통계 메모리 누수 해결 및 O(1) 구조 개선 (#10)

### DIFF
--- a/src/main/java/maple/expectation/aop/aspect/LoggingAspect.java
+++ b/src/main/java/maple/expectation/aop/aspect/LoggingAspect.java
@@ -9,12 +9,10 @@ import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-
 @Aspect
 @Component
 @Slf4j
-@RequiredArgsConstructor // 수집기 주입을 위함
+@RequiredArgsConstructor
 public class LoggingAspect {
 
     private final PerformanceStatisticsCollector statsCollector;
@@ -26,29 +24,23 @@ public class LoggingAspect {
         try {
             return joinPoint.proceed();
         } finally {
-            // 메서드 실행이 성공하든 실패하든 실행 시간 수집
             long executionTime = System.currentTimeMillis() - start;
             statsCollector.addTime(executionTime);
         }
     }
 
-    /**
-     * 테스트 코드 등 외부에서 호출할 때 사용
-     */
-    public List<Long> getAndClearExecutionTimes() {
-        return statsCollector.getAndClear();
+    // 💡 인터페이스 단순화: 수집기에서 직접 통계를 가져옴
+    public String[] getStatistics(String testName) {
+        return statsCollector.calculateStatistics(testName);
     }
 
-    public String[] calculateStatistics(List<Long> times, String testName) {
-        return statsCollector.calculateStatistics(times, testName);
+    public void resetStatistics() {
+        statsCollector.reset();
     }
 
     @PreDestroy
     public void printFinalStatistics() {
-        // 애플리케이션 종료 전 최종 통계 출력
-        List<Long> times = statsCollector.getAndClear();
-        String[] stats = statsCollector.calculateStatistics(times, "전체 성능 통계");
-
+        String[] stats = statsCollector.calculateStatistics("애플리케이션 전체 운영");
         log.info("========================================================");
         for (String stat : stats) {
             log.info(stat);

--- a/src/test/java/maple/expectation/aop/ConcurrencyStatsExtension.java
+++ b/src/test/java/maple/expectation/aop/ConcurrencyStatsExtension.java
@@ -8,9 +8,6 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import java.util.List;
-// ...
-
 @Slf4j
 public class ConcurrencyStatsExtension implements BeforeEachCallback, AfterEachCallback {
 
@@ -20,24 +17,19 @@ public class ConcurrencyStatsExtension implements BeforeEachCallback, AfterEachC
     }
 
     @Override
-    public void beforeEach(ExtensionContext context) throws Exception {
-        // 1. 테스트 시작 전: 데이터 초기화 (청소)
-        getLoggingAspect(context).getAndClearExecutionTimes();
+    public void beforeEach(ExtensionContext context) {
+        // 1. 테스트 시작 전 데이터 초기화
+        getLoggingAspect(context).resetStatistics();
     }
 
     @Override
-    public void afterEach(ExtensionContext context) throws Exception {
-        // 2. 테스트 종료 후: 데이터 가져와서 통계 출력 (자동화!)
+    public void afterEach(ExtensionContext context) {
+        // 2. 테스트 종료 후 결과 출력
         LoggingAspect aspect = getLoggingAspect(context);
-        List<Long> times = aspect.getAndClearExecutionTimes();
+        String testName = context.getDisplayName();
 
-        String testName = context.getDisplayName(); // 테스트 메서드의 이름(@DisplayName)을 가져옵니다.
-
-        // 3. 로그 출력 (이제 테스트 코드에 log.info 안 써도 됨)
-        for (String stat : aspect.calculateStatistics(times, testName)) {
+        for (String stat : aspect.getStatistics(testName)) {
             log.info(stat);
         }
-
     }
-
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- #10

## 🗣 개요
`LoggingAspect`와 `PerformanceStatisticsCollector`에서 모든 호출 내역을 메모리에 유지함에 따라 발생할 수 있는 OOM(Out Of Memory) 위험을 제거하고, 통계 수집 효율을 극대화했습니다.

## 🛠 작업 내용
- **메모리 구조 혁신**: `ConcurrentLinkedQueue`($O(N)$ 공간 복잡도)를 제거하고, `LongAdder` 및 `AtomicLong` 필드($O(1)$ 공간 복잡도)로 교체하여 메모리 사용량을 고정했습니다.
- **동시성 성능 최적화**: 멀티스레드 환경에서 경합을 분산 처리하는 `LongAdder`를 도입하여 높은 트래픽에서도 성능 저하 없이 통계 수집이 가능하도록 개선했습니다.
- **인터페이스 단순화**: 수집 데이터 전처리 로직을 `Collector` 내부로 캡슐화하여 `LoggingAspect` 및 `Test Extension`과의 결합도를 낮췄습니다.
- **안정적인 Max Latency 측정**: `AtomicLong`의 `updateAndGet`을 활용하여 스레드 안전하게 최대 응답 시간을 갱신하도록 구현했습니다.

## 💬 리뷰 포인트
- `LongAdder`를 사용함에 따라 개별 호출 데이터의 분포(Distribution)는 확인할 수 없게 되었으나, 시스템 가용성을 우선순위에 두었습니다. 이에 대해 의견 부탁드립니다.
- `finally` 블록을 통해 예외 발생 시에도 반드시 통계 데이터가 합산되도록 보장한 부분이 적절한지 검토 바랍니다.

## ✅ 체크리스트
- [x] `./gradlew clean test`를 통해 전체 테스트 통과를 확인했는가?