### PR TITLE
refactor: Scale-out 확장을 위한 전역 모니터링 전환 및 성능 메트릭 표준화

### DIFF
--- a/src/main/java/maple/expectation/global/error/CommonErrorCode.java
+++ b/src/main/java/maple/expectation/global/error/CommonErrorCode.java
@@ -18,7 +18,8 @@ public enum CommonErrorCode implements ErrorCode {
     DATABASE_TRANSACTION_FAILURE("S002", "치명적인 트랜잭션 오류가 발생했습니다: %s", HttpStatus.INTERNAL_SERVER_ERROR),
     DATA_INITIALIZATION_FAILED("S003", "데이터 초기화 실패 (대상: %s)", HttpStatus.INTERNAL_SERVER_ERROR),
     DATA_PROCESSING_ERROR("S004", "데이터 처리 중 오류 발생 (%s)", HttpStatus.INTERNAL_SERVER_ERROR),
-    EXTERNAL_API_ERROR("S005", "외부 API 호출 실패 (%s)", HttpStatus.SERVICE_UNAVAILABLE);
+    EXTERNAL_API_ERROR("S005", "외부 API 호출 실패 (%s)", HttpStatus.SERVICE_UNAVAILABLE),
+    SYSTEM_CAPACITY_EXCEEDED("S006", "시스템 부하가 임계치를 초과했습니다. (현재 대기량: %s)", HttpStatus.SERVICE_UNAVAILABLE);
 
 
     private final String code;

--- a/src/main/java/maple/expectation/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/maple/expectation/global/error/GlobalExceptionHandler.java
@@ -2,7 +2,7 @@ package maple.expectation.global.error;
 
 import lombok.extern.slf4j.Slf4j;
 import maple.expectation.global.error.dto.ErrorResponse;
-import maple.expectation.global.error.exception.BaseException;
+import maple.expectation.global.error.exception.base.BaseException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;

--- a/src/main/java/maple/expectation/global/error/dto/ErrorResponse.java
+++ b/src/main/java/maple/expectation/global/error/dto/ErrorResponse.java
@@ -2,7 +2,7 @@ package maple.expectation.global.error.dto;
 
 import lombok.Builder;
 import maple.expectation.global.error.ErrorCode;
-import maple.expectation.global.error.exception.BaseException;
+import maple.expectation.global.error.exception.base.BaseException;
 import org.springframework.http.ResponseEntity;
 
 import java.time.LocalDateTime;

--- a/src/main/java/maple/expectation/global/error/exception/MonitoringException.java
+++ b/src/main/java/maple/expectation/global/error/exception/MonitoringException.java
@@ -1,0 +1,19 @@
+package maple.expectation.global.error.exception;
+
+import maple.expectation.global.error.ErrorCode;
+import maple.expectation.global.error.exception.base.ServerBaseException;
+import maple.expectation.global.error.exception.marker.CircuitBreakerIgnoreMarker;
+
+/**
+ * MonitoringException: 시스템 모니터링 중 임계치 초과나 지표 이상 시 발생
+ */
+public class MonitoringException extends ServerBaseException implements CircuitBreakerIgnoreMarker {
+
+    public MonitoringException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public MonitoringException(ErrorCode errorCode, Object... args) {
+        super(errorCode, args);
+    }
+}

--- a/src/main/java/maple/expectation/global/error/exception/base/BaseException.java
+++ b/src/main/java/maple/expectation/global/error/exception/base/BaseException.java
@@ -1,4 +1,4 @@
-package maple.expectation.global.error.exception;
+package maple.expectation.global.error.exception.base;
 
 import lombok.Getter;
 import maple.expectation.global.error.ErrorCode;

--- a/src/main/java/maple/expectation/global/error/exception/base/ClientBaseException.java
+++ b/src/main/java/maple/expectation/global/error/exception/base/ClientBaseException.java
@@ -1,7 +1,6 @@
 package maple.expectation.global.error.exception.base;
 
 import maple.expectation.global.error.ErrorCode;
-import maple.expectation.global.error.exception.BaseException;
 
 /**
  * ClientBaseException: 사용자의 의도와 다를 때 발생하는 '비즈니스 예외'

--- a/src/main/java/maple/expectation/global/error/exception/base/ServerBaseException.java
+++ b/src/main/java/maple/expectation/global/error/exception/base/ServerBaseException.java
@@ -1,7 +1,6 @@
 package maple.expectation.global.error.exception.base;
 
 import maple.expectation.global.error.ErrorCode;
-import maple.expectation.global.error.exception.BaseException;
 
 /**
  * ServerBaseException: 시스템 내부 오류나 나의 오타로 인해 발생하는 '서버 예외'

--- a/src/main/java/maple/expectation/repository/v2/RedisBufferRepository.java
+++ b/src/main/java/maple/expectation/repository/v2/RedisBufferRepository.java
@@ -1,0 +1,36 @@
+package maple.expectation.repository.v2;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class RedisBufferRepository {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private static final String GLOBAL_PENDING_KEY = "buffer:likes:total_count";
+
+    /**
+     * ✅ 전역 카운터 증가 (로컬 버퍼에 쌓일 때 호출)
+     */
+    public void incrementGlobalCount(long delta) {
+        redisTemplate.opsForValue().increment(GLOBAL_PENDING_KEY, delta);
+    }
+
+    /**
+     * ✅ 전역 카운터 감소 (DB로 Flush 완료 시 호출)
+     */
+    public void decrementGlobalCount(long delta) {
+        redisTemplate.opsForValue().decrement(GLOBAL_PENDING_KEY, delta);
+    }
+
+    /**
+     * ✅ 전역 카운터 조회 (모니터링 서비스에서 호출)
+     */
+    public long getTotalPendingCount() {
+        Object count = redisTemplate.opsForValue().get(GLOBAL_PENDING_KEY);
+        if (count == null) return 0L;
+        return Long.parseLong(count.toString());
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- #27

## 🗣 개요
단일 서버 환경에 고립되어 있던 로컬 상태(인메모리 캐시, 로컬 통계)를 외부 저장소 및 표준 메트릭 체계로 전환하였습니다. 이를 통해 서버 증설(Scale-out) 시에도 데이터 정합성을 유지하고, 시스템 전체 부하를 정확히 감지할 수 있는 인프라 구조를 확립했습니다.

## 🛠 작업 내용
- **전역 모니터링 전환**: `MonitoringAlertService`가 로컬 캐시 대신 `RedisBufferRepository`의 전역 카운트를 조회하도록 수정
- **리더 선출 로직 적용**: `LockStrategy`를 활용하여 여러 인스턴스 중 단 한 대만 전역 수치를 체크하고 알림을 보내도록 설계 (알림 폭풍 방지)
- **성능 통계 표준화**: JVM 내부 필드(`LongAdder`) 기반 수집기를 `Micrometer`의 `MeterRegistry` 체계로 리팩토링하여 외부 모니터링 도구(Prometheus 등) 연동 기반 마련
- **구조화된 예외 도입**: 시스템 임계치 초과 시 발생하는 `MonitoringException`과 전용 에러 코드(`S006`)를 정의하여 알림 메시지 규격화

## 💬 리뷰 포인트
- `MonitoringAlertService`에서 `lockStrategy`를 통해 리더를 선출할 때, `waitTime: 0` 설정이 중복 알림을 방지하기에 적절한지 검토 부탁드립니다.
- `PerformanceStatisticsCollector`가 더 이상 상태를 가지지 않고 `MeterRegistry`에 의존하도록 바뀐 구조가 적절한지 확인 부탁드립니다.

## 💱 트레이드 오프 결정 근거
- **Redis 조회 비용 vs 정확도**: 전역 수치 조회를 위해 Redis 네트워크 통신이 추가되었으나, 트래픽 분산 시 발생하던 '모니터링 사각지대'를 해결하기 위해 반드시 필요한 비용이라 판단했습니다.
- **서킷 브레이커 설정**: `MonitoringException`은 내부 자원 포화 신호이므로 외부 API 장애와 분리하기 위해 서킷 브레이커의 실패율 산정에서 제외(Ignore)하도록 정책을 수립했습니다.

## ✅ 체크리스트
- [x] 모든 단위/통합 테스트 통과 확인
- [x] `@MockitoBean`을 이용한 리더 선출 및 알림 로직 검증 완료
- [x] 커밋 메시지 및 브랜치 네이밍 규칙 준수
- [x] 불필요해진 로컬 상태 필드(LongAdder 등) 제거 완료