### PR TITLE
[Reliability] 좋아요 동기화 실패 대응을 위한 재시도 및 알림 시스템 구축 (#13)

### DIFF
--- a/src/main/java/maple/expectation/service/v2/LikeSyncService.java
+++ b/src/main/java/maple/expectation/service/v2/LikeSyncService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import maple.expectation.aop.annotation.ObservedTransaction;
 import maple.expectation.repository.v2.GameCharacterRepository;
+import maple.expectation.service.v2.alert.DiscordAlertService;
 import maple.expectation.service.v2.cache.LikeBufferStorage;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +19,10 @@ public class LikeSyncService {
 
     private final LikeBufferStorage likeBufferStorage;
     private final GameCharacterRepository gameCharacterRepository;
+    private final DiscordAlertService discordAlertService;
+
+    private static final int MAX_RETRIES = 3; // 최대 재시도 횟수
+    private static final long INITIAL_BACKOFF_MS = 1000; // 초기 대기 시간 (1초)
 
     @Transactional
     @ObservedTransaction("scheduler.like.sync")
@@ -26,26 +31,58 @@ public class LikeSyncService {
         if (bufferMap.isEmpty()) return;
 
         log.debug("[Sync] 데이터 동기화 시작 (대상 유저 수: {})", bufferMap.size());
-
-        // 람다 본문을 메서드로 추출하여 가독성 확보
-        bufferMap.forEach(this::syncEachUserLike);
+        bufferMap.forEach(this::syncEachUserLikeWithRetry); // 재시도 로직 포함 메서드로 변경
     }
 
-    private void syncEachUserLike(String userIgn, AtomicLong atomicCount) {
+    private void syncEachUserLikeWithRetry(String userIgn, AtomicLong atomicCount) {
         long countToAdd = atomicCount.getAndSet(0);
-        
-        // [Guard Clause] 반영할 데이터가 없으면 즉시 리턴 (indent 제거)
         if (countToAdd <= 0) return;
 
-        try {
-            gameCharacterRepository.incrementLikeCount(userIgn, countToAdd);
-        } catch (Exception e) {
-            rollbackBuffer(userIgn, atomicCount, countToAdd, e);
+        boolean success = false;
+        Exception lastException = null;
+
+        for (int attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+            try {
+                gameCharacterRepository.incrementLikeCount(userIgn, countToAdd);
+                success = true;
+                if (attempt > 1) log.info("✅ [Retry Success] {} 유저 데이터가 {}회차 재시도 끝에 반영되었습니다.", userIgn, attempt);
+                break;
+            } catch (Exception e) {
+                lastException = e;
+                log.warn("❌ [Sync Failed] {} 반영 실패 ({}회차). 사유: {}", userIgn, attempt, e.getMessage());
+
+                if (attempt < MAX_RETRIES) {
+                    applyBackoff(attempt); // 지수 백오프 적용
+                }
+            }
+        }
+
+        if (!success) {
+            handleFinalFailure(userIgn, atomicCount, countToAdd, lastException);
         }
     }
 
-    private void rollbackBuffer(String userIgn, AtomicLong atomicCount, long countToAdd, Exception e) {
-        log.error("[Sync Error] {} 반영 실패. 데이터 복구 시도 (발생 에러: {})", userIgn, e.getMessage());
-        atomicCount.addAndGet(countToAdd); 
+    private void applyBackoff(int attempt) {
+        try {
+            // 지수 백오프: 1초 -> 2초 -> 4초...
+            long waitTime = INITIAL_BACKOFF_MS * (long) Math.pow(2, attempt - 1);
+            Thread.sleep(waitTime);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private void handleFinalFailure(String userIgn, AtomicLong atomicCount, long countToAdd, Exception e) {
+        log.error("🚨 [Critical] {} 동기화 최종 실패. 데이터를 버퍼로 롤백하고 알림을 발송합니다.", userIgn);
+
+        // 1. 버퍼 데이터 복구 (데이터 유실 방지)
+        atomicCount.addAndGet(countToAdd);
+
+        // 2. 관리자에게 디스코드 알림 발송 (관측 가능성 확보)
+        discordAlertService.sendCriticalAlert(
+                "좋아요 동기화 장애 발생",
+                String.format("대상 유저: %s\n실패 횟수: %d회\n유실 위기 데이터: %d개", userIgn, MAX_RETRIES, countToAdd),
+                e
+        );
     }
 }

--- a/src/test/java/maple/expectation/service/v2/LikeSyncServiceTest.java
+++ b/src/test/java/maple/expectation/service/v2/LikeSyncServiceTest.java
@@ -1,0 +1,95 @@
+package maple.expectation.service.v2;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import maple.expectation.repository.v2.GameCharacterRepository;
+import maple.expectation.service.v2.alert.DiscordAlertService;
+import maple.expectation.service.v2.cache.LikeBufferStorage;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class LikeSyncServiceTest {
+
+    @InjectMocks
+    private LikeSyncService likeSyncService;
+
+    @Mock
+    private LikeBufferStorage likeBufferStorage;
+
+    @Mock
+    private GameCharacterRepository gameCharacterRepository;
+
+    @Mock
+    private DiscordAlertService discordAlertService;
+
+    @Mock
+    private Cache<String, AtomicLong> mockCache;
+
+    @Test
+    @DisplayName("시나리오 1: DB 장애 시 3회 재시도 후 최종 실패하면 알림을 보내고 데이터를 롤백한다")
+    void syncLikes_ShouldRetryAndSendAlert_OnPersistentFailure() {
+        // [Given]
+        String userIgn = "Gamer";
+        AtomicLong counter = new AtomicLong(10);
+
+        // 💡 해결책 1: ConcurrentMap 타입으로 선언하여 Caffeine 타입에 맞춤
+        ConcurrentMap<String, AtomicLong> bufferMap = new ConcurrentHashMap<>();
+        bufferMap.put(userIgn, counter);
+
+        given(likeBufferStorage.getCache()).willReturn(mockCache);
+        given(mockCache.asMap()).willReturn(bufferMap);
+
+        // 💡 해결책 2: void 메서드 스터빙 시 doThrow를 사용하며, Long 객체 타입은 any(Long.class)가 더 안전함
+        doThrow(new RuntimeException("DB 연결 실패"))
+                .when(gameCharacterRepository).incrementLikeCount(anyString(), any(Long.class));
+
+        // [When]
+        likeSyncService.syncLikesToDatabase();
+
+        // [Then]
+        verify(gameCharacterRepository, times(3)).incrementLikeCount(eq(userIgn), any(Long.class));
+        verify(discordAlertService, times(1)).sendCriticalAlert(anyString(), anyString(), any());
+        assertThat(counter.get()).isEqualTo(10L);
+    }
+
+    @Test
+    @DisplayName("시나리오 2: 1, 2회차에 실패하더라도 3회차에 성공하면 데이터는 정상 반영된다")
+    void syncLikes_ShouldSucceed_OnThirdAttempt() {
+        // [Given]
+        String userIgn = "Gamer";
+        AtomicLong counter = new AtomicLong(5);
+
+        ConcurrentMap<String, AtomicLong> bufferMap = new ConcurrentHashMap<>();
+        bufferMap.put(userIgn, counter);
+
+        given(likeBufferStorage.getCache()).willReturn(mockCache);
+        given(mockCache.asMap()).willReturn(bufferMap);
+
+        // 💡 1, 2회차는 에러, 3회차는 성공 시뮬레이션
+        doThrow(new RuntimeException("1차 실패"))
+                .doThrow(new RuntimeException("2차 실패"))
+                .doNothing()
+                .when(gameCharacterRepository).incrementLikeCount(anyString(), any(Long.class));
+
+        // [When]
+        likeSyncService.syncLikesToDatabase();
+
+        // [Then]
+        verify(gameCharacterRepository, times(3)).incrementLikeCount(anyString(), any(Long.class));
+        verify(discordAlertService, never()).sendCriticalAlert(anyString(), anyString(), any());
+        assertThat(counter.get()).isEqualTo(0L);
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- #13

## 🗣 개요
좋아요 동기화 과정에서 발생할 수 있는 DB 장애 및 네트워크 이슈로부터 데이터를 보호하기 위해 재시도(Retry) 메커니즘과 실시간 장애 전파 체계를 구축했습니다.

## 🛠 작업 내용
- **재시도 로직 구현**: `LikeSyncService`에 최대 3회의 재시도 루프를 추가했습니다.
- **지수 백오프 전략**: 재시도 간격을 1초, 2초, 4초로 점진적으로 늘려 서버 부하를 분산했습니다.
- **원자적 데이터 복구**: 재시도 최종 실패 시 `AtomicLong.addAndGet()`을 통해 데이터를 버퍼로 안전하게 환원하여 유실을 차단했습니다.
- **Discord 알림 연동**: 심각한 장애 상황을 즉시 인지할 수 있도록 `DiscordAlertService`와 연동했습니다.
- **테스트 코드 작성**: Mockito를 활용해 다회차 실패 및 성공 시나리오를 검증했습니다.

## 💬 리뷰 포인트
- `LikeSyncServiceTest`에서 Caffeine 캐시의 `asMap()` 반환 타입인 `ConcurrentMap` 처리가 적절한지 확인 부탁드립니다.
- 백오프 대기 시 사용한 `Thread.sleep()`이 스케줄러 스레드 풀에 미치는 영향에 대해 의견 공유 부탁드립니다.

## ✅ 체크리스트
- [x] `./gradlew clean test`를 통해 전체 테스트 통과를 확인했는가?
- [x] 재시도 최종 실패 시 데이터가 유실되지 않고 버퍼로 돌아오는가?
- [x] 브랜치 네이밍 및 커밋 메시지 규칙(타입만 영어, 내용 한글)을 준수하였는가?