### PR TITLE
fix(#144-185): Codex 리뷰 기반 핵심 버그 수정

### DIFF
--- a/src/main/java/maple/expectation/global/redis/script/LikeAtomicOperations.java
+++ b/src/main/java/maple/expectation/global/redis/script/LikeAtomicOperations.java
@@ -29,8 +29,8 @@ public interface LikeAtomicOperations {
      *
      * <pre>
      * 수행 연산:
-     * 1. HINCRBY buffer:{likes}:hash userIgn count
-     * 2. INCRBY buffer:{likes}:total_count count
+     * 1. HINCRBY {buffer:likes} userIgn count
+     * 2. INCRBY {buffer:likes}:total_count count
      * </pre>
      *
      * @param userIgn 사용자 식별자 (not null, not blank)
@@ -49,7 +49,7 @@ public interface LikeAtomicOperations {
      * <pre>
      * 수행 연산:
      * 1. deleted = HDEL tempKey userIgn
-     * 2. if deleted > 0: DECRBY buffer:{likes}:total_count count
+     * 2. if deleted > 0: DECRBY {buffer:likes}:total_count count
      * </pre>
      *
      * @param tempKey 동기화 임시 키 (not null, not blank)
@@ -67,7 +67,7 @@ public interface LikeAtomicOperations {
      *
      * <pre>
      * 수행 연산:
-     * 1. HINCRBY buffer:{likes}:hash userIgn count
+     * 1. HINCRBY {buffer:likes} userIgn count
      * 2. HDEL tempKey userIgn
      * </pre>
      *

--- a/src/main/java/maple/expectation/global/redis/script/RedissonLikeAtomicOperations.java
+++ b/src/main/java/maple/expectation/global/redis/script/RedissonLikeAtomicOperations.java
@@ -28,8 +28,8 @@ import java.util.Objects;
  *   <li>관측성: 실행 시간, 실패 횟수 메트릭 수집</li>
  * </ul>
  *
- * <h2>Hash Tag</h2>
- * <p>모든 키는 {likes} Hash Tag를 사용하여 Redis Cluster CROSSSLOT 에러를 방지합니다.</p>
+ * <h2>Hash Tag (CRITICAL FIX - PR #175, #164)</h2>
+ * <p>모든 키는 {buffer:likes} Hash Tag를 사용하여 Redis Cluster CROSSSLOT 에러를 방지합니다.</p>
  */
 @Slf4j
 @Component

--- a/src/main/java/maple/expectation/repository/v2/RedisBufferRepository.java
+++ b/src/main/java/maple/expectation/repository/v2/RedisBufferRepository.java
@@ -10,10 +10,10 @@ import org.springframework.stereotype.Repository;
  *
  * <p>좋아요 동기화를 위한 전역 카운터 관리를 담당합니다.</p>
  *
- * <h2>키 구조 (Hash Tag로 CROSSSLOT 방지)</h2>
+ * <h2>키 구조 (Hash Tag로 CROSSSLOT 방지) - PR #175, #164 수정</h2>
  * <pre>
- * buffer:{likes}:hash        - Hash (사용자별 카운트)
- * buffer:{likes}:total_count - String (전역 대기 카운트)
+ * {buffer:likes}              - Hash (사용자별 카운트)
+ * {buffer:likes}:total_count  - String (전역 대기 카운트)
  * </pre>
  *
  * @see LuaScripts.Keys 키 상수 정의

--- a/src/main/java/maple/expectation/service/v2/shutdown/ShutdownDataRecoveryService.java
+++ b/src/main/java/maple/expectation/service/v2/shutdown/ShutdownDataRecoveryService.java
@@ -26,7 +26,13 @@ public class ShutdownDataRecoveryService {
     private final StringRedisTemplate redisTemplate;
     private final LogicExecutor executor; // ✅ 지능형 실행기 주입
 
-    private static final String REDIS_HASH_KEY = "buffer:likes";
+    /**
+     * Redis Hash Key (LikeSyncService.SOURCE_KEY와 동일)
+     *
+     * <p>CRITICAL FIX (PR #175, #164 Codex 지적):
+     * Hash Tag 패턴 적용으로 LikeSyncService와 키 일치 보장</p>
+     */
+    private static final String REDIS_HASH_KEY = "{buffer:likes}";
 
     @PostConstruct
     public void recoverFromBackup() {

--- a/src/test/java/maple/expectation/service/v2/shutdown/ShutdownDataRecoveryIntegrationTest.java
+++ b/src/test/java/maple/expectation/service/v2/shutdown/ShutdownDataRecoveryIntegrationTest.java
@@ -41,7 +41,8 @@ class ShutdownDataRecoveryIntegrationTest extends IntegrationTestSupport {
     @Autowired private LikeBufferStorage likeBufferStorage;
     @Autowired private EquipmentPersistenceTracker persistenceTracker;
 
-    private static final String REDIS_HASH_KEY = "buffer:likes";
+    /** Hash Tag 패턴 적용 (LikeSyncService.SOURCE_KEY와 동일) */
+    private static final String REDIS_HASH_KEY = "{buffer:likes}";
 
     @BeforeEach
     void setUp() throws IOException {


### PR DESCRIPTION
## 🔗 관련 이슈
#144, #154, #157, #160, #164, #175, #176

## 🗣 개요
PR #144~185의 모든 Codex 자동 리뷰 코멘트를 수집하여 5개 Agent(Blue, Green, Yellow, Purple, Red) Council에서 분석 후 CRITICAL/HIGH 우선순위 버그를 수정했습니다.

## 🛠 작업 내용

### CRITICAL Fixes (4개)
- [x] **#175,#164**: Redis Hash Key 통일 (`buffer:likes` → `{buffer:likes}`)
  - Redis Cluster CROSSSLOT 에러 방지
  - ShutdownDataRecoveryService, LuaScripts, 테스트 파일 키 일치
- [x] **#160**: Single-flight Follower timeout 격리
  - `orTimeout()`이 공유 promise를 오염시키는 버그 수정
  - 각 Follower에게 독립적인 Future 생성
- [x] **#154,#157**: Redis 락 해제 버그 - 기존 수정 확인 (검증 완료)
- [x] **#144**: FinallyPolicy PROPAGATE 모드 - 기존 수정 확인 (검증 완료)

### HIGH Fixes (2개)
- [x] **#176**: AbortPolicy → 503 응답 (기존 500 반환 버그)
  - `RejectedExecutionException` 전용 핸들러 추가
  - Retry-After 60초 헤더 포함

## 💬 리뷰 포인트
1. `SingleFlightExecutor.executeAsFollower()` - Follower Future 격리 방식
2. `GlobalExceptionHandler.handleRejectedExecution()` - 동기 예외 처리 추가
3. Redis Hash Key 통일 (`{buffer:likes}` Hash Tag 패턴)

## 💱 트레이드 오프 결정 근거
- **Follower 격리**: 추가 객체 생성 오버헤드 vs 공유 상태 오염 방지 → 안정성 우선
- **RejectedExecutionException 핸들러**: CompletionException 핸들러와 별개로 추가 → AbortPolicy 동기 예외 대응

## ✅ 체크리스트
- [x] 브랜치/커밋 규칙 준수
- [x] 테스트 통과 (BUILD SUCCESSFUL)
- [x] CLAUDE.md 가이드라인 준수

🤖 Generated with [Claude Code](https://claude.com/claude-code)