### PR TITLE
feat(#168): Thread Pool Backpressure - CallerRunsPolicy 제거 및 AbortPolicy 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ mysql_data/
 /redis_data/
 /logs/
 *.http
+/.claude/agents/
+/locust*.*

--- a/src/main/java/maple/expectation/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/maple/expectation/global/error/GlobalExceptionHandler.java
@@ -3,11 +3,14 @@ package maple.expectation.global.error;
 import lombok.extern.slf4j.Slf4j;
 import maple.expectation.global.error.dto.ErrorResponse;
 import maple.expectation.global.error.exception.base.BaseException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.time.LocalDateTime;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeoutException;
 
 @Slf4j
@@ -25,7 +28,7 @@ public class GlobalExceptionHandler {
     }
 
     /**
-     * [Issue #118] CompletionException 처리 (비동기 파이프라인 예외 unwrap)
+     * [Issue #118 + #168] CompletionException 처리 (비동기 파이프라인 예외 unwrap)
      *
      * <p>CompletableFuture.join()에서 발생하는 CompletionException을 unwrap하여
      * 원래 예외 타입에 맞는 핸들러로 위임합니다.</p>
@@ -33,7 +36,8 @@ public class GlobalExceptionHandler {
      * <h4>처리 순서</h4>
      * <ol>
      *   <li>cause가 BaseException → handleBaseException으로 위임</li>
-     *   <li>cause가 TimeoutException → 503 Service Unavailable</li>
+     *   <li>cause가 RejectedExecutionException → 503 + Retry-After 60s (Issue #168)</li>
+     *   <li>cause가 TimeoutException → 503 + Retry-After 30s</li>
      *   <li>그 외 → 500 Internal Server Error</li>
      * </ol>
      */
@@ -46,15 +50,43 @@ public class GlobalExceptionHandler {
             return handleBaseException(be);
         }
 
-        // 2. TimeoutException → 503 Service Unavailable
-        if (cause instanceof TimeoutException) {
-            log.warn("Async operation timeout: {}", cause.getMessage());
-            return ErrorResponse.toResponseEntity(CommonErrorCode.SERVICE_UNAVAILABLE);
+        // 2. RejectedExecutionException → 503 + Retry-After 60초 (Issue #168)
+        // 5-Agent 합의: 톰캣 스레드 보호를 위해 큐 포화 시 즉시 거부 후 503 반환
+        if (cause instanceof RejectedExecutionException) {
+            log.warn("Task rejected (executor queue full): {}", cause.getMessage());
+            return buildServiceUnavailableResponse(60);  // 60초 후 재시도 권장
         }
 
-        // 3. 그 외 시스템 예외 → 500 (cause를 로깅)
+        // 3. TimeoutException → 503 + Retry-After 30초
+        if (cause instanceof TimeoutException) {
+            log.warn("Async operation timeout: {}", cause.getMessage());
+            return buildServiceUnavailableResponse(30);  // 30초 후 재시도 권장
+        }
+
+        // 4. 그 외 시스템 예외 → 500 (cause를 로깅)
         log.error("CompletionException unwrapped - cause: ", cause);
         return ErrorResponse.toResponseEntity(CommonErrorCode.INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * [Issue #168] 503 Service Unavailable 응답 빌더 (Retry-After 헤더 포함)
+     *
+     * <p>HTTP 표준 Retry-After 헤더를 포함하여 클라이언트에게 재시도 시점을 안내합니다.</p>
+     *
+     * @param retryAfterSeconds 재시도 권장 시간 (초)
+     * @return 503 응답 + Retry-After 헤더
+     */
+    private ResponseEntity<ErrorResponse> buildServiceUnavailableResponse(int retryAfterSeconds) {
+        ErrorResponse body = ErrorResponse.builder()
+                .status(CommonErrorCode.SERVICE_UNAVAILABLE.getStatus().value())
+                .code(CommonErrorCode.SERVICE_UNAVAILABLE.getCode())
+                .message(CommonErrorCode.SERVICE_UNAVAILABLE.getMessage())
+                .timestamp(LocalDateTime.now())
+                .build();
+        return ResponseEntity
+                .status(HttpStatus.SERVICE_UNAVAILABLE)
+                .header("Retry-After", String.valueOf(retryAfterSeconds))
+                .body(body);
     }
 
     /**

--- a/src/test/java/maple/expectation/concurrency/LikeConcurrencyTest.java
+++ b/src/test/java/maple/expectation/concurrency/LikeConcurrencyTest.java
@@ -76,6 +76,8 @@ public class LikeConcurrencyTest extends IntegrationTestSupport {
         }
         latch.await(10, TimeUnit.SECONDS);
         executorService.shutdown();
+        // 5-Agent 합의: 모든 작업 완료 대기 (incrementAndGet 완료 보장)
+        executorService.awaitTermination(5, TimeUnit.SECONDS);
 
         likeSyncService.flushLocalToRedis();
         likeSyncService.syncRedisToDatabase();


### PR DESCRIPTION
## 🔗 관련 이슈
#168

## 🗣 개요
CallerRunsPolicy로 인한 톰캣 스레드 고갈 문제를 해결하고, 적절한 Backpressure 메커니즘을 구현합니다.

## 🛠 작업 내용
- [x] CallerRunsPolicy → AbortPolicy 변경 (톰캣 스레드 보호)
- [x] Micrometer ExecutorServiceMetrics 등록
- [x] `executor.rejected` Counter 추가 (커스텀 메트릭)
- [x] 503 + Retry-After 헤더 응답 구현
- [x] 샘플링 로깅 패턴 (log storm 방지)
- [x] GlobalExceptionHandler에서 RejectedExecutionException 처리
- [x] 테스트 코드 추가 (GlobalExceptionHandlerTest)
- [x] CLAUDE.md 업데이트 (섹션 22, 23)

## 💬 리뷰 포인트
1. **ExecutorConfig.java**: CallerRunsPolicy 제거 후 AbortPolicy + 샘플링 로깅 패턴 적용
2. **GlobalExceptionHandler.java**: CompletionException unwrap 시 RejectedExecutionException → 503 + Retry-After
3. **CLAUDE.md**: Best Practice 섹션 22, 23 추가

## 💱 트레이드 오프 결정 근거

| 정책 | 장점 | 단점 |
|------|------|------|
| CallerRunsPolicy | 드롭 없음 | 톰캣 스레드 고갈, 메트릭 불가 |
| **AbortPolicy (선택)** | 톰캣 스레드 보호, 메트릭 가능 | 503 응답 발생 |

**결정**: 서비스 가용성(톰캣 스레드 보호) > 단일 요청 성공률

## 🤖 5-Agent 협력 검토 결과
| Agent | 역할 | 결과 |
|-------|------|------|
| 🟥 Red | SRE-Gatekeeper | ✅ APPROVED |
| 🟦 Blue | Spring-Architect | ✅ APPROVED |
| 🟩 Green | Performance-Guru | ✅ APPROVED |
| 🟨 Yellow | QA-Master | ✅ APPROVED |
| 🟪 Purple | Financial-Grade-Auditor | ✅ APPROVED |

## ✅ 체크리스트
- [x] 브랜치/커밋 규칙 준수 여부
- [x] 테스트 통과 여부
- [x] CLAUDE.md 업데이트

🤖 Generated with [Claude Code](https://claude.ai/code)