### PR TITLE
perf: 장비 데이터 캐싱 최적화 및 비동기 정합성 보완

### DIFF
--- a/src/main/java/maple/expectation/service/v2/cache/EquipmentCacheService.java
+++ b/src/main/java/maple/expectation/service/v2/cache/EquipmentCacheService.java
@@ -3,9 +3,8 @@ package maple.expectation.service.v2.cache;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import maple.expectation.domain.v2.CharacterEquipment;
 import maple.expectation.external.dto.v2.EquipmentResponse;
-import maple.expectation.repository.v2.CharacterEquipmentRepository;
+import maple.expectation.service.v2.worker.EquipmentDbWorker;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Service;
@@ -19,85 +18,64 @@ import java.util.concurrent.CompletableFuture;
 @Service
 @RequiredArgsConstructor
 public class EquipmentCacheService {
-    private final CharacterEquipmentRepository repository;
+    private final maple.expectation.repository.v2.CharacterEquipmentRepository repository;
     private final ObjectMapper objectMapper;
     private final CacheManager cacheManager;
+    private final EquipmentDbWorker dbWorker;
 
-    /**
-     * 캐시 계층을 우선 확인 (변경 없음)
-     */
+    // 🚀 [429 방어] 데이터 없음(404) 상태를 나타내는 내부 마커
+    private static final EquipmentResponse NULL_MARKER = new EquipmentResponse();
+
     @Transactional(readOnly = true)
     public Optional<EquipmentResponse> getValidCache(String ocid) {
         Cache tieredCache = cacheManager.getCache("equipment");
         EquipmentResponse cached = tieredCache.get(ocid, EquipmentResponse.class);
 
         if (cached != null) {
-            log.debug("⚡ [Tiered Cache Hit] : {}", ocid);
+            if (isNullMarker(cached)) return Optional.empty();
             return Optional.of(cached);
         }
 
         return repository.findById(ocid)
                 .filter(e -> e.getUpdatedAt().isAfter(LocalDateTime.now().minusMinutes(15)))
-                .map(this::convertToResponse)
-                .map(res -> {
-                    tieredCache.put(ocid, res);
+                .map(entity -> {
+                    EquipmentResponse res = convertToResponse(entity);
+                    if (res != null) tieredCache.put(ocid, res);
                     return res;
                 });
     }
 
-    public Optional<EquipmentResponse> getLocalCacheOnly(String ocid) {
-        Cache cache = cacheManager.getCache("equipment");
-        EquipmentResponse response = cache.get(ocid, EquipmentResponse.class);
-        return Optional.ofNullable(response);
-    }
-
-    /**
-     * [최종 개선] 캐시는 즉시 갱신하고 DB 저장은 비동기로 처리합니다.
-     */
     public void saveCache(String ocid, EquipmentResponse response) {
+        if (response == null) {
+            cacheManager.getCache("equipment").put(ocid, NULL_MARKER);
+            log.warn("🚫 [Negative Cache Saved] 존재하지 않는 유저: {}", ocid);
+            return;
+        }
+
         try {
-            // 1️⃣ [동기] Tiered Cache(L1, L2)를 즉시 업데이트
-            // 이 시점 이후부터 "진성" 캐릭터는 DB에 없어도 캐시에서 조회 가능해집니다.
             cacheManager.getCache("equipment").put(ocid, response);
-            log.debug("🚀 [Cache Warm-up Success] 캐시 우선 갱신 완료: {}", ocid);
-
-            // 2️⃣ [비동기] DB 저장은 백그라운드 스레드에 위임
-            // 호출 스레드(Request Thread)는 여기서 즉시 리턴되어 다음 요청을 받으러 갑니다.
-            CompletableFuture.runAsync(() -> {
-                try {
-                    persistToDatabase(ocid, response);
-                } catch (Exception e) {
-                    log.error("❌ [Async DB Error] 비동기 DB 저장 실패: ocid={}", ocid, e);
-                }
-            });
-
+            CompletableFuture.runAsync(() -> dbWorker.persist(ocid, response));
         } catch (Exception e) {
-            log.error("❌ 캐시 저장 로직 오류: ocid={}", ocid, e);
+            log.error("❌ 캐시 저장 오류 : {}", ocid, e);
         }
     }
 
-    /**
-     * 실제 DB 저장 로직 (비동기 스레드에서 실행됨)
-     */
-    private void persistToDatabase(String ocid, EquipmentResponse response) throws Exception {
-        String json = objectMapper.writeValueAsString(response);
-
-        // 신규 캐릭터면 Insert, 기존 캐릭터면 Update를 자동으로 수행
-        CharacterEquipment entity = repository.findById(ocid)
-                .orElseGet(() -> CharacterEquipment.builder().ocid(ocid).build());
-
-        entity.updateData(json);
-        repository.saveAndFlush(entity); // 비동기이므로 즉시 반영(Flush) 권장
-
-        log.info("💾 [Async DB Save] DB 영속화 완료: {}", ocid);
+    // 🚀 Aspect에서 컴파일 에러가 나지 않도록 public으로 선언
+    public boolean isNullMarker(EquipmentResponse res) {
+        return res == NULL_MARKER || (res != null && res.getCharacterClass() == null);
     }
 
-    private EquipmentResponse convertToResponse(CharacterEquipment entity) {
+    // 🚀 Aspect에서 컴파일 에러가 나지 않도록 public으로 선언
+    public boolean hasNegativeCache(String ocid) {
+        Cache cache = cacheManager.getCache("equipment");
+        if (cache == null) return false;
+        EquipmentResponse res = cache.get(ocid, EquipmentResponse.class);
+        return isNullMarker(res);
+    }
+
+    private EquipmentResponse convertToResponse(maple.expectation.domain.v2.CharacterEquipment entity) {
         try {
             return objectMapper.readValue(entity.getJsonContent(), EquipmentResponse.class);
-        } catch (Exception e) {
-            log.error("❌ JSON 파싱 에러: ocid={}", entity.getOcid());
-            return null;
-        }
+        } catch (Exception e) { return null; }
     }
 }

--- a/src/main/java/maple/expectation/service/v2/worker/EquipmentDbWorker.java
+++ b/src/main/java/maple/expectation/service/v2/worker/EquipmentDbWorker.java
@@ -1,0 +1,38 @@
+package maple.expectation.service.v2.worker;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import maple.expectation.domain.v2.CharacterEquipment;
+import maple.expectation.external.dto.v2.EquipmentResponse;
+import maple.expectation.repository.v2.CharacterEquipmentRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EquipmentDbWorker {
+    private final CharacterEquipmentRepository repository;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * REQUIRES_NEW를 통해 호출측 트랜잭션과 무관하게 즉시 커밋합니다.
+     * 이 작업이 끝나야만 404(조회 실패) 현상이 근본적으로 해결됩니다.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void persist(String ocid, EquipmentResponse response) {
+        try {
+            String json = objectMapper.writeValueAsString(response);
+            CharacterEquipment entity = repository.findById(ocid)
+                    .orElseGet(() -> CharacterEquipment.builder().ocid(ocid).build());
+
+            entity.updateData(json);
+            repository.saveAndFlush(entity); // 즉시 물리적 저장
+            log.info("💾 [Async DB Save Success] ocid: {}", ocid);
+        } catch (Exception e) {
+            log.error("❌ [Async DB Save Error] ocid: {}", ocid, e);
+        }
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- X

## 🗣 개요
고부하 환경(240 RPS 이상)에서 발생하는 넥슨 API의 429(Too Many Requests) 에러와 비동기 저장 시점의 데이터 불일치(404) 문제를 해결하기 위해 캐싱 전략과 영속화 구조를 전면 개편했습니다.

## 🛠 작업 내용
- **Negative Caching 도입**: 존재하지 않는 유저(404)에 대해 `NULL_MARKER`를 캐싱하여 반복적인 외부 API 호출을 차단했습니다.
- **영속화 레이어 분리**: `EquipmentDbWorker`를 별도 클래스로 분리하고 `REQUIRES_NEW` 전파 속성을 적용하여 비동기 스레드의 커밋 가시성을 즉시 확보했습니다.
- **Aspect 락 전략 수정**: 1등 스레드(Winner)가 API 응답을 완료하고 캐시를 채울 때까지 락을 유지(`join()`)하도록 변경하여 Request Collapsing을 구현했습니다.
- **Optional 기반 조회 로직**: 서비스 레이어의 반환 타입을 `Optional`로 표준화하여 가독성과 안정성을 높였습니다.

## 💬 리뷰 포인트
- `EquipmentDbWorker` 분리를 통해 Spring AOP의 자기 호출(Self-invocation) 문제가 해결되었는지 확인 부탁드립니다.
- `NULL_MARKER`를 활용한 Negative Caching이 넥슨 API 제한을 효과적으로 방어하는지 검토 바랍니다.

## 💱 트레이드 오프 결정 근거
- **성능 vs 정합성**: 모든 데이터를 동기로 저장하면 RPS가 급격히 떨어지므로, 캐시 갱신은 **동기(Sync)**로 처리하여 즉시 조회를 보장하고, 실제 DB 영속화는 **비동기(Async)**로 처리하되 독립 트랜잭션을 사용하여 가시성 시차를 최소화했습니다.
- **메모리 vs API 한도**: 데이터가 없는 경우도 메모리(L1/L2)를 점유하게 되지만, 외부 API 호출 비용과 429 에러로 인한 서비스 불능 리스크가 더 크다고 판단하여 Negative Caching을 적용했습니다.

## ✅ 체크리스트
- [x] develop 브랜치에서 분기했는가?
- [x] 커밋 메시지 규칙을 준수했는가?
- [x] 존재하지 않는 유저 조회 시 API 호출이 차단되는가?
- [x] 신규 유저 조회 시 비동기 저장 후 즉시 조회가 가능한가?