### PR TITLE
feat(#195,#196,#197,#198): 방어적 프로그래밍 및 논블로킹 전환

### DIFF
--- a/src/main/java/maple/expectation/domain/v2/PotentialGrade.java
+++ b/src/main/java/maple/expectation/domain/v2/PotentialGrade.java
@@ -1,0 +1,51 @@
+package maple.expectation.domain.v2;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import maple.expectation.global.error.exception.InvalidPotentialGradeException;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * 잠재능력 등급 Enum
+ *
+ * <p>큐브 사용 시 입력되는 잠재능력 등급의 유효성을 검증합니다.
+ * 잘못된 등급 입력 시 Silent Failure(0원 반환) 대신 명시적 예외를 발생시킵니다.</p>
+ *
+ * @see InvalidPotentialGradeException
+ */
+@Getter
+@RequiredArgsConstructor
+public enum PotentialGrade {
+    RARE("레어"),
+    EPIC("에픽"),
+    UNIQUE("유니크"),
+    LEGENDARY("레전드리");
+
+    private final String koreanName;
+
+    private static final Map<String, PotentialGrade> KOREAN_MAP =
+            Arrays.stream(values())
+                    .collect(Collectors.toMap(g -> g.koreanName, Function.identity()));
+
+    /**
+     * 한글 등급명으로 PotentialGrade를 조회합니다.
+     *
+     * @param korean 한글 등급명 (예: "레어", "에픽", "유니크", "레전드리")
+     * @return 매칭되는 PotentialGrade
+     * @throws InvalidPotentialGradeException 유효하지 않은 등급명인 경우
+     */
+    public static PotentialGrade fromKorean(String korean) {
+        if (korean == null) {
+            throw new InvalidPotentialGradeException("null");
+        }
+        PotentialGrade grade = KOREAN_MAP.get(korean.trim());
+        if (grade == null) {
+            throw new InvalidPotentialGradeException(korean);
+        }
+        return grade;
+    }
+}

--- a/src/main/java/maple/expectation/external/NexonApiClient.java
+++ b/src/main/java/maple/expectation/external/NexonApiClient.java
@@ -6,7 +6,15 @@ import maple.expectation.external.dto.v2.EquipmentResponse;
 import java.util.concurrent.CompletableFuture;
 
 public interface NexonApiClient {
-    CharacterOcidResponse getOcidByCharacterName(String characterName);
+    /**
+     * 캐릭터 이름으로 OCID 조회 (비동기)
+     *
+     * <p>Issue #195: .block() 제거 - Reactor 체인 내 블로킹 호출 anti-pattern 해결</p>
+     *
+     * @param characterName 캐릭터 이름
+     * @return OCID 응답 Future
+     */
+    CompletableFuture<CharacterOcidResponse> getOcidByCharacterName(String characterName);
 
     @NexonDataCache
     CompletableFuture<EquipmentResponse> getItemDataByOcid(String ocid);

--- a/src/main/java/maple/expectation/global/error/exception/CriticalTransactionFailureException.java
+++ b/src/main/java/maple/expectation/global/error/exception/CriticalTransactionFailureException.java
@@ -5,8 +5,17 @@ import maple.expectation.global.error.exception.base.ServerBaseException;
 import maple.expectation.global.error.exception.marker.CircuitBreakerIgnoreMarker;
 
 public class CriticalTransactionFailureException extends ServerBaseException implements CircuitBreakerIgnoreMarker {
+
+    /**
+     * 치명적 트랜잭션 실패 예외
+     *
+     * <p>Purple Agent P0 Fix: Exception chaining 유지로 root cause 보존.
+     * 프로덕션 장애 분석 시 원인 추적 가능.</p>
+     *
+     * @param detail 상세 메시지
+     * @param cause  원인 예외 (반드시 전달되어야 함)
+     */
     public CriticalTransactionFailureException(String detail, Throwable cause) {
-        super(CommonErrorCode.DATABASE_TRANSACTION_FAILURE, detail);
-        // 필요 시 별도로 cause를 로깅하거나 상위로 전달 가능
+        super(CommonErrorCode.DATABASE_TRANSACTION_FAILURE, cause, detail);
     }
 }

--- a/src/main/java/maple/expectation/global/error/exception/InvalidPotentialGradeException.java
+++ b/src/main/java/maple/expectation/global/error/exception/InvalidPotentialGradeException.java
@@ -1,0 +1,21 @@
+package maple.expectation.global.error.exception;
+
+import maple.expectation.global.error.CommonErrorCode;
+import maple.expectation.global.error.exception.base.ClientBaseException;
+import maple.expectation.global.error.exception.marker.CircuitBreakerIgnoreMarker;
+
+/**
+ * 유효하지 않은 잠재능력 등급 예외
+ *
+ * <p>CubeCostPolicy에서 잘못된 등급명 입력 시 발생합니다.
+ * CircuitBreakerIgnoreMarker를 구현하여 서킷브레이커에 영향을 주지 않습니다.</p>
+ *
+ * @see maple.expectation.domain.v2.PotentialGrade
+ */
+public class InvalidPotentialGradeException extends ClientBaseException
+        implements CircuitBreakerIgnoreMarker {
+
+    public InvalidPotentialGradeException(String grade) {
+        super(CommonErrorCode.INVALID_INPUT_VALUE, "잠재능력 등급: " + grade);
+    }
+}

--- a/src/main/java/maple/expectation/service/v2/DonationService.java
+++ b/src/main/java/maple/expectation/service/v2/DonationService.java
@@ -19,6 +19,7 @@ import maple.expectation.service.v2.donation.event.DonationProcessor;
 import maple.expectation.service.v2.donation.listener.DonationFailedEvent;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
@@ -51,6 +52,9 @@ public class DonationService {
     /**
      * Admin(개발자)에게 커피 보내기
      *
+     * <p>Issue #198: 금융 거래 데이터 일관성을 위해 READ_COMMITTED isolation level 명시.
+     * MySQL InnoDB 기본값과 동일하나 명시적 선언으로 의도를 표현합니다.</p>
+     *
      * @param guestUuid        발신자 UUID
      * @param adminFingerprint 수신자 Admin fingerprint
      * @param amount           후원 금액
@@ -59,7 +63,7 @@ public class DonationService {
      * @throws AdminMemberNotFoundException Admin의 Member 계정이 없음
      * @throws InsufficientPointException   잔액 부족
      */
-    @Transactional
+    @Transactional(isolation = Isolation.READ_COMMITTED)
     @Locked(key = "#guestUuid")
     @ObservedTransaction("service.v2.DonationService.sendCoffee")
     public void sendCoffee(String guestUuid, String adminFingerprint, Long amount, String requestId) {

--- a/src/main/java/maple/expectation/service/v2/GameCharacterService.java
+++ b/src/main/java/maple/expectation/service/v2/GameCharacterService.java
@@ -77,7 +77,8 @@ public class GameCharacterService {
         return executor.executeOrCatch(
                 () -> {
                     log.info("✨ [Creation] 캐릭터 생성 시작: {}", cleanUserIgn);
-                    String ocid = nexonApiClient.getOcidByCharacterName(cleanUserIgn).getOcid();
+                    // Issue #195: .block() 제거 - 이 메서드는 이미 async 스레드에서 실행됨
+                    String ocid = nexonApiClient.getOcidByCharacterName(cleanUserIgn).join().getOcid();
 
                     GameCharacter saved = gameCharacterRepository.saveAndFlush(new GameCharacter(cleanUserIgn, ocid));
 

--- a/src/main/java/maple/expectation/service/v2/OcidResolver.java
+++ b/src/main/java/maple/expectation/service/v2/OcidResolver.java
@@ -117,7 +117,8 @@ public class OcidResolver {
         return executor.executeOrCatch(
                 () -> {
                     log.info("✨ [Creation] 캐릭터 생성 시작: {}", userIgn);
-                    String ocid = nexonApiClient.getOcidByCharacterName(userIgn).getOcid();
+                    // Issue #195: .block() 제거 - 이 메서드는 이미 async 스레드에서 실행됨
+                    String ocid = nexonApiClient.getOcidByCharacterName(userIgn).join().getOcid();
 
                     GameCharacter saved = gameCharacterRepository.saveAndFlush(
                             new GameCharacter(userIgn, ocid)

--- a/src/main/java/maple/expectation/service/v2/alert/DiscordAlertService.java
+++ b/src/main/java/maple/expectation/service/v2/alert/DiscordAlertService.java
@@ -8,10 +8,19 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import java.time.Duration;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class DiscordAlertService {
+
+    /**
+     * Discord 알림 타임아웃 (3초)
+     *
+     * <p>Issue #196: Fire-and-Forget 특성상 짧게 설정하여 리소스 점유 최소화</p>
+     */
+    private static final Duration ALERT_TIMEOUT = Duration.ofSeconds(3);
 
     private final WebClient webClient;
     private final DiscordMessageFactory messageFactory;
@@ -37,9 +46,10 @@ public class DiscordAlertService {
                 .bodyValue(payload)
                 .retrieve()
                 .toBodilessEntity()
+                .timeout(ALERT_TIMEOUT)
                 .subscribe(
-                        response -> log.info("✅ Discord Alert Sent successfully to {}", maskedUrl),
-                        error -> log.error("❌ Failed to send Discord Alert: {}", error.getMessage())
+                        response -> log.info("[Discord] Alert sent successfully to {}", maskedUrl),
+                        error -> log.error("[Discord] Failed to send alert: {}", error.getMessage())
                 );
     }
 }

--- a/src/main/java/maple/expectation/service/v2/policy/CubeCostPolicy.java
+++ b/src/main/java/maple/expectation/service/v2/policy/CubeCostPolicy.java
@@ -1,47 +1,90 @@
 package maple.expectation.service.v2.policy;
 
 import maple.expectation.domain.v2.CubeType;
+import maple.expectation.domain.v2.PotentialGrade;
 import org.springframework.stereotype.Component;
+
 import java.util.EnumMap;
 import java.util.Map;
 import java.util.TreeMap;
 
+/**
+ * 큐브 비용 정책
+ *
+ * <p>큐브 타입, 장비 레벨, 잠재능력 등급에 따른 비용을 조회합니다.
+ * 잘못된 등급 입력 시 Silent Failure(0원 반환) 대신 명시적 예외를 발생시킵니다.</p>
+ *
+ * <p><b>Performance (Green Agent):</b> 이중 EnumMap 구조로 O(1) 조회 보장.
+ * 외부: EnumMap&lt;CubeType&gt;, 내부: EnumMap&lt;PotentialGrade&gt;</p>
+ *
+ * @see PotentialGrade
+ */
 @Component
 public class CubeCostPolicy {
-    private static final Map<CubeType, TreeMap<Integer, Map<String, Long>>> COST_MASTER_TABLE = new EnumMap<>(CubeType.class);
+    private static final Map<CubeType, TreeMap<Integer, EnumMap<PotentialGrade, Long>>> COST_MASTER_TABLE = new EnumMap<>(CubeType.class);
 
     static {
         // 1. 블랙큐브(윗잠재) 비용 테이블 - 이미지 상단 표 반영
-        TreeMap<Integer, Map<String, Long>> blackTable = new TreeMap<>();
-        blackTable.put(0,   Map.of("레어", 4000000L, "에픽", 16000000L, "유니크", 34000000L, "레전드리", 40000000L));
-        blackTable.put(160, Map.of("레어", 4250000L, "에픽", 17000000L, "유니크", 36125000L, "레전드리", 42500000L));
-        blackTable.put(200, Map.of("레어", 4500000L, "에픽", 18000000L, "유니크", 38250000L, "레전드리", 45000000L));
-        blackTable.put(250, Map.of("레어", 5000000L, "에픽", 20000000L, "유니크", 42500000L, "레전드리", 50000000L));
+        TreeMap<Integer, EnumMap<PotentialGrade, Long>> blackTable = new TreeMap<>();
+        blackTable.put(0,   createGradeMap(4000000L, 16000000L, 34000000L, 40000000L));
+        blackTable.put(160, createGradeMap(4250000L, 17000000L, 36125000L, 42500000L));
+        blackTable.put(200, createGradeMap(4500000L, 18000000L, 38250000L, 45000000L));
+        blackTable.put(250, createGradeMap(5000000L, 20000000L, 42500000L, 50000000L));
         COST_MASTER_TABLE.put(CubeType.BLACK, blackTable);
 
         // 2. 에디셔널큐브(아랫잠재) 비용 테이블 - 이미지 하단 표 반영
-        TreeMap<Integer, Map<String, Long>> addiTable = new TreeMap<>();
-        addiTable.put(0,   Map.of("레어", 13000000L, "에픽", 36400000L, "유니크", 44200000L, "레전드리", 52000000L));
-        addiTable.put(160, Map.of("레어", 13812500L, "에픽", 38675000L, "유니크", 46962500L, "레전드리", 55250000L));
-        addiTable.put(200, Map.of("레어", 14625000L, "에픽", 40950000L, "유니크", 49725000L, "레전드리", 58500000L));
-        addiTable.put(250, Map.of("레어", 16250000L, "에픽", 45500000L, "유니크", 55250000L, "레전드리", 65000000L));
+        TreeMap<Integer, EnumMap<PotentialGrade, Long>> addiTable = new TreeMap<>();
+        addiTable.put(0,   createGradeMap(13000000L, 36400000L, 44200000L, 52000000L));
+        addiTable.put(160, createGradeMap(13812500L, 38675000L, 46962500L, 55250000L));
+        addiTable.put(200, createGradeMap(14625000L, 40950000L, 49725000L, 58500000L));
+        addiTable.put(250, createGradeMap(16250000L, 45500000L, 55250000L, 65000000L));
         COST_MASTER_TABLE.put(CubeType.ADDITIONAL, addiTable);
 
         // 3. 레드큐브 - 레벨 구분 없음, 비용 계산 시 1을 반환하여 '개수'로 취급 가능하게 설정
         // 나중에 Service/Decorator에서 여기에 시세를 곱하는 로직을 추가하면 됩니다.
-        TreeMap<Integer, Map<String, Long>> redTable = new TreeMap<>();
-        redTable.put(0, Map.of("레어", 1L, "에픽", 1L, "유니크", 1L, "레전드리", 1L));
+        TreeMap<Integer, EnumMap<PotentialGrade, Long>> redTable = new TreeMap<>();
+        redTable.put(0, createGradeMap(1L, 1L, 1L, 1L));
         COST_MASTER_TABLE.put(CubeType.RED, redTable);
     }
 
+    /**
+     * EnumMap 생성 헬퍼 - RARE, EPIC, UNIQUE, LEGENDARY 순서로 비용 매핑
+     */
+    private static EnumMap<PotentialGrade, Long> createGradeMap(long rare, long epic, long unique, long legendary) {
+        EnumMap<PotentialGrade, Long> map = new EnumMap<>(PotentialGrade.class);
+        map.put(PotentialGrade.RARE, rare);
+        map.put(PotentialGrade.EPIC, epic);
+        map.put(PotentialGrade.UNIQUE, unique);
+        map.put(PotentialGrade.LEGENDARY, legendary);
+        return map;
+    }
+
+    /**
+     * 큐브 비용을 조회합니다.
+     *
+     * @param type  큐브 타입 (BLACK, RED, ADDITIONAL)
+     * @param level 장비 레벨
+     * @param grade 잠재능력 등급 (한글: "레어", "에픽", "유니크", "레전드리")
+     * @return 큐브 1회 사용 비용
+     * @throws maple.expectation.global.error.exception.InvalidPotentialGradeException 유효하지 않은 등급명인 경우
+     * @throws IllegalStateException 유효하지 않은 CubeType인 경우
+     */
     public long getCubeCost(CubeType type, int level, String grade) {
-        TreeMap<Integer, Map<String, Long>> typeTable = COST_MASTER_TABLE.get(type);
-        if (typeTable == null) return 0L;
+        // Fail-Fast: 잘못된 입력 즉시 예외 (Silent Failure 방지)
+        PotentialGrade validGrade = PotentialGrade.fromKorean(grade);
+
+        TreeMap<Integer, EnumMap<PotentialGrade, Long>> typeTable = COST_MASTER_TABLE.get(type);
+        if (typeTable == null) {
+            throw new IllegalStateException("Unknown CubeType: " + type);
+        }
 
         // 레벨에 맞는 가장 가까운 하위 구간 키를 찾음 (예: 210레벨 -> 200 키 선택)
         Integer levelKey = typeTable.floorKey(level);
-        if (levelKey == null) levelKey = typeTable.firstKey();
+        if (levelKey == null) {
+            levelKey = typeTable.firstKey();
+        }
 
-        return typeTable.get(levelKey).getOrDefault(grade, 0L);
+        // O(1) EnumMap lookup - String 기반 조회보다 효율적
+        return typeTable.get(levelKey).get(validGrade);
     }
 }

--- a/src/test/java/maple/expectation/domain/v2/PotentialGradeTest.java
+++ b/src/test/java/maple/expectation/domain/v2/PotentialGradeTest.java
@@ -1,0 +1,94 @@
+package maple.expectation.domain.v2;
+
+import maple.expectation.global.error.exception.InvalidPotentialGradeException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * PotentialGrade Enum 단위 테스트
+ *
+ * <p>Issue #197: CubeCostPolicy 입력값 검증을 위한 Grade Enum 테스트</p>
+ */
+@DisplayName("PotentialGrade Enum 테스트")
+class PotentialGradeTest {
+
+    @ParameterizedTest(name = "한글명 \"{0}\" -> {1}")
+    @CsvSource({
+            "레어, RARE",
+            "에픽, EPIC",
+            "유니크, UNIQUE",
+            "레전드리, LEGENDARY"
+    })
+    @DisplayName("유효한 한글 등급명은 해당 Enum으로 변환된다")
+    void fromKorean_validGrades_returnsCorrectEnum(String korean, PotentialGrade expected) {
+        // When
+        PotentialGrade result = PotentialGrade.fromKorean(korean);
+
+        // Then
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("앞뒤 공백이 포함된 등급명은 trim 후 정상 변환된다")
+    void fromKorean_withWhitespace_trimAndReturnsCorrectEnum() {
+        // Given
+        String gradeWithSpaces = "  레어  ";
+
+        // When
+        PotentialGrade result = PotentialGrade.fromKorean(gradeWithSpaces);
+
+        // Then
+        assertThat(result).isEqualTo(PotentialGrade.RARE);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"레어레", "RARE", "rare", "Legendary", "없음", "테스트"})
+    @DisplayName("유효하지 않은 등급명은 InvalidPotentialGradeException을 발생시킨다")
+    void fromKorean_invalidGrades_throwsException(String invalidGrade) {
+        // When & Then
+        assertThatThrownBy(() -> PotentialGrade.fromKorean(invalidGrade))
+                .isInstanceOf(InvalidPotentialGradeException.class)
+                .hasMessageContaining("잠재능력 등급: " + invalidGrade);
+    }
+
+    @Test
+    @DisplayName("null 등급명은 InvalidPotentialGradeException을 발생시킨다")
+    void fromKorean_null_throwsException() {
+        // When & Then
+        assertThatThrownBy(() -> PotentialGrade.fromKorean(null))
+                .isInstanceOf(InvalidPotentialGradeException.class)
+                .hasMessageContaining("잠재능력 등급: null");
+    }
+
+    @Test
+    @DisplayName("빈 문자열 등급명은 InvalidPotentialGradeException을 발생시킨다")
+    void fromKorean_emptyString_throwsException() {
+        // When & Then
+        assertThatThrownBy(() -> PotentialGrade.fromKorean(""))
+                .isInstanceOf(InvalidPotentialGradeException.class);
+    }
+
+    @Test
+    @DisplayName("공백만 있는 등급명은 InvalidPotentialGradeException을 발생시킨다")
+    void fromKorean_whitespaceOnly_throwsException() {
+        // When & Then
+        assertThatThrownBy(() -> PotentialGrade.fromKorean("   "))
+                .isInstanceOf(InvalidPotentialGradeException.class);
+    }
+
+    @Test
+    @DisplayName("getKoreanName()은 정확한 한글명을 반환한다")
+    void getKoreanName_returnsCorrectKoreanName() {
+        assertThat(PotentialGrade.RARE.getKoreanName()).isEqualTo("레어");
+        assertThat(PotentialGrade.EPIC.getKoreanName()).isEqualTo("에픽");
+        assertThat(PotentialGrade.UNIQUE.getKoreanName()).isEqualTo("유니크");
+        assertThat(PotentialGrade.LEGENDARY.getKoreanName()).isEqualTo("레전드리");
+    }
+}

--- a/src/test/java/maple/expectation/external/proxy/ResilientNexonApiClientTest.java
+++ b/src/test/java/maple/expectation/external/proxy/ResilientNexonApiClientTest.java
@@ -34,19 +34,23 @@ class ResilientNexonApiClientTest extends IntegrationTestSupport {
     @DisplayName("성공 시나리오: 결과값을 그대로 반환")
     void successDelegationTest() {
         String name = "메이플고수";
-        given(nexonApiClient.getOcidByCharacterName(name)).willReturn(new CharacterOcidResponse("ocid-123"));
+        // Issue #195: CompletableFuture 반환으로 변경
+        given(nexonApiClient.getOcidByCharacterName(name))
+                .willReturn(CompletableFuture.completedFuture(new CharacterOcidResponse("ocid-123")));
 
-        assertThat(resilientNexonApiClient.getOcidByCharacterName(name).getOcid()).isEqualTo("ocid-123");
+        assertThat(resilientNexonApiClient.getOcidByCharacterName(name).join().getOcid()).isEqualTo("ocid-123");
     }
 
     @Test
     @DisplayName("재시도 시나리오: 실패 시 3번 재시도 수행")
     void retryLogicTest() {
         String name = "네트워크불안정";
-        given(nexonApiClient.getOcidByCharacterName(name)).willThrow(new ExternalServiceException("Error"));
+        // Issue #195: CompletableFuture.failedFuture 반환으로 변경
+        given(nexonApiClient.getOcidByCharacterName(name))
+                .willReturn(CompletableFuture.failedFuture(new ExternalServiceException("Error")));
 
-        assertThatThrownBy(() -> resilientNexonApiClient.getOcidByCharacterName(name))
-                .isInstanceOf(ExternalServiceException.class);
+        assertThatThrownBy(() -> resilientNexonApiClient.getOcidByCharacterName(name).join())
+                .hasCauseInstanceOf(ExternalServiceException.class);
 
         verify(nexonApiClient, times(3)).getOcidByCharacterName(name);
     }

--- a/src/test/java/maple/expectation/service/v2/DonationServiceTransactionTest.java
+++ b/src/test/java/maple/expectation/service/v2/DonationServiceTransactionTest.java
@@ -1,0 +1,56 @@
+package maple.expectation.service.v2;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.lang.reflect.Method;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * DonationService @Transactional 어노테이션 검증 테스트
+ *
+ * <p>Issue #198: 금융 거래 데이터 일관성을 위해 명시적 isolation level 설정 확인</p>
+ */
+@DisplayName("DonationService Transaction Isolation 테스트")
+class DonationServiceTransactionTest {
+
+    @Test
+    @DisplayName("sendCoffee 메서드는 READ_COMMITTED isolation level이 명시되어 있다")
+    void sendCoffee_hasReadCommittedIsolation() throws NoSuchMethodException {
+        // Given
+        Method sendCoffeeMethod = DonationService.class.getMethod(
+                "sendCoffee",
+                String.class,  // guestUuid
+                String.class,  // adminFingerprint
+                Long.class,    // amount
+                String.class   // requestId
+        );
+
+        // When
+        Transactional transactionalAnnotation = sendCoffeeMethod.getAnnotation(Transactional.class);
+
+        // Then
+        assertThat(transactionalAnnotation)
+                .as("@Transactional 어노테이션이 존재해야 합니다")
+                .isNotNull();
+
+        assertThat(transactionalAnnotation.isolation())
+                .as("Isolation level이 READ_COMMITTED로 명시되어야 합니다")
+                .isEqualTo(Isolation.READ_COMMITTED);
+    }
+
+    @Test
+    @DisplayName("@Transactional 어노테이션의 기본값은 DEFAULT(DB 기본값)이다")
+    void transactional_defaultIsolation_isDefault() {
+        // Given: Spring의 기본 동작 확인
+        Isolation defaultIsolation = Isolation.DEFAULT;
+
+        // Then: 기본값이 DEFAULT임을 명시 (문서화 목적)
+        assertThat(defaultIsolation)
+                .as("Spring @Transactional 기본값은 DEFAULT(DB 설정 따름)")
+                .isEqualTo(Isolation.DEFAULT);
+    }
+}

--- a/src/test/java/maple/expectation/service/v2/EquipmentServiceTest.java
+++ b/src/test/java/maple/expectation/service/v2/EquipmentServiceTest.java
@@ -28,7 +28,9 @@ class EquipmentServiceTest extends IntegrationTestSupport {
     void setUp() {
         cacheManager.getCacheNames().forEach(n -> cacheManager.getCache(n).clear());
         CharacterOcidResponse mockOcid = new CharacterOcidResponse(TEST_OCID);
-        when(nexonApiClient.getOcidByCharacterName(anyString())).thenReturn(mockOcid);
+        // Issue #195: CompletableFuture 반환으로 변경
+        when(nexonApiClient.getOcidByCharacterName(anyString()))
+                .thenReturn(java.util.concurrent.CompletableFuture.completedFuture(mockOcid));
 
         // 테스트용 캐릭터 저장
         gameCharacterRepository.save(new GameCharacter(TEST_IGN, TEST_OCID));

--- a/src/test/java/maple/expectation/service/v2/GameCharacterServiceConcurrencyTest.java
+++ b/src/test/java/maple/expectation/service/v2/GameCharacterServiceConcurrencyTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -22,7 +23,9 @@ class GameCharacterServiceConcurrencyTest extends IntegrationTestSupport {
     void findCharacterConcurrencyTest() throws InterruptedException {
         int threadCount = 10;
         String name = "NewUser_" + UUID.randomUUID().toString().substring(0, 8);
-        when(nexonApiClient.getOcidByCharacterName(anyString())).thenReturn(new CharacterOcidResponse("mock_ocid"));
+        // Issue #195: CompletableFuture 반환으로 변경
+        when(nexonApiClient.getOcidByCharacterName(anyString()))
+                .thenReturn(CompletableFuture.completedFuture(new CharacterOcidResponse("mock_ocid")));
 
         ExecutorService executor = Executors.newFixedThreadPool(threadCount);
         CountDownLatch latch = new CountDownLatch(threadCount);

--- a/src/test/java/maple/expectation/service/v2/policy/CubeCostPolicyTest.java
+++ b/src/test/java/maple/expectation/service/v2/policy/CubeCostPolicyTest.java
@@ -1,0 +1,165 @@
+package maple.expectation.service.v2.policy;
+
+import maple.expectation.domain.v2.CubeType;
+import maple.expectation.global.error.exception.InvalidPotentialGradeException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * CubeCostPolicy 단위 테스트
+ *
+ * <p>Issue #197: 잘못된 등급 입력 시 Silent Failure(0원 반환) 대신
+ * 명시적 예외 발생 검증</p>
+ */
+@DisplayName("CubeCostPolicy 테스트")
+class CubeCostPolicyTest {
+
+    private CubeCostPolicy cubeCostPolicy;
+
+    @BeforeEach
+    void setUp() {
+        cubeCostPolicy = new CubeCostPolicy();
+    }
+
+    @Nested
+    @DisplayName("유효한 등급 테스트")
+    class ValidGradeTest {
+
+        @ParameterizedTest(name = "BLACK 큐브, 레벨 {0}, 등급 {1} -> {2}원")
+        @CsvSource({
+                "200, 레어, 4500000",
+                "200, 에픽, 18000000",
+                "200, 유니크, 38250000",
+                "200, 레전드리, 45000000"
+        })
+        @DisplayName("BLACK 큐브 유효 등급은 정확한 비용을 반환한다")
+        void getCubeCost_blackCube_validGrades(int level, String grade, long expectedCost) {
+            // When
+            long result = cubeCostPolicy.getCubeCost(CubeType.BLACK, level, grade);
+
+            // Then
+            assertThat(result).isEqualTo(expectedCost);
+        }
+
+        @ParameterizedTest(name = "ADDITIONAL 큐브, 레벨 {0}, 등급 {1} -> {2}원")
+        @CsvSource({
+                "200, 레어, 14625000",
+                "200, 에픽, 40950000",
+                "200, 유니크, 49725000",
+                "200, 레전드리, 58500000"
+        })
+        @DisplayName("ADDITIONAL 큐브 유효 등급은 정확한 비용을 반환한다")
+        void getCubeCost_additionalCube_validGrades(int level, String grade, long expectedCost) {
+            // When
+            long result = cubeCostPolicy.getCubeCost(CubeType.ADDITIONAL, level, grade);
+
+            // Then
+            assertThat(result).isEqualTo(expectedCost);
+        }
+
+        @Test
+        @DisplayName("RED 큐브는 모든 등급에서 1을 반환한다 (시세 곱셈용)")
+        void getCubeCost_redCube_returnsOne() {
+            assertThat(cubeCostPolicy.getCubeCost(CubeType.RED, 200, "레어")).isEqualTo(1L);
+            assertThat(cubeCostPolicy.getCubeCost(CubeType.RED, 200, "에픽")).isEqualTo(1L);
+            assertThat(cubeCostPolicy.getCubeCost(CubeType.RED, 200, "유니크")).isEqualTo(1L);
+            assertThat(cubeCostPolicy.getCubeCost(CubeType.RED, 200, "레전드리")).isEqualTo(1L);
+        }
+    }
+
+    @Nested
+    @DisplayName("레벨 구간 테스트")
+    class LevelBracketTest {
+
+        @ParameterizedTest(name = "레벨 {0} -> 레벨 구간 {1}의 비용 적용")
+        @CsvSource({
+                "100, 4000000",   // 0-159 구간 -> 0레벨 테이블
+                "159, 4000000",   // 0-159 구간
+                "160, 4250000",   // 160-199 구간
+                "199, 4250000",   // 160-199 구간
+                "200, 4500000",   // 200-249 구간
+                "249, 4500000",   // 200-249 구간
+                "250, 5000000",   // 250+ 구간
+                "300, 5000000"    // 250+ 구간
+        })
+        @DisplayName("레벨에 맞는 하위 구간 비용이 적용된다")
+        void getCubeCost_levelBrackets_appliesCorrectCost(int level, long expectedCost) {
+            // When
+            long result = cubeCostPolicy.getCubeCost(CubeType.BLACK, level, "레어");
+
+            // Then
+            assertThat(result).isEqualTo(expectedCost);
+        }
+    }
+
+    @Nested
+    @DisplayName("잘못된 등급 테스트 (Issue #197)")
+    class InvalidGradeTest {
+
+        @ParameterizedTest
+        @ValueSource(strings = {"레어레", "RARE", "rare", "Legendary", "없음", "테스트"})
+        @DisplayName("잘못된 등급명은 InvalidPotentialGradeException을 발생시킨다")
+        void getCubeCost_invalidGrade_throwsException(String invalidGrade) {
+            // When & Then
+            assertThatThrownBy(() ->
+                    cubeCostPolicy.getCubeCost(CubeType.BLACK, 200, invalidGrade)
+            ).isInstanceOf(InvalidPotentialGradeException.class);
+        }
+
+        @Test
+        @DisplayName("null 등급은 InvalidPotentialGradeException을 발생시킨다")
+        void getCubeCost_nullGrade_throwsException() {
+            // When & Then
+            assertThatThrownBy(() ->
+                    cubeCostPolicy.getCubeCost(CubeType.BLACK, 200, null)
+            ).isInstanceOf(InvalidPotentialGradeException.class);
+        }
+
+        @Test
+        @DisplayName("빈 문자열 등급은 InvalidPotentialGradeException을 발생시킨다")
+        void getCubeCost_emptyGrade_throwsException() {
+            // When & Then
+            assertThatThrownBy(() ->
+                    cubeCostPolicy.getCubeCost(CubeType.BLACK, 200, "")
+            ).isInstanceOf(InvalidPotentialGradeException.class);
+        }
+
+        @Test
+        @DisplayName("잘못된 등급이 Silent Failure(0원)를 반환하지 않는다")
+        void getCubeCost_invalidGrade_doesNotReturnZero() {
+            // Given: 이전 코드는 getOrDefault(grade, 0L)로 0을 반환했음
+            String invalidGrade = "존재하지않는등급";
+
+            // When & Then: 0원 대신 예외가 발생해야 함
+            assertThatThrownBy(() ->
+                    cubeCostPolicy.getCubeCost(CubeType.BLACK, 200, invalidGrade)
+            ).isInstanceOf(InvalidPotentialGradeException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("앞뒤 공백 처리 테스트")
+    class WhitespaceTrimTest {
+
+        @Test
+        @DisplayName("등급명 앞뒤 공백은 trim되어 정상 처리된다")
+        void getCubeCost_gradeWithWhitespace_trimAndProcess() {
+            // Given
+            String gradeWithSpaces = "  레어  ";
+
+            // When
+            long result = cubeCostPolicy.getCubeCost(CubeType.BLACK, 200, gradeWithSpaces);
+
+            // Then
+            assertThat(result).isEqualTo(4500000L);
+        }
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- #195 (P0): Blocking Call 제거
- #196 (P0): WebClient Timeout 설정 누락
- #197 (P1): CubeCostPolicy 입력값 검증 누락
- #198 (P0): @Transactional Isolation Level 명시

## 🗣 개요
방어적 프로그래밍 원칙 적용 및 Reactor 체인 내 `.block()` anti-pattern 제거를 통한 시스템 안정성 향상

## 🛠 작업 내용

### Issue #195: Blocking Call 제거 (P0)
- [x] `RealNexonApiClient.getOcidByCharacterName()` `.block()` → `.toFuture()` 전환
- [x] `NexonApiClient` 인터페이스 `CompletableFuture` 반환으로 변경
- [x] `ResilientNexonApiClient` TimeLimiter 추가 (비동기 타임아웃)
- [x] 호출부(`GameCharacterService`, `OcidResolver`) `.join()` 사용 (이미 async 스레드에서 실행)
- [x] `EquipmentDataProvider.streamAndDecompress()` ADR 문서화 (StreamingResponseBody 컨텍스트)

### Issue #196: WebClient Timeout 설정 (P0)
- [x] `RealNexonApiClient`: `API_TIMEOUT` 5초 설정
- [x] `DiscordAlertService`: `ALERT_TIMEOUT` 3초 설정 (Fire-and-Forget)
- [x] `onErrorResume` 패턴으로 에러 본문 로깅 (디버깅 가시성)

### Issue #197: CubeCostPolicy 입력값 검증 (P1)
- [x] `PotentialGrade` enum 도입 (한글 등급명 매핑)
- [x] `InvalidPotentialGradeException` 추가 (CircuitBreakerIgnoreMarker)
- [x] Silent Failure(0원) → 명시적 예외 발생으로 Fail-Fast 패턴 적용
- [x] EnumMap 이중 구조로 O(1) 조회 최적화 (Green Agent)

### Issue #198: @Transactional Isolation Level 명시 (P0)
- [x] `DonationService.sendCoffee()` READ_COMMITTED isolation 명시

### Agent Review Fixes
- [x] [Purple] `CriticalTransactionFailureException` cause 체이닝 수정 (root cause 보존)

## 💬 리뷰 포인트
1. `getOcidByCharacterName()` 비동기 전환이 Resilience4j `@Retry`, `@CircuitBreaker`와 올바르게 동작하는지
2. `PotentialGrade.fromKorean()` 검증 로직 적절성
3. EnumMap 구조 변경으로 인한 기존 테스트 영향

## 💱 트레이드 오프 결정 근거

| 결정 | 선택 | 이유 |
|------|------|------|
| `.block()` 제거 | `.toFuture()` + `.join()` | Reactor 체인 내 블로킹 제거, 호출부는 이미 async 스레드 |
| Timeout 설정 | 상수로 하드코딩 | 추후 `application.yml` 외부화 예정, 현재는 간단한 상수 |
| Grade 검증 | Enum + fromKorean() | 타입 안전성 + O(1) 조회, 기존 String 시그니처 유지 |
| StreamingResponseBody `.join()` | ADR 문서화 | Tomcat 스레드 이미 반환, OutputStream 본질적 블로킹 |

## ✅ 체크리스트
- [x] 브랜치/커밋 규칙 준수 여부
- [x] 빌드 통과 여부 (`./gradlew clean build -x test`)
- [x] 관련 테스트 통과 여부
  - `CubeCostPolicyTest` ✅
  - `PotentialGradeTest` ✅
  - `DonationServiceTransactionTest` ✅
  - `ResilientNexonApiClientTest` ✅
  - `GameCharacterServiceConcurrencyTest` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)