### PR TITLE
feat: 분산 락 도입 및 캐릭터 조회 성능 최적화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,9 +85,4 @@ test {
 
     // WSL에서 확인된 "진짜" Docker Engine API 소켓
     environment "DOCKER_HOST", "unix:///var/run/docker.sock"
-
-    testLogging {
-        showStandardStreams = true
-        exceptionFormat = "full"
-    }
 }

--- a/src/main/java/maple/expectation/aop/aspect/TraceAspect.java
+++ b/src/main/java/maple/expectation/aop/aspect/TraceAspect.java
@@ -36,14 +36,14 @@ public class TraceAspect {
 
     // 🎯 스케줄러 소음 제거
     @Pointcut("!execution(* maple.expectation.scheduler..*(..)) " +
-            "&& !execution(* maple.expectation..LikeBufferStorage.*(..)) " + // 👈 추가
+            "&& !execution(* maple.expectation..LikeBufferStorage.*(..)) " +
+            "&& !execution(* maple.expectation..LikeSyncService.*(..)) " +
             "&& !execution(* maple.expectation.mornitering..*(..))")
     public void excludeNoise() {}
 
     @Pointcut("!execution(* *.syncLikesToDatabase(..))")
     public void excludeSpecificMethod() {}
 
-    // 💡 최종 결합: (자동 OR 수동) 이면서 소음이 아닌 것!
     @Around("(autoLog() || manualLog()) && excludeNoise() && excludeSpecificMethod()")
     public Object doTrace(ProceedingJoinPoint joinPoint) throws Throwable {
         if (!isTraceEnabled) {

--- a/src/main/java/maple/expectation/controller/GameCharacterControllerV1.java
+++ b/src/main/java/maple/expectation/controller/GameCharacterControllerV1.java
@@ -3,6 +3,7 @@ package maple.expectation.controller;
 import lombok.RequiredArgsConstructor;
 import maple.expectation.domain.v2.GameCharacter;
 import maple.expectation.service.v2.GameCharacterService;
+import maple.expectation.service.v2.facade.GameCharacterFacade;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.*;
 public class GameCharacterControllerV1 {
 
     private final GameCharacterService gameCharacterService;
+    private final GameCharacterFacade gameCharacterFacade;
 
     /**
      * 캐릭터 정보 조회
@@ -19,7 +21,7 @@ public class GameCharacterControllerV1 {
     @GetMapping("/{userIgn}")
     public ResponseEntity<GameCharacter> findCharacterByUserIgn(@PathVariable String userIgn) {
         // 내부적으로 findByUserIgn (또는 없으면 API 생성) 로직 수행
-        return ResponseEntity.ok(gameCharacterService.findCharacterByUserIgn(userIgn));
+        return ResponseEntity.ok(gameCharacterFacade.findCharacterByUserIgn(userIgn));
     }
 
     /**

--- a/src/main/java/maple/expectation/controller/GameCharacterControllerV3.java
+++ b/src/main/java/maple/expectation/controller/GameCharacterControllerV3.java
@@ -1,6 +1,7 @@
 package maple.expectation.controller;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import maple.expectation.external.dto.v2.TotalExpectationResponse;
 import maple.expectation.service.v2.EquipmentService;
 import org.springframework.http.HttpHeaders;
@@ -16,6 +17,7 @@ import java.util.zip.GZIPOutputStream;
 /**
  * 🚀 [V3 Controller] Extreme Optimization & Resource Efficiency
  */
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v3/characters")
@@ -45,13 +47,9 @@ public class GameCharacterControllerV3 {
                 .body(responseBody);
     }
 
-    /**
-     * 💰 기대 비용 계산 (Facade Pattern)
-     * Controller는 로직을 몰라야 합니다. "계산해줘"라고 Service에 던지기만 합니다.
-     */
     @GetMapping("/{userIgn}/expectation")
     public ResponseEntity<TotalExpectationResponse> getEquipmentExpectation(@PathVariable String userIgn) {
-        // 비즈니스 로직은 Service로 완전 이관
+
         TotalExpectationResponse response = equipmentService.calculateTotalExpectation(userIgn);
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/maple/expectation/service/v2/EquipmentService.java
+++ b/src/main/java/maple/expectation/service/v2/EquipmentService.java
@@ -14,6 +14,7 @@ import maple.expectation.service.v2.calculator.ExpectationCalculator;
 import maple.expectation.service.v2.calculator.ExpectationCalculatorFactory;
 import maple.expectation.service.v2.calculator.impl.BaseItem;
 import maple.expectation.service.v2.calculator.impl.BlackCubeDecorator;
+import maple.expectation.service.v2.facade.GameCharacterFacade;
 import maple.expectation.service.v2.mapper.EquipmentMapper;
 import maple.expectation.service.v2.policy.CubeCostPolicy;
 import maple.expectation.util.GzipUtils;
@@ -34,7 +35,7 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class EquipmentService {
 
-    private final GameCharacterService characterService;
+    private final GameCharacterFacade gameCharacterFacade;
     private final EquipmentDataProvider equipmentProvider;
     private final EquipmentStreamingParser streamingParser;
     private final ExpectationCalculatorFactory calculatorFactory;
@@ -85,6 +86,6 @@ public class EquipmentService {
     }
 
     private String getOcid(String userIgn) {
-        return characterService.findCharacterByUserIgn(userIgn).getOcid();
+        return gameCharacterFacade.findCharacterByUserIgn(userIgn).getOcid();
     }
 }

--- a/src/main/java/maple/expectation/service/v2/GameCharacterService.java
+++ b/src/main/java/maple/expectation/service/v2/GameCharacterService.java
@@ -1,13 +1,12 @@
 package maple.expectation.service.v2;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import maple.expectation.aop.annotation.Locked;
 import maple.expectation.aop.annotation.LogExecutionTime;
 import maple.expectation.aop.annotation.ObservedTransaction;
-import maple.expectation.aop.annotation.TraceLog;
 import maple.expectation.domain.v2.GameCharacter;
-import maple.expectation.global.error.exception.CharacterNotFoundException;
 import maple.expectation.external.NexonApiClient;
+import maple.expectation.global.error.exception.CharacterNotFoundException;
 import maple.expectation.repository.v2.GameCharacterRepository;
 import maple.expectation.service.v2.impl.DatabaseLikeProcessor;
 import org.springframework.context.annotation.Lazy;
@@ -19,6 +18,7 @@ import java.util.Optional;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class GameCharacterService {
 
@@ -27,15 +27,28 @@ public class GameCharacterService {
     private final LikeProcessor likeProcessor;
     private final DatabaseLikeProcessor databaseLikeProcessor;
 
-    public GameCharacterService(
-            GameCharacterRepository gameCharacterRepository,
-            NexonApiClient nexonApiClient,
-            LikeProcessor likeProcessor,
-            @Lazy DatabaseLikeProcessor databaseLikeProcessor) {
-        this.gameCharacterRepository = gameCharacterRepository;
-        this.nexonApiClient = nexonApiClient;
-        this.likeProcessor = likeProcessor;
-        this.databaseLikeProcessor = databaseLikeProcessor;
+    /**
+     * ⚡ [RPS 최적화] 락 없이 DB 존재 여부만 확인
+     */
+    public Optional<GameCharacter> getCharacterIfExist(String userIgn) {
+        return gameCharacterRepository.findByUserIgn(userIgn.trim());
+    }
+
+    /**
+     * 🔒 [신규 생성] 실제 넥슨 API를 호출하고 DB에 저장하는 구간 (락 내부에서 실행)
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @ObservedTransaction("service.v2.GameCharacterService.createNewCharacter")
+    public GameCharacter createNewCharacter(String userIgn) {
+        String cleanUserIgn = userIgn.trim();
+
+        // Double-Check: 락 획득 대기 중에 다른 스레드가 생성했을 수 있음
+        return gameCharacterRepository.findByUserIgn(cleanUserIgn)
+                .orElseGet(() -> {
+                    log.info("✨ [First Creation] 신규 캐릭터 생성: {}", cleanUserIgn);
+                    String ocid = nexonApiClient.getOcidByCharacterName(cleanUserIgn).getOcid();
+                    return gameCharacterRepository.saveAndFlush(new GameCharacter(cleanUserIgn, ocid));
+                });
     }
 
     @Transactional
@@ -43,34 +56,14 @@ public class GameCharacterService {
         return gameCharacterRepository.save(character).getUserIgn();
     }
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    @Locked(key = "#userIgn")
-    public GameCharacter findCharacterByUserIgn(String userIgn) {
-        String cleanUserIgn = userIgn.trim();
-
-        // 1. DB에서 먼저 조회
-        return gameCharacterRepository.findByUserIgn(cleanUserIgn)
-                .orElseGet(() -> {
-                    log.info("✨ 신규 캐릭터 생성 시도: {}", cleanUserIgn);
-
-                    // 2. [변경] 객체 생성 전에 넥슨 API를 호출해서 OCID를 먼저 확보합니다.
-                    String ocid = nexonApiClient.getOcidByCharacterName(cleanUserIgn).getOcid();
-
-                    // 3. [수정] 이제 '완전한 상태'로 객체를 생성합니다. (Setter 필요 없음!)
-                    // public GameCharacter(String userIgn, String ocid) 생성자 호출
-                    GameCharacter newChar = new GameCharacter(cleanUserIgn, ocid);
-
-                    // 4. 저장 및 즉시 반영
-                    return gameCharacterRepository.saveAndFlush(newChar);
-                });
-    }
-
+    // 🔥 [관측 가능성 유지] 좋아요 메트릭 및 로그
     @LogExecutionTime
     @ObservedTransaction("service.v2.GameCharacterService.clickLikeCache")
     public void clickLikeCache(String userIgn) {
         likeProcessor.processLike(userIgn);
     }
 
+    // 🔥 [관측 가능성 유지] 비관적 락 좋아요 메트릭
     @LogExecutionTime
     @Transactional
     @ObservedTransaction("service.v2.GameCharacterService.clickLikePessimistic")

--- a/src/main/java/maple/expectation/service/v2/LikeSyncService.java
+++ b/src/main/java/maple/expectation/service/v2/LikeSyncService.java
@@ -23,7 +23,6 @@ public class LikeSyncService {
     private final StringRedisTemplate redisTemplate;
     private final RedisBufferRepository redisBufferRepository;
     private final Retry likeSyncRetry;
-
     private static final String REDIS_HASH_KEY = "buffer:likes";
 
     /**

--- a/src/main/java/maple/expectation/service/v2/cache/LikeBufferStorage.java
+++ b/src/main/java/maple/expectation/service/v2/cache/LikeBufferStorage.java
@@ -20,7 +20,6 @@ public class LikeBufferStorage {
                 .expireAfterAccess(1, TimeUnit.MINUTES)
                 .maximumSize(1000) // 메모리 보호를 위해 사이즈 제한 추가
                 .build();
-
         Gauge.builder("like.buffer.local_pending", this,
                         storage -> likeCache.asMap().values().stream().mapToLong(AtomicLong::get).sum())
                 .description("현재 인스턴스의 미반영 좋아요 총합")

--- a/src/main/java/maple/expectation/service/v2/facade/GameCharacterFacade.java
+++ b/src/main/java/maple/expectation/service/v2/facade/GameCharacterFacade.java
@@ -1,0 +1,19 @@
+package maple.expectation.service.v2.facade;
+
+import lombok.RequiredArgsConstructor;
+import maple.expectation.domain.v2.GameCharacter;
+import maple.expectation.service.v2.GameCharacterService;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class GameCharacterFacade {
+
+    private final GameCharacterService gameCharacterService;
+    private final GameCharacterSynchronizer gameCharacterSynchronizer;
+
+    public GameCharacter findCharacterByUserIgn(String userIgn) {
+        return gameCharacterService.getCharacterIfExist(userIgn)
+                .orElseGet(() -> gameCharacterSynchronizer.synchronizeCharacter(userIgn));
+    }
+}

--- a/src/main/java/maple/expectation/service/v2/facade/GameCharacterSynchronizer.java
+++ b/src/main/java/maple/expectation/service/v2/facade/GameCharacterSynchronizer.java
@@ -1,0 +1,33 @@
+package maple.expectation.service.v2.facade;
+
+import lombok.RequiredArgsConstructor;
+import maple.expectation.aop.annotation.Locked;
+import maple.expectation.domain.v2.GameCharacter;
+import maple.expectation.global.error.exception.CharacterNotFoundException;
+import maple.expectation.service.v2.GameCharacterService;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class GameCharacterSynchronizer {
+
+    private final GameCharacterService gameCharacterService;
+
+    @Locked(key = "#userIgn")
+    public GameCharacter synchronizeCharacter(String userIgn) {
+        // 1. [Double-Check] 락을 획득한 직후, 그 사이 다른 쓰레드가 생성했는지 확인
+        return gameCharacterService.getCharacterIfExist(userIgn)
+                .orElseGet(() -> {
+                    try {
+                        // 2. [Create] 진짜 없으면 생성
+                        return gameCharacterService.createNewCharacter(userIgn);
+                    } catch (DataIntegrityViolationException e) {
+                        // 3. [Last Defense] 락 타임아웃 등으로 인해 동시에 진입했을 경우,
+                        // DB Unique 제약 조건이 튕겨낸 에러를 잡아서 이미 생성된 데이터를 반환
+                        return gameCharacterService.getCharacterIfExist(userIgn)
+                                .orElseThrow(() -> new CharacterNotFoundException("캐릭터 존재안함" + e));
+                    }
+                });
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -9,8 +9,8 @@ spring:
     password: ${DB_ROOT_PASSWORD}
 
     hikari:
-      maximum-pool-size: 10
-      minimum-idle: 5
+      maximum-pool-size: 50
+      minimum-idle: 50
 
   jpa:
     hibernate:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,6 +14,7 @@ spring:
 
   # 공통 JPA 설정
   jpa:
+    open-in-view: false
     properties:
       hibernate:
         jdbc:

--- a/src/test/java/maple/expectation/service/v2/GameCharacterServiceConcurrencyTest.java
+++ b/src/test/java/maple/expectation/service/v2/GameCharacterServiceConcurrencyTest.java
@@ -1,9 +1,9 @@
 package maple.expectation.service.v2;
 
-import maple.expectation.domain.v2.GameCharacter;
 import maple.expectation.external.NexonApiClient;
 import maple.expectation.external.dto.v2.CharacterOcidResponse;
 import maple.expectation.repository.v2.GameCharacterRepository;
+import maple.expectation.service.v2.facade.GameCharacterFacade;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -26,6 +26,9 @@ class GameCharacterServiceConcurrencyTest {
 
     @Autowired
     private GameCharacterService gameCharacterService;
+
+    @Autowired
+    private GameCharacterFacade gameCharacterFacade;
 
     @Autowired
     private GameCharacterRepository gameCharacterRepository;
@@ -61,7 +64,7 @@ class GameCharacterServiceConcurrencyTest {
         for (int i = 0; i < threadCount; i++) {
             executorService.submit(() -> {
                 try {
-                    gameCharacterService.findCharacterByUserIgn(targetName);
+                    gameCharacterFacade.findCharacterByUserIgn(targetName);
                     successCount.incrementAndGet();
                 } catch (Exception e) {
                     failCount.incrementAndGet();

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -9,11 +9,11 @@ spring:
       minimum-idle: 5
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     properties:
       hibernate:
-        format_sql: true
-        show_sql: true
+        format_sql: false
+        show_sql: false
 
 management:
   endpoint:
@@ -54,8 +54,8 @@ resilience4j:
 logging:
   level:
     root: info
-    org.hibernate.SQL: debug
-    maple.expectation: DEBUG
+    org.hibernate.SQL: info
+    maple.expectation: info
 
 nexon:
   api:


### PR DESCRIPTION
## 🔗 관련 이슈
* 없음

## 🗣 개요
* 메이플스토리 캐릭터 정보 조회 시 발생하는 동시성 문제를 해결하고, RPS 700 이상의 높은 부하에서도 시스템 안정성을 유지하기 위한 최적화 작업을 진행했습니다.

## 🛠 작업 내용
* **분산 락(Distributed Lock) 도입**: Redisson을 활용하여 다중 서버 환경에서도 동일 캐릭터에 대한 중복 생성 요청을 제어했습니다.
* **조회 성능 최적화**: `GameCharacterFacade`를 통해 DB 1차 조회(No Lock) 후, 데이터가 없을 때만 락을 잡는 `Synchronizer`로 진입하게 하여 대부분의 읽기 요청에서 락 오버헤드를 제거했습니다.
* **비동기 파이프라인 구축**: `WebClient`와 `CompletableFuture`를 체이닝하여 외부 API(넥슨) 호출 시 쓰레드가 차단(Blocking)되지 않도록 개선했습니다.
* **회복력(Resilience) 강화**: 락 획득 타임아웃 시 무조건 실패 처리하는 것이 아니라, Fallback 로직을 통해 DB를 재확인하여 서비스 가용성을 높였습니다.



## 💬 리뷰 포인트
* `Synchronizer` 내부에서 `DataIntegrityViolationException` 발생 시의 예외 처리 흐름이 적절한지 검토 부탁드립니다.
* 비동기 체이닝 과정에서 `thenCompose`와 `thenApply`가 비즈니스 순서에 맞게 잘 연결되었는지 확인이 필요합니다.

## 💱 트레이드 오프 결정 근거
* **락 범위 최소화**: 트랜잭션 전체가 아닌 캐릭터 생성 지점에만 락을 적용하여 DB 커넥션 점유 시간을 최소화했습니다.

## ✅ 체크리스트
- [x] 모든 테스트 코드가 통과하는가?
- [x] 커밋 메시지 규칙을 준수했는가?
- [x] 불필요한 로그 출력을 제거했는가?