### PR TITLE
refactor: 인메모리 성능 수집기를 표준 Micrometer 메트릭 체계로 전환

### DIFF
--- a/src/main/java/maple/expectation/aop/aspect/LoggingAspect.java
+++ b/src/main/java/maple/expectation/aop/aspect/LoggingAspect.java
@@ -21,25 +21,33 @@ public class LoggingAspect {
     public Object logExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
         long start = System.currentTimeMillis();
 
+        // ✅ 메서드 이름을 가져와서 통계의 구분값(testName)으로 사용합니다.
+        String methodName = joinPoint.getSignature().toShortString();
+
         try {
             return joinPoint.proceed();
         } finally {
             long executionTime = System.currentTimeMillis() - start;
-            statsCollector.addTime(executionTime);
+            // ✅ 수정: 이제 '어떤 메서드'의 소요 시간인지 이름을 함께 넘겨야 합니다.
+            statsCollector.addTime(methodName, executionTime);
         }
     }
 
-    // 💡 인터페이스 단순화: 수집기에서 직접 통계를 가져옴
     public String[] getStatistics(String testName) {
         return statsCollector.calculateStatistics(testName);
     }
 
+    /**
+     * 💡 수정: Micrometer 체계에서는 수동 reset이 권장되지 않으므로 삭제하거나
+     * 기능을 비워둡니다. (Prometheus가 시간 흐름에 따라 관리하기 때문)
+     */
     public void resetStatistics() {
-        statsCollector.reset();
+        log.warn("🔄 Micrometer 통계는 수동으로 리셋되지 않습니다. Prometheus 대시보드를 확인하세요.");
     }
 
     @PreDestroy
     public void printFinalStatistics() {
+        // ✅ 수정: 바뀐 메서드 시그니처에 맞춰 호출
         String[] stats = statsCollector.calculateStatistics("애플리케이션 전체 운영");
         log.info("========================================================");
         for (String stat : stats) {

--- a/src/main/java/maple/expectation/aop/collector/PerformanceStatisticsCollector.java
+++ b/src/main/java/maple/expectation/aop/collector/PerformanceStatisticsCollector.java
@@ -1,42 +1,53 @@
 package maple.expectation.aop.collector;
 
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.LongAdder;
+
+import java.util.concurrent.TimeUnit;
 
 @Component
+@RequiredArgsConstructor
 public class PerformanceStatisticsCollector {
 
-    // 💡 메모리 누수 방지: 큐를 버리고 누적 합산 필드(상수 메모리) 사용
-    private final LongAdder totalTimeAdder = new LongAdder();
-    private final LongAdder countAdder = new LongAdder();
-    private final AtomicLong maxTime = new AtomicLong(0);
+    private final MeterRegistry registry; // ✅ 스프링 표준 메트릭 저장소
 
-    public void addTime(long time) {
-        totalTimeAdder.add(time);
-        countAdder.increment();
-        // 💡 최대 응답 시간 갱신 (스레드 안전)
-        maxTime.updateAndGet(currentMax -> Math.max(currentMax, time));
+    /**
+     * ✅ JVM 내부 필드를 삭제하고 Micrometer Timer로 대체
+     * Timer는 내부적으로 count, sum, max를 모두 관리합니다.
+     */
+    public void addTime(String testName, long time) {
+        Timer.builder("nexon.api.performance") // 메트릭 이름
+                .tag("service", testName)        // 태그를 통해 인스턴스별/API별 구분 가능
+                .description("Nexon API 호출 성능 통계")
+                .register(registry)
+                .record(time, TimeUnit.MILLISECONDS);
     }
 
-    public void reset() {
-        totalTimeAdder.reset();
-        countAdder.reset();
-        maxTime.set(0);
-    }
-
+    /**
+     * ✅ Micrometer에서 집계된 데이터를 가져와 출력용 데이터로 변환
+     */
     public String[] calculateStatistics(String testName) {
-        long count = countAdder.sum();
-        long sum = totalTimeAdder.sum();
-        long max = maxTime.get();
-        double average = (count == 0) ? 0 : (double) sum / count;
+        Timer timer = registry.find("nexon.api.performance")
+                .tag("service", testName)
+                .timer();
+
+        if (timer == null) {
+            return new String[]{"🏆 [" + testName + "] 수집된 통계 데이터가 없습니다."};
+        }
+
+        long count = timer.count();
+        double totalTime = timer.totalTime(TimeUnit.MILLISECONDS);
+        double maxTime = timer.max(TimeUnit.MILLISECONDS);
+        double average = timer.mean(TimeUnit.MILLISECONDS);
 
         return new String[]{
-                String.format("🏆 [%s] 성능 통계:", testName),
+                String.format("🏆 [%s] 전역 성능 통계 (Micrometer):", testName),
                 String.format("- 총 호출 수: %d회", count),
-                String.format("- 총 소요 시간: %dms", sum),
+                String.format("- 총 소요 시간: %.0fms", totalTime),
                 String.format("- 평균 응답 시간: %.2fms", average),
-                String.format("- 최대 Latency: %dms", max)
+                String.format("- 최대 Latency: %.0fms", maxTime)
         };
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- #27

## 🗣 개요
기존 JVM 메모리(`LongAdder`)에 의존하던 성능 통계 수집 방식은 서버 증설(Scale-out) 시 데이터가 인스턴스별로 고립되고 휘발되는 한계가 있습니다. 이를 해결하기 위해 스프링 표준 메트릭 라이브러리인 Micrometer로 리팩토링을 수행했습니다.

## 🛠 작업 내용
- **JVM 상태 제거**: `LongAdder`, `AtomicLong` 등 로컬 필드 삭제 (Stateless화)
- **MeterRegistry 도입**: Micrometer `Timer`를 사용하여 호출 수, 합계, 최대 응답 시간 자동 관리
- **태그(Tag) 활용**: `testName`을 태그로 등록하여 다수의 API 통계를 전역적으로 식별 및 집계 가능하도록 개선

## 💬 리뷰 포인트
- `Timer.record()` 호출 시 단위(`TimeUnit.MILLISECONDS`)가 기존 로직과 일치하는지 확인 부탁드립니다.
- `calculateStatistics` 메서드가 UI나 로그 노출용으로 여전히 유효한지 검토 부탁드립니다.

## 💱 트레이드 오프 결정 근거
- **직접 구현 vs 표준**: 직접 구현한 `Collector`는 메모리 효율적(상수 메모리)이지만, 확장성이 없습니다. `Micrometer`는 약간의 오버헤드가 있을 수 있으나 Prometheus 등 외부 솔루션과의 연동성이 압도적이므로 전환을 결정했습니다.

## ✅ 체크리스트
- [x] JVM 메모리 내 가변 상태값 제거 확인
- [x] Micrometer를 통한 통계 데이터 정상 추출 확인
- [x] Scale-out 시 통합 모니터링이 가능한 구조인지 검토 완료