### PR TITLE
perf: CI Gate Unit Only - Integration 테스트 Nightly 이동

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,39 +37,11 @@ jobs:
   # JOB 1: Build & Test (Gate)
   # ==========================================================================
   test:
-    name: Build & Test
+    name: Build & Test (Unit Only)
     runs-on: ubuntu-latest
-    timeout-minutes: 15  # Hard deadline - prevent zombie jobs
+    timeout-minutes: 10  # Unit tests only - 10분이면 충분
 
-    services:
-      # Redis service for integration tests (Testcontainers alternative)
-      redis:
-        image: redis:7.0-alpine
-        ports:
-          - 6379:6379
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 5s
-          --health-timeout 3s
-          --health-retries 10
-          --memory 256m
-
-      # MySQL service for integration tests requiring real DB
-      mysql:
-        image: mysql:8.0
-        ports:
-          - 3306:3306
-        env:
-          MYSQL_ROOT_PASSWORD: testpassword
-          MYSQL_DATABASE: maple_test
-          MYSQL_USER: testuser
-          MYSQL_PASSWORD: testpassword
-        options: >-
-          --health-cmd "mysqladmin ping -h 127.0.0.1 -u root -ptestpassword"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 10
-          --memory 512m
+    # Services 제거: Unit 테스트는 Mock 사용, Integration은 Nightly에서 실행
 
     steps:
       # ------------------------------------------------------------------

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -20,17 +20,9 @@ jobs:
   # ==========================================
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 20  # SRE: Prevent zombie jobs (Issue #240)
-    services:
-      redis:
-        image: redis
-        ports:
-          - 6379:6379
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+    timeout-minutes: 10  # Unit tests only - 10분이면 충분
+
+    # Services 제거: Unit 테스트는 Mock 사용, Integration은 Nightly에서 실행
 
     steps:
       - uses: actions/checkout@v4

--- a/build.gradle
+++ b/build.gradle
@@ -114,8 +114,8 @@ test {
         if (project.hasProperty('sentinelTest')) {
             includeTags 'sentinel'
         } else if (project.hasProperty('fastTest')) {
-            // CI Gate: chaos, nightmare, slow, sentinel, quarantine 제외
-            excludeTags 'sentinel', 'slow', 'quarantine', 'chaos', 'nightmare'
+            // CI Gate: integration, chaos, nightmare 등 무거운 테스트 제외 (1-2분)
+            excludeTags 'sentinel', 'slow', 'quarantine', 'chaos', 'nightmare', 'integration'
         } else {
             // Nightly: sentinel, quarantine만 제외
             excludeTags 'sentinel', 'quarantine'


### PR DESCRIPTION
## 관련 이슈
#240

## 개요
CI Gate에서 Integration 테스트 제외하여 속도 대폭 개선

## 변경 사항
| 구분 | 변경 전 | 변경 후 |
|------|--------|--------|
| CI Gate | Unit + Integration (3-5분) | **Unit Only (1-2분)** |
| Services | MySQL + Redis | 없음 (Mock 사용) |
| Timeout | 15분 | 10분 |

## 테스트 전략
```
CI Gate (PR/Push) → Unit Only (1-2분)
Nightly (매일 00:00) → Unit + Integration + Chaos (15분)
```

## 제외되는 태그
`sentinel`, `slow`, `quarantine`, `chaos`, `nightmare`, `integration`

🤖 Generated with [Claude Code](https://claude.ai/code)