### PR TITLE
fix: 분산 락 경합 최적화 및 DB 커넥션 풀 고갈 문제 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,12 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation platform('org.testcontainers:testcontainers-bom:1.19.3')
+    testImplementation "org.testcontainers:testcontainers"
+    testImplementation "org.testcontainers:junit-jupiter"
+    testImplementation "org.testcontainers:mysql"
+    testImplementation "org.testcontainers:toxiproxy"
+
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     testCompileOnly 'org.projectlombok:lombok'
@@ -72,4 +78,16 @@ tasks.named('test') {
 
 tasks.named("jar") {
     enabled = false
+}
+
+test {
+    useJUnitPlatform()
+
+    // WSL에서 확인된 "진짜" Docker Engine API 소켓
+    environment "DOCKER_HOST", "unix:///var/run/docker.sock"
+
+    testLogging {
+        showStandardStreams = true
+        exceptionFormat = "full"
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -69,7 +69,7 @@ resilience4j:
 
 logging:
   level:
-    org.springframework.cache: TRACE
+    org.springframework.cache: INFO
     maple.expectation.aop.aspect: INFO
     root: info
     org.hibernate.SQL: info

--- a/src/test/java/maple/expectation/support/AbstractContainerBaseTest.java
+++ b/src/test/java/maple/expectation/support/AbstractContainerBaseTest.java
@@ -1,0 +1,83 @@
+package maple.expectation.support;
+
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.ToxiproxyContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import java.time.Duration;
+
+/**
+ * 🚀 모든 통합 테스트의 부모 클래스 (Testcontainers 기반)
+ */
+public abstract class AbstractContainerBaseTest {
+
+    protected static final Network NETWORK = Network.newNetwork();
+
+    protected static final MySQLContainer<?> MYSQL;
+    protected static final GenericContainer<?> REDIS;
+    protected static final ToxiproxyContainer TOXIPROXY;
+
+    protected static ToxiproxyContainer.ContainerProxy redisProxy;
+
+    static {
+        // Docker 환경 강제 (WSL 환경 안정화 목적)
+        System.setProperty("docker.host", "unix:///var/run/docker.sock");
+        System.setProperty(
+                "docker.client.strategy",
+                "org.testcontainers.dockerclient.UnixSocketClientProviderStrategy"
+        );
+
+        // 1) MySQL
+        MYSQL = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"))
+                .withDatabaseName("maple_expectation")
+                .withUsername("root")
+                .withPassword("1234")
+                .withNetwork(NETWORK)
+                .waitingFor(Wait.forLogMessage(".*ready for connections.*\\s", 2))
+                .withStartupTimeout(Duration.ofMinutes(2));
+
+        // 2) Redis
+        REDIS = new GenericContainer<>(DockerImageName.parse("redis:7.0"))
+                .withExposedPorts(6379)
+                .withNetwork(NETWORK)
+                .withNetworkAliases("redis-server")
+                .waitingFor(Wait.forListeningPort())
+                .withStartupTimeout(Duration.ofMinutes(1));
+
+        // 3) Toxiproxy
+        TOXIPROXY = new ToxiproxyContainer(DockerImageName.parse("ghcr.io/shopify/toxiproxy:2.5.0"))
+                .withNetwork(NETWORK)
+                .waitingFor(Wait.forListeningPort())
+                .withStartupTimeout(Duration.ofMinutes(1));
+
+        // 컨테이너 시작
+        MYSQL.start();
+        REDIS.start();
+        TOXIPROXY.start();
+
+        // redis-server(네트워크 alias) -> toxiproxy 프록시 생성
+        redisProxy = TOXIPROXY.getProxy("redis-server", 6379);
+    }
+
+    @DynamicPropertySource
+    static void setProperties(DynamicPropertyRegistry registry) {
+        // MySQL
+        registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL::getUsername);
+        registry.add("spring.datasource.password", MYSQL::getPassword);
+        registry.add("spring.datasource.driver-class-name", () -> "com.mysql.cj.jdbc.Driver");
+
+        // ✅ Redis: 애플리케이션은 "Toxiproxy(호스트) + 프록시 포트(호스트 포트)"로 접속해야 함
+        registry.add("spring.data.redis.host", TOXIPROXY::getHost);
+        registry.add("spring.data.redis.port", redisProxy::getProxyPort); // ✅ 핵심 수정 (getMappedPort로 감싸지 말 것)
+
+        // (선택) Redisson/레거시 설정이 spring.redis.* 를 참조하는 경우 대비
+        registry.add("spring.redis.host", TOXIPROXY::getHost);
+        registry.add("spring.redis.port", redisProxy::getProxyPort);
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
#98 

## 🗣 개요
500명 동시 접속 부하 테스트 중 발생한 시스템 마비 현상(커넥션 풀 고갈 및 락 타임아웃)을 해결하기 위한 긴급 성능 최적화 작업입니다.

## 🛠 작업 내용
- **AOP 로직 다이어트**: `NexonDataCacheAspect`에서 분산 락을 획득하기 전에 호출하던 `cacheService.getValidCache(ocid)` 로직을 제거했습니다. (500개의 스레드가 동시에 커넥션을 점유하는 현상 해결)
- **Double Check 전략 도입**: 락을 획득한 스레드만 DB를 확인하고, 데이터가 있으면 즉시 반환하도록 개선하여 외부 API 호출을 최소화했습니다.
- **AOP 우선순위 조정**: `@Order(Ordered.LOWEST_PRECEDENCE)`를 적용하여 `@Cacheable` 레이어에서 먼저 처리된 요청은 락 레이어까지 도달하지 않도록 흐름을 개선했습니다.
- **로그 병목 제거**: 테스트 시 CPU 부하의 원인이 된 `TRACE` 레벨 로그를 `INFO`로 조정했습니다.

## 💬 리뷰 포인트
- 락 획득 전에 트랜잭션이 시작되지 않도록 보장되었는지 확인 부탁드립니다.
- `executeWithLock` 내부에서 `joinPoint.proceed()`가 실행될 때 발생할 수 있는 예외 처리가 적절한지 검토 부탁드립니다.

## 💱 트레이드 오프 결정 근거
- **정합성 vs 가용성**: 락 밖에서 캐시를 한 번 더 체크하면 성능은 미세하게 좋아지나, 500명이 몰리는 상황에서는 DB 커넥션을 500개나 소모하는 리스크가 더 크다고 판단하여 '락 선점 후 체크' 방식으로 변경했습니다.

## ✅ 체크리스트
- [x] 500명 동접 부하 테스트 시 에러율 0% 확인
- [x] 분산 락 획득 실패 시 비즈니스 예외(S002) 정상 발생 확인
- [x] 커밋 컨벤션 준수 여부