### PR TITLE
feat(#56,#14,#64): JaCoCo 테스트 커버리지 + 미사용 코드 정리 + Runbook 문서화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.5.4'
 	id 'io.spring.dependency-management' version '1.1.7'
+	id 'jacoco'
 }
 
 group = 'maple'
@@ -101,4 +102,58 @@ test {
     exclude '**/vintage/**'
     // WSL에서 확인된 "진짜" Docker Engine API 소켓
     environment "DOCKER_HOST", "unix:///var/run/docker.sock"
+    finalizedBy jacocoTestReport
 }
+
+// ========================================
+// JaCoCo 테스트 커버리지 설정 (#56)
+// ========================================
+jacoco {
+    toolVersion = "0.8.11"
+}
+
+jacocoTestReport {
+    dependsOn test
+
+    reports {
+        xml.required = true   // CI 통합용
+        html.required = true  // 로컬 확인용
+    }
+
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: [
+                '**/config/**',
+                '**/dto/**',
+                '**/entity/**',
+                '**/domain/**',
+                '**/*Config*',
+                '**/*Properties*',
+                '**/*Application*'
+            ])
+        }))
+    }
+}
+
+// ⚠️ P0-7 (Red Agent): jacocoTestCoverageVerification은 초기 비활성화
+// 테스트 커버리지가 충분히 확보된 후 별도 이슈로 활성화 권장
+// 활성화 시 아래 주석 해제:
+//
+// jacocoTestCoverageVerification {
+//     dependsOn jacocoTestReport
+//     violationRules {
+//         rule {
+//             limit {
+//                 minimum = 0.45  // 초기 45%, 점진 상향
+//             }
+//         }
+//         rule {
+//             element = 'CLASS'
+//             includes = ['maple.expectation.service.v2.*']
+//             limit {
+//                 counter = 'LINE'
+//                 minimum = 0.60  // 핵심 서비스 60%
+//             }
+//         }
+//     }
+// }

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,0 +1,101 @@
+# MapleExpectation 운영 가이드 (Runbook)
+
+## 1. 장애 대응 매뉴얼
+
+### 1.1 ExternalServiceException (Nexon API 장애)
+
+**증상:**
+- 로그: `[ERROR] ExternalServiceException: Nexon API call failed`
+- 영향: 캐릭터 조회, 장비 조회 실패
+
+**조치:**
+1. Nexon API 상태 확인: https://openapi.nexon.com/
+2. Circuit Breaker 상태 확인: `/actuator/health`
+3. 임시 조치: 캐시된 데이터 반환 (Graceful Degradation)
+
+### 1.2 RateLimitExceededException (429)
+
+**증상:**
+- HTTP 429 응답
+- 헤더: `Retry-After: {seconds}`
+
+**조치:**
+1. 클라이언트에게 재시도 안내
+2. IP/User별 요청량 모니터링
+3. 필요 시 Rate Limit 임계값 조정
+
+### 1.3 Redis 장애
+
+**증상:**
+- 로그: `[WARN] Redis connection failed, using Fail-Open`
+- 영향: 캐시 MISS 증가, DB 부하 상승
+
+**조치:**
+1. Redis 서버 상태 확인
+2. Sentinel failover 확인
+3. 임시 조치: 서비스는 Fail-Open으로 계속 동작
+4. MySQL Named Lock Pool 모니터링 (`MySQLLockPool` - Fixed Size: 30)
+
+### 1.4 MySQL Named Lock Pool 고갈
+
+**증상:**
+- 로그: `HikariPool-MySQLLockPool - Connection is not available`
+- 영향: 락 획득 실패, 동시성 제어 불가
+
+**조치:**
+1. Redis 복구 우선 시도 (근본 원인)
+2. Pool 상태 확인: `/actuator/metrics/hikaricp.connections`
+3. 비상시 Pool Size 임시 증설 (환경변수 또는 재배포)
+
+## 2. 모니터링 체크리스트
+
+### 2.1 Health Check 엔드포인트
+- [ ] `/actuator/health` - 서비스 상태
+- [ ] `/actuator/prometheus` - 메트릭
+- [ ] `/actuator/info` - 앱 정보
+
+### 2.2 핵심 메트릭
+
+| 메트릭 | 정상 범위 | 경고 임계값 |
+|--------|----------|------------|
+| `http_server_requests_seconds` | < 500ms | > 1s |
+| `cache.hit{layer=L1}` | > 80% | < 60% |
+| `cache.hit{layer=L2}` | > 90% | < 70% |
+| `hikaricp.connections.active` | < 80% pool | > 90% pool |
+| `resilience4j.circuitbreaker.state` | CLOSED | OPEN |
+
+### 2.3 JaCoCo 커버리지 리포트
+- 로컬: `build/reports/jacoco/test/html/index.html`
+- 목표: 핵심 서비스 60% 이상
+
+## 3. 배포 체크리스트
+
+### 3.1 배포 전
+- [ ] `./gradlew clean test` All Green
+- [ ] JaCoCo 커버리지 확인
+- [ ] 환경변수 확인 (API Key, DB 연결정보)
+
+### 3.2 배포 후
+- [ ] `/actuator/health` 정상 응답
+- [ ] 로그 에러 없음 확인
+- [ ] 주요 API 응답 시간 정상
+
+## 4. 긴급 연락처
+
+- 운영팀: Discord #ops-alerts
+- 온콜: 당직 담당자
+
+## 5. 롤백 절차
+
+### 5.1 Docker 환경
+```bash
+# 이전 버전으로 롤백
+docker-compose down
+docker-compose -f docker-compose.rollback.yml up -d
+```
+
+### 5.2 Kubernetes 환경
+```bash
+# 이전 리비전으로 롤백
+kubectl rollout undo deployment/maple-expectation
+```

