### PR TITLE
fix: Tiered Locking 비즈니스 예외 Fallback 오인 결함 수정 (#130)

### DIFF
--- a/src/main/java/maple/expectation/global/common/function/ThrowingSupplier.java
+++ b/src/main/java/maple/expectation/global/common/function/ThrowingSupplier.java
@@ -1,6 +1,54 @@
 package maple.expectation.global.common.function;
 
+/**
+ * Throwable을 던질 수 있는 Supplier
+ *
+ * <p>락 획득, 외부 API 호출 등 checked exception이 발생할 수 있는
+ * 작업에서 사용합니다.
+ *
+ * <h3>정책 (ADR)</h3>
+ * <ul>
+ *   <li>Biz 레이어에서는 checked exception이 올라오면 안 됨</li>
+ *   <li>{@link #getUnchecked()}는 checked가 발생하면 정책 위반으로
+ *       {@link IllegalStateException} throw</li>
+ * </ul>
+ */
 @FunctionalInterface
 public interface ThrowingSupplier<T> {
+
+    /**
+     * 결과를 계산하거나 예외를 던집니다.
+     *
+     * @return 계산 결과
+     * @throws Throwable 작업 중 발생한 예외
+     */
     T get() throws Throwable;
+
+    /**
+     * Checked exception을 정책 위반으로 처리하는 unchecked 실행
+     *
+     * <p><b>예외 처리</b>:
+     * <ul>
+     *   <li>Error: 즉시 throw</li>
+     *   <li>RuntimeException: 즉시 throw</li>
+     *   <li>Checked Exception: 정책 위반이므로 {@link IllegalStateException}으로 래핑</li>
+     * </ul>
+     *
+     * <p><b>NOTE</b>: try-catch는 이 인프라 메서드에만 존재하며,
+     * 비즈니스 로직에서는 사용되지 않습니다.
+     *
+     * @return 계산 결과
+     * @throws RuntimeException Error, RuntimeException, 또는 정책 위반 시 IllegalStateException
+     */
+    default T getUnchecked() {
+        try {
+            return get();
+        } catch (Error | RuntimeException e) {
+            throw e;
+        } catch (Throwable t) {
+            // Biz 경계에서 checked Throwable이 올라오는 것은 설계 위반
+            throw new IllegalStateException(
+                    "Unexpected checked Throwable (policy violation): " + t.getClass().getName(), t);
+        }
+    }
 }

--- a/src/test/java/maple/expectation/global/lock/ResilientLockStrategyExceptionFilterTest.java
+++ b/src/test/java/maple/expectation/global/lock/ResilientLockStrategyExceptionFilterTest.java
@@ -1,0 +1,401 @@
+package maple.expectation.global.lock;
+
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import maple.expectation.global.common.function.ThrowingSupplier;
+import maple.expectation.global.error.exception.CharacterNotFoundException;
+import maple.expectation.global.error.exception.DistributedLockException;
+import maple.expectation.global.executor.LogicExecutor;
+import maple.expectation.global.executor.TaskContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.redisson.client.RedisException;
+import org.redisson.client.RedisTimeoutException;
+
+import java.util.concurrent.CompletionException;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+/**
+ * ResilientLockStrategy 예외 필터링 테스트 (정책 검증)
+ *
+ * <p><b>테스트 목표</b>:
+ * <ul>
+ *   <li>비즈니스 예외(ClientBaseException)는 MySQL fallback 없이 상위 전파</li>
+ *   <li>래핑된 비즈니스 예외(CompletionException 내부)도 fallback 없이 상위 전파</li>
+ *   <li>인프라 예외(Redis/CircuitBreaker)만 MySQL fallback 트리거</li>
+ *   <li>Unknown 예외(NPE 등)는 fallback 없이 상위 전파</li>
+ * </ul>
+ *
+ * <p><b>P0 수정</b>: executeWithLock() 기반 테스트로 전환
+ * - task 실행 중 발생하는 비즈니스 예외 필터링 검증
+ */
+@ExtendWith(MockitoExtension.class)
+class ResilientLockStrategyExceptionFilterTest {
+
+    @Mock
+    private LockStrategy redisLockStrategy;
+
+    @Mock
+    private MySqlNamedLockStrategy mysqlLockStrategy;
+
+    @Mock
+    private CircuitBreakerRegistry circuitBreakerRegistry;
+
+    @Mock
+    private CircuitBreaker circuitBreaker;
+
+    @Mock
+    private LogicExecutor executor;
+
+    private ResilientLockStrategy resilientLockStrategy;
+
+    private static final String TEST_KEY = "test-key";
+    private static final long WAIT_TIME = 1000L;
+    private static final long LEASE_TIME = 5000L;
+
+    @BeforeEach
+    void setUp() {
+        when(circuitBreakerRegistry.circuitBreaker("redisLock")).thenReturn(circuitBreaker);
+        lenient().when(circuitBreaker.getState()).thenReturn(CircuitBreaker.State.CLOSED);
+        lenient().when(circuitBreaker.getName()).thenReturn("redisLock");
+
+        resilientLockStrategy = new ResilientLockStrategy(
+                redisLockStrategy,
+                mysqlLockStrategy,
+                circuitBreakerRegistry,
+                executor
+        );
+    }
+
+    /**
+     * executor.executeWithFallback()를 passthrough로 설정
+     * - task 실행 후 예외 발생 시 fallback 함수 호출
+     */
+    @SuppressWarnings("unchecked")
+    private void setupExecutorFallbackPassthrough() {
+        when(executor.executeWithFallback(any(ThrowingSupplier.class), any(Function.class), any(TaskContext.class)))
+                .thenAnswer(invocation -> {
+                    ThrowingSupplier<?> task = invocation.getArgument(0, ThrowingSupplier.class);
+                    Function<Throwable, ?> fallback = invocation.getArgument(1, Function.class);
+
+                    try {
+                        return task.get();
+                    } catch (Throwable t) {
+                        return fallback.apply(t);
+                    }
+                });
+    }
+
+    /**
+     * CircuitBreaker passthrough: executeCheckedSupplier가 받은 supplier를 실제로 실행
+     */
+    @SuppressWarnings("unchecked")
+    private void setupCircuitBreakerPassthrough() throws Throwable {
+        when(circuitBreaker.executeCheckedSupplier(any()))
+                .thenAnswer(inv -> {
+                    var supplier = inv.getArgument(
+                            0,
+                            io.github.resilience4j.core.functions.CheckedSupplier.class
+                    );
+                    return supplier.get();
+                });
+    }
+
+    /**
+     * Redis passthrough: redisLockStrategy.executeWithLock이 받은 task를 실제로 실행
+     * Issue #130 핵심: task 내부에서 발생하는 예외가 전파되는지 검증
+     */
+    @SuppressWarnings("unchecked")
+    private void setupRedisExecuteWithLockPassthrough() throws Throwable {
+        when(redisLockStrategy.executeWithLock(anyString(), anyLong(), anyLong(), any()))
+                .thenAnswer(inv -> {
+                    ThrowingSupplier<?> task = inv.getArgument(3, ThrowingSupplier.class);
+                    return task.get(); // task 실행
+                });
+    }
+
+    // ========================================
+    // 인프라 예외 → MySQL Fallback 테스트
+    // ========================================
+
+    @Nested
+    @DisplayName("인프라 예외 발생 시 MySQL Fallback (executeWithLock)")
+    class InfrastructureExceptionFallbackTest {
+
+        @Test
+        @DisplayName("1. DistributedLockException 발생 시 MySQL fallback 실행")
+        void shouldFallbackToMySql_WhenRedisThrowsDistributedLockException() throws Throwable {
+            // given
+            setupExecutorFallbackPassthrough();
+            DistributedLockException lockException = new DistributedLockException("Redis lock timeout");
+
+            when(circuitBreaker.executeCheckedSupplier(any()))
+                    .thenThrow(lockException);
+            when(mysqlLockStrategy.executeWithLock(anyString(), anyLong(), anyLong(), any()))
+                    .thenReturn("fallback-result");
+
+            // when
+            Object result = resilientLockStrategy.executeWithLock(TEST_KEY, WAIT_TIME, LEASE_TIME, () -> "success");
+
+            // then
+            assertThat(result).isEqualTo("fallback-result");
+            verify(mysqlLockStrategy, times(1)).executeWithLock(eq(TEST_KEY), eq(WAIT_TIME), eq(LEASE_TIME), any());
+        }
+
+        @Test
+        @DisplayName("2. CallNotPermittedException (CircuitBreaker OPEN) 발생 시 MySQL fallback 실행")
+        void shouldFallbackToMySql_WhenCircuitBreakerOpen() throws Throwable {
+            // given
+            setupExecutorFallbackPassthrough();
+            // Mock으로 CallNotPermittedException 생성 (factory method 대신)
+            CallNotPermittedException cbException = mock(CallNotPermittedException.class);
+
+            when(circuitBreaker.executeCheckedSupplier(any()))
+                    .thenThrow(cbException);
+            when(mysqlLockStrategy.executeWithLock(anyString(), anyLong(), anyLong(), any()))
+                    .thenReturn("fallback-result");
+
+            // when
+            Object result = resilientLockStrategy.executeWithLock(TEST_KEY, WAIT_TIME, LEASE_TIME, () -> "success");
+
+            // then
+            assertThat(result).isEqualTo("fallback-result");
+            verify(mysqlLockStrategy, times(1)).executeWithLock(eq(TEST_KEY), eq(WAIT_TIME), eq(LEASE_TIME), any());
+        }
+
+        @Test
+        @DisplayName("3. RedisException 발생 시 MySQL fallback 실행")
+        void shouldFallbackToMySql_WhenRedisExceptionOccurs() throws Throwable {
+            // given
+            setupExecutorFallbackPassthrough();
+            RedisException redisException = new RedisException("Redis connection failed");
+
+            when(circuitBreaker.executeCheckedSupplier(any()))
+                    .thenThrow(redisException);
+            when(mysqlLockStrategy.executeWithLock(anyString(), anyLong(), anyLong(), any()))
+                    .thenReturn("fallback-result");
+
+            // when
+            Object result = resilientLockStrategy.executeWithLock(TEST_KEY, WAIT_TIME, LEASE_TIME, () -> "success");
+
+            // then
+            assertThat(result).isEqualTo("fallback-result");
+            verify(mysqlLockStrategy, times(1)).executeWithLock(eq(TEST_KEY), eq(WAIT_TIME), eq(LEASE_TIME), any());
+        }
+
+        @Test
+        @DisplayName("4. RedisTimeoutException 발생 시 MySQL fallback 실행")
+        void shouldFallbackToMySql_WhenRedisTimeoutExceptionOccurs() throws Throwable {
+            // given
+            setupExecutorFallbackPassthrough();
+            RedisTimeoutException timeoutException = new RedisTimeoutException("Redis timeout");
+
+            when(circuitBreaker.executeCheckedSupplier(any()))
+                    .thenThrow(timeoutException);
+            when(mysqlLockStrategy.executeWithLock(anyString(), anyLong(), anyLong(), any()))
+                    .thenReturn("fallback-result");
+
+            // when
+            Object result = resilientLockStrategy.executeWithLock(TEST_KEY, WAIT_TIME, LEASE_TIME, () -> "success");
+
+            // then
+            assertThat(result).isEqualTo("fallback-result");
+            verify(mysqlLockStrategy, times(1)).executeWithLock(eq(TEST_KEY), eq(WAIT_TIME), eq(LEASE_TIME), any());
+        }
+    }
+
+    // ========================================
+    // 비즈니스 예외 → Fallback 없이 상위 전파 테스트
+    // ========================================
+
+    @Nested
+    @DisplayName("비즈니스 예외 발생 시 Fallback 없이 상위 전파 (executeWithLock)")
+    class BusinessExceptionPropagationTest {
+
+        @Test
+        @DisplayName("5. ClientBaseException(CharacterNotFoundException) 발생 시 MySQL fallback 미실행, 예외 상위 전파")
+        void shouldPropagateBusinessException_WhenClientBaseExceptionThrown() throws Throwable {
+            // given
+            setupExecutorFallbackPassthrough();
+            CharacterNotFoundException businessException = new CharacterNotFoundException("TestUser");
+
+            when(circuitBreaker.executeCheckedSupplier(any()))
+                    .thenThrow(businessException);
+
+            // when & then
+            assertThatThrownBy(() -> resilientLockStrategy.executeWithLock(TEST_KEY, WAIT_TIME, LEASE_TIME, () -> "success"))
+                    .isSameAs(businessException);
+
+            // MySQL fallback이 호출되지 않았음을 검증
+            verify(mysqlLockStrategy, never()).executeWithLock(anyString(), anyLong(), anyLong(), any());
+        }
+
+        @Test
+        @DisplayName("6. [핵심] CompletionException으로 래핑된 비즈니스 예외도 fallback 없이 상위 전파")
+        void shouldPropagateWrappedBusinessException_WhenCompletionExceptionWrapsClientBaseException() throws Throwable {
+            // given
+            setupExecutorFallbackPassthrough();
+            CharacterNotFoundException businessException = new CharacterNotFoundException("TestUser");
+            CompletionException wrappedException = new CompletionException(businessException);
+
+            when(circuitBreaker.executeCheckedSupplier(any()))
+                    .thenThrow(wrappedException);
+
+            // when & then
+            // unwrap 로직으로 인해 원본 ClientBaseException이 전파되어야 함
+            assertThatThrownBy(() -> resilientLockStrategy.executeWithLock(TEST_KEY, WAIT_TIME, LEASE_TIME, () -> "success"))
+                    .isSameAs(businessException);
+
+            // MySQL fallback이 호출되지 않았음을 검증
+            verify(mysqlLockStrategy, never()).executeWithLock(anyString(), anyLong(), anyLong(), any());
+        }
+
+        @Test
+        @DisplayName("7. 다중 래핑된 비즈니스 예외도 unwrap하여 상위 전파")
+        void shouldPropagateMultiWrappedBusinessException() throws Throwable {
+            // given
+            setupExecutorFallbackPassthrough();
+            CharacterNotFoundException businessException = new CharacterNotFoundException("TestUser");
+            // CompletionException(CompletionException(businessException))
+            CompletionException innerWrapper = new CompletionException(businessException);
+            CompletionException outerWrapper = new CompletionException(innerWrapper);
+
+            when(circuitBreaker.executeCheckedSupplier(any()))
+                    .thenThrow(outerWrapper);
+
+            // when & then
+            assertThatThrownBy(() -> resilientLockStrategy.executeWithLock(TEST_KEY, WAIT_TIME, LEASE_TIME, () -> "success"))
+                    .isSameAs(businessException);
+
+            verify(mysqlLockStrategy, never()).executeWithLock(anyString(), anyLong(), anyLong(), any());
+        }
+    }
+
+    // ========================================
+    // Unknown 예외 → Fallback 없이 상위 전파 (보수 정책)
+    // ========================================
+
+    @Nested
+    @DisplayName("Unknown 예외 발생 시 Fallback 없이 상위 전파 (버그 조기 발견)")
+    class UnknownExceptionPropagationTest {
+
+        @Test
+        @DisplayName("8. NullPointerException 발생 시 MySQL fallback 미실행, 예외 상위 전파")
+        void shouldPropagateUnknownException_WhenNPEOccurs() throws Throwable {
+            // given
+            setupExecutorFallbackPassthrough();
+            NullPointerException npe = new NullPointerException("Unexpected null");
+
+            when(circuitBreaker.executeCheckedSupplier(any()))
+                    .thenThrow(npe);
+
+            // when & then
+            assertThatThrownBy(() -> resilientLockStrategy.executeWithLock(TEST_KEY, WAIT_TIME, LEASE_TIME, () -> "success"))
+                    .isSameAs(npe);
+
+            // MySQL fallback이 호출되지 않았음을 검증 (보수 정책: 버그 조기 발견)
+            verify(mysqlLockStrategy, never()).executeWithLock(anyString(), anyLong(), anyLong(), any());
+        }
+
+        @Test
+        @DisplayName("9. IllegalArgumentException 발생 시 MySQL fallback 미실행, 예외 상위 전파")
+        void shouldPropagateUnknownException_WhenIllegalArgumentExceptionOccurs() throws Throwable {
+            // given
+            setupExecutorFallbackPassthrough();
+            IllegalArgumentException iae = new IllegalArgumentException("Invalid argument");
+
+            when(circuitBreaker.executeCheckedSupplier(any()))
+                    .thenThrow(iae);
+
+            // when & then
+            assertThatThrownBy(() -> resilientLockStrategy.executeWithLock(TEST_KEY, WAIT_TIME, LEASE_TIME, () -> "success"))
+                    .isSameAs(iae);
+
+            verify(mysqlLockStrategy, never()).executeWithLock(anyString(), anyLong(), anyLong(), any());
+        }
+
+        @Test
+        @DisplayName("10. RuntimeException (일반) 발생 시 MySQL fallback 미실행, 예외 상위 전파")
+        void shouldPropagateUnknownException_WhenGenericRuntimeExceptionOccurs() throws Throwable {
+            // given
+            setupExecutorFallbackPassthrough();
+            RuntimeException runtimeException = new RuntimeException("Generic runtime error");
+
+            when(circuitBreaker.executeCheckedSupplier(any()))
+                    .thenThrow(runtimeException);
+
+            // when & then
+            assertThatThrownBy(() -> resilientLockStrategy.executeWithLock(TEST_KEY, WAIT_TIME, LEASE_TIME, () -> "success"))
+                    .isSameAs(runtimeException);
+
+            verify(mysqlLockStrategy, never()).executeWithLock(anyString(), anyLong(), anyLong(), any());
+        }
+    }
+
+    // ========================================
+    // Task 내부 비즈니스 예외 전파 테스트 (P0 핵심 시나리오)
+    // Issue #130: "task 예외가 Redis 장애로 오인되어 fallback 되는 문제" 검증
+    // ========================================
+
+    @Nested
+    @DisplayName("Task 실행 중 비즈니스 예외 발생 시 상위 전파 (Issue #130 핵심)")
+    class TaskBusinessExceptionTest {
+
+        @Test
+        @DisplayName("11. [핵심] task에서 CharacterNotFoundException 발생 시 MySQL fallback 미실행")
+        void shouldPropagateTaskBusinessException_WhenTaskThrowsClientBaseException() throws Throwable {
+            // given
+            // 실경로: executor → CB.executeCheckedSupplier(supplier.get()) → redis.executeWithLock(task.get()) → task throws
+            setupExecutorFallbackPassthrough();
+            setupCircuitBreakerPassthrough();
+            setupRedisExecuteWithLockPassthrough();
+
+            CharacterNotFoundException business = new CharacterNotFoundException("TestUser");
+
+            // when & then
+            // task가 실제로 실행되어 비즈니스 예외를 던지고, handleFallback에서 fallback 없이 전파
+            assertThatThrownBy(() ->
+                    resilientLockStrategy.executeWithLock(TEST_KEY, WAIT_TIME, LEASE_TIME,
+                            () -> { throw business; })
+            ).isSameAs(business);
+
+            // MySQL fallback이 호출되지 않았음을 검증
+            verify(mysqlLockStrategy, never()).executeWithLock(anyString(), anyLong(), anyLong(), any());
+        }
+
+        @Test
+        @DisplayName("12. [핵심] task에서 CompletionException으로 래핑된 비즈니스 예외 발생 시 unwrap 후 상위 전파")
+        void shouldUnwrapAndPropagateTaskBusinessException_WhenTaskThrowsWrappedClientBaseException() throws Throwable {
+            // given
+            // 실경로: executor → CB → redis → task throws CompletionException(business) → unwrap → 전파
+            setupExecutorFallbackPassthrough();
+            setupCircuitBreakerPassthrough();
+            setupRedisExecuteWithLockPassthrough();
+
+            CharacterNotFoundException business = new CharacterNotFoundException("TestUser");
+
+            // when & then
+            // task가 CompletionException으로 래핑된 비즈니스 예외를 던지고, unwrap 후 원본 전파
+            assertThatThrownBy(() ->
+                    resilientLockStrategy.executeWithLock(TEST_KEY, WAIT_TIME, LEASE_TIME,
+                            () -> { throw new CompletionException(business); })
+            ).isSameAs(business);
+
+            // MySQL fallback이 호출되지 않았음을 검증
+            verify(mysqlLockStrategy, never()).executeWithLock(anyString(), anyLong(), anyLong(), any());
+        }
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
#130

## 🗣 개요
Tiered Locking에서 비즈니스 예외(ClientBaseException)가 MySQL fallback을 잘못 트리거하는 정합성 결함을 수정합니다.

## 🛠 작업 내용

### 예외 필터링 정책 (금융급 보수적 설계)
| 구분 | 예외 타입 | 동작 |
|-----|----------|------|
| **비즈니스 예외** | `ClientBaseException` 하위 클래스 | 상위 전파 (Fallback 절대 금지) |
| **인프라 예외** | `DistributedLockException`, `CallNotPermittedException`, `RedisException`, `RedisTimeoutException` | MySQL Fallback |
| **Unknown 예외** | 그 외 모든 예외 (NPE, IAE 등) | **상위 전파** (버그 조기 발견) |
| **Checked Throwable** | 체크 예외 | fail-fast (IllegalStateException) |

### 구현 세부사항
- [x] `executeWithFallback()` 단일 파이프라인 사용 (중첩 executor 호출 금지)
- [x] `unwrap()`: CompletionException/ExecutionException 래핑 해제
- [x] `throwAsRuntime()`: RuntimeException/Error 원형 전파
- [x] `ThrowingSupplier.getUnchecked()`: 인프라 레이어 try-catch 캡슐화
- [x] InterruptedException → DistributedLockException 정규화

### Zero Try-Catch Policy 준수
- 비즈니스 로직(`ResilientLockStrategy`)에 try-catch 없음
- try-catch는 `ThrowingSupplier.getUnchecked()`에만 존재 (인프라 레이어)

## 💬 리뷰 포인트
1. **예외 필터링 정책**: `handleFallback()` 메서드의 분기 로직이 금융급 정책에 부합하는지
2. **sneakyThrow 대체**: `throwAsRuntime()` 방식이 checked 예외를 IllegalStateException으로 래핑하는 것이 적절한지
3. **unwrap 로직**: CompletionException/ExecutionException/UndeclaredThrowableException 외에 추가로 처리해야 할 래핑 예외가 있는지

## 💱 트레이드 오프 결정 근거

### sneakyThrow vs throwAsRuntime
- **선택**: `throwAsRuntime()` (checked → IllegalStateException)
- **근거**: 
  - Biz 경계에서 checked Throwable이 올라오는 것은 설계 위반
  - fail-fast로 정책 위반을 조기 발견
  - sneakyThrow는 바이트코드 트릭으로 IDE 경고 유발 가능

### Unknown 예외 처리
- **선택**: Fallback 없이 상위 전파
- **근거**: 금융급 보수적 정책 - NPE 등 버그성 예외를 Fallback으로 가리면 정합성 문제를 발견하기 어려움

## ✅ 체크리스트
- [x] 브랜치/커밋 규칙 준수 여부
- [x] 테스트 통과 여부 (12개 테스트 케이스)
- [x] 전체 회귀 테스트 통과
- [x] Zero Try-Catch Policy 준수
- [x] LogicExecutor 패턴 준수 (executeWithFallback 단일 파이프라인)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)