### PR TITLE
Handle null in gzip string converter

### DIFF
--- a/src/main/java/maple/expectation/util/converter/GzipStringConverter.java
+++ b/src/main/java/maple/expectation/util/converter/GzipStringConverter.java
@@ -9,11 +9,13 @@ public class GzipStringConverter implements AttributeConverter<String, byte[]> {
 
     @Override
     public byte[] convertToDatabaseColumn(String attribute) {
+        if (attribute == null) return null;
         return GzipUtils.compress(attribute);
     }
 
     @Override
     public String convertToEntityAttribute(byte[] dbData) {
+        if (dbData == null) return null;
         return GzipUtils.decompress(dbData);
     }
 }

--- a/src/test/java/maple/expectation/util/converter/GzipStringConverterTest.java
+++ b/src/test/java/maple/expectation/util/converter/GzipStringConverterTest.java
@@ -1,0 +1,20 @@
+package maple.expectation.util.converter;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class GzipStringConverterTest {
+
+    private final GzipStringConverter converter = new GzipStringConverter();
+
+    @Test
+    void convertToDatabaseColumnReturnsNullWhenAttributeIsNull() {
+        assertNull(converter.convertToDatabaseColumn(null));
+    }
+
+    @Test
+    void convertToEntityAttributeReturnsNullWhenDbDataIsNull() {
+        assertNull(converter.convertToEntityAttribute(null));
+    }
+}


### PR DESCRIPTION
## Summary
- return null from `GzipStringConverter` when given null attribute or database data
- add unit tests to verify null handling for converter

## Testing
- `./gradlew test --tests maple.expectation.util.converter.GzipStringConverterTest` *(fails: toolchain could not download Java 17 in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695444130460832da4a185c156a86e7f)