### PR TITLE
feat(#118): V2 Controller 비동기 파이프라인 전환 및 .join() 제거

### DIFF
--- a/src/main/java/maple/expectation/controller/GameCharacterControllerV2.java
+++ b/src/main/java/maple/expectation/controller/GameCharacterControllerV2.java
@@ -11,6 +11,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.concurrent.CompletableFuture;
+
 /**
  * 캐릭터 API 컨트롤러 V2
  *
@@ -33,18 +35,26 @@ public class GameCharacterControllerV2 {
 
     /**
      * 캐릭터 장비 조회 (Public)
+     *
+     * <p>Issue #118: 비동기 파이프라인 전환 - 톰캣 스레드 즉시 반환</p>
      */
     @GetMapping("/{userIgn}/equipment")
-    public ResponseEntity<EquipmentResponse> getCharacterEquipment(@PathVariable String userIgn) {
-        return ResponseEntity.ok(equipmentService.getEquipmentByUserIgn(userIgn));
+    public CompletableFuture<ResponseEntity<EquipmentResponse>> getCharacterEquipment(
+            @PathVariable String userIgn) {
+        return equipmentService.getEquipmentByUserIgnAsync(userIgn)
+                .thenApply(ResponseEntity::ok);
     }
 
     /**
      * 기대 비용 시뮬레이션 (Public)
+     *
+     * <p>Issue #118: 비동기 파이프라인 전환 - calculateTotalExpectationAsync (모던 캐싱 버전) 사용</p>
      */
     @GetMapping("/{userIgn}/expectation")
-    public ResponseEntity<TotalExpectationResponse> calculateTotalCost(@PathVariable String userIgn) {
-        return ResponseEntity.ok(equipmentService.calculateTotalExpectationLegacy(userIgn));
+    public CompletableFuture<ResponseEntity<TotalExpectationResponse>> calculateTotalCost(
+            @PathVariable String userIgn) {
+        return equipmentService.calculateTotalExpectationAsync(userIgn)
+                .thenApply(ResponseEntity::ok);
     }
 
     /**

--- a/src/main/java/maple/expectation/provider/EquipmentFetchProvider.java
+++ b/src/main/java/maple/expectation/provider/EquipmentFetchProvider.java
@@ -9,16 +9,60 @@ import org.springframework.stereotype.Component;
 
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * 장비 데이터 Fetch Provider (캐시 적용)
+ *
+ * <h2>ADR: .join() 유지 결정 (Issue #118)</h2>
+ *
+ * <h3>Context</h3>
+ * <p>Issue #118에서 비동기 파이프라인 전환을 진행하며 모든 .join() 제거를 검토함.</p>
+ *
+ * <h3>Decision</h3>
+ * <p>이 클래스의 .join()은 <b>의도적으로 유지</b>합니다.</p>
+ *
+ * <h3>Rationale</h3>
+ * <ul>
+ *   <li>Spring @Cacheable은 {@code CompletableFuture<T>} 반환 타입을 지원하지 않음</li>
+ *   <li>@Cacheable(sync=true)는 Cache Stampede 방지용이며, 비동기 지원과 무관</li>
+ *   <li>캐시 프록시가 실제 값을 저장하려면 동기 반환이 필수</li>
+ *   <li>호출자(EquipmentCacheService)가 이미 비동기 래퍼를 제공하므로 전체 파이프라인은 논블로킹</li>
+ * </ul>
+ *
+ * <h3>Consequences</h3>
+ * <ul>
+ *   <li>캐시 MISS 시 이 지점에서 일시적 블로킹 발생 (예상: 100~300ms)</li>
+ *   <li>캐시 HIT 시 블로킹 없음 (Caffeine L1 또는 Redis L2에서 즉시 반환)</li>
+ *   <li>전용 Executor(expectationComputeExecutor)에서 실행되어 톰캣 스레드 영향 없음</li>
+ * </ul>
+ *
+ * <h3>Alternatives Considered</h3>
+ * <ul>
+ *   <li>Option A: @Cacheable 제거 후 수동 캐싱 → 코드 복잡도 증가, 캐시 일관성 관리 어려움</li>
+ *   <li>Option B: Reactor/Mono 전환 → 전체 스택 변경 필요, 과도한 변경</li>
+ *   <li>Option C: 현상 유지 (선택) → 실용적, 성능 영향 미미</li>
+ * </ul>
+ *
+ * @see maple.expectation.service.v2.cache.EquipmentCacheService
+ */
 @Component
 @RequiredArgsConstructor
 public class EquipmentFetchProvider {
 
     private final NexonApiClient nexonApiClient;
 
+    /**
+     * 캐시 적용 장비 데이터 조회
+     *
+     * <p><b>⚠️ ADR: .join() 의도적 유지</b></p>
+     * <p>Spring @Cacheable이 CompletableFuture를 지원하지 않아 동기 반환 필수.
+     * 상세 사유는 클래스 Javadoc 참조.</p>
+     *
+     * @param ocid 캐릭터 OCID
+     * @return 장비 응답 (캐시 HIT 시 즉시 반환, MISS 시 API 호출)
+     */
     @NexonDataCache
     @Cacheable(value = "equipment", key = "#ocid")
     public EquipmentResponse fetchWithCache(String ocid) {
-        // 비동기 결과를 동기로 전환해서 캐시에 저장 (Spring 6의 호환성 문제 해결)
         return nexonApiClient.getItemDataByOcid(ocid).join();
     }
 }

--- a/src/test/java/maple/expectation/service/v2/EquipmentServiceTest.java
+++ b/src/test/java/maple/expectation/service/v2/EquipmentServiceTest.java
@@ -1,11 +1,18 @@
 package maple.expectation.service.v2;
 
+import maple.expectation.domain.v2.GameCharacter;
 import maple.expectation.external.dto.v2.CharacterOcidResponse;
+import maple.expectation.external.dto.v2.EquipmentResponse;
 import maple.expectation.support.IntegrationTestSupport;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.CacheManager;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
@@ -14,16 +21,97 @@ class EquipmentServiceTest extends IntegrationTestSupport {
     @Autowired private CacheManager cacheManager;
     @Autowired private EquipmentService equipmentService;
 
+    private static final String TEST_IGN = "테스트캐릭터";
+    private static final String TEST_OCID = "test-ocid-12345";
+
     @BeforeEach
     void setUp() {
         cacheManager.getCacheNames().forEach(n -> cacheManager.getCache(n).clear());
-        CharacterOcidResponse mockOcid = new CharacterOcidResponse("test-ocid");
+        CharacterOcidResponse mockOcid = new CharacterOcidResponse(TEST_OCID);
         when(nexonApiClient.getOcidByCharacterName(anyString())).thenReturn(mockOcid);
+
+        // 테스트용 캐릭터 저장
+        gameCharacterRepository.save(new GameCharacter(TEST_IGN, TEST_OCID));
+    }
+
+    @AfterEach
+    void tearDown() {
+        gameCharacterRepository.deleteAllInBatch();
     }
 
     @Test
     @DisplayName("Stream API: GZIP 데이터 압축 해제 검증")
     void streamEquipmentData_Gzip_Success() throws Exception {
         // Given/When/Then 로직 유지 (부모의 Mock 사용)
+    }
+
+    // ==================== Issue #118: 비동기 파이프라인 테스트 ====================
+
+    @Test
+    @DisplayName("Issue #118: getEquipmentByUserIgnAsync - 비동기 장비 조회 성공")
+    void getEquipmentByUserIgnAsync_Success() throws ExecutionException, InterruptedException {
+        // Given: Mock 설정 - 비동기 응답 반환
+        EquipmentResponse mockResponse = new EquipmentResponse();
+        when(nexonApiClient.getItemDataByOcid(anyString()))
+                .thenReturn(CompletableFuture.completedFuture(mockResponse));
+
+        // When: 비동기 메서드 호출
+        CompletableFuture<EquipmentResponse> future =
+                equipmentService.getEquipmentByUserIgnAsync(TEST_IGN);
+
+        // Then: 결과 검증
+        EquipmentResponse result = future.get();
+        assertThat(result).isNotNull();
+        verify(nexonApiClient).getItemDataByOcid(TEST_OCID);
+    }
+
+    @Test
+    @DisplayName("Issue #118: getEquipmentByUserIgnAsync - CompletableFuture 체이닝 검증")
+    void getEquipmentByUserIgnAsync_ChainingWorks() {
+        // Given
+        EquipmentResponse mockResponse = new EquipmentResponse();
+        when(nexonApiClient.getItemDataByOcid(anyString()))
+                .thenReturn(CompletableFuture.completedFuture(mockResponse));
+
+        // When: thenApply 체이닝
+        CompletableFuture<Boolean> chainedFuture = equipmentService
+                .getEquipmentByUserIgnAsync(TEST_IGN)
+                .thenApply(response -> response != null);
+
+        // Then: 체이닝 결과 검증
+        Boolean result = chainedFuture.join();
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("Issue #118: 비동기 메서드가 톰캣 스레드를 블로킹하지 않음 검증")
+    void getEquipmentByUserIgnAsync_NonBlocking() {
+        // Given
+        EquipmentResponse mockResponse = new EquipmentResponse();
+        // 지연 응답 시뮬레이션
+        when(nexonApiClient.getItemDataByOcid(anyString()))
+                .thenReturn(CompletableFuture.supplyAsync(() -> {
+                    try {
+                        Thread.sleep(100);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                    return mockResponse;
+                }));
+
+        // When: 비동기 호출 (즉시 반환되어야 함)
+        long startTime = System.currentTimeMillis();
+        CompletableFuture<EquipmentResponse> future =
+                equipmentService.getEquipmentByUserIgnAsync(TEST_IGN);
+        long callTime = System.currentTimeMillis() - startTime;
+
+        // Then: 호출 자체는 즉시 반환 (100ms 미만)
+        assertThat(callTime).isLessThan(50);
+        assertThat(future).isNotNull();
+        assertThat(future.isDone()).isFalse();
+
+        // 결과 대기 후 완료 확인
+        future.orTimeout(5, TimeUnit.SECONDS).join();
+        assertThat(future.isDone()).isTrue();
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
#118

## 🗣 개요
V2 Controller 엔드포인트를 완전 비동기로 전환하고, 불필요한 `.join()` 호출을 제거합니다.
톰캣 스레드가 즉시 반환되어 RPS 240+ 처리량을 유지할 수 있습니다.

## 🛠 작업 내용
- [x] `EquipmentService.getEquipmentByUserIgnAsync()` 비동기 메서드 추가
- [x] `EquipmentService.calculateTotalExpectationLegacyAsync()` 비동기 메서드 추가
- [x] `GameCharacterControllerV2` → `CompletableFuture<ResponseEntity>` 반환으로 전환
- [x] `EquipmentFetchProvider` ADR 문서화 (Spring @Cacheable 제약으로 .join() 유지 사유)
- [x] 동기 메서드 `@Deprecated(since="2.5", forRemoval=true)` 적용
- [x] 비동기 테스트 3개 추가

## 💬 리뷰 포인트
1. **CompletableFuture 체이닝**: `supplyAsync → thenCompose → thenApplyAsync → orTimeout → exceptionally`
2. **예외 처리**: `handleEquipmentException()`에서 `EquipmentDataProcessingException` 커스텀 예외 사용
3. **ADR 문서화**: `EquipmentFetchProvider`의 `.join()` 유지 사유

## 💱 트레이드 오프 결정 근거
| 결정 | 선택 | 근거 |
|------|------|------|
| V2 기대값 엔드포인트 | `calculateTotalExpectationAsync` (모던 캐싱) | 더 효율적인 캐싱 전략 |
| EquipmentFetchProvider .join() | 유지 | Spring @Cacheable이 CompletableFuture 미지원 |
| 동기 메서드 | Deprecated로 유지 | 기존 호출자 점진적 마이그레이션 |

## ✅ 체크리스트
- [x] 브랜치/커밋 규칙 준수 여부
- [x] 테스트 통과 여부 (./gradlew test)
- [x] 빌드 확인 (./gradlew build -x test)
- [x] 5-Agent 협력 검토 완료

## 🤖 5-Agent 검토 결과
| Agent | 결과 | 검토 내용 |
|-------|------|----------|
| 🟦 Blue (Architect) | ✅ PASS | Method Extraction, Deprecation Strategy |
| 🟩 Green (Performance) | ✅ PASS | 전용 Executor, orTimeout() 설정 |
| 🟨 Yellow (QA) | ✅ PASS | 테스트 3개 추가 |
| 🟪 Purple (Auditor) | ✅ PASS | 커스텀 예외 사용 |
| 🟥 Red (SRE) | ✅ PASS | 무한 대기 방지, 예외 전파 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)