### PR TITLE
feat: 분산 락 기반 모니터링 알림 중복 방지

### DIFF
--- a/src/main/java/maple/expectation/mornitering/MonitoringAlertService.java
+++ b/src/main/java/maple/expectation/mornitering/MonitoringAlertService.java
@@ -1,6 +1,8 @@
 package maple.expectation.mornitering;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import maple.expectation.global.lock.LockStrategy; // ✅ 추가
 import maple.expectation.service.v2.alert.DiscordAlertService;
 import maple.expectation.service.v2.cache.LikeBufferStorage;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -8,23 +10,42 @@ import org.springframework.stereotype.Component;
 
 import java.util.concurrent.atomic.AtomicLong;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class MonitoringAlertService {
     private final LikeBufferStorage likeBufferStorage;
     private final DiscordAlertService discordAlertService;
+    private final LockStrategy lockStrategy; // ✅ 주입 추가
 
     @Scheduled(fixedRate = 5000) // 5초마다 체크
     public void checkBufferSaturation() {
-        long currentPending = likeBufferStorage.getCache().asMap().values().stream()
-                .mapToLong(AtomicLong::get).sum();
+        try {
+            // 💡 리더 선출: 락을 획득한 단 한 대의 인스턴스만 모니터링 및 알림 수행
+            // waitTime 0: 락 획득 실패 시 즉시 무시 (다른 서버가 이미 체크 중)
+            lockStrategy.executeWithLock("monitoring-alert-lock", 0, 4, () -> {
 
-        if (currentPending > 2000) { // 임계치 설정
-            discordAlertService.sendCriticalAlert(
-                "BUFFER SATURATION WARNING",
-                "현재 좋아요 버퍼 잔량이 너무 높습니다: " + currentPending,
-                new RuntimeException("System Load High")
-            );
+                // 1. 현재 인스턴스 혹은 공유 저장소의 수치 계산
+                // (이슈 #27의 취지에 따라 나중에는 Redis의 전역 수치를 가져오게 됩니다)
+                long currentPending = likeBufferStorage.getCache().asMap().values().stream()
+                        .mapToLong(AtomicLong::get).sum();
+
+                log.debug("📊 [Monitoring] 버퍼 체크 수행 중: {}", currentPending);
+
+                // 2. 임계치 초과 시 알림 발송
+                if (currentPending > 2000) {
+                    discordAlertService.sendCriticalAlert(
+                            "BUFFER SATURATION WARNING",
+                            "현재 시스템의 좋아요 버퍼 잔량이 임계치를 초과했습니다: " + currentPending,
+                            new RuntimeException("System Load High (Detected by Leader)")
+                    );
+                }
+
+                return null;
+            });
+        } catch (Throwable t) {
+            // DistributedLockException 등이 발생하면 리더가 아니라고 판단하고 조용히 넘어감
+            log.trace("⏭️ [Monitoring] 리더 권한이 없어 체크를 스킵합니다.");
         }
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- #27

## 🗣 개요
서버 가용성 확장(Scale-out) 시 발생할 수 있는 '알림 폭풍(Alert Storm)' 문제를 해결하기 위해 분산 락을 이용한 리더 선출 로직을 모니터링 서비스에 도입했습니다. 또한 최신 스프링 부트 표준에 맞춰 테스트 코드를 리팩토링했습니다.

## 🛠 작업 내용
- **분산 락 적용**: `MonitoringAlertService`에 `LockStrategy`를 주입하여 오직 한 대의 인스턴스만 알림을 발송하도록 제어
- **경합 로직 최적화**: `waitTime: 0` 설정을 통해 락 획득 실패 시 대기 없이 즉시 스킵하여 시스템 자원 보호
- **테스트 코드 최신화**: Spring Boot 3.4의 `@MockitoBean`을 도입하여 기존 `@MockBean` 대체 및 분산 환경 시뮬레이션 검증

## 💬 리뷰 포인트
- `MonitoringAlertService`에서 `lockStrategy.executeWithLock` 호출 시 `Throwable` 캐치 블록이 락 획득 실패(스킵) 상황을 적절히 처리하는지 확인 부탁드립니다.
- 테스트 코드에서 `willAnswer`를 통해 분산 락 성공 시나리오를 모킹한 방식이 적절한지 검토 부탁드립니다.

## 💱 트레이드 오프 결정 근거
- **네트워크 비용 vs 정합성**: 락을 잡기 위한 Redis 통신 비용이 발생하지만, 중복 알림으로 인한 외부 API(Discord) 호출 낭비와 운영상의 혼란을 방지하는 이득이 더 크다고 판단했습니다.
- **Lease Time 설정**: 모니터링 주기(5초)보다 짧은 락 점유 시간(4초)을 설정하여, 인스턴스 장애 시에도 다음 주기에서 즉시 다른 서버가 리더를 승계할 수 있도록 설계했습니다.

## ✅ 체크리스트
- [x] 분산 락 적용 후 단일 알림 발송 여부 확인
- [x] Spring Boot 3.4 `@MockitoBean` 정상 작동 확인
- [x] 락 획득 실패 시 예외가 외부로 전파되지 않고 조용히 스킵되는지 확인
- [x] 브랜치 네이밍 및 커밋 메시지 규칙 준수