--- a/src/main/java/maple/expectation/config/LockHikariConfig.java
+++ b/src/main/java/maple/expectation/config/LockHikariConfig.java
@@ -16,12 +16,13 @@ import javax.sql.DataSource;
  *
  * [목적]
  * - Redis 장애 시 MySQL Named Lock을 사용할 때 메인 커넥션 풀이 고갈되는 것을 방지
- * - 락 전용 작은 커넥션 풀을 별도로 운영하여 애플리케이션 안정성 확보
+ * - 락 전용 커넥션 풀을 별도로 운영하여 애플리케이션 안정성 확보
  *
  * [설계 원칙]
- * - 작은 풀 크기 (10개): 락 작업은 가볍고 빠르므로 많은 커넥션 불필요
- * - 짧은 타임아웃: 락 획득/해제는 빨라야 하므로 짧은 타임아웃 설정
- * - 메인 풀과 분리: 메인 비즈니스 로직과 락 로직을 격리
+ * - Fixed Pool Size: Min과 Max를 동일하게 설정하여 연결 비용(Handshake) 제거
+ * - Size 30: RPS 235 트래픽이 Redis 장애로 넘어왔을 때 병목 없이 처리하기 위한 최소 용량
+ * (Little's Law: 235 req/s * 0.1s latency + buffer ≈ 30 connections)
+ * - Fail-fast: 락 획득 타임아웃을 짧게 가져가서 스레드 고갈 방지
  */
 @Slf4j
 @Configuration
@@ -37,6 +38,9 @@ public class LockHikariConfig {
     @Value("${spring.datasource.password}")
     private String password;
 
+    // [Audit 반영] RPS 235를 감당하기 위한 최소 안전 계수 (Golden Number)
+    private static final int POOL_SIZE = 30;
+
     @Bean(name = "lockDataSource")
     public DataSource lockDataSource() {
         HikariConfig config = new HikariConfig();
@@ -47,21 +51,22 @@ public class LockHikariConfig {
         config.setPassword(password);
         config.setDriverClassName("com.mysql.cj.jdbc.Driver");
 
-        // Lock 전용 풀 설정
-        // [수정 1] 주석 의도(작은 풀)에 맞춰 50 -> 10으로 축소
-        config.setMaximumPoolSize(10);
-        config.setMinimumIdle(2);
-        config.setConnectionTimeout(5000);
+        // [핵심 수정 1] Pool Size 증설 (10 -> 30) 및 고정 (Fixed Pool)
+        // Redis가 죽으면 트래픽이 몰리므로 10개로는 부족함.
+        // MinIdle = MaxPoolSize로 설정하여 불필요한 연결/해제 비용 제거.
+        config.setMaximumPoolSize(POOL_SIZE);
+        config.setMinimumIdle(POOL_SIZE);
+
+        // [핵심 수정 2] Fail-fast 전략 유지
+        config.setConnectionTimeout(5000); // 5초 안에 연결 못 얻으면 에러 (스레드 보호)
         config.setIdleTimeout(300000);
         config.setMaxLifetime(600000);
         config.setPoolName("MySQLLockPool");
 
-        // 검증 설정
-        // [수정 2] setConnectionTestQuery("SELECT 1") 제거
-        // MySQL Connector/J는 JDBC4 표준 isValid()를 지원하므로 제거하는 것이 성능상 유리합니다.
+        // 검증 설정 (JDBC4 isValid 사용으로 쿼리 비용 절감)
         config.setValidationTimeout(3000);
 
-        log.info("✅ [Lock Pool] Initialized dedicated MySQL lock connection pool (max: 10)");
+        log.info("[Lock Pool] Initialized dedicated MySQL lock connection pool (Fixed Size: {})", POOL_SIZE);
 
         return new HikariDataSource(config);
     }

--- a/src/main/java/maple/expectation/service/v2/EquipmentService.java
+++ b/src/main/java/maple/expectation/service/v2/EquipmentService.java
@@ -176,15 +176,6 @@ public class EquipmentService {
                 .whenComplete((r, e) -> SkipEquipmentL2CacheContext.restore(beforeContext));
     }
 
-    /**
-     * @deprecated V2 컨트롤러는 {@link #calculateTotalExpectationAsync(String)} 직접 호출 (Issue #118)
-     */
-    @Deprecated(since = "2.5", forRemoval = true)
-    @TraceLog
-    public TotalExpectationResponse calculateTotalExpectation(String userIgn) {
-        return calculateTotalExpectationAsync(userIgn).join();
-    }
-
     // ==================== 오케스트레이션 ====================
 
     private CompletableFuture<TotalExpectationResponse> processAfterLightSnapshot(
@@ -382,14 +373,6 @@ public class EquipmentService {
         }, TaskContext.of("EquipmentService", "ProcessLegacy", userIgn));
     }
 
-    /**
-     * @deprecated Use {@link #calculateTotalExpectationLegacyAsync(String)} instead (Issue #118)
-     */
-    @Deprecated(since = "2.5", forRemoval = true)
-    public TotalExpectationResponse calculateTotalExpectationLegacy(String userIgn) {
-        return calculateTotalExpectationLegacyAsync(userIgn).join();
-    }
-
     public void streamEquipmentData(String userIgn, OutputStream outputStream) {
         executor.executeVoid(
                 () -> equipmentProvider.streamAndDecompress(getOcid(userIgn), outputStream),
@@ -412,14 +395,6 @@ public class EquipmentService {
                 .thenCompose(ocid -> equipmentProvider.getEquipmentResponse(ocid))
                 .orTimeout(LEADER_DEADLINE_SECONDS, TimeUnit.SECONDS)
                 .exceptionally(e -> handleEquipmentException(e, userIgn));
-    }
-
-    /**
-     * @deprecated Use {@link #getEquipmentByUserIgnAsync(String)} instead (Issue #118)
-     */
-    @Deprecated(since = "2.5", forRemoval = true)
-    public EquipmentResponse getEquipmentByUserIgn(String userIgn) {
-        return getEquipmentByUserIgnAsync(userIgn).join();
     }
 
     // ==================== 예외 처리 (Issue #118) ====================


### PR DESCRIPTION
## 🔗 관련 이슈
- #56 JaCoCo 테스트 커버리지 설정
- #14 미사용 코드 정리
- #64 DTO 네이밍/Runbook 문서화

## 🗣 개요
JaCoCo 테스트 커버리지 도구 설정, @Deprecated 코드 삭제, LockHikariConfig 최적화, Runbook 문서 추가

## 🛠 작업 내용
- [x] JaCoCo 플러그인 설정 (toolVersion 0.8.11)
- [x] jacocoTestReport 태스크 추가 (HTML + XML 리포트)
- [x] config/dto/entity/domain 제외 패턴 설정
- [x] @Deprecated 메서드 3개 삭제 (EquipmentService)
  - `calculateTotalExpectation()`
  - `calculateTotalExpectationLegacy()`
  - `getEquipmentByUserIgn()`
- [x] LockHikariConfig Pool Size 증설 (10 → 30, Fixed Pool)
  - RPS 235 트래픽 대비 Little's Law 기반 계산
- [x] docs/runbook.md 운영 가이드 문서 추가

## 💬 리뷰 포인트
- JaCoCo 제외 패턴이 적절한지
- LockHikariConfig Pool Size 30이 적절한지 (Little's Law 기반)

## 💱 트레이드 오프 결정 근거
- **jacocoTestCoverageVerification 비활성화**: 초기 커버리지 45% 수준에서 빌드 실패 방지 (Red Agent P0-7)
- **Pool Size 30**: RPS 235 * 0.1s latency + buffer = 약 24개 필요, 안전 마진 포함 30개

## ✅ 체크리스트
- [x] 브랜치/커밋 규칙 준수 여부
- [x] 테스트 통과 여부 (340개 All Green)
- [x] JaCoCo 리포트 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)