### PR TITLE
fix(aop): 분산 락 경합 최적화 및 가용성 확보를 위한 Fallback 전략 도입

### DIFF
--- a/src/main/java/maple/expectation/aop/aspect/NexonDataCacheAspect.java
+++ b/src/main/java/maple/expectation/aop/aspect/NexonDataCacheAspect.java
@@ -4,6 +4,7 @@ import io.github.resilience4j.retry.annotation.Retry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import maple.expectation.external.dto.v2.EquipmentResponse;
+import maple.expectation.global.error.exception.DistributedLockException;
 import maple.expectation.global.lock.LockStrategy;
 import maple.expectation.service.v2.cache.EquipmentCacheService;
 import org.aspectj.lang.ProceedingJoinPoint;
@@ -21,7 +22,7 @@ import java.util.concurrent.CompletableFuture;
 @Aspect
 @Component
 @RequiredArgsConstructor
-@Order(Ordered.LOWEST_PRECEDENCE)
+@Order(Ordered.LOWEST_PRECEDENCE) // 캐시(@Cacheable)가 먼저 실행되도록 우선순위를 낮춤
 public class NexonDataCacheAspect {
 
     private final EquipmentCacheService cacheService;
@@ -33,37 +34,55 @@ public class NexonDataCacheAspect {
         MethodSignature signature = (MethodSignature) joinPoint.getSignature();
         Class<?> returnType = signature.getReturnType();
 
-        // ❌ [삭제] 락 획득 전 DB 조회(getValidCache)는 커넥션 풀 고갈의 주범입니다.
+        try {
+            // 1. [Lock Path] 분산 락 획득 시도 (실패 시 Retry 설정에 따라 재시도)
+            return lockStrategy.executeWithLock(ocid, () -> {
 
-        // 1. 바로 분산 락부터 획득 시도
-        // 락을 기다리는 동안은 DB 커넥션을 잡지 않으므로 500명이 대기해도 안전합니다.
-        return lockStrategy.executeWithLock(ocid, () -> {
+                // 2. [Double Check] 락 획득 성공 후, 다른 스레드가 이미 채워둔 캐시가 있는지 확인
+                Optional<EquipmentResponse> latest = cacheService.getValidCache(ocid);
+                if (latest.isPresent()) {
+                    log.info("🎯 [Lock Winner - Cache Hit] ocid: {}", ocid);
+                    return wrapResponse(latest.get(), returnType);
+                }
 
-            // 2. 락 획득 후 딱 한 명만 DB(L3) 확인 (Double Check)
-            Optional<EquipmentResponse> latest = cacheService.getValidCache(ocid);
-            if (latest.isPresent()) {
-                log.info("🎯 [Lock Winner - Cache Hit] ocid: {}", ocid);
-                return wrapResponse(latest.get(), returnType);
-            }
+                // 3. [Miss Path] 락 승리자가 직접 API 호출 및 캐시 갱신
+                log.info("🔄 [Lock Winner - Cache Miss] API 직접 호출 시작: {}", ocid);
+                return proceedAndSave(joinPoint, ocid, returnType);
+            });
 
-            log.info("🔄 [Lock Winner - Cache Miss] API 호출 시작: {}", ocid);
-            Object result = joinPoint.proceed();
-
-            // 3. 비동기/동기 결과 저장 로직 (기존 유지)
-            if (CompletableFuture.class.isAssignableFrom(returnType)) {
-                return ((CompletableFuture<?>) result).thenApply(res -> {
-                    cacheService.saveCache(ocid, (EquipmentResponse) res);
-                    return res;
-                });
-            }
-
-            cacheService.saveCache(ocid, (EquipmentResponse) result);
-            return result;
-        });
+        } catch (DistributedLockException e) {
+            // 🚀 [Fallback Path] 5번의 리트라이 후에도 락을 못 잡은 경우 (S002 방지)
+            // 에러를 던져서 사용자를 튕기게 하는 대신, 그냥 원본 데이터를 직접 호출하게 우회합니다.
+            log.warn("⚠️ [Lock Timeout Fallback] 락 경합 과다로 직접 호출을 선택합니다: {}", ocid);
+            return proceedAndSave(joinPoint, ocid, returnType);
+        }
     }
 
     /**
-     * 캐시된 데이터를 메서드의 반환 타입에 맞게 래핑합니다.
+     * 실제 타겟 메서드(API 호출)를 실행하고 결과를 캐시에 저장하는 공통 로직
+     */
+    private Object proceedAndSave(ProceedingJoinPoint joinPoint, String ocid, Class<?> returnType) throws Throwable {
+        Object result = joinPoint.proceed();
+
+        // 비동기 처리(CompletableFuture) 대응
+        if (CompletableFuture.class.isAssignableFrom(returnType)) {
+            return ((CompletableFuture<?>) result).thenApply(res -> {
+                if (res instanceof EquipmentResponse) {
+                    cacheService.saveCache(ocid, (EquipmentResponse) res);
+                }
+                return res;
+            });
+        }
+
+        // 동기 처리 대응
+        if (result instanceof EquipmentResponse) {
+            cacheService.saveCache(ocid, (EquipmentResponse) result);
+        }
+        return result;
+    }
+
+    /**
+     * 캐시된 데이터를 메서드의 반환 타입(동기/비동기)에 맞게 래핑
      */
     private Object wrapResponse(EquipmentResponse response, Class<?> returnType) {
         if (CompletableFuture.class.isAssignableFrom(returnType)) {

--- a/src/main/java/maple/expectation/global/error/exception/base/BaseException.java
+++ b/src/main/java/maple/expectation/global/error/exception/base/BaseException.java
@@ -21,4 +21,10 @@ public abstract class BaseException extends RuntimeException {
         this.errorCode = errorCode;
         this.message = String.format(errorCode.getMessage(), args);
     }
+
+    public BaseException(ErrorCode errorCode, Throwable cause, Object... args) {
+        super(String.format(errorCode.getMessage(), args), cause);
+        this.errorCode = errorCode;
+        this.message = String.format(errorCode.getMessage(), args);
+    }
 }

--- a/src/main/java/maple/expectation/global/error/exception/base/ServerBaseException.java
+++ b/src/main/java/maple/expectation/global/error/exception/base/ServerBaseException.java
@@ -16,4 +16,14 @@ public abstract class ServerBaseException extends BaseException {
     public ServerBaseException(ErrorCode errorCode, Object... args) {
         super(errorCode, args);
     }
+
+    // 🚀 [추가] 실제 에러(cause)를 포함하여 디버깅 정보 확보
+    public ServerBaseException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode, cause);
+    }
+
+    // 🚀 [추가] 상세 메시지(args)와 실제 에러(cause)를 동시에 기록
+    public ServerBaseException(ErrorCode errorCode, Throwable cause, Object... args) {
+        super(errorCode, cause, args);
+    }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
#98

## 🗣 개요
부하 테스트(500 CCU) 중 특정 캐릭터(Hot Key)에 요청이 몰릴 때 발생하는 락 타임아웃(S002) 문제를 해결하고, 시스템의 전체 가용성을 확보하기 위한 긴급 최적화 작업입니다.

## 🛠 작업 내용
- **재시도 메커니즘(Retry) 강화**: `Resilience4j`의 `@Retry`를 AOP 레이어에 적용하여 락 경합 발생 시 즉시 실패하지 않고 재시도하도록 개선했습니다.
- **전략적 우회(Fallback) 도입**: 설정된 리트라이 횟수를 초과하더라도 에러를 던지는 대신, API를 직접 호출하여 응답을 보장하는 Fallback 로직을 구현했습니다.
- **커넥션 풀(HikariPool) 보호**: 락 획득 전에 수행되던 트랜잭션 조회를 제거하여, 대기 중인 스레드가 DB 커넥션을 점유하지 않도록 구조를 변경했습니다.
- **예외 체이닝 및 디버깅 강화**: `ServerBaseException`을 수정하여 원인 예외(`cause`)의 Stacktrace가 보존되도록 개선했습니다.

## 💬 리뷰 포인트
- 락 실패 시 수행되는 `proceedAndSave` 메서드가 동기/비동기 반환 타입을 정확히 처리하는지 검토 부탁드립니다.
- `Catch` 블록에서 `DistributedLockException` 발생 시 Fallback 로직으로의 전환이 매끄러운지 확인이 필요합니다.

## 💱 트레이드 오프 결정 근거
- **데이터 정합성 vs 가용성**: 모든 요청에 대해 엄격하게 락을 강제하기보다, 극심한 경합 상황에서는 직접 호출을 허용(Fallback)함으로써 사용자에게 에러 대신 데이터를 전달하는 '가용성' 중심의 설계를 선택했습니다. 외부 API 부하는 기존에 구축한 `Resilience4j`가 방어합니다.

## ✅ 체크리스트
- [x] 500명 동시 접속 부하 테스트 시 에러율 0% 달성 확인
- [x] 락 타임아웃 발생 시 에러 대신 Fallback 로그와 함께 정상 응답 확인
- [x] 커밋 메시지 및 브랜치 네이밍 컨벤션 준수