### PR TITLE
refactor: 비동기 캐싱 파이프라인 및 분산 락 전략 고도화

### DIFF
--- a/src/main/java/maple/expectation/global/common/function/ThrowingSupplier.java
+++ b/src/main/java/maple/expectation/global/common/function/ThrowingSupplier.java
@@ -1,0 +1,6 @@
+package maple.expectation.global.common.function;
+
+@FunctionalInterface
+public interface ThrowingSupplier<T> {
+    T get() throws Throwable;
+}

--- a/src/main/java/maple/expectation/global/lock/GuavaLockStrategy.java
+++ b/src/main/java/maple/expectation/global/lock/GuavaLockStrategy.java
@@ -2,13 +2,13 @@ package maple.expectation.global.lock;
 
 import com.google.common.util.concurrent.Striped;
 import lombok.extern.slf4j.Slf4j;
+import maple.expectation.global.common.function.ThrowingSupplier;
 import maple.expectation.global.error.exception.DistributedLockException;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
-import java.util.function.Supplier;
 
 @Slf4j
 @Component
@@ -17,28 +17,24 @@ public class GuavaLockStrategy implements LockStrategy {
     private final Striped<Lock> locks = Striped.lock(128);
 
     @Override
-    public <T> T executeWithLock(String key, Supplier<T> task) {
-        // 기본값: 무한정 대기 (기존 로직 유지)
+    public <T> T executeWithLock(String key, ThrowingSupplier<T> task) throws Throwable {
         return executeWithLock(key, Long.MAX_VALUE, -1, task);
     }
 
     @Override
-    public <T> T executeWithLock(String key, long waitTime, long leaseTime, Supplier<T> task) {
+    public <T> T executeWithLock(String key, long waitTime, long leaseTime, ThrowingSupplier<T> task) throws Throwable {
         Lock lock = locks.get(key);
         try {
-            // 💡 waitTime 동안 락 획득 시도
             boolean isLocked = lock.tryLock(waitTime, TimeUnit.SECONDS);
 
             if (!isLocked) {
-                log.warn("⏭️ [Guava Lock] '{}' 획득 실패. 타임아웃 발생.", key);
-                // 💡 Redis와 동일하게 예외를 던져서 테스트의 catch 블록이 작동하게 함
+                log.warn("⏭️ [Guava Lock] '{}' 획득 실패.", key);
                 throw new DistributedLockException("로컬 락 획득 실패: " + key);
             }
 
             try {
-                return task.get();
+                return task.get(); // ✅ ThrowingSupplier의 예외를 그대로 전파
             } finally {
-                // 💡 로컬 락은 leaseTime(자동 해제)이 없으므로 직접 해제 필수
                 lock.unlock();
             }
         } catch (InterruptedException e) {

--- a/src/main/java/maple/expectation/global/lock/LockStrategy.java
+++ b/src/main/java/maple/expectation/global/lock/LockStrategy.java
@@ -1,9 +1,12 @@
 package maple.expectation.global.lock;
 
+import maple.expectation.global.common.function.ThrowingSupplier;
+
 import java.util.function.Supplier;
 
 public interface LockStrategy {
-    <T> T executeWithLock(String key, Supplier<T> task);
 
-    <T> T executeWithLock(String key, long waitTime, long leaseTime, Supplier<T> task);
+    <T> T executeWithLock(String key, long waitTime, long leaseTime, ThrowingSupplier<T> task) throws Throwable;
+
+    <T> T executeWithLock(String key, ThrowingSupplier<T> task) throws Throwable;
 }

--- a/src/main/java/maple/expectation/global/lock/RedisDistributedLockStrategy.java
+++ b/src/main/java/maple/expectation/global/lock/RedisDistributedLockStrategy.java
@@ -2,6 +2,7 @@ package maple.expectation.global.lock;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import maple.expectation.global.common.function.ThrowingSupplier; // ✅ 패키지 경로 확인
 import maple.expectation.global.error.exception.DistributedLockException;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
@@ -10,7 +11,6 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
 
 @Slf4j
 @Component
@@ -21,29 +21,26 @@ public class RedisDistributedLockStrategy implements LockStrategy {
 
     private final RedissonClient redissonClient;
 
-    // 인터페이스 기본 구현: 비즈니스 로직(후원 등)을 위해 3초간 대기하도록 설정
     @Override
-    public <T> T executeWithLock(String key, Supplier<T> task) {
-        return executeWithLock(key, 3, 10, task); // 기본 waitTime 3초 부여
+    public <T> T executeWithLock(String key, ThrowingSupplier<T> task) throws Throwable {
+        return executeWithLock(key, 3, 10, task);
     }
 
-    // 오버로딩: 대기 시간을 직접 조절해야 하는 경우 (스케줄러 등) 사용
-    public <T> T executeWithLock(String key, long waitTime, long leaseTime, Supplier<T> task) {
+    @Override
+    public <T> T executeWithLock(String key, long waitTime, long leaseTime, ThrowingSupplier<T> task) throws Throwable {
         RLock lock = redissonClient.getLock("lock:" + key);
 
         try {
-            // tryLock(대기시간, 점유시간, 단위)
             boolean isLocked = lock.tryLock(waitTime, leaseTime, TimeUnit.SECONDS);
 
             if (!isLocked) {
-                log.warn("⏭️ [Distributed Lock] '{}' 획득 실패. 경합 중이거나 작업 진행 중.", key);
-                // 💡 핵심: null이 아닌 예외를 던져서 테스트의 catch 블록이 작동하게 함
+                log.warn("⏭️ [Distributed Lock] '{}' 획득 실패.", key);
                 throw new DistributedLockException("락 획득 타임아웃: " + key);
             }
 
             try {
                 log.debug("🔓 [Distributed Lock] '{}' 획득 성공.", key);
-                return task.get();
+                return task.get(); // ✅ 이제 예외를 여기서 감싸지 않고 그대로 던집니다.
             } finally {
                 if (lock.isHeldByCurrentThread()) {
                     lock.unlock();

--- a/src/main/java/maple/expectation/global/shutdown/GracefulShutdownCoordinator.java
+++ b/src/main/java/maple/expectation/global/shutdown/GracefulShutdownCoordinator.java
@@ -31,13 +31,17 @@ public class GracefulShutdownCoordinator {
         // 2. 리더 서버인 경우 DB 최종 동기화 (단일 인스턴스 수행)
         try {
             log.info("▶️ [2/2] DB 최종 동기화 시도 중...");
+
+            // ✅ 수정: ThrowingSupplier를 사용하며, Throwable을 캐치하도록 변경
             lockStrategy.executeWithLock("like-db-sync-lock", 0, 5, () -> {
                 likeSyncService.syncRedisToDatabase();
-                return null;
+                return null; // ThrowingSupplier는 반환값이 필요하므로 null 반환
             });
+
             log.info("✅ DB 최종 동기화 완료.");
-        } catch (Exception e) {
-            log.info("ℹ️ DB 최종 동기화는 타 서버에서 처리되었거나 권한이 없습니다.");
+        } catch (Throwable t) { // ✅ Exception 대신 Throwable로 넓게 잡음 (LockStrategy 변경 대응)
+            // 락 획득 실패(타임아웃)나 이미 다른 서버가 작업 중인 경우 포함
+            log.info("ℹ️ DB 최종 동기화 스킵: 타 서버가 처리 중이거나 락 획득에 실패했습니다. (사유: {})", t.getMessage());
         }
 
         log.info("========= [System Shutdown] 종료 완료 =========");

--- a/src/main/java/maple/expectation/service/v2/cache/EquipmentCacheService.java
+++ b/src/main/java/maple/expectation/service/v2/cache/EquipmentCacheService.java
@@ -1,0 +1,48 @@
+package maple.expectation.service.v2.cache;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import maple.expectation.domain.v2.CharacterEquipment;
+import maple.expectation.external.dto.v2.EquipmentResponse;
+import maple.expectation.repository.v2.CharacterEquipmentRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EquipmentCacheService {
+    private final CharacterEquipmentRepository repository;
+    private final ObjectMapper objectMapper;
+
+    @Transactional(readOnly = true)
+    public Optional<EquipmentResponse> getValidCache(String ocid) {
+        return repository.findById(ocid)
+                .filter(e -> e.getUpdatedAt().isAfter(LocalDateTime.now().minusMinutes(15)))
+                .map(this::convertToResponse);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW) // ✅ 메인 로직과 별개로 무조건 저장
+    public void saveCache(String ocid, EquipmentResponse response) {
+        try {
+            String json = objectMapper.writeValueAsString(response);
+            CharacterEquipment entity = repository.findById(ocid)
+                    .orElseGet(() -> CharacterEquipment.builder().ocid(ocid).build());
+            entity.updateData(json);
+            repository.saveAndFlush(entity);
+        } catch (Exception e) {
+            log.error("❌ 캐시 저장 실패: ocid={}", ocid, e);
+        }
+    }
+
+    private EquipmentResponse convertToResponse(CharacterEquipment entity) {
+        try {
+            return objectMapper.readValue(entity.getJsonContent(), EquipmentResponse.class);
+        } catch (Exception e) { return null; }
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- 관련 이슈 없음 (이슈 미생성 상태에서 리팩토링 진행)

## 🗣 개요
외부 API(넥슨) 데이터를 처리하는 비동기 파이프라인의 성능 병목을 제거하고, 분산 시스템 환경에서의 회복 탄력성(Resilience)을 강화하기 위해 전면 리팩토링을 수행했습니다. 특히 스레드 차단(Blocking) 문제를 해결하고 트랜잭션 경계를 명확히 하는 데 집중했습니다.

## 🛠 작업 내용
- **비동기 파이프라인 최적화**: `NexonDataCacheAspect` 내 `.join()` 호출을 제거하고 `thenApply` 체이닝을 도입하여 완전한 Non-blocking 구조 구현
- **락 전략(LockStrategy) 고도화**: 체크 예외 전파가 가능한 `ThrowingSupplier`를 도입하여 인프라 계층의 예외 은닉 문제 해결
- **캐시 서비스 분리**: `EquipmentCacheService`를 신설하여 캐시 저장 로직을 `REQUIRES_NEW` 트랜잭션으로 격리하고 비동기 환경에서의 정합성 확보
- **AOP 가독성 개선**: `args(ocid, ..)` 바인딩을 적용하여 리플렉션 기반 인자 추출 로직 제거 및 타입 안정성 강화
- **자가 치유(Self-healing) 로직**: 캐시 역직렬화 실패 시 `Optional.empty()`를 반환하여 자동으로 최신 데이터를 재수급하도록 구현

## 💬 리뷰 포인트
- `NexonDataCacheAspect`에서 비동기 반환 타입일 경우에만 `thenApply`가 적용되어 Future 체인이 유지되는지 확인 부탁드립니다.
- `EquipmentCacheService`에서 발생한 예외가 로그만 남기고 메인 비즈니스 로직에 영향을 주지 않도록 설계된 부분이 적절한지 검토 부탁드립니다.

## 💱 트레이드 오프 결정 근거
- **CompletableFuture 유지**: 단순 비동기보다 복잡하지만, `Scenario C(TimeLimiter)`를 통한 지연 격리와 `Scenario A/B` 분기 로직을 선언적으로 관리하기 위해 채택했습니다.
- **Fail-safe over Accuracy**: 캐시 파싱 실패 시 에러를 던지지 않고 빈 값을 반환하여 시스템의 연속성을 보장하되, 최신 데이터를 다시 가져오는 방향을 선택했습니다.

## ✅ 체크리스트
- [x] 비동기 파이프라인 내 블로킹 코드(join) 존재 여부 확인
- [x] 분산 락 획득/해제 및 예외 전파 정상 작동 확인
- [x] 로컬(Guava) 및 운영(Redis) 락 전략 인터페이스 일치 여부 확인
- [x] 시스템 종료(Graceful Shutdown) 시 데이터 유실 방지 로직 검증 완료