### PR TITLE
feat(#DLQ): DLQ 관리 Admin API 구현

### DIFF
--- a/src/main/java/maple/expectation/controller/dto/dlq/DlqDetailResponse.java
+++ b/src/main/java/maple/expectation/controller/dto/dlq/DlqDetailResponse.java
@@ -1,0 +1,40 @@
+package maple.expectation.controller.dto.dlq;
+
+import maple.expectation.domain.v2.DonationDlq;
+
+import java.time.LocalDateTime;
+
+/**
+ * DLQ 상세 조회 응답 DTO
+ *
+ * <p>Admin 전용: 전체 payload 포함 (민감 데이터 주의)</p>
+ *
+ * @param id DLQ ID
+ * @param originalOutboxId 원본 Outbox ID
+ * @param requestId 멱등성 키
+ * @param eventType 이벤트 타입
+ * @param payload 전체 payload (JSON)
+ * @param failureReason 실패 사유
+ * @param movedAt DLQ 이동 시각
+ */
+public record DlqDetailResponse(
+        Long id,
+        Long originalOutboxId,
+        String requestId,
+        String eventType,
+        String payload,
+        String failureReason,
+        LocalDateTime movedAt
+) {
+    public static DlqDetailResponse from(DonationDlq dlq) {
+        return new DlqDetailResponse(
+                dlq.getId(),
+                dlq.getOriginalOutboxId(),
+                dlq.getRequestId(),
+                dlq.getEventType(),
+                dlq.getPayload(),
+                dlq.getFailureReason(),
+                dlq.getMovedAt()
+        );
+    }
+}

--- a/src/main/java/maple/expectation/controller/dto/dlq/DlqEntryResponse.java
+++ b/src/main/java/maple/expectation/controller/dto/dlq/DlqEntryResponse.java
@@ -1,0 +1,48 @@
+package maple.expectation.controller.dto.dlq;
+
+import maple.expectation.domain.v2.DonationDlq;
+
+import java.time.LocalDateTime;
+
+/**
+ * DLQ 조회 응답 DTO
+ *
+ * <p>CLAUDE.md 19 준수: payload 마스킹 처리</p>
+ *
+ * @param id DLQ ID
+ * @param originalOutboxId 원본 Outbox ID
+ * @param requestId 멱등성 키
+ * @param eventType 이벤트 타입
+ * @param payloadPreview payload 미리보기 (100자)
+ * @param failureReason 실패 사유
+ * @param movedAt DLQ 이동 시각
+ */
+public record DlqEntryResponse(
+        Long id,
+        Long originalOutboxId,
+        String requestId,
+        String eventType,
+        String payloadPreview,
+        String failureReason,
+        LocalDateTime movedAt
+) {
+    private static final int PREVIEW_LENGTH = 100;
+
+    public static DlqEntryResponse from(DonationDlq dlq) {
+        return new DlqEntryResponse(
+                dlq.getId(),
+                dlq.getOriginalOutboxId(),
+                dlq.getRequestId(),
+                dlq.getEventType(),
+                truncatePayload(dlq.getPayload()),
+                dlq.getFailureReason(),
+                dlq.getMovedAt()
+        );
+    }
+
+    private static String truncatePayload(String payload) {
+        if (payload == null) return null;
+        if (payload.length() <= PREVIEW_LENGTH) return payload;
+        return payload.substring(0, PREVIEW_LENGTH) + "...";
+    }
+}

--- a/src/main/java/maple/expectation/controller/dto/dlq/DlqReprocessResult.java
+++ b/src/main/java/maple/expectation/controller/dto/dlq/DlqReprocessResult.java
@@ -1,0 +1,25 @@
+package maple.expectation.controller.dto.dlq;
+
+/**
+ * DLQ 재처리 결과 응답 DTO
+ *
+ * @param dlqId 처리된 DLQ ID
+ * @param newOutboxId 새로 생성된 Outbox ID
+ * @param requestId 멱등성 키
+ * @param message 처리 결과 메시지
+ */
+public record DlqReprocessResult(
+        Long dlqId,
+        Long newOutboxId,
+        String requestId,
+        String message
+) {
+    public static DlqReprocessResult success(Long dlqId, Long newOutboxId, String requestId) {
+        return new DlqReprocessResult(
+                dlqId,
+                newOutboxId,
+                requestId,
+                "Successfully requeued to Outbox for reprocessing"
+        );
+    }
+}

--- a/src/main/java/maple/expectation/global/error/CommonErrorCode.java
+++ b/src/main/java/maple/expectation/global/error/CommonErrorCode.java
@@ -23,6 +23,10 @@ public enum CommonErrorCode implements ErrorCode {
     ADMIN_NOT_FOUND("A007", "유효하지 않은 Admin입니다.", HttpStatus.NOT_FOUND),
     ADMIN_MEMBER_NOT_FOUND("A008", "Admin의 Member 계정이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
 
+    // === DLQ Errors (4xx) ===
+    DLQ_NOT_FOUND("D001", "해당 DLQ 항목을 찾을 수 없습니다 (ID: %s)", HttpStatus.NOT_FOUND),
+    DLQ_ALREADY_REPROCESSED("D002", "이미 재처리된 DLQ 항목입니다 (requestId: %s)", HttpStatus.CONFLICT),
+
     // === Server Errors (5xx) ===
     INTERNAL_SERVER_ERROR("S001", "서버 내부 오류가 발생했습니다. (%s)", HttpStatus.INTERNAL_SERVER_ERROR),
     DATABASE_TRANSACTION_FAILURE("S002", "치명적인 트랜잭션 오류가 발생했습니다: %s", HttpStatus.INTERNAL_SERVER_ERROR),

--- a/src/main/java/maple/expectation/global/error/exception/DlqNotFoundException.java
+++ b/src/main/java/maple/expectation/global/error/exception/DlqNotFoundException.java
@@ -1,0 +1,17 @@
+package maple.expectation.global.error.exception;
+
+import maple.expectation.global.error.CommonErrorCode;
+import maple.expectation.global.error.exception.base.ClientBaseException;
+import maple.expectation.global.error.exception.marker.CircuitBreakerIgnoreMarker;
+
+/**
+ * DLQ 항목을 찾을 수 없을 때 발생하는 예외
+ *
+ * <p>CircuitBreakerIgnoreMarker: 클라이언트 오류로 서킷브레이커 카운트 제외</p>
+ */
+public class DlqNotFoundException extends ClientBaseException implements CircuitBreakerIgnoreMarker {
+
+    public DlqNotFoundException(Long dlqId) {
+        super(CommonErrorCode.DLQ_NOT_FOUND, dlqId);
+    }
+}

--- a/src/main/java/maple/expectation/repository/v2/DonationDlqRepository.java
+++ b/src/main/java/maple/expectation/repository/v2/DonationDlqRepository.java
@@ -1,7 +1,12 @@
 package maple.expectation.repository.v2;
 
 import maple.expectation.domain.v2.DonationDlq;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 /**
  * Dead Letter Queue Repository (Issue #80)
@@ -13,5 +18,20 @@ import org.springframework.data.jpa.repository.JpaRepository;
  * @see maple.expectation.service.v2.donation.outbox.application.DlqHandler
  */
 public interface DonationDlqRepository extends JpaRepository<DonationDlq, Long> {
-    // 기본 CRUD만 사용
+
+    /**
+     * DLQ 목록 조회 (최신순 정렬, 페이징)
+     */
+    Page<DonationDlq> findAllByOrderByMovedAtDesc(Pageable pageable);
+
+    /**
+     * requestId로 DLQ 조회
+     */
+    Optional<DonationDlq> findByRequestId(String requestId);
+
+    /**
+     * DLQ 총 건수
+     */
+    @Query("SELECT COUNT(d) FROM DonationDlq d")
+    long countAll();
 }

--- a/src/main/java/maple/expectation/service/v2/donation/outbox/DlqAdminService.java
+++ b/src/main/java/maple/expectation/service/v2/donation/outbox/DlqAdminService.java
@@ -1,0 +1,184 @@
+package maple.expectation.service.v2.donation.outbox;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import maple.expectation.controller.dto.dlq.DlqDetailResponse;
+import maple.expectation.controller.dto.dlq.DlqEntryResponse;
+import maple.expectation.controller.dto.dlq.DlqReprocessResult;
+import maple.expectation.domain.v2.DonationDlq;
+import maple.expectation.domain.v2.DonationOutbox;
+import maple.expectation.global.error.exception.DlqNotFoundException;
+import maple.expectation.global.executor.LogicExecutor;
+import maple.expectation.global.executor.TaskContext;
+import maple.expectation.repository.v2.DonationDlqRepository;
+import maple.expectation.repository.v2.DonationOutboxRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * DLQ 관리 서비스 (Admin 전용)
+ *
+ * <h3>기능</h3>
+ * <ul>
+ *   <li>DLQ 목록/상세 조회</li>
+ *   <li>DLQ 재처리 (Outbox로 복원)</li>
+ *   <li>DLQ 폐기 (삭제)</li>
+ * </ul>
+ *
+ * <h3>CLAUDE.md 준수</h3>
+ * <ul>
+ *   <li>LogicExecutor: Zero try-catch 정책</li>
+ *   <li>@Transactional: 재처리 시 원자성 보장</li>
+ * </ul>
+ *
+ * @see DonationDlqRepository
+ * @see DonationOutboxRepository
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DlqAdminService {
+
+    private final DonationDlqRepository dlqRepository;
+    private final DonationOutboxRepository outboxRepository;
+    private final OutboxMetrics metrics;
+    private final LogicExecutor executor;
+
+    private static final int DEFAULT_PAGE_SIZE = 20;
+
+    /**
+     * DLQ 목록 조회 (페이징)
+     *
+     * @param page 페이지 번호 (0-based)
+     * @param size 페이지 크기
+     * @return DLQ 항목 페이지
+     */
+    @Transactional(readOnly = true)
+    public Page<DlqEntryResponse> findAll(int page, int size) {
+        TaskContext context = TaskContext.of("DlqAdmin", "FindAll", String.valueOf(page));
+
+        return executor.execute(
+                () -> {
+                    PageRequest pageRequest = PageRequest.of(page, size > 0 ? size : DEFAULT_PAGE_SIZE);
+                    Page<DonationDlq> dlqPage = dlqRepository.findAllByOrderByMovedAtDesc(pageRequest);
+                    return dlqPage.map(DlqEntryResponse::from);
+                },
+                context
+        );
+    }
+
+    /**
+     * DLQ 상세 조회
+     *
+     * @param id DLQ ID
+     * @return DLQ 상세 정보
+     * @throws DlqNotFoundException DLQ 항목이 없을 경우
+     */
+    @Transactional(readOnly = true)
+    public DlqDetailResponse findById(Long id) {
+        TaskContext context = TaskContext.of("DlqAdmin", "FindById", String.valueOf(id));
+
+        return executor.execute(
+                () -> {
+                    DonationDlq dlq = dlqRepository.findById(id)
+                            .orElseThrow(() -> new DlqNotFoundException(id));
+                    return DlqDetailResponse.from(dlq);
+                },
+                context
+        );
+    }
+
+    /**
+     * DLQ 재처리 (Outbox로 복원)
+     *
+     * <p>동일 트랜잭션에서 Outbox 생성 후 DLQ 삭제 (원자성 보장)</p>
+     *
+     * @param id DLQ ID
+     * @return 재처리 결과
+     * @throws DlqNotFoundException DLQ 항목이 없을 경우
+     */
+    @Transactional
+    public DlqReprocessResult reprocess(Long id) {
+        TaskContext context = TaskContext.of("DlqAdmin", "Reprocess", String.valueOf(id));
+
+        return executor.execute(
+                () -> {
+                    // 1. DLQ 조회
+                    DonationDlq dlq = dlqRepository.findById(id)
+                            .orElseThrow(() -> new DlqNotFoundException(id));
+
+                    log.info("🔄 [DLQ Admin] 재처리 시작: id={}, requestId={}", id, dlq.getRequestId());
+
+                    // 2. 기존 Outbox에서 동일 requestId 존재 여부 확인 (멱등성)
+                    if (outboxRepository.existsByRequestId(dlq.getRequestId())) {
+                        log.warn("⚠️ [DLQ Admin] 중복 requestId 발견, Outbox 재생성 스킵: {}",
+                                dlq.getRequestId());
+                    } else {
+                        // 3. 새 Outbox 생성 (PENDING 상태)
+                        DonationOutbox newOutbox = DonationOutbox.create(
+                                dlq.getRequestId(),
+                                dlq.getEventType(),
+                                dlq.getPayload()
+                        );
+                        outboxRepository.save(newOutbox);
+
+                        log.info("✅ [DLQ Admin] Outbox 복원 완료: newOutboxId={}", newOutbox.getId());
+                    }
+
+                    // 4. DLQ에서 삭제
+                    dlqRepository.delete(dlq);
+                    metrics.incrementDlqReprocessed();
+
+                    log.info("🗑️ [DLQ Admin] DLQ 삭제 완료: id={}", id);
+
+                    return DlqReprocessResult.success(
+                            id,
+                            outboxRepository.findByRequestId(dlq.getRequestId())
+                                    .map(DonationOutbox::getId)
+                                    .orElse(null),
+                            dlq.getRequestId()
+                    );
+                },
+                context
+        );
+    }
+
+    /**
+     * DLQ 폐기 (삭제)
+     *
+     * <p>복구 불가능한 데이터를 수동으로 폐기할 때 사용</p>
+     *
+     * @param id DLQ ID
+     * @throws DlqNotFoundException DLQ 항목이 없을 경우
+     */
+    @Transactional
+    public void discard(Long id) {
+        TaskContext context = TaskContext.of("DlqAdmin", "Discard", String.valueOf(id));
+
+        executor.executeVoid(
+                () -> {
+                    DonationDlq dlq = dlqRepository.findById(id)
+                            .orElseThrow(() -> new DlqNotFoundException(id));
+
+                    log.warn("🗑️ [DLQ Admin] 폐기 처리: id={}, requestId={}, reason={}",
+                            id, dlq.getRequestId(), dlq.getFailureReason());
+
+                    dlqRepository.delete(dlq);
+                    metrics.incrementDlqDiscarded();
+                },
+                context
+        );
+    }
+
+    /**
+     * DLQ 총 건수 조회
+     *
+     * @return DLQ 총 건수
+     */
+    @Transactional(readOnly = true)
+    public long count() {
+        return dlqRepository.countAll();
+    }
+}

--- a/src/main/java/maple/expectation/service/v2/donation/outbox/OutboxMetrics.java
+++ b/src/main/java/maple/expectation/service/v2/donation/outbox/OutboxMetrics.java
@@ -36,6 +36,8 @@ public class OutboxMetrics {
     private Counter processedCounter;
     private Counter failedCounter;
     private Counter dlqCounter;
+    private Counter dlqReprocessedCounter;
+    private Counter dlqDiscardedCounter;
     private Counter fileBackupCounter;
     private Counter criticalCounter;
     private Counter integrityFailureCounter;
@@ -57,6 +59,8 @@ public class OutboxMetrics {
         processedCounter = registry.counter("outbox.processed.total");
         failedCounter = registry.counter("outbox.failed.total");
         dlqCounter = registry.counter("outbox.dlq.total");
+        dlqReprocessedCounter = registry.counter("outbox.dlq.reprocessed.total");
+        dlqDiscardedCounter = registry.counter("outbox.dlq.discarded.total");
         fileBackupCounter = registry.counter("outbox.safety.file.total");
         criticalCounter = registry.counter("outbox.safety.critical.total");
         integrityFailureCounter = registry.counter("outbox.integrity.failure.total");
@@ -80,6 +84,14 @@ public class OutboxMetrics {
 
     public void incrementDlq() {
         dlqCounter.increment();
+    }
+
+    public void incrementDlqReprocessed() {
+        dlqReprocessedCounter.increment();
+    }
+
+    public void incrementDlqDiscarded() {
+        dlqDiscardedCounter.increment();
     }
 
     public void incrementFileBackup() {

--- a/src/test/java/maple/expectation/service/v2/donation/outbox/DlqAdminServiceTest.java
+++ b/src/test/java/maple/expectation/service/v2/donation/outbox/DlqAdminServiceTest.java
@@ -1,0 +1,262 @@
+package maple.expectation.service.v2.donation.outbox;
+
+import maple.expectation.controller.dto.dlq.DlqDetailResponse;
+import maple.expectation.controller.dto.dlq.DlqEntryResponse;
+import maple.expectation.controller.dto.dlq.DlqReprocessResult;
+import maple.expectation.domain.v2.DonationDlq;
+import maple.expectation.domain.v2.DonationOutbox;
+import maple.expectation.global.common.function.ThrowingSupplier;
+import maple.expectation.global.error.exception.DlqNotFoundException;
+import maple.expectation.global.executor.LogicExecutor;
+import maple.expectation.global.executor.TaskContext;
+import maple.expectation.global.executor.function.ThrowingRunnable;
+import maple.expectation.repository.v2.DonationDlqRepository;
+import maple.expectation.repository.v2.DonationOutboxRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
+
+/**
+ * DlqAdminService 단위 테스트
+ *
+ * <h3>테스트 케이스</h3>
+ * <ul>
+ *   <li>DLQ 목록 조회 (페이징)</li>
+ *   <li>DLQ 상세 조회 (성공/실패)</li>
+ *   <li>DLQ 재처리 (성공/중복/실패)</li>
+ *   <li>DLQ 폐기 (성공/실패)</li>
+ *   <li>DLQ 총 건수 조회</li>
+ * </ul>
+ */
+@ExtendWith(MockitoExtension.class)
+class DlqAdminServiceTest {
+
+    @Mock DonationDlqRepository dlqRepository;
+    @Mock DonationOutboxRepository outboxRepository;
+    @Mock OutboxMetrics metrics;
+    @Mock LogicExecutor executor;
+
+    @InjectMocks
+    DlqAdminService dlqAdminService;
+
+    private DonationDlq sampleDlq;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        // LogicExecutor Mock - 람다 실제 실행 (Passthrough)
+        lenient().when(executor.execute(any(ThrowingSupplier.class), any(TaskContext.class)))
+                .thenAnswer(invocation -> {
+                    ThrowingSupplier<?> task = invocation.getArgument(0);
+                    return task.get();
+                });
+
+        lenient().doAnswer(invocation -> {
+            ThrowingRunnable task = invocation.getArgument(0);
+            task.run();
+            return null;
+        }).when(executor).executeVoid(any(ThrowingRunnable.class), any(TaskContext.class));
+
+        // Sample DLQ 생성 (Reflection 사용 - protected constructor)
+        sampleDlq = createSampleDlq(1L, "req-001", "DONATION_COMPLETED",
+                "{\"amount\":1000}", "Max retry exceeded");
+    }
+
+    @Nested
+    @DisplayName("findAll - DLQ 목록 조회")
+    class FindAllTest {
+
+        @Test
+        @DisplayName("페이징으로 DLQ 목록을 조회한다")
+        void findAllWithPaging() {
+            // Given
+            DonationDlq dlq1 = createSampleDlq(1L, "req-001", "DONATION_COMPLETED", "{}", "error1");
+            DonationDlq dlq2 = createSampleDlq(2L, "req-002", "DONATION_COMPLETED", "{}", "error2");
+            Page<DonationDlq> page = new PageImpl<>(List.of(dlq1, dlq2), PageRequest.of(0, 20), 2);
+
+            given(dlqRepository.findAllByOrderByMovedAtDesc(any(PageRequest.class))).willReturn(page);
+
+            // When
+            Page<DlqEntryResponse> result = dlqAdminService.findAll(0, 20);
+
+            // Then
+            assertThat(result.getTotalElements()).isEqualTo(2);
+            assertThat(result.getContent()).hasSize(2);
+            assertThat(result.getContent().get(0).requestId()).isEqualTo("req-001");
+        }
+    }
+
+    @Nested
+    @DisplayName("findById - DLQ 상세 조회")
+    class FindByIdTest {
+
+        @Test
+        @DisplayName("존재하는 DLQ를 조회한다")
+        void findByIdSuccess() {
+            // Given
+            given(dlqRepository.findById(1L)).willReturn(Optional.of(sampleDlq));
+
+            // When
+            DlqDetailResponse result = dlqAdminService.findById(1L);
+
+            // Then
+            assertThat(result.id()).isEqualTo(1L);
+            assertThat(result.requestId()).isEqualTo("req-001");
+            assertThat(result.payload()).isEqualTo("{\"amount\":1000}");
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 DLQ 조회 시 예외가 발생한다")
+        void findByIdNotFound() {
+            // Given
+            given(dlqRepository.findById(999L)).willReturn(Optional.empty());
+
+            // When & Then
+            assertThatThrownBy(() -> dlqAdminService.findById(999L))
+                    .isInstanceOf(DlqNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("reprocess - DLQ 재처리")
+    class ReprocessTest {
+
+        @Test
+        @DisplayName("DLQ를 Outbox로 복원하여 재처리한다")
+        void reprocessSuccess() {
+            // Given
+            given(dlqRepository.findById(1L)).willReturn(Optional.of(sampleDlq));
+            given(outboxRepository.existsByRequestId("req-001")).willReturn(false);
+            when(outboxRepository.save(any(DonationOutbox.class))).thenAnswer(invocation -> {
+                DonationOutbox outbox = invocation.getArgument(0);
+                ReflectionTestUtils.setField(outbox, "id", 100L);
+                return outbox;
+            });
+            when(outboxRepository.findByRequestId("req-001")).thenReturn(
+                    Optional.of(DonationOutbox.create("req-001", "DONATION_COMPLETED", "{\"amount\":1000}")));
+
+            // When
+            DlqReprocessResult result = dlqAdminService.reprocess(1L);
+
+            // Then
+            assertThat(result.dlqId()).isEqualTo(1L);
+            assertThat(result.requestId()).isEqualTo("req-001");
+
+            verify(dlqRepository).delete(sampleDlq);
+            verify(metrics).incrementDlqReprocessed();
+        }
+
+        @Test
+        @DisplayName("중복 requestId가 있으면 Outbox 생성을 스킵하고 DLQ만 삭제한다")
+        void reprocessWithDuplicateRequestId() {
+            // Given
+            given(dlqRepository.findById(1L)).willReturn(Optional.of(sampleDlq));
+            given(outboxRepository.existsByRequestId("req-001")).willReturn(true);
+            when(outboxRepository.findByRequestId("req-001")).thenReturn(
+                    Optional.of(DonationOutbox.create("req-001", "DONATION_COMPLETED", "{}")));
+
+            // When
+            DlqReprocessResult result = dlqAdminService.reprocess(1L);
+
+            // Then
+            verify(outboxRepository, never()).save(any(DonationOutbox.class));
+            verify(dlqRepository).delete(sampleDlq);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 DLQ 재처리 시 예외가 발생한다")
+        void reprocessNotFound() {
+            // Given
+            given(dlqRepository.findById(999L)).willReturn(Optional.empty());
+
+            // When & Then
+            assertThatThrownBy(() -> dlqAdminService.reprocess(999L))
+                    .isInstanceOf(DlqNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("discard - DLQ 폐기")
+    class DiscardTest {
+
+        @Test
+        @DisplayName("DLQ를 폐기(삭제)한다")
+        void discardSuccess() {
+            // Given
+            given(dlqRepository.findById(1L)).willReturn(Optional.of(sampleDlq));
+
+            // When
+            dlqAdminService.discard(1L);
+
+            // Then
+            verify(dlqRepository).delete(sampleDlq);
+            verify(metrics).incrementDlqDiscarded();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 DLQ 폐기 시 예외가 발생한다")
+        void discardNotFound() {
+            // Given
+            given(dlqRepository.findById(999L)).willReturn(Optional.empty());
+
+            // When & Then
+            assertThatThrownBy(() -> dlqAdminService.discard(999L))
+                    .isInstanceOf(DlqNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("count - DLQ 총 건수")
+    class CountTest {
+
+        @Test
+        @DisplayName("DLQ 총 건수를 조회한다")
+        void countSuccess() {
+            // Given
+            given(dlqRepository.countAll()).willReturn(42L);
+
+            // When
+            long count = dlqAdminService.count();
+
+            // Then
+            assertThat(count).isEqualTo(42L);
+        }
+    }
+
+    // ========== Helper Methods ==========
+
+    /**
+     * 테스트용 DonationDlq 생성
+     *
+     * <p>Spring ReflectionTestUtils 사용 (JDK 17+ 호환)</p>
+     */
+    private DonationDlq createSampleDlq(Long id, String requestId, String eventType,
+                                         String payload, String failureReason) {
+        // DonationOutbox 생성하여 from() 팩토리 메서드 사용
+        DonationOutbox outbox = DonationOutbox.create(requestId, eventType, payload);
+        ReflectionTestUtils.setField(outbox, "id", 1L);
+
+        DonationDlq dlq = DonationDlq.from(outbox, failureReason);
+        ReflectionTestUtils.setField(dlq, "id", id);
+
+        return dlq;
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
DLQ 수동 복구 프로세스 API화

## 🗣 개요
Dead Letter Queue(DLQ) 항목을 Admin이 직접 관리할 수 있는 REST API 구현

## 🛠 작업 내용
- [x] `DlqAdminController`: REST API 엔드포인트 추가
  - GET `/api/admin/dlq`: DLQ 목록 조회 (페이징)
  - GET `/api/admin/dlq/{id}`: DLQ 상세 조회 (전체 payload)
  - POST `/api/admin/dlq/{id}/reprocess`: DLQ 재처리 (Outbox로 복원)
  - DELETE `/api/admin/dlq/{id}`: DLQ 폐기
  - GET `/api/admin/dlq/count`: DLQ 총 건수 조회
- [x] `DlqAdminService`: 비즈니스 로직 구현
  - 재처리 시 멱등성 체크 (중복 requestId 스킵)
  - LogicExecutor 패턴 적용 (Zero try-catch)
- [x] DLQ DTO 추가: `DlqEntryResponse`, `DlqDetailResponse`, `DlqReprocessResult`
- [x] `DonationDlqRepository`: 페이징 쿼리 메서드 추가
- [x] `OutboxMetrics`: `dlqReprocessed`, `dlqDiscarded` 카운터 추가
- [x] `DlqNotFoundException`: 클라이언트 예외 정의
- [x] `DlqAdminServiceTest`: 단위 테스트 9개 작성

## 💬 리뷰 포인트
- DLQ 재처리 시 멱등성 처리 로직 (중복 requestId 존재 시 Outbox 생성 스킵)
- 메트릭 카운터 분리 (`dlqReprocessed` vs `dlqDiscarded`)

## 💱 트레이드 오프 결정 근거
| 결정 | 선택 | 이유 |
|------|------|------|
| 재처리 방식 | Outbox 복원 | 기존 Outbox Processor 로직 재사용 |
| 중복 requestId | 스킵 (not 예외) | 멱등성 보장, 운영 편의성 |
| 메트릭 | Counter (증가만) | Micrometer 표준, Gauge는 DLQ 총 건수용 |

## ✅ 체크리스트
- [x] 브랜치/커밋 규칙 준수 여부
- [x] 테스트 통과 여부 (9/9 passed)
- [x] SecurityConfig ADMIN 권한 확인 (`/api/admin/**`)

🤖 Generated with [Claude Code](https://claude.ai/code)