### PR TITLE
fix: Codex 코드리뷰 12건 해결 (PR #186 ~ #248)

### DIFF
--- a/docker/grafana/provisioning/datasources/loki.yml
+++ b/docker/grafana/provisioning/datasources/loki.yml
@@ -6,6 +6,7 @@ apiVersion: 1
 datasources:
   - name: Loki
     type: loki
+    uid: loki  # PR #206: 대시보드 참조용 UID 추가
     access: proxy
     url: http://loki:3100
     isDefault: true

--- a/src/main/java/maple/expectation/config/SecurityConfig.java
+++ b/src/main/java/maple/expectation/config/SecurityConfig.java
@@ -192,12 +192,13 @@ public class SecurityConfig {
                 .anyRequest().authenticated()
             )
 
-            // Rate Limiting 필터 추가 (Issue #152: JWT 필터 이전에 실행)
-            .addFilterBefore(rateLimitingFilter, UsernamePasswordAuthenticationFilter.class)
-
-            // JWT 인증 필터 추가
+            // JWT 인증 필터 추가 (UsernamePasswordAuthenticationFilter 이전)
             .addFilterBefore(jwtAuthenticationFilter,
                 UsernamePasswordAuthenticationFilter.class)
+
+            // PR #192 Fix: Rate Limiting 필터는 JWT 필터 이후에 배치
+            // (User-based rate limiting에 SecurityContext 필요)
+            .addFilterAfter(rateLimitingFilter, JwtAuthenticationFilter.class)
 
             // 인증 실패 핸들링
             .exceptionHandling(ex -> ex

--- a/src/main/java/maple/expectation/dto/v4/EquipmentExpectationResponseV4.java
+++ b/src/main/java/maple/expectation/dto/v4/EquipmentExpectationResponseV4.java
@@ -2,6 +2,7 @@ package maple.expectation.dto.v4;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.extern.jackson.Jacksonized;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -18,9 +19,14 @@ import java.util.List;
  *   <li>메타 정보: 계산 시점, 캐시 여부</li>
  *   <li>비용 텍스트: 조/억/만 단위 포맷</li>
  * </ul>
+ *
+ * <h3>PR #242: Jackson 역직렬화 지원</h3>
+ * <p>{@code @Jacksonized}를 사용하여 {@code @Builder}와 Jackson 역직렬화를 호환시킵니다.
+ * PER 캐시에서 Redis JSON을 역직렬화할 때 필수입니다.</p>
  */
 @Getter
 @Builder
+@Jacksonized
 public class EquipmentExpectationResponseV4 {
 
     // ==================== 기본 정보 ====================
@@ -44,6 +50,7 @@ public class EquipmentExpectationResponseV4 {
 
     @Getter
     @Builder
+    @Jacksonized
     public static class PresetExpectation {
         private final int presetNo;
         private final BigDecimal totalExpectedCost;
@@ -54,6 +61,7 @@ public class EquipmentExpectationResponseV4 {
 
     @Getter
     @Builder
+    @Jacksonized
     public static class ItemExpectationV4 {
         private final String itemName;
         private final String itemIcon;           // 아이콘 URL (#240 V4)
@@ -88,6 +96,7 @@ public class EquipmentExpectationResponseV4 {
      */
     @Getter
     @Builder
+    @Jacksonized
     public static class CubeExpectationDto {
         private final BigDecimal expectedCost;
         private final String expectedCostText;       // "5000억"
@@ -113,6 +122,7 @@ public class EquipmentExpectationResponseV4 {
      */
     @Getter
     @Builder
+    @Jacksonized
     public static class StarforceExpectationDto {
 
         // 현재/목표 스타 (#240 V4)
@@ -147,6 +157,7 @@ public class EquipmentExpectationResponseV4 {
 
     @Getter
     @Builder
+    @Jacksonized
     public static class CostBreakdownDto {
         private final BigDecimal blackCubeCost;
         private final BigDecimal redCubeCost;

--- a/src/main/java/maple/expectation/global/ratelimit/strategy/IpBasedRateLimiter.java
+++ b/src/main/java/maple/expectation/global/ratelimit/strategy/IpBasedRateLimiter.java
@@ -4,6 +4,7 @@ import io.github.bucket4j.distributed.proxy.ProxyManager;
 import io.micrometer.core.instrument.MeterRegistry;
 import maple.expectation.global.executor.LogicExecutor;
 import maple.expectation.global.ratelimit.config.RateLimitProperties;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
@@ -20,9 +21,13 @@ import java.time.Duration;
  *   <li>Redis 키: {ratelimit}:ip:{clientIp}</li>
  * </ul>
  *
+ * <h4>PR #192: Conditional Bean 등록</h4>
+ * <p>{@code ratelimit.enabled=true} 설정 시에만 Bean 등록됨 (기본값: true)</p>
+ *
  * @since Issue #152
  */
 @Component
+@ConditionalOnProperty(prefix = "ratelimit", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class IpBasedRateLimiter extends AbstractBucket4jRateLimiter {
 
     private static final String STRATEGY_NAME = "ip";

--- a/src/main/java/maple/expectation/global/ratelimit/strategy/UserBasedRateLimiter.java
+++ b/src/main/java/maple/expectation/global/ratelimit/strategy/UserBasedRateLimiter.java
@@ -4,6 +4,7 @@ import io.github.bucket4j.distributed.proxy.ProxyManager;
 import io.micrometer.core.instrument.MeterRegistry;
 import maple.expectation.global.executor.LogicExecutor;
 import maple.expectation.global.ratelimit.config.RateLimitProperties;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
@@ -20,9 +21,13 @@ import java.time.Duration;
  *   <li>Redis 키: {ratelimit}:user:{fingerprint}</li>
  * </ul>
  *
+ * <h4>PR #192: Conditional Bean 등록</h4>
+ * <p>{@code ratelimit.enabled=true} 설정 시에만 Bean 등록됨 (기본값: true)</p>
+ *
  * @since Issue #152
  */
 @Component
+@ConditionalOnProperty(prefix = "ratelimit", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class UserBasedRateLimiter extends AbstractBucket4jRateLimiter {
 
     private static final String STRATEGY_NAME = "user";

--- a/src/main/java/maple/expectation/global/util/ExceptionUtils.java
+++ b/src/main/java/maple/expectation/global/util/ExceptionUtils.java
@@ -1,0 +1,135 @@
+package maple.expectation.global.util;
+
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * 예외 처리 유틸리티 (PR #199, #241)
+ *
+ * <h3>목적</h3>
+ * <p>비동기 실행 시 발생하는 래퍼 예외(CompletionException, ExecutionException)를
+ * 원본 예외로 unwrap하여 정확한 예외 타입 감지를 지원합니다.</p>
+ *
+ * <h3>문제 상황</h3>
+ * <p>{@code CompletableFuture.join()} 호출 시 예외가 CompletionException으로 래핑되어
+ * {@code CharacterNotFoundException} 같은 비즈니스 예외를 직접 감지할 수 없습니다.</p>
+ *
+ * <h3>사용 예시</h3>
+ * <pre>{@code
+ * executor.executeOrCatch(
+ *     () -> nexonApiClient.getOcid(userIgn).join().getOcid(),
+ *     e -> {
+ *         Throwable unwrapped = ExceptionUtils.unwrapAsyncException(e);
+ *         if (unwrapped instanceof CharacterNotFoundException) {
+ *             // Negative Cache 저장
+ *         }
+ *         throw (RuntimeException) e;
+ *     },
+ *     context
+ * );
+ * }</pre>
+ *
+ * <h3>CLAUDE.md 준수</h3>
+ * <ul>
+ *   <li>Section 4: DRY 원칙 - 3곳 이상에서 동일 로직 사용 시 유틸리티로 추출</li>
+ *   <li>Section 6: Utility 클래스 → private 생성자, static 메서드</li>
+ * </ul>
+ *
+ * @since PR #199, #241
+ */
+public final class ExceptionUtils {
+
+    private static final int MAX_UNWRAP_DEPTH = 10;
+
+    private ExceptionUtils() {
+        // Utility class - private constructor
+    }
+
+    /**
+     * 비동기 래퍼 예외를 원본 예외로 unwrap
+     *
+     * <h4>지원하는 래퍼 예외</h4>
+     * <ul>
+     *   <li>{@link CompletionException} - CompletableFuture.join() 시 발생</li>
+     *   <li>{@link ExecutionException} - Future.get() 시 발생</li>
+     * </ul>
+     *
+     * <h4>안전 장치</h4>
+     * <p>무한 루프 방지를 위해 최대 10단계까지만 unwrap합니다.</p>
+     *
+     * @param throwable unwrap할 예외
+     * @return 원본 예외 (래퍼 예외가 아닌 경우 입력 그대로 반환)
+     */
+    public static Throwable unwrapAsyncException(Throwable throwable) {
+        if (throwable == null) {
+            return null;
+        }
+
+        Throwable current = throwable;
+        for (int i = 0; i < MAX_UNWRAP_DEPTH && current != null; i++) {
+            if (current instanceof CompletionException || current instanceof ExecutionException) {
+                Throwable cause = current.getCause();
+                if (cause != null) {
+                    current = cause;
+                    continue;
+                }
+            }
+            break;
+        }
+
+        return current != null ? current : throwable;
+    }
+
+    /**
+     * 특정 예외 타입으로 unwrap 후 캐스팅
+     *
+     * <h4>사용 예시</h4>
+     * <pre>{@code
+     * CharacterNotFoundException unwrapped = ExceptionUtils.unwrapAs(e, CharacterNotFoundException.class);
+     * if (unwrapped != null) {
+     *     // 처리
+     * }
+     * }</pre>
+     *
+     * @param throwable unwrap할 예외
+     * @param targetType 목표 예외 타입
+     * @return 목표 타입으로 캐스팅된 예외, 불가능하면 null
+     */
+    public static <T extends Throwable> T unwrapAs(Throwable throwable, Class<T> targetType) {
+        Throwable unwrapped = unwrapAsyncException(throwable);
+        if (targetType.isInstance(unwrapped)) {
+            return targetType.cast(unwrapped);
+        }
+        return null;
+    }
+
+    /**
+     * 예외 체인에서 특정 타입 존재 여부 확인
+     *
+     * <h4>사용 예시</h4>
+     * <pre>{@code
+     * if (ExceptionUtils.containsCause(e, CharacterNotFoundException.class)) {
+     *     // Negative Cache 저장
+     * }
+     * }</pre>
+     *
+     * @param throwable 검사할 예외
+     * @param targetType 찾고자 하는 예외 타입
+     * @return 해당 타입이 예외 체인에 존재하면 true
+     */
+    public static boolean containsCause(Throwable throwable, Class<? extends Throwable> targetType) {
+        if (throwable == null) {
+            return false;
+        }
+
+        Throwable current = throwable;
+        for (int i = 0; i < MAX_UNWRAP_DEPTH && current != null; i++) {
+            if (targetType.isInstance(current)) {
+                return true;
+            }
+            current = current.getCause();
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/maple/expectation/service/v2/GameCharacterService.java
+++ b/src/main/java/maple/expectation/service/v2/GameCharacterService.java
@@ -8,6 +8,7 @@ import maple.expectation.external.NexonApiClient;
 import maple.expectation.global.error.exception.CharacterNotFoundException;
 import maple.expectation.global.executor.LogicExecutor;
 import maple.expectation.global.executor.TaskContext;
+import maple.expectation.global.util.ExceptionUtils;
 import maple.expectation.repository.v2.GameCharacterRepository;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
@@ -94,8 +95,9 @@ public class GameCharacterService {
                     return saveCharacterWithCaching(cleanUserIgn, ocid);
                 },
                 (e) -> {
-                    // CharacterNotFoundException 발생 시에만 네거티브 캐싱 수행 후 예외 재전파
-                    if (e instanceof CharacterNotFoundException) {
+                    // PR #199, #241 Fix: CompletionException unwrap 후 CharacterNotFoundException 감지
+                    Throwable unwrapped = ExceptionUtils.unwrapAsyncException(e);
+                    if (unwrapped instanceof CharacterNotFoundException) {
                         log.warn("🚫 [Recovery] 캐릭터 미존재 확인 -> 네거티브 캐시 저장: {}", cleanUserIgn);
                         Optional.ofNullable(cacheManager.getCache("ocidNegativeCache"))
                                 .ifPresent(c -> c.put(cleanUserIgn, "NOT_FOUND"));

--- a/src/main/java/maple/expectation/service/v2/OcidResolver.java
+++ b/src/main/java/maple/expectation/service/v2/OcidResolver.java
@@ -7,6 +7,7 @@ import maple.expectation.external.NexonApiClient;
 import maple.expectation.global.error.exception.CharacterNotFoundException;
 import maple.expectation.global.executor.LogicExecutor;
 import maple.expectation.global.executor.TaskContext;
+import maple.expectation.global.util.ExceptionUtils;
 import maple.expectation.repository.v2.GameCharacterRepository;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
@@ -121,8 +122,9 @@ public class OcidResolver {
                     return saveCharacterWithCaching(userIgn, ocid);
                 },
                 e -> {
-                    // CharacterNotFoundException → Negative Cache 저장
-                    if (e instanceof CharacterNotFoundException) {
+                    // PR #199, #241 Fix: CompletionException unwrap 후 CharacterNotFoundException 감지
+                    Throwable unwrapped = ExceptionUtils.unwrapAsyncException(e);
+                    if (unwrapped instanceof CharacterNotFoundException) {
                         log.warn("🚫 [Recovery] 캐릭터 미존재 → 네거티브 캐시 저장: {}", userIgn);
                         Optional.ofNullable(cacheManager.getCache("ocidNegativeCache"))
                                 .ifPresent(c -> c.put(userIgn, "NOT_FOUND"));

--- a/src/main/java/maple/expectation/service/v2/like/strategy/LuaScriptAtomicFetchStrategy.java
+++ b/src/main/java/maple/expectation/service/v2/like/strategy/LuaScriptAtomicFetchStrategy.java
@@ -221,17 +221,38 @@ public class LuaScriptAtomicFetchStrategy implements AtomicFetchStrategy {
         if (value == null) return 0L;
         if (value instanceof Number n) return n.longValue();
         if (value instanceof String s) {
-            try {
-                return Long.parseLong(s);
-            } catch (NumberFormatException e) {
-                log.warn("Malformed Redis data ignored: value={}", s);
-                recordParseFailure();
-                return 0L;
-            }
+            return parseStringToLong(s);
         }
         log.warn("Unexpected Redis data type: class={}, value={}", value.getClass().getSimpleName(), value);
         recordParseFailure();
         return 0L;
+    }
+
+    /**
+     * 문자열 Long 파싱 (CLAUDE.md Section 12 준수: 선검증 후 파싱)
+     */
+    private long parseStringToLong(String s) {
+        if (s == null || s.isBlank()) {
+            recordParseFailure();
+            return 0L;
+        }
+        // 선검증: 숫자 형식 확인 (try-catch 회피)
+        if (isValidLongFormat(s)) {
+            return Long.parseLong(s);
+        }
+        log.warn("Malformed Redis data ignored: value={}", s);
+        recordParseFailure();
+        return 0L;
+    }
+
+    private boolean isValidLongFormat(String s) {
+        if (s.isEmpty()) return false;
+        int start = (s.charAt(0) == '-') ? 1 : 0;
+        if (start == s.length()) return false;
+        for (int i = start; i < s.length(); i++) {
+            if (!Character.isDigit(s.charAt(i))) return false;
+        }
+        return true;
     }
 
     /**

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -73,8 +73,9 @@
         </root>
     </springProfile>
 
-    <!-- Local/Test 프로파일: Console만 사용 -->
-    <springProfile name="local,test,default">
+    <!-- Local/Test/CI 프로파일: Console만 사용 -->
+    <!-- PR #206: CI 프로파일 추가 (GitHub Actions에서 Loki 미사용) -->
+    <springProfile name="local,test,default,ci">
         <root level="INFO">
             <appender-ref ref="CONSOLE" />
         </root>


### PR DESCRIPTION
## 관련 이슈
#186, #187, #189, #192, #199, #206, #236, #238, #241, #242

## 개요
Codex 코드리뷰 12건을 CLAUDE.md 가이드라인에 따라 해결합니다.

## 작업 내용

### P1 Critical Issues
- [x] ExceptionUtils: CompletionException unwrap 유틸리티 추가
- [x] ProbabilisticCacheAspect: JavaType으로 제네릭 타입 보존 (PR #238)
- [x] ShutdownDataRecoveryService: 파일명 기반 결정론적 ID로 멱등성 보장 (PR #187)
- [x] OrderedLockExecutor: MySQL Named Lock 중첩 콜백 전략 지원 (PR #236)

### P2 Important Issues
- [x] DonationController: Idempotency-Key 헤더 지원 (PR #189)
- [x] Rate Limit: @ConditionalOnProperty 추가, 필터 순서 수정 (PR #192)
- [x] Loki: datasource UID 추가 (PR #206)
- [x] logback-spring.xml: CI 프로파일 추가 (PR #206)
- [x] EquipmentExpectationResponseV4: @Jacksonized 추가 (PR #242)

### CLAUDE.md 위반사항 수정
- [x] synchronized → AtomicReference (OrderedLockExecutor)
- [x] try-catch → LogicExecutor 패턴 (JwtTokenProvider, FingerprintGenerator 등)
- [x] try-catch → 선검증 패턴 (RenameAtomicFetchStrategy, LuaScriptAtomicFetchStrategy)
- [x] try-finally → executeWithFinally (OrderedLockExecutor)
- [x] try-catch → CompletableFuture 체이닝 (SingleFlightExecutor)

## 리뷰 포인트
1. OrderedLockExecutor의 AtomicReference CAS 패턴이 적절한지
2. 선검증 패턴(isValidLongFormat)이 NumberFormatException을 완전히 방지하는지
3. JPA 엔티티(DonationOutbox)의 try-catch 예외 허용이 적절한지

## 트레이드 오프 결정 근거
| 이슈 | 결정 | 근거 |
|-----|------|------|
| CompletionException unwrap | 공유 유틸리티 클래스 | DRY 원칙, 3곳 이상에서 사용 |
| MySQL Named Lock | 중첩 콜백 전략 | 세션 유지, 하위 호환 |
| PER 캐시 타입 | JavaType 해석 | Jackson 내장 기능, JSON에 타입 메타데이터 불필요 |
| Long 파싱 | 선검증 패턴 | try-catch 회피, 성능 최적화 |

## 체크리스트
- [x] 브랜치/커밋 규칙 준수 여부
- [x] 컴파일 통과 여부
- [x] CLAUDE.md 위반사항 검사 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)