### PR TITLE
fix(aop): 분산 락 재시도 메커니즘 도입 및 커넥션 풀 병목 현상 해결

### DIFF
--- a/src/main/java/maple/expectation/aop/aspect/NexonDataCacheAspect.java
+++ b/src/main/java/maple/expectation/aop/aspect/NexonDataCacheAspect.java
@@ -1,5 +1,6 @@
 package maple.expectation.aop.aspect;
 
+import io.github.resilience4j.retry.annotation.Retry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import maple.expectation.external.dto.v2.EquipmentResponse;
@@ -27,6 +28,7 @@ public class NexonDataCacheAspect {
     private final LockStrategy lockStrategy;
 
     @Around("@annotation(maple.expectation.aop.annotation.NexonDataCache) && args(ocid, ..)")
+    @Retry(name = "nexonLockRetry")
     public Object handleNexonCache(ProceedingJoinPoint joinPoint, String ocid) throws Throwable {
         MethodSignature signature = (MethodSignature) joinPoint.getSignature();
         Class<?> returnType = signature.getReturnType();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -66,6 +66,11 @@ resilience4j:
           - java.util.concurrent.TimeoutException
           - org.springframework.web.reactive.function.client.WebClientRequestException # 네트워크 단절 대응
           - java.net.UnknownHostException
+      nexonLockRetry:
+        maxAttempts: 5             # 최대 5번 시도 (락 경합이 심할 때를 대비해 조금 넉넉히)
+        waitDuration: 200ms        # 0.2초 간격으로 다시 시도
+        retryExceptions:           # 이 예외가 발생했을 때만 재시도함
+          - maple.expectation.global.error.exception.DistributedLockException
 
 logging:
   level:


### PR DESCRIPTION
## 🔗 관련 이슈
#98

## 🗣 개요
운영 환경(`master`)의 부하 테스트 중 확인된 V3 엔진의 락 경합(Lock Contention) 및 그로 인한 DB 커넥션 풀 고갈 문제를 해결하기 위한 긴급 패치입니다.

## 🛠 작업 내용
- **재시도 로직(Retry) 도입**: `Resilience4j`의 `@Retry`를 `NexonDataCacheAspect`에 적용하여, 락 획득 실패 시 즉시 에러를 반환하지 않고 5회 재시도하도록 개선했습니다.
- **Connection Pool 보호**: 락 획득 전 실행되던 `@Transactional` 기반의 DB 조회 로직을 제거했습니다. 이를 통해 락 대기 스레드가 불필요하게 DB 커넥션을 점유하여 시스템이 마비되는 현상을 차단했습니다.
- **AOP 실행 순서 최적화**: `@Order(Ordered.LOWEST_PRECEDENCE)`를 적용하여 `@Cacheable` 레이어(L1/L2)에서 처리 가능한 요청이 락 레이어에 진입하지 않도록 보장했습니다.
- **설정 최적화**: `application.yml`에 락 전용 리트라이 전략(`nexonLockRetry`)을 추가했습니다.

## 💬 리뷰 포인트
- 락 획득 전에 트랜잭션이 시작되지 않도록 보장되어 HikariPool을 안전하게 보호하는지 확인 부탁드립니다.
- 락 내부의 `Double Check` 로직이 외부 API 중복 호출을 성공적으로 방어하는지 검토가 필요합니다.

## 💱 트레이드 오프 결정 근거
- **가용성 최우선**: 락 대기 시간을 무작정 늘리는 대신, 짧은 주기의 재시도(Retry) 메커니즘을 도입했습니다. 이는 일시적인 경합을 해소함과 동시에 락 획득 실패 시 빠르게 제어권을 반환하여 서버 전체의 가용성을 유지하기 위함입니다.

## ✅ 체크리스트
- [x] 500명 동시 접속 테스트 시 락 타임아웃 에러 0건 확인
- [x] 락 획득 전 DB 커넥션을 점유하지 않는지 로그 검증 완료
- [x] 커밋 컨벤션(타입 영어, 제목 한글) 준수 완료