### PR TITLE
refactor: AOP 기반 트레이스 로그 최적화 및 실시간 관측성(Observability) 강화

### DIFF
--- a/src/main/java/maple/expectation/aop/aspect/LockAspect.java
+++ b/src/main/java/maple/expectation/aop/aspect/LockAspect.java
@@ -29,7 +29,7 @@ public class LockAspect {
     public Object applyLock(ProceedingJoinPoint joinPoint, Locked locked) throws Throwable {
         String key = getDynamicKey(joinPoint, locked.key());
 
-        // 💡 락 전략 실행 시 내부 로직을 별도 메서드로 래핑하여 괄호 지옥을 탈출합니다.
+        // 💡 락 전략 실행 시 내부 로직을 별도 메서드로 래핑
         return lockStrategy.executeWithLock(key, () -> proceedWithExceptionHandling(joinPoint, key));
     }
 

--- a/src/main/java/maple/expectation/controller/GameCharacterControllerV2.java
+++ b/src/main/java/maple/expectation/controller/GameCharacterControllerV2.java
@@ -9,7 +9,6 @@ import maple.expectation.service.v2.GameCharacterService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-@TraceLog
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v2/characters")

--- a/src/main/java/maple/expectation/dto/CubeCalculationInput.java
+++ b/src/main/java/maple/expectation/dto/CubeCalculationInput.java
@@ -8,7 +8,6 @@ import java.util.List;
 
 @Data
 @Builder
-@TraceLog
 @NoArgsConstructor  // 1. 기본 생성자 추가 (new CubeCalculationInput() 가능하게 함)
 @AllArgsConstructor // 2. @Builder가 작동하려면 전체 생성자도 필요함
 public class CubeCalculationInput {

--- a/src/main/java/maple/expectation/external/dto/v2/EquipmentResponse.java
+++ b/src/main/java/maple/expectation/external/dto/v2/EquipmentResponse.java
@@ -8,7 +8,6 @@ import maple.expectation.aop.annotation.TraceLog;
 import java.util.List;
 
 @Data
-@TraceLog
 @JsonIgnoreProperties(ignoreUnknown = true) // 정의하지 않은 필드가 와도 에러 안 나게 무시
 public class EquipmentResponse {
 

--- a/src/main/java/maple/expectation/global/lock/RedisDistributedLockStrategy.java
+++ b/src/main/java/maple/expectation/global/lock/RedisDistributedLockStrategy.java
@@ -40,12 +40,12 @@ public class RedisDistributedLockStrategy implements LockStrategy {
             }
 
             try {
-                log.info("🔓 [Distributed Lock] '{}' 획득 성공.", key);
+                log.debug("🔓 [Distributed Lock] '{}' 획득 성공.", key);
                 return task.get();
             } finally {
                 if (lock.isHeldByCurrentThread()) {
                     lock.unlock();
-                    log.info("🔒 [Distributed Lock] '{}' 해제 완료.", key);
+                    log.debug("🔒 [Distributed Lock] '{}' 해제 완료.", key);
                 }
             }
         } catch (InterruptedException e) {

--- a/src/main/java/maple/expectation/parser/EquipmentStreamingParser.java
+++ b/src/main/java/maple/expectation/parser/EquipmentStreamingParser.java
@@ -27,7 +27,6 @@ import java.util.zip.GZIPInputStream;
 
 @Slf4j
 @Component
-@TraceLog
 @RequiredArgsConstructor
 public class EquipmentStreamingParser {
 

--- a/src/main/java/maple/expectation/repository/v2/CharacterEquipmentRepository.java
+++ b/src/main/java/maple/expectation/repository/v2/CharacterEquipmentRepository.java
@@ -4,6 +4,5 @@ import maple.expectation.aop.annotation.TraceLog;
 import maple.expectation.domain.v2.CharacterEquipment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-@TraceLog
 public interface CharacterEquipmentRepository extends JpaRepository<CharacterEquipment, String> {
 }

--- a/src/main/java/maple/expectation/repository/v2/CubeProbabilityRepository.java
+++ b/src/main/java/maple/expectation/repository/v2/CubeProbabilityRepository.java
@@ -17,7 +17,6 @@ import java.io.InputStream;
 import java.util.*;
 
 @Slf4j
-@TraceLog
 @Repository("cubeProbabilityRepositoryV1")
 public class CubeProbabilityRepository {
 

--- a/src/main/java/maple/expectation/repository/v2/GameCharacterRepository.java
+++ b/src/main/java/maple/expectation/repository/v2/GameCharacterRepository.java
@@ -12,7 +12,6 @@ import org.springframework.data.repository.query.Param;
 import java.util.Optional;
 
 // 1. 인터페이스로 변경하고 JpaRepository 상속 (Entity, PK타입)
-@TraceLog
 public interface GameCharacterRepository extends JpaRepository<GameCharacter, Long> {
 
     // 2. 일반 조회 (기존 findOptionalByUserIgn 대체)

--- a/src/main/java/maple/expectation/service/v2/GameCharacterService.java
+++ b/src/main/java/maple/expectation/service/v2/GameCharacterService.java
@@ -19,7 +19,6 @@ import java.util.Optional;
 
 @Slf4j
 @Service
-@TraceLog
 @Transactional(readOnly = true)
 public class GameCharacterService {
 

--- a/src/main/java/maple/expectation/service/v2/calculator/CubeRateCalculator.java
+++ b/src/main/java/maple/expectation/service/v2/calculator/CubeRateCalculator.java
@@ -9,7 +9,6 @@ import maple.expectation.util.StatType;
 import org.springframework.stereotype.Component;
 
 @Component
-@TraceLog
 @RequiredArgsConstructor
 public class CubeRateCalculator {
 

--- a/src/main/java/maple/expectation/service/v2/impl/CubeServiceImpl.java
+++ b/src/main/java/maple/expectation/service/v2/impl/CubeServiceImpl.java
@@ -17,7 +17,6 @@ import java.util.Set;
 
 @Slf4j
 @Service("cubeServiceImpl")
-@TraceLog
 @RequiredArgsConstructor
 public class CubeServiceImpl implements CubeTrialsProvider {
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,7 +26,8 @@ management:
   endpoints:
     web:
       exposure:
-        include: "health,info,metrics,prometheus"
+        include: "health,info,metrics,prometheus,loggers"
+
   endpoint:
     health:
       show-details: always # 서킷 브레이커 상태를 상세히 보기 위해 필수


### PR DESCRIPTION
## 🔗 관련 이슈


## 🗣 개요
기존에 수동으로 관리하던 `@TraceLog` 어노테이션 방식의 한계를 극복하고, Spring AOP의 포인트컷 지시자(PCD)를 활용하여 시스템 전체의 가시성을 자동화하고 운영 효율성을 극대화했습니다.

## 🛠 작업 내용
* **TraceAspect 고도화**: `execution` PCD를 도입하여 서비스/컨트롤러/조력자 패키지 자동 추적 기능을 구현했습니다.
* **로그 소음 필터링**: 스케줄러(`scheduler`) 및 버퍼 저장소(`LikeBufferStorage`) 등 비즈니스 흐름 파악에 방해가 되는 로그를 포인트컷 단계에서 원천 차단했습니다.
* **실시간 로그 레벨 제어**: 
    * 추적 로그를 `DEBUG` 레벨로 전환하여 평시 성능 오버헤드를 방지했습니다.
    * Spring Boot Actuator의 `loggers` 엔드포인트를 활성화하여 서버 재시작 없이 실시간으로 로그 추적을 On/Off 할 수 있는 기반을 마련했습니다.
* **MDC 연동 확인**: 기존에 구축된 `requestId`가 모든 계층형 로그에 일관되게 출력됨을 검증했습니다.

## 💬 리뷰 포인트
* `TraceAspect`의 `excludeNoise()` 포인트컷에 제외 대상 패키지가 누락되지 않았는지 확인 부탁드립니다.
* `application.yml`의 Actuator 노출 설정(`loggers` 추가)이 보안 가이드라인에 적합한지 검토가 필요합니다.

## ✅ 체크리스트
- [x] 서비스 계층 메서드 호출 시 계층형 로그가 정상 출력되는가?
- [x] 스케줄러 로직 실행 시 로그 소음이 제거되었는가?
- [x] Actuator `/actuator/loggers`를 통해 실시간으로 레벨 변경이 가능한가?
- [x] 로컬 환경(`local` 프로파일)에서 정상 작동하는가?