### PR TITLE
feat(#151, #172): Bean Validation 전면 적용 및 CORS 보안 강화

### DIFF
--- a/src/main/java/maple/expectation/config/CorsProperties.java
+++ b/src/main/java/maple/expectation/config/CorsProperties.java
@@ -1,0 +1,68 @@
+package maple.expectation.config;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import java.util.List;
+
+/**
+ * CORS 설정 프로퍼티 (환경별 분리)
+ *
+ * <p>Issue #172: CORS 와일드카드 제거 - 환경별 명시적 오리진 설정</p>
+ *
+ * <h4>5-Agent Council Round 2 결정</h4>
+ * <ul>
+ *   <li><b>Red Agent</b>: fail-fast 원칙 - 빈 리스트 시 앱 시작 실패</li>
+ *   <li><b>Blue Agent</b>: @ConfigurationProperties + @Validated 패턴</li>
+ *   <li><b>Purple Agent</b>: 와일드카드 + credentials 조합은 보안 취약점</li>
+ * </ul>
+ *
+ * <h4>환경별 설정 예시</h4>
+ * <ul>
+ *   <li><b>local</b>: localhost 개발 오리진 허용</li>
+ *   <li><b>prod</b>: 명시적 프로덕션 도메인만 허용 (환경변수 필수)</li>
+ * </ul>
+ *
+ * <p>CLAUDE.md 섹션 18 준수: Spring Security 6.x CORS Best Practice</p>
+ */
+@Getter
+@Setter
+@Validated
+@ConfigurationProperties(prefix = "cors")
+public class CorsProperties {
+
+    /**
+     * 허용할 오리진 목록 (필수)
+     *
+     * <p>보안 규칙:
+     * <ul>
+     *   <li>와일드카드(*) 사용 금지 - CSRF 공격 벡터</li>
+     *   <li>빈 리스트 시 앱 시작 실패 (fail-fast)</li>
+     *   <li>프로덕션에서는 환경변수로 주입 권장</li>
+     * </ul>
+     * </p>
+     */
+    @NotEmpty(message = "CORS 허용 오리진 목록은 필수입니다. cors.allowed-origins 설정을 확인하세요.")
+    private List<String> allowedOrigins;
+
+    /**
+     * credentials 허용 여부 (기본: true)
+     *
+     * <p>true일 경우 와일드카드 오리진 사용 불가 (Spring Security 규칙)</p>
+     */
+    @NotNull
+    private Boolean allowCredentials = true;
+
+    /**
+     * preflight 캐시 시간 (초) (기본: 3600 = 1시간)
+     *
+     * <p>OPTIONS 요청 결과를 브라우저가 캐시하는 시간</p>
+     */
+    @Min(0)
+    private Long maxAge = 3600L;
+}

--- a/src/main/java/maple/expectation/controller/dto/admin/AddAdminRequest.java
+++ b/src/main/java/maple/expectation/controller/dto/admin/AddAdminRequest.java
@@ -1,0 +1,56 @@
+package maple.expectation.controller.dto.admin;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Admin 추가 요청 DTO
+ *
+ * <h4>Issue #151: Bean Validation 적용</h4>
+ * <ul>
+ *   <li>@NotBlank: 빈 문자열 및 null 방지</li>
+ *   <li>@Size: 정확히 64자 검증 (SHA-256 hex digest)</li>
+ *   <li>@Pattern: SQL Injection/XSS 패턴 차단 (16진수만 허용)</li>
+ * </ul>
+ *
+ * <h4>5-Agent Council Round 2 결정</h4>
+ * <ul>
+ *   <li><b>Blue Agent</b>: SRP 준수 - Controller 내부에서 분리</li>
+ *   <li><b>Purple Agent</b>: toString() 마스킹으로 PII 보호</li>
+ *   <li><b>Yellow Agent</b>: 경계값 테스트 (63자, 65자, 비hex) 필수</li>
+ * </ul>
+ *
+ * <p>CLAUDE.md 섹션 19 준수: toString() 마스킹 필수</p>
+ */
+public record AddAdminRequest(
+        @NotBlank(message = "fingerprint는 필수입니다")
+        @Size(min = 64, max = 64, message = "fingerprint는 64자여야 합니다")
+        @Pattern(regexp = "^[a-fA-F0-9]+$", message = "fingerprint는 16진수만 허용됩니다")
+        String fingerprint
+) {
+    /**
+     * 마스킹된 fingerprint 반환
+     *
+     * <p>로그 및 응답 메시지에서 사용</p>
+     *
+     * @return 앞 4자리 + **** + 뒤 4자리 형식 (예: "abcd****efgh")
+     */
+    public String maskedFingerprint() {
+        if (fingerprint == null || fingerprint.length() < 8) {
+            return "****";
+        }
+        return fingerprint.substring(0, 4) + "****" + fingerprint.substring(fingerprint.length() - 4);
+    }
+
+    /**
+     * 민감정보 마스킹된 toString
+     *
+     * <p>CRITICAL: TraceAspect 로깅 시 fingerprint 노출 방지</p>
+     * <p>Java Record의 기본 toString()은 모든 필드를 노출하므로 오버라이드 필수</p>
+     */
+    @Override
+    public String toString() {
+        return "AddAdminRequest[fingerprint=" + maskedFingerprint() + "]";
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -36,3 +36,11 @@ cube:
 auth:
   admin:
     allowlist: "ahzQRmenBwQcgIQuzsb9kZ58zCjwlTv4v1IfvpXxCSE"  # 긱델 계정
+
+# CORS 설정 (Issue #172: 로컬 개발 환경)
+cors:
+  allowed-origins:
+    - "http://localhost:3000"
+    - "http://localhost:5173"
+    - "http://127.0.0.1:3000"
+    - "http://127.0.0.1:5173"

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -29,3 +29,9 @@ spring:
 
 discord:
   webhook-url: ${DISCORD_WEBHOOK_URL}
+
+# CORS 설정 (Issue #172: 프로덕션 환경)
+# CRITICAL: CORS_ALLOWED_ORIGINS 환경변수 미설정 시 앱 시작 실패 (fail-fast)
+cors:
+  allowed-origins: ${CORS_ALLOWED_ORIGINS}  # 필수 환경변수 (예: https://example.com,https://www.example.com)
+  max-age: 86400  # 24시간 (프로덕션에서는 캐시 시간 늘림)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -168,3 +168,11 @@ auth:
     allowlist: ${ADMIN_FINGERPRINTS:}  # 쉼표 구분 fingerprint 목록
   session:
     ttl: 1800  # 30분 (초)
+
+# CORS 설정 (Issue #172: 환경별 분리)
+# 주의: 반드시 환경별 프로필(local/prod)에서 allowed-origins 오버라이드 필요
+cors:
+  allowed-origins:
+    - "http://localhost:3000"  # 기본값 (환경별 오버라이드 필수)
+  allow-credentials: true
+  max-age: 3600  # 1시간

--- a/src/test/java/maple/expectation/controller/AdminControllerTest.java
+++ b/src/test/java/maple/expectation/controller/AdminControllerTest.java
@@ -1,0 +1,264 @@
+package maple.expectation.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import maple.expectation.controller.dto.admin.AddAdminRequest;
+import maple.expectation.global.security.AuthenticatedUser;
+import maple.expectation.service.v2.auth.AdminService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * AdminController 단위 테스트 (Issue #151: Bean Validation 검증)
+ *
+ * <h4>5-Agent Council Round 2 결정</h4>
+ * <ul>
+ *   <li><b>Yellow Agent</b>: 경계값 테스트 (63자, 65자, 비hex) 필수</li>
+ *   <li><b>Purple Agent</b>: SQL Injection/XSS 패턴 차단 검증</li>
+ *   <li><b>Blue Agent</b>: @Valid + @Validated 동작 검증</li>
+ * </ul>
+ *
+ * <p>테스트 범위:
+ * <ul>
+ *   <li>TC-151-01: addAdmin() 빈 fingerprint → 400</li>
+ *   <li>TC-151-02: addAdmin() null fingerprint → 400</li>
+ *   <li>TC-151-03: addAdmin() 63자 fingerprint (경계값) → 400</li>
+ *   <li>TC-151-04: addAdmin() 65자 fingerprint (경계값) → 400</li>
+ *   <li>TC-151-05: addAdmin() SQL Injection/XSS 패턴 → 400</li>
+ *   <li>TC-151-06: addAdmin() 정상 64자 hex fingerprint → 200</li>
+ *   <li>TC-151-07: removeAdmin() 빈 fingerprint → 404 (URL 매칭 실패)</li>
+ *   <li>TC-151-08: 자기 자신 삭제 시도 → 400</li>
+ * </ul>
+ * </p>
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class AdminControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private AdminService adminService;
+
+    // 정상적인 64자 hex fingerprint
+    private static final String VALID_FINGERPRINT_64 =
+            "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+
+    // 63자 fingerprint (경계값 - 너무 짧음)
+    private static final String FINGERPRINT_63 =
+            "abcdef0123456789abcdef0123456789abcdef0123456789abcdef012345678";
+
+    // 65자 fingerprint (경계값 - 너무 김)
+    private static final String FINGERPRINT_65 =
+            "abcdef0123456789abcdef0123456789abcdef0123456789abcdef01234567890";
+
+    @Nested
+    @DisplayName("addAdmin() @Valid 검증 테스트")
+    class AddAdminValidationTests {
+
+        @Test
+        @DisplayName("TC-151-01: 빈 fingerprint → 400 + C001")
+        void addAdmin_emptyFingerprint_returns400() throws Exception {
+            // Given
+            setupAdminAuthentication();
+            AddAdminRequest request = new AddAdminRequest("");
+
+            // When & Then
+            mockMvc.perform(post("/api/admin/admins")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("C001"));
+        }
+
+        @Test
+        @DisplayName("TC-151-02: null fingerprint → 400 + C001")
+        void addAdmin_nullFingerprint_returns400() throws Exception {
+            // Given
+            setupAdminAuthentication();
+            // JSON에서 null 전송
+            String jsonWithNull = "{\"fingerprint\":null}";
+
+            // When & Then
+            mockMvc.perform(post("/api/admin/admins")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(jsonWithNull))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("C001"));
+        }
+
+        @Test
+        @DisplayName("TC-151-03: 63자 fingerprint (경계값) → 400 + C001")
+        void addAdmin_63CharFingerprint_returns400() throws Exception {
+            // Given
+            setupAdminAuthentication();
+            AddAdminRequest request = new AddAdminRequest(FINGERPRINT_63);
+
+            // When & Then
+            mockMvc.perform(post("/api/admin/admins")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("C001"));
+        }
+
+        @Test
+        @DisplayName("TC-151-04: 65자 fingerprint (경계값) → 400 + C001")
+        void addAdmin_65CharFingerprint_returns400() throws Exception {
+            // Given
+            setupAdminAuthentication();
+            AddAdminRequest request = new AddAdminRequest(FINGERPRINT_65);
+
+            // When & Then
+            mockMvc.perform(post("/api/admin/admins")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("C001"));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "'; DROP TABLE admins; --",              // SQL Injection
+                "<script>alert('xss')</script>",         // XSS
+                "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz", // 비hex (64자)
+                "GHIJKLMNOPQRSTUVWXYZ0123456789abcdef0123456789abcdef0123456789ab", // 비hex 대문자
+                "   ",                                   // 공백만
+                "abcdef0123456789abcdef0123456789abcdef0123456789abcdef012345678X" // 마지막 비hex
+        })
+        @DisplayName("TC-151-05: SQL Injection/XSS/비hex 패턴 → 400 + C001")
+        void addAdmin_invalidPatterns_returns400(String invalidFingerprint) throws Exception {
+            // Given
+            setupAdminAuthentication();
+            AddAdminRequest request = new AddAdminRequest(invalidFingerprint);
+
+            // When & Then
+            mockMvc.perform(post("/api/admin/admins")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("C001"));
+        }
+
+        @Test
+        @DisplayName("TC-151-06: 정상 64자 hex fingerprint → 200")
+        void addAdmin_validFingerprint_returns200() throws Exception {
+            // Given
+            setupAdminAuthentication();
+            AddAdminRequest request = new AddAdminRequest(VALID_FINGERPRINT_64);
+
+            // When & Then
+            mockMvc.perform(post("/api/admin/admins")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true));
+        }
+    }
+
+    @Nested
+    @DisplayName("removeAdmin() 검증 테스트")
+    class RemoveAdminTests {
+
+        @Test
+        @DisplayName("TC-151-07: 빈 fingerprint로 삭제 시도 → URL 패턴 매칭 안됨 (Spring 기본 동작)")
+        void removeAdmin_emptyFingerprint_returnsError() throws Exception {
+            // Given
+            setupAdminAuthentication();
+
+            // When & Then: /api/admin/admins/ 와 / 없는 경우 모두 테스트
+            // Spring MVC는 trailing slash에 따라 다른 결과를 반환할 수 있음
+            // 빈 문자열 경로 변수는 Spring이 다르게 처리함
+            mockMvc.perform(delete("/api/admin/admins/ "))  // 공백 fingerprint
+                    .andExpect(status().is4xxClientError());  // 4xx 에러 범위
+        }
+
+        @Test
+        @DisplayName("TC-151-08: 자기 자신 삭제 시도 → 400 + SELF_REMOVAL_NOT_ALLOWED")
+        void removeAdmin_selfRemoval_returns400() throws Exception {
+            // Given: 현재 사용자의 fingerprint로 삭제 시도
+            String currentUserFingerprint = VALID_FINGERPRINT_64;
+            setupAdminAuthentication(currentUserFingerprint);
+
+            // When & Then: ApiResponse.error 구조: $.error.code
+            mockMvc.perform(delete("/api/admin/admins/" + currentUserFingerprint))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error.code").value("SELF_REMOVAL_NOT_ALLOWED"));
+        }
+    }
+
+    @Nested
+    @DisplayName("getAdmins() 테스트")
+    class GetAdminsTests {
+
+        @Test
+        @DisplayName("Admin 목록 조회 성공")
+        void getAdmins_returns200() throws Exception {
+            // Given
+            setupAdminAuthentication();
+            given(adminService.getAllAdmins()).willReturn(Set.of(VALID_FINGERPRINT_64));
+
+            // When & Then
+            mockMvc.perform(get("/api/admin/admins"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true));
+        }
+    }
+
+    // ==================== Helper Methods ====================
+
+    /**
+     * ADMIN 권한으로 SecurityContext 설정 (기본 fingerprint)
+     */
+    private void setupAdminAuthentication() {
+        setupAdminAuthentication("default-admin-fingerprint-for-testing-1234567890abcdef1234");
+    }
+
+    /**
+     * ADMIN 권한으로 SecurityContext 설정 (지정된 fingerprint)
+     *
+     * <p>AuthenticatedUser 필드: sessionId, fingerprint, apiKey, myOcids, role</p>
+     */
+    private void setupAdminAuthentication(String fingerprint) {
+        AuthenticatedUser user = new AuthenticatedUser(
+                "test-session-id",    // sessionId
+                fingerprint,           // fingerprint
+                "test-api-key",        // apiKey
+                Collections.emptySet(),// myOcids
+                "ADMIN"                // role
+        );
+
+        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+                user,
+                null,
+                List.of(new SimpleGrantedAuthority("ROLE_ADMIN"))
+        );
+
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -96,3 +96,10 @@ springdoc:
 scheduler:
   like-sync:
     enabled: false
+
+# CORS 설정 (테스트 환경)
+cors:
+  allowed-origins:
+    - "http://localhost:3000"
+  allow-credentials: true
+  max-age: 3600


### PR DESCRIPTION
## 🔗 관련 이슈
- #151 [P0]: 입력값 검증(Validation) 전면 적용
- #170 [P1]: JwtAuthenticationFilter Redis Timeout 설정 (기존 구현 검증)
- #172 [P1]: SecurityConfig CORS 와일드카드 제거

## 🗣 개요
보안 및 입력 검증의 세 가지 핵심 문제를 해결합니다:
- Bean Validation + GlobalExceptionHandler로 입력값 검증 체계 확립
- CORS 와일드카드 제거 및 환경별 설정 분리
- Redis Timeout 기존 구현 정상 동작 검증

## 🛠 작업 내용

### Issue #151: Bean Validation 전면 적용
- [x] GlobalExceptionHandler: MethodArgumentNotValidException 핸들러 추가
- [x] GlobalExceptionHandler: ConstraintViolationException 핸들러 추가
- [x] AddAdminRequest: @NotBlank + @Size(64) + @Pattern(hex) 검증
- [x] AdminController: @Valid, @Validated 어노테이션 적용
- [x] AddAdminRequest 별도 파일 분리 (SRP 준수)
- [x] toString() 오버라이드로 fingerprint PII 마스킹

### Issue #172: CORS 보안 강화
- [x] CorsProperties: @ConfigurationProperties + @Validated 패턴
- [x] SecurityConfig: 하드코딩 제거, CorsProperties 주입
- [x] application-local.yml: 로컬 개발 오리진 설정
- [x] application-prod.yml: 환경변수 기반 오리진 설정
- [x] @NotEmpty로 빈 리스트 시 앱 시작 실패 (fail-fast)

### Issue #170: Redis Timeout (검증)
- [x] 기존 LogicExecutor.executeOrDefault() 구현 정상 동작 확인

## 💬 리뷰 포인트
1. **CorsProperties**: @ConfigurationProperties + @Validated 조합이 적절한지
2. **AddAdminRequest**: @Pattern 정규식이 SQL Injection/XSS를 충분히 방어하는지
3. **GlobalExceptionHandler**: 에러 메시지 포맷이 클라이언트 친화적인지

## 💱 트레이드 오프 결정 근거

### CORS 설정 외부화 방식
| 대안 | 장점 | 단점 | 결정 |
|------|------|------|------|
| 환경변수 직접 주입 | 간단 | 타입 안전성 없음 | ❌ |
| @ConfigurationProperties | 타입 안전, 검증 가능 | 클래스 추가 | ✅ 채택 |

## ✅ 체크리스트
- [x] 브랜치/커밋 규칙 준수
- [x] 테스트 통과 (10 TC)
- [x] SOLID 원칙 준수 (SRP: AddAdminRequest 분리)
- [x] 보안 검증 (PII 마스킹, SQL Injection 차단)

## 🧪 테스트 결과
```
AdminControllerTest: 8 TC ✅
GlobalExceptionHandlerTest: 2 TC 추가 ✅
BUILD SUCCESSFUL
```

## 📊 5-Agent Council 판정
| Agent | 판정 |
|-------|------|
| 🟥 Red (SRE) | ✅ PASS |
| 🟦 Blue (Architect) | ✅ PASS |
| 🟩 Green (Performance) | ✅ PASS |
| 🟨 Yellow (QA) | ✅ PASS |
| 🟪 Purple (Auditor) | ✅ PASS |

🤖 Generated with [Claude Code](https://claude.com/claude-code)