### PR TITLE
refactor: 분산 환경 대응을 위한 데이터 정합성 확보 및 가시성 고도화

### DIFF
--- a/src/main/java/maple/expectation/global/resilience/DistributedCircuitBreakerManager.java
+++ b/src/main/java/maple/expectation/global/resilience/DistributedCircuitBreakerManager.java
@@ -1,0 +1,52 @@
+package maple.expectation.global.resilience;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import jakarta.annotation.PostConstruct;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DistributedCircuitBreakerManager {
+
+    private final CircuitBreakerRegistry registry;
+    private final StringRedisTemplate redisTemplate;
+    private static final String CHANNEL_NAME = "cb-state-sync";
+
+    @PostConstruct
+    public void init() {
+        // 1. 기존에 이미 생성된 서킷 브레이커들에 리스너 등록
+        registry.getAllCircuitBreakers().forEach(this::registerEventListener);
+
+        // ✅ 2. 핵심 수정: 향후 "새롭게 생성되는" 서킷 브레이커에도 자동으로 리스너 등록
+        registry.getEventPublisher().onEntryAdded(event -> {
+            CircuitBreaker addedCb = event.getAddedEntry();
+            log.info("🆕 [CB Sync] 새 서킷 브레이커 감지 및 리스너 등록: {}", addedCb.getName());
+            registerEventListener(addedCb);
+        });
+    }
+
+    private void registerEventListener(CircuitBreaker cb) {
+        cb.getEventPublisher().onStateTransition(event -> {
+            String state = event.getStateTransition().getToState().name();
+            // 상태가 OPEN으로 변할 때만 Redis 전파
+            if ("OPEN".equals(state)) {
+                log.info("📢 [CB Sync] 서킷 열림 감지 -> 전역 전파: {}", cb.getName());
+                redisTemplate.convertAndSend(CHANNEL_NAME, cb.getName() + ":" + state);
+            }
+        });
+    }
+
+    public void syncState(String message) {
+        String[] parts = message.split(":");
+        String cbName = parts[0];
+        // 수신 시 로컬 서킷 강제 오픈
+        registry.circuitBreaker(cbName).transitionToOpenState();
+        log.warn("🔄 [CB Sync] 전역 신호 수신: {} 서킷 강제 오픈", cbName);
+    }
+}

--- a/src/main/java/maple/expectation/repository/v2/RedisBufferRepository.java
+++ b/src/main/java/maple/expectation/repository/v2/RedisBufferRepository.java
@@ -1,36 +1,44 @@
 package maple.expectation.repository.v2;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
 public class RedisBufferRepository {
 
-    private final RedisTemplate<String, Object> redisTemplate;
+    private final StringRedisTemplate redisTemplate;
     private static final String GLOBAL_PENDING_KEY = "buffer:likes:total_count";
 
     /**
-     * ✅ 전역 카운터 증가 (로컬 버퍼에 쌓일 때 호출)
+     * ✅ 전역 카운터 증가 (L1 -> L2 전송 시 호출)
      */
     public void incrementGlobalCount(long delta) {
         redisTemplate.opsForValue().increment(GLOBAL_PENDING_KEY, delta);
     }
 
     /**
-     * ✅ 전역 카운터 감소 (DB로 Flush 완료 시 호출)
+     * ✅ [추가됨] 전역 카운터 감소 (L2 -> L3 동기화 성공 시 호출)
      */
     public void decrementGlobalCount(long delta) {
+        // 성공적으로 DB에 반영된 수량만큼 전역 카운터에서 차감합니다.
         redisTemplate.opsForValue().decrement(GLOBAL_PENDING_KEY, delta);
     }
 
     /**
-     * ✅ 전역 카운터 조회 (모니터링 서비스에서 호출)
+     * ✅ 전역 카운터 조회 (모니터링용)
      */
     public long getTotalPendingCount() {
-        Object count = redisTemplate.opsForValue().get(GLOBAL_PENDING_KEY);
-        if (count == null) return 0L;
-        return Long.parseLong(count.toString());
+        String count = redisTemplate.opsForValue().get(GLOBAL_PENDING_KEY);
+        return (count == null) ? 0L : Long.parseLong(count);
+    }
+
+    /**
+     * 💡 참고: 만약 rename 전략이 아닌 getAndSet 전략을 쓴다면 아래 메서드를 사용합니다.
+     */
+    public long getAndClearGlobalCount() {
+        String count = redisTemplate.opsForValue().getAndSet(GLOBAL_PENDING_KEY, "0");
+        return (count == null) ? 0L : Long.parseLong(count);
     }
 }

