### PR TITLE
Hotfix 2.3.1

### DIFF
--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -38,3 +38,7 @@ logging:
     root: info
     maple.expectation: debug
     org.springframework.test: info
+
+nexon:
+  api:
+    key: dummy-test-key # Codex Bot이 지적한 @Value 주입 실패 해결


### PR DESCRIPTION
## 🔗 관련 이슈
* 로컬 환경 기동 시 Redis Sentinel 연결 타임아웃 이슈

## 🗣 개요
* v2.3.0 배포 후 발견된 로컬 개발 환경의 연결성 문제와 테스트 코드의 설정 누락을 긴급 수정합니다.

## 🛠 작업 내용
* **NatMapper 자동화**: `RedissonConfig`에 Docker 내부 대역(172.x.x.x) 감지 시 자동으로 `127.0.0.1`로 우회하는 로직을 추가하여 로컬 기동성을 확보했습니다.
* **Test Property 복구**: `application-test.yml`에 `nexon.api.key`를 추가하여 `@EnableTimeLogging` 사용 테스트들이 정상적으로 수행되도록 조치했습니다.

## 💬 리뷰 포인트
* `RedissonConfig`에서 `startsWith("172.")` 외에 다른 Docker 대역(예: 192.168.x.x)이 쓰일 가능성이 있는지 체크 부탁드립니다.

## 💱 트레이드 오프 결정 근거
* **전역 설정 주입**: 테스트마다 프로퍼티를 개별 선언하는 대신 `application-test.yml`에 통합하여 테스트 코드의 간결함을 유지하고 누락 가능성을 차단했습니다.

## ✅ 체크리스트
- [x] 로컬 환경에서 Sentinel 연결 및 앱 구동 성공 확인
- [x] `CubeServiceTest` 등 @EnableTimeLogging 기반 테스트 정상 통과 확인
- [x] master 브랜치에서 분기하여 작업 진행함