### PR TITLE
refactor: #12 캐시 영역별 개별 정책(TTL/Max) 적용 및 명칭 최적화

### DIFF
--- a/src/main/java/maple/expectation/config/CacheConfig.java
+++ b/src/main/java/maple/expectation/config/CacheConfig.java
@@ -3,10 +3,12 @@ package maple.expectation.config;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
-import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.support.SimpleCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
 @Configuration
@@ -15,13 +17,26 @@ public class CacheConfig {
 
     @Bean
     public CacheManager cacheManager() {
-        // 💡 "equipment" 영역 추가
-        CaffeineCacheManager cacheManager = new CaffeineCacheManager("cubeTrials", "ocidCache", "equipment");
+        SimpleCacheManager cacheManager = new SimpleCacheManager();
 
-        cacheManager.setCaffeine(Caffeine.newBuilder()
-                // 💡 이슈 #11 정책: 15분 후 만료 (Write 기준)
-                .expireAfterWrite(15, TimeUnit.MINUTES)
-                .maximumSize(10_000));
+        // 1. 장비 정보 캐시 (이슈 #11: 15분, DB 동기화 최적화)
+        CaffeineCache equipmentCache = buildCaffeineCache("equipment", 15, 5000);
+
+        // 2. 계산 결과 캐시 (이슈 #12: 20분, 연산 비용 절감)
+        CaffeineCache calculationCache = buildCaffeineCache("cubeTrials", 20, 10000);
+
+        // 3. OCID 캐시 (자주 안 변하므로 더 길게 가져가도 됨)
+        CaffeineCache ocidCache = buildCaffeineCache("ocidCache", 60, 10000);
+
+        cacheManager.setCaches(Arrays.asList(equipmentCache, calculationCache, ocidCache));
         return cacheManager;
+    }
+
+    private CaffeineCache buildCaffeineCache(String name, int durationMinute, int maximumSize) {
+        return new CaffeineCache(name,
+                Caffeine.newBuilder()
+                        .expireAfterWrite(durationMinute, TimeUnit.MINUTES)
+                        .maximumSize(maximumSize)
+                        .build());
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- #12

## 🗣 개요
- 모든 캐시에 일괄 적용되던 전역 정책을 폐기하고, 데이터의 성격(정합성 중요도 및 연산 비용)에 따라 캐시 영역별로 최적화된 개별 정책을 수립하고 적용했습니다.

## 🛠 작업 내용
- **SimpleCacheManager 도입:** 단일 설정만 가능하던 기존 구조에서 벗어나 각 캐시(equipment, cubeTrials, ocidCache)마다 독립적인 Caffeine 빌더를 가질 수 있도록 개선했습니다.
- **차등 TTL 적용:** - `equipment`: 15분 (API 정합성 우선)
  - `cubeTrials`: 20분 (고비용 연산 결과 보호)
  - `ocidCache`: 60분 (변경 빈도가 낮은 고정 데이터)
- **리팩토링:** `buildCaffeineCache` private 메서드를 생성하여 반복되는 Caffeine 빌더 코드를 캡슐화하고 가독성을 높였습니다.
- **메모리 안정성:** 모든 캐시 영역에 `maximumSize` 제한을 명시하여 무한 성장을 방지했습니다.

## 💬 리뷰 포인트
- `CacheConfig` 내에서 정의한 캐시 이름(`cubeTrials` 등)이 실제 서비스 레이어(`CubeServiceImpl`)의 `@Cacheable` 설정값과 정확히 일치하는지 검토 부탁드립니다.
- 차등 적용된 TTL(15분/20분/60분) 값이 각 데이터의 비즈니스 중요도에 적절한지 의견 부탁드립니다.

## 💱 트레이드 오프 결정 근거
- **유연성 vs 복잡도:** 설정 코드는 소폭 늘어났으나, 데이터 성격에 맞는 자원 관리가 가능해짐에 따라 불필요한 API 호출을 줄이고 메모리 효율을 극대화하는 실익이 더 크다고 판단했습니다.
- **Helper 메서드 도입:** 프라이빗 메서드로 설정을 분리하여 향후 새로운 캐시 영역이 추가되더라도 코드 한 줄로 안정적인 정책을 생성할 수 있는 확장성을 확보했습니다.

## ✅ 체크리스트
- [x] SimpleCacheManager를 통해 각 캐시 영역이 독립적으로 설정되었는가
- [x] 각 캐시별로 의도한 TTL과 MaximumSize가 반영되었는가
- [x] 중복 코드가 제거되고 buildCaffeineCache 메서드로 단일화되었는가