--- a/src/main/java/maple/expectation/service/v2/LikeSyncService.java
+++ b/src/main/java/maple/expectation/service/v2/LikeSyncService.java
@@ -4,11 +4,13 @@ import io.github.resilience4j.retry.Retry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import maple.expectation.aop.annotation.ObservedTransaction;
+import maple.expectation.repository.v2.RedisBufferRepository;
 import maple.expectation.service.v2.cache.LikeBufferStorage;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 
 @Slf4j
@@ -19,21 +21,70 @@ public class LikeSyncService {
     private final LikeBufferStorage likeBufferStorage;
     private final LikeSyncExecutor syncExecutor;
     private final StringRedisTemplate redisTemplate;
+    private final RedisBufferRepository redisBufferRepository;
     private final Retry likeSyncRetry;
 
     private static final String REDIS_HASH_KEY = "buffer:likes";
 
+    /**
+     * ✅ L1(Caffeine) -> L2(Redis) 전송
+     */
     public void flushLocalToRedis() {
         Map<String, AtomicLong> snapshot = likeBufferStorage.getCache().asMap();
         if (snapshot.isEmpty()) return;
         snapshot.forEach(this::processLocalBufferEntry);
     }
 
+    /**
+     * 💡 [Issue #28 해결] L2(Redis) -> L3(DB) 최종 동기화
+     * 원자적 Rename 전략과 부분 성공 집계 로직을 적용했습니다.
+     */
     @ObservedTransaction("scheduler.like.redis_to_db")
     public void syncRedisToDatabase() {
-        Map<Object, Object> entries = fetchRedisEntries();
-        if (entries.isEmpty()) return;
-        entries.forEach((key, value) -> syncWithRetry((String) key, Long.parseLong((String) value)));
+        // 1. 작업 격리를 위한 임시 키 생성 (UUID 활용)
+        String tempKey = REDIS_HASH_KEY + ":sync:" + UUID.randomUUID();
+
+        try {
+            // 2. 처리할 데이터가 있는지 확인
+            Boolean hasKey = redisTemplate.hasKey(REDIS_HASH_KEY);
+            if (Boolean.FALSE.equals(hasKey)) return;
+
+            // 3. [Atomic Rename] 원본 버퍼를 나만 아는 임시 키로 이동
+            redisTemplate.rename(REDIS_HASH_KEY, tempKey);
+
+            Map<Object, Object> entries = redisTemplate.opsForHash().entries(tempKey);
+            if (entries.isEmpty()) return;
+
+            // ✅ 4. 실제 성공한 총 수량을 추적 (AtomicLong 사용)
+            AtomicLong actualSuccessTotal = new AtomicLong(0);
+
+            entries.forEach((key, value) -> {
+                String userIgn = (String) key;
+                long count = Long.parseLong((String) value);
+
+                // ✅ 5. 개별 데이터 반영 시도 및 결과 확인
+                if (syncWithRetry(userIgn, count)) {
+                    actualSuccessTotal.addAndGet(count);
+                } else {
+                    // ❌ 6. 실패 시 데이터 유실 방지를 위해 원본 버퍼(REDIS_HASH_KEY)로 복구
+                    redisTemplate.opsForHash().increment(REDIS_HASH_KEY, userIgn, count);
+                    log.warn("♻️ [Sync Recovery] DB 반영 실패로 데이터 Redis 복구: {} ({}건)", userIgn, count);
+                }
+            });
+
+            // ✅ 7. 실제로 성공한 수량만큼만 전역 카운터에서 차감 (1704 문제 해결)
+            long totalToDecrement = actualSuccessTotal.get();
+            if (totalToDecrement > 0) {
+                redisBufferRepository.decrementGlobalCount(totalToDecrement);
+                log.info("✅ [Sync Success] 총 {}건의 좋아요가 DB에 반영되었습니다.", totalToDecrement);
+            }
+
+            // 8. 처리가 끝난 임시 키 삭제
+            redisTemplate.delete(tempKey);
+
+        } catch (Exception e) {
+            log.error("⚠️ [Sync Logic Error] 동기화 프로세스 중 치명적 오류: {}", e.getMessage());
+        }
     }
 
     private void processLocalBufferEntry(String userIgn, AtomicLong atomicCount) {
@@ -41,6 +92,7 @@ public class LikeSyncService {
         if (count <= 0) return;
         try {
             redisTemplate.opsForHash().increment(REDIS_HASH_KEY, userIgn, count);
+            redisBufferRepository.incrementGlobalCount(count);
         } catch (Exception e) {
             handleRedisFailure(userIgn, count, e);
         }
@@ -56,19 +108,18 @@ public class LikeSyncService {
         }
     }
 
-    private Map<Object, Object> fetchRedisEntries() {
-        try { return redisTemplate.opsForHash().entries(REDIS_HASH_KEY); }
-        catch (Exception e) { return Map.of(); }
-    }
-
-    private void syncWithRetry(String userIgn, long count) {
+    /**
+     * 💡 리턴 타입을 boolean으로 변경하여 성공 여부를 반환합니다.
+     */
+    private boolean syncWithRetry(String userIgn, long count) {
         try {
             Retry.decorateRunnable(likeSyncRetry, () -> {
                 syncExecutor.executeIncrement(userIgn, count);
-                redisTemplate.opsForHash().increment(REDIS_HASH_KEY, userIgn, -count);
             }).run();
+            return true; // 성공 시 true
         } catch (Exception e) {
-            log.error("❌ [L2->L3 Sync] 최종 실패: {}", userIgn);
+            log.error("❌ [L2->L3 Sync] 재시도 후 최종 실패: {}", userIgn);
+            return false; // 실패 시 false
         }
     }
 }

--- a/src/test/java/maple/expectation/concurrency/LikeConcurrencyTest.java
+++ b/src/test/java/maple/expectation/concurrency/LikeConcurrencyTest.java
@@ -10,6 +10,7 @@ import maple.expectation.service.v2.LikeSyncService; // 💡 추가
 import maple.expectation.support.SpringBootTestWithTimeLogging;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.UUID;

--- a/src/test/java/maple/expectation/global/resilience/DistributedCircuitBreakerTest.java
+++ b/src/test/java/maple/expectation/global/resilience/DistributedCircuitBreakerTest.java
@@ -1,0 +1,67 @@
+package maple.expectation.global.resilience;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import maple.expectation.mornitering.MonitoringAlertService;
+import maple.expectation.repository.v2.RedisBufferRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@SpringBootTest
+class DistributedCircuitBreakerTest {
+
+    @Autowired
+    private CircuitBreakerRegistry registry;
+
+    @Autowired
+    private DistributedCircuitBreakerManager manager;
+
+    @MockitoBean
+    private StringRedisTemplate redisTemplate; // 발행 여부 확인용
+
+    // 💡 핵심: 테스트와 직접 관계없는 빈들을 Mock으로 대체하여 컨텍스트 로딩 에러를 방지합니다.
+    @MockitoBean
+    private MonitoringAlertService monitoringAlertService;
+
+    @MockitoBean
+    private RedisBufferRepository redisBufferRepository;
+
+    @Test
+    @DisplayName("로컬 서킷이 OPEN으로 변하면 Redis 채널로 상태 변경 메시지를 발행한다")
+    void localOpen_ShouldPublishToRedis() {
+        // Given
+        CircuitBreaker cb = registry.circuitBreaker("nexonApiClient");
+        cb.transitionToClosedState(); // ✅ 확실하게 CLOSED 상태에서 시작
+
+        // When: 서킷 상태를 강제로 OPEN으로 변경 (이때 이벤트가 터져야 함)
+        cb.transitionToOpenState();
+
+        // Then: 리스너가 동작하여 Redis로 메시지를 보냈는지 확인
+        verify(redisTemplate, times(1))
+                .convertAndSend(eq("cb-state-sync"), eq("nexonApiClient:OPEN"));
+    }
+
+    @Test
+    @DisplayName("Redis 메시지를 수신하면 해당 서킷의 상태를 OPEN으로 강제 전환한다")
+    void receivedRedisMessage_ShouldTransitionToOpen() {
+        // Given
+        String cbName = "nexonApiClient";
+        CircuitBreaker cb = registry.circuitBreaker(cbName);
+        cb.transitionToClosedState(); // 초기 상태: CLOSED
+
+        // When: 매니저의 syncState를 직접 호출 (Redis 메시지 수신 상황 시뮬레이션)
+        manager.syncState(cbName + ":OPEN");
+
+        // Then: 로컬 서킷 상태가 OPEN으로 변했는지 확인
+        assertThat(cb.getState()).isEqualTo(CircuitBreaker.State.OPEN);
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -69,4 +69,4 @@ app:
     use-compression: false
   aop:
     trace:
-      enabled: true
+      enabled: false


### PR DESCRIPTION
## 🔗 관련 이슈
- #27

## 🗣 개요
단일 서버 환경의 한계를 극복하고, Scale-out 환경에서도 데이터 정합성을 유지하며 시스템 전반의 상태를 관찰할 수 있도록 아키텍처를 고도화했습니다. 특히 동시성 테스트 중 발견된 데이터 중복 반영 문제를 원자적 연산을 통해 해결했습니다.

## 🛠 작업 내용
- **좋아요 동기화 원자성 확보**: Redis `rename` 명령어를 이용해 처리 대상 데이터를 격리하고, 실제 DB 반영 성공 수량만 전역 카운터에서 차감하도록 개선
- **분산 서킷 브레이커 동기화**: Redis Pub/Sub을 활용해 특정 인스턴스의 서킷 오픈 상태를 전역 인스턴스에 즉시 전파하는 `DistributedCircuitBreakerManager` 구현
- **전역 모니터링 전환**: 로컬 Caffeine 캐시 기반 통계를 Redis 전역 카운터 및 Micrometer(`MeterRegistry`) 표준 체계로 전환하여 시스템 가시성 확보
- **분산 로그 추적(MDC)**: 외부 유입 `X-Correlation-ID` 헤더를 계승하거나 생성하는 구조로 개선하여 서버 간 요청 흐름 추적 가능화
- **장애 내성 강화**: DB 반영 실패 시 데이터를 Redis 버퍼로 다시 복구하는 로직을 추가하여 데이터 유실 방지

## 💬 리뷰 포인트
- `LikeSyncService`에서 `rename`을 통해 임시 키로 데이터를 옮긴 후 처리하는 과정이 레이스 컨디션을 완벽히 방어하는지 검토 부탁드립니다.
- 실패한 데이터를 `increment`를 통해 다시 원본 버퍼로 되돌리는 복구 로직의 적절성을 확인 부탁드립니다.

## 💱 트레이드 오프 결정 근거
- **네트워크 비용 vs 정합성**: Redis와의 추가 교신이 발생하지만, 분산 환경에서 '좋아요' 수치가 튀는 비즈니스 오류를 막기 위해 원자적 연산(`rename`, `getAndSet`) 도입이 필수적이라 판단했습니다.
- **스케줄러 비활성화**: 테스트 시 `spring.task.scheduling.enabled=false` 설정을 통해 외부 요인을 통제하고 순수 로직의 정합성을 검증하는 방식을 채택했습니다.

## ✅ 체크리스트
- [x] 1,000건 동시 요청 테스트 시 DB 최종 값 1,000건 확인 (정합성 검증 완료)
- [x] 분산 서킷 브레이커 상태 전파 유닛 테스트 통과
- [x] 실패 시나리오에서 전역 카운터가 차감되지 않고 데이터가 복구되는지 확인
- [x] 브랜치 네이밍 및 커밋 메시지 규칙 준수