### PR TITLE
feat(#143): Observability 인프라 구축 (Loki + Grafana + MDC Tracing)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,9 @@ dependencies {
     // SpringDoc OpenAPI (Swagger UI) - Context7 Best Practice
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13'
 
+    // Observability - Loki Appender (Issue #143)
+    implementation 'com.github.loki4j:loki-logback-appender:1.4.2'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/docker-compose.observability.yml
+++ b/docker-compose.observability.yml
@@ -1,0 +1,71 @@
+# Issue #143: Observability Infrastructure (Loki + Grafana)
+# 5-Agent Council 합의:
+# - P0-1 해결: external 대신 동일 네트워크 재정의 (단독 실행 가능)
+# - P0-3 해결: Grafana 비밀번호 환경변수 외부화
+#
+# 사용법:
+#   docker-compose -f docker-compose.observability.yml up -d
+#
+# Grafana 접속: http://localhost:3000 (admin/admin 또는 GRAFANA_PASSWORD 환경변수)
+# Loki API: http://localhost:3100
+
+version: '3.8'
+
+services:
+  loki:
+    image: grafana/loki:2.9.0
+    container_name: loki
+    ports:
+      - "3100:3100"
+    command: -config.file=/etc/loki/local-config.yaml
+    volumes:
+      - loki_data:/loki
+    networks:
+      - maple-network
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+          cpus: '0.5'
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:3100/ready || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  grafana:
+    image: grafana/grafana:10.2.0
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      # P0-3 해결: 환경변수 외부화
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD:-admin}
+      - GF_USERS_ALLOW_SIGN_UP=false
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./docker/grafana/provisioning:/etc/grafana/provisioning
+    networks:
+      - maple-network
+    depends_on:
+      loki:
+        condition: service_healthy
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+          cpus: '0.25'
+
+volumes:
+  loki_data:
+  grafana_data:
+
+# P0-1 해결: external 대신 동일 네트워크 재정의
+# 기존 docker-compose.yml과 동일한 설정 (단독 또는 함께 실행 가능)
+networks:
+  maple-network:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.20.0.0/16

--- a/docker/grafana/provisioning/dashboards/application.json
+++ b/docker/grafana/provisioning/dashboards/application.json
@@ -1,0 +1,214 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "description": "MapleExpectation 애플리케이션 로그 볼륨 시계열",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 50,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "editorMode": "code",
+          "expr": "sum(count_over_time({app=\"maple-expectation\"} [1m])) by (level)",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Log Volume by Level",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "description": "requestId로 요청 추적",
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 2,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": false
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "editorMode": "code",
+          "expr": "{app=\"maple-expectation\"} |= `$requestId`",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Logs by Request ID",
+      "type": "logs"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "description": "ERROR 레벨 로그만 필터링",
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "id": 3,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": false
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "editorMode": "code",
+          "expr": "{app=\"maple-expectation\"} | json | level = `ERROR`",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Error Logs",
+      "type": "logs"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [
+    "maple-expectation",
+    "observability"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "",
+          "value": ""
+        },
+        "description": "Filter logs by requestId",
+        "hide": 0,
+        "label": "Request ID",
+        "name": "requestId",
+        "options": [],
+        "query": "",
+        "skipUrlSync": false,
+        "type": "textbox"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "MapleExpectation Application Logs",
+  "uid": "maple-expectation-logs",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docker/grafana/provisioning/dashboards/dashboard.yml
+++ b/docker/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,14 @@
+# Issue #143: Dashboard Provider Configuration
+# Grafana가 시작될 때 자동으로 대시보드를 로드합니다.
+
+apiVersion: 1
+
+providers:
+  - name: 'default'
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/docker/grafana/provisioning/datasources/loki.yml
+++ b/docker/grafana/provisioning/datasources/loki.yml
@@ -1,0 +1,12 @@
+# Issue #143: Loki Datasource Configuration
+# Grafana가 시작될 때 자동으로 Loki 데이터소스를 등록합니다.
+
+apiVersion: 1
+
+datasources:
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    isDefault: true
+    editable: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -119,6 +119,11 @@ logging:
   pattern:
     console: "%d{yyyy-MM-dd HH:mm:ss.SSS} %5p [%X{requestId}] --- [%thread] %-40.40logger{39} : %m%n"
 
