### PR TITLE
fix: gradle.yml 타임아웃 설정 추가

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [ "master" ]
 
+# SRE: Cancel in-progress runs for same PR (save resources)
+concurrency:
+  group: gradle-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -15,6 +20,7 @@ jobs:
   # ==========================================
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 20  # SRE: Prevent zombie jobs (Issue #240)
     services:
       redis:
         image: redis
@@ -61,6 +67,7 @@ jobs:
     needs: build
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
+    timeout-minutes: 10  # SRE: Prevent zombie deploy jobs
 
     steps:
       - name: Download Build Artifact


### PR DESCRIPTION
## 관련 이슈
#240

## 개요
CI/CD 워크플로우 좀비 잡 방지를 위한 타임아웃 설정 추가

## 작업 내용
- [x] build job: timeout-minutes: 20 추가
- [x] deploy job: timeout-minutes: 10 추가
- [x] concurrency 설정 추가 (동일 PR 중복 실행 자동 취소)

## 리뷰 포인트
- 4시간+ 실행되던 워크플로우 → 최대 20분으로 제한

🤖 Generated with [Claude Code](https://claude.ai/code)