### PR TITLE
[Refactor] 도메인 엔티티 무결성 확보 및 JPA Converter 기반 압축 자동화

### DIFF
--- a/src/main/java/maple/expectation/aop/aspect/NexonDataCacheAspect.java
+++ b/src/main/java/maple/expectation/aop/aspect/NexonDataCacheAspect.java
@@ -9,15 +9,12 @@ import maple.expectation.external.dto.v2.EquipmentResponse;
 import maple.expectation.global.error.exception.EquipmentDataProcessingException;
 import maple.expectation.global.lock.LockStrategy;
 import maple.expectation.repository.v2.CharacterEquipmentRepository;
-import maple.expectation.util.GzipUtils;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.reflect.MethodSignature;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -32,33 +29,26 @@ public class NexonDataCacheAspect {
     private final LockStrategy lockStrategy;
     private final ObjectMapper objectMapper;
 
-    @Value("${app.optimization.use-compression:true}")
-    private boolean USE_COMPRESSION;
-
     @Around("@annotation(maple.expectation.aop.annotation.NexonDataCache)")
     public Object handleNexonCache(ProceedingJoinPoint joinPoint) throws Throwable {
-        // 1. 첫 번째 인자를 OCID로 간주
         String ocid = (String) joinPoint.getArgs()[0];
-
-        // 대상 메서드의 반환 타입 확인 (비동기 여부 판단용)
         Class<?> returnType = ((MethodSignature) joinPoint.getSignature()).getReturnType();
 
-        // 2. DB 유효 캐시 확인 (Fast Path)
+        // 1. DB 유효 캐시 확인 (Fast Path)
         Optional<CharacterEquipment> cache = equipmentRepository.findById(ocid);
         if (cache.isPresent() && isValid(cache.get())) {
             log.info("🎯 [AOP Cache Hit] DB에서 데이터를 반환합니다: {}", ocid);
             EquipmentResponse response = convertToResponse(cache.get());
 
-            // 리턴 타입이 CompletableFuture면 감싸서 반환
             return returnType.equals(CompletableFuture.class)
                     ? CompletableFuture.completedFuture(response)
                     : response;
         }
 
-        // 3. 캐시 없거나 만료됨 -> 락 잡고 진행 (Slow Path)
+        // 2. 캐시 없거나 만료됨 -> 락 잡고 진행 (Slow Path)
         return lockStrategy.executeWithLock(ocid, () -> {
             try {
-                // Double Check (락 획득 후 재확인)
+                // Double Check
                 Optional<CharacterEquipment> latest = equipmentRepository.findById(ocid);
                 if (latest.isPresent() && isValid(latest.get())) {
                     return returnType.equals(CompletableFuture.class)
@@ -67,10 +57,8 @@ public class NexonDataCacheAspect {
                 }
 
                 log.info("🔄 [AOP Cache Miss] API를 호출하고 DB를 갱신합니다: {}", ocid);
+                Object result = joinPoint.proceed();
 
-                Object result = joinPoint.proceed(); // 실제 메서드(RealClient) 실행
-
-                // 비동기 처리 분기
                 if (result instanceof CompletableFuture<?> future) {
                     return future.thenApply(res -> {
                         saveToDb(ocid, (EquipmentResponse) res);
@@ -82,7 +70,6 @@ public class NexonDataCacheAspect {
                 return result;
 
             } catch (Throwable e) {
-                // 람다 내부에서 발생한 Throwable을 RuntimeException으로 래핑
                 throw (e instanceof RuntimeException) ? (RuntimeException) e : new RuntimeException(e);
             }
         });
@@ -92,28 +79,36 @@ public class NexonDataCacheAspect {
         return e != null && e.getUpdatedAt().isAfter(LocalDateTime.now().minusMinutes(15));
     }
 
+    /**
+     * 💡 리팩토링 포인트: 더 이상 압축 해제를 고민하지 않습니다.
+     * Converter가 이미 String으로 다 풀어놨기 때문에 그냥 읽기만 하면 됩니다.
+     */
     private EquipmentResponse convertToResponse(CharacterEquipment entity) {
         try {
-            byte[] data = entity.getRawData();
-            String json = (data.length > 2 && data[0] == (byte) 0x1F)
-                    ? GzipUtils.decompress(data)
-                    : new String(data, StandardCharsets.UTF_8);
-            return objectMapper.readValue(json, EquipmentResponse.class);
+            return objectMapper.readValue(entity.getJsonContent(), EquipmentResponse.class);
         } catch (Exception e) {
+            log.error("캐시 역직렬화 실패: ocid={}", entity.getOcid(), e);
             throw new EquipmentDataProcessingException("캐시 데이터 파싱 실패 (AOP)");
         }
     }
 
+    /**
+     * 💡 리팩토링 포인트: 더 이상 수동 압축을 하지 않습니다.
+     * 엔티티에 String만 넘겨주면, 저장 시점에 Converter가 알아서 압축해서 DB에 넣습니다.
+     */
     private void saveToDb(String ocid, EquipmentResponse res) {
         try {
             String json = objectMapper.writeValueAsString(res);
-            byte[] data = USE_COMPRESSION ? GzipUtils.compress(json) : json.getBytes(StandardCharsets.UTF_8);
 
             CharacterEquipment entity = equipmentRepository.findById(ocid)
-                    .orElse(new CharacterEquipment(ocid, data));
-            entity.updateData(data);
+                    .orElseGet(() -> CharacterEquipment.builder()
+                            .ocid(ocid)
+                            .jsonContent(json)
+                            .build());
 
+            entity.updateData(json);
             equipmentRepository.saveAndFlush(entity);
+
         } catch (JsonProcessingException e) {
             throw new EquipmentDataProcessingException("데이터 직렬화 실패 (AOP)");
         }

--- a/src/main/java/maple/expectation/domain/v2/CharacterEquipment.java
+++ b/src/main/java/maple/expectation/domain/v2/CharacterEquipment.java
@@ -1,13 +1,11 @@
 package maple.expectation.domain.v2;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Lob;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import maple.expectation.util.converter.GzipStringConverter; // 💡 컨버터 임포트
 
 import java.time.LocalDateTime;
 
@@ -17,24 +15,26 @@ import java.time.LocalDateTime;
 public class CharacterEquipment {
 
     @Id
-    @Column(length = 100) // OCID는 PK
+    @Column(length = 100)
     private String ocid;
 
+    // 💡 핵심: 필드 타입을 String으로 변경하고 컨버터 장착!
+    @Convert(converter = GzipStringConverter.class)
     @Lob
     @Column(columnDefinition = "LONGBLOB", nullable = false)
-    private byte[] rawData;
+    private String jsonContent; // 💡 이름도 의미에 맞게 rawData -> jsonContent로 변경
 
-    private LocalDateTime updatedAt; // 마지막 갱신 시간
+    private LocalDateTime updatedAt;
 
     @Builder
-    public CharacterEquipment(String ocid, byte[] rawData) { // 생성자도 byte[]로
+    public CharacterEquipment(String ocid, String jsonContent) { // 💡 String을 받음
         this.ocid = ocid;
-        this.rawData = rawData;
+        this.jsonContent = jsonContent;
         this.updatedAt = LocalDateTime.now();
     }
 
-    public void updateData(byte[] newJsonData) { // 업데이트도 byte[]로
-        this.rawData = newJsonData;
+    public void updateData(String newJsonContent) { // 💡 String으로 업데이트
+        this.jsonContent = newJsonContent;
         this.updatedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/maple/expectation/util/GzipUtils.java
+++ b/src/main/java/maple/expectation/util/GzipUtils.java
@@ -1,39 +1,48 @@
 package maple.expectation.util;
 
 import maple.expectation.global.error.exception.CompressionException;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
+import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE) // 유틸 클래스는 생성 방지
 public class GzipUtils {
 
-    // 문자열 -> 압축된 byte[]
     public static byte[] compress(String str) {
-        if (str == null || str.isEmpty()) return new byte[0];
-        
+        if (str == null || str.isBlank()) return new byte[0];
+
         try (ByteArrayOutputStream out = new ByteArrayOutputStream();
              GZIPOutputStream gzip = new GZIPOutputStream(out)) {
             gzip.write(str.getBytes(StandardCharsets.UTF_8));
-            gzip.finish();
+            gzip.finish(); // 명시적으로 스트림 종료
             return out.toByteArray();
         } catch (IOException e) {
-            throw new CompressionException(e.toString());
+            throw new CompressionException("압축 중 오류 발생: " + e.getMessage());
         }
     }
 
-    // 압축된 byte[] -> 문자열
     public static String decompress(byte[] compressed) {
         if (compressed == null || compressed.length == 0) return "";
 
-        try (ByteArrayInputStream in = new ByteArrayInputStream(compressed);
-             GZIPInputStream gzip = new GZIPInputStream(in)) {
+        // GZIP 포맷인지 확인 (Magic Number 체크)
+        if (!isGzipped(compressed)) {
+            return new String(compressed, StandardCharsets.UTF_8);
+        }
+
+        try (GZIPInputStream gzip = new GZIPInputStream(new ByteArrayInputStream(compressed))) {
             return new String(gzip.readAllBytes(), StandardCharsets.UTF_8);
         } catch (IOException e) {
-            throw new CompressionException(e.toString());
+            throw new CompressionException("압축 해제 중 오류 발생: " + e.getMessage());
         }
+    }
+
+    private static boolean isGzipped(byte[] data) {
+        return data.length >= 2 &&
+                data[0] == (byte) (GZIPInputStream.GZIP_MAGIC) &&
+                data[1] == (byte) (GZIPInputStream.GZIP_MAGIC >> 8);
     }
 }

--- a/src/main/java/maple/expectation/util/converter/GzipStringConverter.java
+++ b/src/main/java/maple/expectation/util/converter/GzipStringConverter.java
@@ -1,0 +1,19 @@
+package maple.expectation.util.converter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import maple.expectation.util.GzipUtils;
+
+@Converter
+public class GzipStringConverter implements AttributeConverter<String, byte[]> {
+
+    @Override
+    public byte[] convertToDatabaseColumn(String attribute) {
+        return GzipUtils.compress(attribute);
+    }
+
+    @Override
+    public String convertToEntityAttribute(byte[] dbData) {
+        return GzipUtils.decompress(dbData);
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- 관련 이슈 없음 (도메인 고도화 및 리팩토링)

## 🗣 개요
도메인 엔티티의 캡슐화를 강화하고, 인프라 로직(Gzip 압축)을 비즈니스 로직에서 분리하기 위한 대대적인 리팩토링을 진행했습니다.

## 🛠 작업 내용
- **도메인 엔티티 리팩토링**: `Member`, `GameCharacter` 엔티티의 Setter를 제거하고 생성자를 `protected`로 제한.
- **정적 팩토리 메서드 도입**: `createSystemAdmin`, `createGuest` 등 의미 있는 생성 메서드를 통해 객체 생성 무결성 확보.
- **JPA Attribute Converter 적용**: `GzipStringConverter`를 도입하여 DB 저장 시 자동 압축/해제 로직 구현.
- **관심사 분리**: `NexonDataCacheAspect` 및 `ResilientNexonApiClient`에서 저수준의 `byte[]` 및 압축 처리 로직 제거.
- **테스트 코드 현행화**: 변경된 생성자 및 필드 타입(`byte[]` -> `String`)에 맞춰 전체 통합/동시성 테스트 케이스 수정.

## 💬 리뷰 포인트
- 엔티티의 정적 팩토리 메서드 네이밍이 비즈니스 의도를 잘 나타내는지 확인 부탁드립니다.
- `CharacterEquipment` 엔티티의 `jsonContent` 필드에 적용된 `GzipStringConverter`가 정상적으로 동작하는지 검토 부탁드립니다.
- Aspect 레이어에서 `byte[]`를 다루지 않고 `String`으로 역직렬화하는 과정이 적절한지 확인 부탁드립니다.

## ✅ 체크리스트
- [x] 모든 엔티티에서 불필요한 Setter가 제거되었는가
- [x] 정적 팩토리 메서드를 통해서만 객체가 생성되는가
- [x] 전체 테스트 코드가 초록불(Passed)을 유지하는가
- [x] 빌드 시 컴파일 에러나 경고가 발생하지 않는가