+# Observability 설정 (Issue #143)
+observability:
+  loki:
+    url: ${LOKI_URL:http://localhost:3100}
+
 # 넥슨 API 설정
 nexon:
   api:

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -34,16 +34,55 @@
         <appender-ref ref="TRACE_ASYNC" />
     </logger>
 
-    <!-- 나머지 로그는 기존대로: 콘솔(필요 시 기존 파일 appender도 여기에 유지) -->
+    <!-- Console Appender (requestId 포함) -->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} : %msg%n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] [%X{requestId:-}] %-5level %logger{36} : %msg%n</pattern>
         </encoder>
     </appender>
 
-    <root level="INFO">
-        <appender-ref ref="CONSOLE" />
-    </root>
+    <!-- ========================================
+         Loki Appender (prod 프로파일 전용)
+         Issue #143: Observability Infrastructure
+         ======================================== -->
+    <springProfile name="prod">
+        <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
+            <http>
+                <url>${LOKI_URL:-http://localhost:3100}/loki/api/v1/push</url>
+                <connectionTimeoutMs>5000</connectionTimeoutMs>
+                <requestTimeoutMs>10000</requestTimeoutMs>
+            </http>
+            <format>
+                <label>
+                    <pattern>app=maple-expectation,env=${ENV:-prod},host=${HOSTNAME:-unknown}</pattern>
+                </label>
+                <!-- P1-1 해결: JsonLayout으로 자동 이스케이프 -->
+                <message class="com.github.loki4j.logback.JsonLayout">
+                    <includeMDC>true</includeMDC>
+                </message>
+            </format>
+            <batchSize>1000</batchSize>
+            <batchTimeoutMs>3000</batchTimeoutMs>
+        </appender>
+
+        <appender name="LOKI_ASYNC" class="ch.qos.logback.classic.AsyncAppender">
+            <queueSize>8192</queueSize>
+            <discardingThreshold>0</discardingThreshold>
+            <neverBlock>true</neverBlock>
+            <appender-ref ref="LOKI" />
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="LOKI_ASYNC" />
+        </root>
+    </springProfile>
+
+    <!-- Local/Test 프로파일: Console만 사용 -->
+    <springProfile name="local,test,default">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE" />
+        </root>
+    </springProfile>
 
 </configuration>

--- a/src/test/java/maple/expectation/global/filter/MDCFilterTest.java
+++ b/src/test/java/maple/expectation/global/filter/MDCFilterTest.java
@@ -1,0 +1,133 @@
+package maple.expectation.global.filter;
+
+import jakarta.servlet.FilterChain;
+import maple.expectation.global.common.function.ThrowingSupplier;
+import maple.expectation.global.executor.LogicExecutor;
+import maple.expectation.global.executor.TaskContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+
+/**
+ * Issue #143: MDCFilter 단위 테스트
+ * P1-3 해결: MDCFilter 테스트 부재 → 테스트 추가
+ *
+ * 테스트 케이스:
+ * 1. X-Correlation-ID 헤더가 있으면 해당 ID를 사용
+ * 2. 헤더가 없으면 UUID를 자동 생성
+ * 3. 응답 헤더에 X-Correlation-ID가 포함됨
+ */
+@ExtendWith(MockitoExtension.class)
+class MDCFilterTest {
+
+    @Mock
+    private LogicExecutor executor;
+
+    @Mock
+    private FilterChain filterChain;
+
+    private MDCFilter mdcFilter;
+
+    @BeforeEach
+    void setUp() {
+        mdcFilter = new MDCFilter(executor);
+
+        // LogicExecutor passthrough 설정 (CLAUDE.md 섹션 10 준수)
+        doAnswer(invocation -> {
+            @SuppressWarnings("unchecked")
+            ThrowingSupplier<Object> task = invocation.getArgument(0);
+            Runnable finalizer = invocation.getArgument(1);
+            try {
+                return task.get();
+            } finally {
+                finalizer.run();
+            }
+        }).when(executor).executeWithFinally(any(ThrowingSupplier.class), any(Runnable.class), any(TaskContext.class));
+    }
+
+    @Test
+    @DisplayName("X-Correlation-ID 헤더가 있으면 해당 ID를 사용한다")
+    void shouldUseProvidedCorrelationId() throws Exception {
+        // given
+        String expectedId = "test-correlation-id-12345";
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("X-Correlation-ID", expectedId);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        // when
+        mdcFilter.doFilter(request, response, filterChain);
+
+        // then
+        assertThat(response.getHeader("X-Correlation-ID")).isEqualTo(expectedId);
+    }
+
+    @Test
+    @DisplayName("X-Correlation-ID 헤더가 없으면 UUID를 자동 생성한다")
+    void shouldGenerateUuidWhenNoHeader() throws Exception {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        // when
+        mdcFilter.doFilter(request, response, filterChain);
+
+        // then
+        String correlationId = response.getHeader("X-Correlation-ID");
+        assertThat(correlationId).isNotNull();
+        assertThat(correlationId).isNotBlank();
+
+        // UUID 형식 검증
+        assertThat(UUID.fromString(correlationId)).isNotNull();
+    }
+
+    @Test
+    @DisplayName("빈 문자열 헤더가 있으면 UUID를 자동 생성한다")
+    void shouldGenerateUuidWhenEmptyHeader() throws Exception {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("X-Correlation-ID", "");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        // when
+        mdcFilter.doFilter(request, response, filterChain);
+
+        // then
+        String correlationId = response.getHeader("X-Correlation-ID");
+        assertThat(correlationId).isNotNull();
+        assertThat(correlationId).isNotBlank();
+
+        // UUID 형식 검증
+        assertThat(UUID.fromString(correlationId)).isNotNull();
+    }
+
+    @Test
+    @DisplayName("공백만 있는 헤더가 있으면 UUID를 자동 생성한다")
+    void shouldGenerateUuidWhenBlankHeader() throws Exception {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("X-Correlation-ID", "   ");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        // when
+        mdcFilter.doFilter(request, response, filterChain);
+
+        // then
+        String correlationId = response.getHeader("X-Correlation-ID");
+        assertThat(correlationId).isNotNull();
+        assertThat(correlationId).isNotBlank();
+
+        // UUID 형식 검증
+        assertThat(UUID.fromString(correlationId)).isNotNull();
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
#143

## 🗣 개요
DevOps 관측성 인프라를 구축하여 분산 로그 수집, 시각화, 요청 추적 기능을 제공합니다.

## 🛠 작업 내용
- [x] `build.gradle`: loki4j-logback-appender 1.4.2 의존성 추가
- [x] `logback-spring.xml`: Profile별 Appender 분리
  - prod: Loki AsyncAppender + JsonLayout
  - local/test: Console Appender
  - neverBlock=true로 I/O 비차단 보장
- [x] `application.yml`: observability.loki.url 설정 추가
- [x] `docker-compose.observability.yml`: PLG 스택 (Loki + Grafana)
- [x] `docker/grafana/provisioning/`: 데이터소스 + 대시보드 자동 프로비저닝
- [x] `MDCFilterTest`: X-Correlation-ID 헤더 처리 검증

## 💬 리뷰 포인트
1. **P0-1 해결**: 네트워크 충돌 방지를 위해 `external: true` 대신 동일 네트워크 재정의
2. **P0-3 해결**: Grafana 비밀번호 환경변수 외부화 (`${GRAFANA_PASSWORD:-admin}`)
3. **P1-1 해결**: JsonLayout 클래스 사용으로 JSON 이스케이프 자동 처리
4. **P1-3 해결**: MDCFilterTest 추가로 테스트 커버리지 확보

## 💱 트레이드 오프 결정 근거

| 결정 | 대안 | 선택 이유 |
|------|------|----------|
| AsyncAppender + neverBlock=true | 동기 로깅 | Loki 장애 시 서비스 영향 없음 |
| JsonLayout | 수동 패턴 | JSON 이스케이프 자동 처리로 P1-1 해결 |
| Profile 분리 | 단일 설정 | 로컬 개발 환경 복잡도 최소화 |
| 별도 docker-compose 파일 | 기존 파일 수정 | 관측 스택 선택적 실행 가능 |

## ✅ 체크리스트
- [x] 브랜치/커밋 규칙 준수 여부
- [x] 빌드 성공 (`./gradlew clean build -x test`)
- [x] MDCFilterTest 통과
- [x] 5개 에이전트(Blue, Green, Yellow, Purple, Red) 협업 완료

## 📊 5개 에이전트 승인 현황

| Agent | 역할 | 승인 |
|-------|------|------|
| Blue (Spring-Architect) | SOLID 아키텍처 | ✅ |
| Green (Performance-Guru) | 성능 최적화 | ✅ |
| Yellow (QA-Master) | 테스트 전략 | ✅ |
| Purple (Financial-Auditor) | 보안/무결성 | ✅ |
| Red (SRE-Gatekeeper) | 인프라/안정성 | ✅ |

🤖 Generated with [Claude Code](https://claude.ai/code)