### PR TITLE
hotfix: README QuickStart 섹션 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,38 @@
 
 ---
 
+## 🚀 QuickStart (2-3분)
+
+> Docker와 JDK 17이 설치되어 있어야 합니다.
+
+### Step 1: 인프라 + 서버 구동
+
+```bash
+# 터미널 1: 인프라 구동 (MySQL, Redis)
+docker-compose up -d
+
+# 터미널 2: 애플리케이션 시작 (첫 실행 시 빌드 포함)
+./gradlew bootRun --args='--spring.profiles.active=local'
+```
+
+### Step 2: 동작 확인
+
+```bash
+# Health Check (서버 준비 확인)
+curl http://localhost:8080/actuator/health
+
+# 핵심 API 호출 (V3 기대값 계산 - 인증 불필요)
+curl "http://localhost:8080/api/v3/characters/%EA%B0%95%EC%9D%80%ED%98%B8/expectation"
+```
+
+**예상 결과:**
+- Health: `{"status":"UP"}`
+- API: `{"userIgn":"강은호", "totalCost":..., "items":[...]}`
+
+> ⚠️ **첫 호출 시 Cold Cache**로 인해 290ms~690ms 소요될 수 있습니다. (Nexon API 호출 포함)
+
+---
+
 ## ⚠️ Engineering Standards & Operational Reality
 
 ### 1. Performance Context (Benchmark Conditions)


### PR DESCRIPTION
## 🔗 관련 이슈
README 개선 (QuickStart 가이드 추가)

## 🗣 개요
Performance와 Engineering Standards 사이에 **2-3분 QuickStart** 섹션 추가

## 🛠 작업 내용
- [x] QuickStart 섹션 추가 (Step 1: 인프라+서버, Step 2: 검증)
- [x] Health Check 명령어 (`/actuator/health`)
- [x] V3 API 호출 명령어 (URL 인코딩된 한글 캐릭터)
- [x] Cold Cache 경고 안내
- [x] **실제 테스트 검증 완료**

## 💬 리뷰 포인트
- curl 호환성 (7.68.0 이하에서도 동작 확인)
- URL 인코딩된 한글 캐릭터 (`%EA%B0%95%EC%9D%80%ED%98%B8` = 강은호)

## 💱 트레이드 오프 결정 근거
| 옵션 | 장점 | 단점 | 결정 |
|------|------|------|------|
| `--retry-all-errors` | 서버 준비 자동 대기 | curl 7.71.0+ 필요 | ❌ |
| 단순 curl | 모든 버전 호환 | 수동 재시도 필요 | ✅ |

## ✅ 테스트 검증 결과
```
Health Check: {"status":"UP"} ✅
V3 API: {"userIgn":"강은호", "totalCost":96588685000000, ...} ✅
```

## 🏛️ 5 Agent Council 합의
- **Blue (Architect)**: SRP에 따라 3단계 구조 (Prerequisites → Step 1 → Step 2)
- **Green (Performance)**: curl 호환성 최적화
- **Yellow (QA)**: 실제 테스트 검증 완료
- **Purple (Auditor)**: V3 API는 인증 불필요, 보안 이슈 없음
- **Red (SRE)**: Cold Cache 경고 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)