### PR TITLE
Rename monitoring package

### DIFF
--- a/src/main/java/maple/expectation/aop/aspect/TraceAspect.java
+++ b/src/main/java/maple/expectation/aop/aspect/TraceAspect.java
@@ -38,7 +38,7 @@ public class TraceAspect {
     @Pointcut("!execution(* maple.expectation.scheduler..*(..)) " +
             "&& !execution(* maple.expectation..LikeBufferStorage.*(..)) " +
             "&& !execution(* maple.expectation..LikeSyncService.*(..)) " +
-            "&& !execution(* maple.expectation.mornitering..*(..))")
+            "&& !execution(* maple.expectation.monitoring..*(..))")
     public void excludeNoise() {}
 
     @Pointcut("!execution(* *.syncLikesToDatabase(..))")

--- a/src/main/java/maple/expectation/monitoring/MonitoringAlertService.java
+++ b/src/main/java/maple/expectation/monitoring/MonitoringAlertService.java
@@ -1,4 +1,4 @@
-package maple.expectation.mornitering;
+package maple.expectation.monitoring;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/test/java/maple/expectation/global/resilience/DistributedCircuitBreakerTest.java
+++ b/src/test/java/maple/expectation/global/resilience/DistributedCircuitBreakerTest.java
@@ -2,7 +2,7 @@ package maple.expectation.global.resilience;
 
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
-import maple.expectation.mornitering.MonitoringAlertService;
+import maple.expectation.monitoring.MonitoringAlertService;
 import maple.expectation.repository.v2.RedisBufferRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/maple/expectation/monitoring/MonitoringAlertServiceTest.java
+++ b/src/test/java/maple/expectation/monitoring/MonitoringAlertServiceTest.java
@@ -1,4 +1,4 @@
-package maple.expectation.mornitering;
+package maple.expectation.monitoring;
 
 import maple.expectation.global.common.function.ThrowingSupplier;
 import maple.expectation.global.error.CommonErrorCode;


### PR DESCRIPTION
## Summary
- rename the misspelled monitoring package directory and update package declarations
- adjust imports, pointcuts, and test references to the corrected package name

## Testing
- ./gradlew clean build *(fails: Java 17 toolchain not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954436ed210832da5a2c3e851eab6ad)