### PR TITLE
refactor: Resilience4j 장애 격리 모듈 P0/P1 리팩토링

### DIFF
--- a/src/main/java/maple/expectation/config/ResilienceConfig.java
+++ b/src/main/java/maple/expectation/config/ResilienceConfig.java
@@ -1,26 +1,26 @@
 package maple.expectation.config;
 
-import io.github.resilience4j.core.IntervalFunction;
 import io.github.resilience4j.retry.Retry;
-import io.github.resilience4j.retry.RetryConfig;
 import io.github.resilience4j.retry.RetryRegistry;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.time.Duration;
-
+/**
+ * Resilience4j Retry Bean 등록 (P1-2: YAML 이관)
+ *
+ * <h4>변경 사항</h4>
+ * <ul>
+ *   <li>Before: 독립 RetryRegistry 생성 → Actuator 추적 불가</li>
+ *   <li>After: Spring 관리 RetryRegistry에서 인스턴스 조회 → /actuator/retries 노출</li>
+ * </ul>
+ *
+ * <p>설정은 application.yml의 resilience4j.retry.instances.likeSyncRetry에서 관리됩니다.</p>
+ */
 @Configuration
 public class ResilienceConfig {
 
     @Bean
-    public Retry likeSyncRetry() {
-        // 우리가 applyBackoff에서 짰던 '1초부터 시작해서 2배씩 늘어나는 로직'을 그대로 옮깁니다.
-        RetryConfig config = RetryConfig.custom()
-                .maxAttempts(3) // 최대 3번 시도 (처음 1번 + 재시도 2번)
-                .intervalFunction(IntervalFunction.ofExponentialBackoff(1000, 2.0)) // 1초부터 2.0배씩 증가
-                .build();
-
-        RetryRegistry registry = RetryRegistry.of(config);
-        return registry.retry("likeSyncRetry");
+    public Retry likeSyncRetry(RetryRegistry retryRegistry) {
+        return retryRegistry.retry("likeSyncRetry");
     }
 }

--- a/src/main/java/maple/expectation/global/error/exception/DistributedLockException.java
+++ b/src/main/java/maple/expectation/global/error/exception/DistributedLockException.java
@@ -14,6 +14,6 @@ public class DistributedLockException extends ServerBaseException implements Cir
     }
 
     public DistributedLockException(String lockKey, Throwable cause) {
-        super(CommonErrorCode.DATABASE_TRANSACTION_FAILURE, "락 시도 중 오류: " + lockKey);
+        super(CommonErrorCode.DATABASE_TRANSACTION_FAILURE, cause, "락 시도 중 오류: " + lockKey);
     }
 }

--- a/src/main/java/maple/expectation/global/executor/strategy/ExceptionTranslator.java
+++ b/src/main/java/maple/expectation/global/executor/strategy/ExceptionTranslator.java
@@ -22,23 +22,45 @@ public interface ExceptionTranslator {
 
     /**
      * 예외를 변환하여 반환
-     * * @param e 원본 예외
-     * @param context 작업 컨텍스트 (수정됨: TaskContext 추가)
+     *
+     * @param e 원본 예외
+     * @param context 작업 컨텍스트
      * @return 변환된 RuntimeException
      */
     RuntimeException translate(Throwable e, TaskContext context);
 
     /**
+     * Error guard + async unwrap을 선행 적용하는 Decorator
+     *
+     * <p>모든 팩토리 메서드에서 반복되는 패턴을 DRY로 통합합니다:
+     * <ol>
+     *   <li>Error → 즉시 rethrow (VirtualMachineError 등)</li>
+     *   <li>CompletionException/ExecutionException → 원본으로 unwrap</li>
+     *   <li>unwrap된 예외를 내부 translator에 위임</li>
+     * </ol>
+     *
+     * @param inner unwrap된 예외를 받아 변환하는 내부 translator
+     * @return Error guard + unwrap이 적용된 ExceptionTranslator
+     */
+    static ExceptionTranslator withErrorGuardAndUnwrap(ExceptionTranslator inner) {
+        return (e, context) -> {
+            if (e instanceof Error err) {
+                throw err;
+            }
+            Throwable unwrapped = ExceptionUtils.unwrapAsyncException(e);
+            // BaseException pass-through: 이미 도메인 예외이면 그대로 반환 (DRY)
+            if (unwrapped instanceof BaseException be) {
+                return be;
+            }
+            return inner.translate(unwrapped, context);
+        };
+    }
+
+    /**
      * JSON 처리 예외 변환기
      */
     static ExceptionTranslator forJson() {
-        return (e, context) -> {
-            if (e instanceof Error) {
-                throw (Error) e;
-            }
-
-            Throwable unwrapped = ExceptionUtils.unwrapAsyncException(e);
-
+        return withErrorGuardAndUnwrap((unwrapped, context) -> {
             if (unwrapped instanceof JsonProcessingException) {
                 return new EquipmentDataProcessingException(
                         "JSON 직렬화 실패 [" + context.toTaskName() + "]: " + unwrapped.getMessage(),
@@ -51,54 +73,33 @@ public interface ExceptionTranslator {
                         unwrapped
                 );
             }
-            if (unwrapped instanceof BaseException be) {
-                return be;
-            }
-            return new InternalSystemException("json-processing:" + context.operation(), e);
-        };
+            return new InternalSystemException("json-processing:" + context.operation(), unwrapped);
+        });
     }
 
     /**
      * Lock 예외 변환기
      */
     static ExceptionTranslator forLock() {
-        return (e, context) -> {
-            if (e instanceof Error) {
-                throw (Error) e;
-            }
-
-            Throwable unwrapped = ExceptionUtils.unwrapAsyncException(e);
-
+        return withErrorGuardAndUnwrap((unwrapped, context) -> {
             if (unwrapped instanceof InterruptedException) {
                 Thread.currentThread().interrupt();
                 return new DistributedLockException("락 획득 중 인터럽트 [" + context.toTaskName() + "]", unwrapped);
             }
-            if (unwrapped instanceof BaseException be) {
-                return be;
-            }
-            return new InternalSystemException("lock-operation:" + context.operation(), e);
-        };
+            return new InternalSystemException("lock-operation:" + context.operation(), unwrapped);
+        });
     }
 
     /**
      * 파일 I/O 예외 변환기
      */
     static ExceptionTranslator forFileIO() {
-        return (e, context) -> {
-            if (e instanceof Error) {
-                throw (Error) e;
-            }
-
-            Throwable unwrapped = ExceptionUtils.unwrapAsyncException(e);
-
+        return withErrorGuardAndUnwrap((unwrapped, context) -> {
             if (unwrapped instanceof IOException) {
                 return new InternalSystemException("file-io:" + context.toTaskName(), unwrapped);
             }
-            if (unwrapped instanceof BaseException be) {
-                return be;
-            }
-            return new InternalSystemException("file-operation:" + context.operation(), e);
-        };
+            return new InternalSystemException("file-operation:" + context.operation(), unwrapped);
+        });
     }
 
     /**
@@ -107,17 +108,9 @@ public interface ExceptionTranslator {
      * <p>CompletionException/ExecutionException unwrap 후 BaseException 감지</p>
      */
     static ExceptionTranslator defaultTranslator() {
-        return (e, context) -> {
-            if (e instanceof Error) {
-                throw (Error) e;
-            }
-
-            Throwable unwrapped = ExceptionUtils.unwrapAsyncException(e);
-            if (unwrapped instanceof BaseException be) {
-                return be;
-            }
-            return new InternalSystemException("default-task:" + context.toTaskName(), e);
-        };
+        return withErrorGuardAndUnwrap((unwrapped, context) ->
+                new InternalSystemException("default-task:" + context.toTaskName(), unwrapped)
+        );
     }
 
     /**
@@ -125,22 +118,13 @@ public interface ExceptionTranslator {
      * 기술적 예외(IOException 등)를 도메인 예외(MapleDataProcessingException)로 변환합니다.
      */
     static ExceptionTranslator forMaple() {
-        return (ex, context) -> {
-            if (ex instanceof Error) {
-                throw (Error) ex;
-            }
-
-            Throwable unwrapped = ExceptionUtils.unwrapAsyncException(ex);
-
-            if (unwrapped instanceof java.io.IOException) {
+        return withErrorGuardAndUnwrap((unwrapped, context) -> {
+            if (unwrapped instanceof IOException) {
                 return new MapleDataProcessingException(
                         "메이플 데이터 파싱 중 기술적 오류 발생: " + unwrapped.getMessage(), unwrapped);
             }
-            if (unwrapped instanceof BaseException be) {
-                return be;
-            }
-            return new InternalSystemException(context.toTaskName(), ex);
-        };
+            return new InternalSystemException(context.toTaskName(), unwrapped);
+        });
     }
 
     static ExceptionTranslator forCache(Object key, Callable<?> loader) {
@@ -164,23 +148,13 @@ public interface ExceptionTranslator {
      * </p>
      */
     static ExceptionTranslator forRedisScript() {
-        return (e, context) -> {
-            if (e instanceof Error) {
-                throw (Error) e;
-            }
-
-            Throwable unwrapped = ExceptionUtils.unwrapAsyncException(e);
-
-            if (unwrapped instanceof BaseException be) {
-                return be;
-            }
-
-            return new AtomicFetchException(
-                    context.operation(),
-                    context.dynamicValue(),
-                    e
-            );
-        };
+        return withErrorGuardAndUnwrap((unwrapped, context) ->
+                new AtomicFetchException(
+                        context.operation(),
+                        context.dynamicValue(),
+                        unwrapped
+                )
+        );
     }
 
     /**
@@ -197,22 +171,12 @@ public interface ExceptionTranslator {
      * @return 시작 전용 예외 변환기
      */
     static ExceptionTranslator forStartup(String componentName) {
-        return (e, context) -> {
-            if (e instanceof Error) {
-                throw (Error) e;
-            }
-
-            Throwable unwrapped = ExceptionUtils.unwrapAsyncException(e);
-
-            if (unwrapped instanceof BaseException be) {
-                return be;
-            }
-
-            return new InternalSystemException(
-                    "startup:" + componentName + ":" + context.operation(),
-                    e
-            );
-        };
+        return withErrorGuardAndUnwrap((unwrapped, context) ->
+                new InternalSystemException(
+                        "startup:" + componentName + ":" + context.operation(),
+                        unwrapped
+                )
+        );
     }
 
 }

--- a/src/main/java/maple/expectation/monitoring/collector/CircuitBreakerEventLogger.java
+++ b/src/main/java/maple/expectation/monitoring/collector/CircuitBreakerEventLogger.java
@@ -1,0 +1,56 @@
+package maple.expectation.monitoring.collector;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * CircuitBreaker 상태 전이 이벤트 로거 (P1-5)
+ *
+ * <h3>목적</h3>
+ * <p>서킷브레이커 상태 전이(CLOSED→OPEN→HALF_OPEN 등)를 로그로 기록하여
+ * 운영 가시성을 확보합니다.</p>
+ *
+ * <h3>기록 대상</h3>
+ * <ul>
+ *   <li>상태 전이 (State Transition): WARN 레벨</li>
+ *   <li>예외 기록 (Error): ERROR 레벨 (WARN으로 낮춤 - 이미 handler에서 처리)</li>
+ * </ul>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CircuitBreakerEventLogger {
+
+    private final CircuitBreakerRegistry circuitBreakerRegistry;
+
+    @PostConstruct
+    void registerEventListeners() {
+        circuitBreakerRegistry.getAllCircuitBreakers()
+                .forEach(this::registerStateTransitionListener);
+
+        // 동적으로 추가되는 CB도 등록
+        circuitBreakerRegistry.getEventPublisher()
+                .onEntryAdded(event -> registerStateTransitionListener(event.getAddedEntry()));
+    }
+
+    private void registerStateTransitionListener(CircuitBreaker cb) {
+        cb.getEventPublisher()
+                .onStateTransition(event ->
+                        log.warn("[CircuitBreaker:{}] State transition: {} → {}",
+                                event.getCircuitBreakerName(),
+                                event.getStateTransition().getFromState(),
+                                event.getStateTransition().getToState()))
+                .onSlowCallRateExceeded(event ->
+                        log.warn("[CircuitBreaker:{}] Slow call rate exceeded: {}%",
+                                event.getCircuitBreakerName(),
+                                event.getSlowCallRate()))
+                .onFailureRateExceeded(event ->
+                        log.warn("[CircuitBreaker:{}] Failure rate exceeded: {}%",
+                                event.getCircuitBreakerName(),
+                                event.getFailureRate()));
+    }
+}

--- a/src/main/java/maple/expectation/service/v2/LikeSyncExecutor.java
+++ b/src/main/java/maple/expectation/service/v2/LikeSyncExecutor.java
@@ -105,7 +105,7 @@ public class LikeSyncExecutor {
      * <p>서킷이 열리면 예외를 던져 상위 레이어에서 보상 트랜잭션이 실행되도록 합니다.</p>
      */
     @SuppressWarnings("unused")  // CircuitBreaker fallback으로 사용됨
-    private void batchFallback(List<Map.Entry<String, Long>> entries, Throwable t) {
+    void batchFallback(List<Map.Entry<String, Long>> entries, Throwable t) {
         log.warn("[LikeSync] Circuit OPEN, batch skipped ({} entries): {}",
                 entries.size(), t.getMessage());
         throw new LikeSyncCircuitOpenException(t);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -79,6 +79,7 @@ resilience4j:
         baseConfig: default
         minimumNumberOfCalls: 10        # 최소 10번 호출 후 통계 산출 (Red Agent P1 Fix)
       likeSyncDb:  # Issue #48: Like Sync DB Batch Update 전용 Circuit Breaker
+        baseConfig: default
         slidingWindowSize: 5            # 최근 5번의 청크 처리 기준
         failureRateThreshold: 60        # 60% 실패율에서 Open
         waitDurationInOpenState: 30s    # Open 후 30초 대기 (DB 복구 시간 확보)
@@ -96,14 +97,20 @@ resilience4j:
           - org.redisson.client.RedisException
           - org.redisson.client.RedisTimeoutException
           - java.util.concurrent.TimeoutException
-          - maple.expectation.global.error.exception.DistributedLockException
       openAiApi:  # [P0-Red] Issue #251: OpenAI API Circuit Breaker
+        baseConfig: default
         slidingWindowSize: 10
         failureRateThreshold: 50
         waitDurationInOpenState: 60s       # LLM 복구 시간 확보
         minimumNumberOfCalls: 5
         permittedNumberOfCallsInHalfOpenState: 3
         registerHealthIndicator: true
+
+  bulkhead:
+    instances:
+      nexonApi:
+        maxConcurrentCalls: 50          # 동시 Nexon API 호출 최대 50개
+        maxWaitDuration: 500ms          # 대기 최대 500ms
 
   retry:
     retry-aspect-order: 399 # Retry가 CircuitBreaker를 감싸도록 설정
@@ -117,6 +124,15 @@ resilience4j:
           - org.springframework.web.reactive.function.client.WebClientRequestException # 네트워크 단절 대응
           - java.net.UnknownHostException
           - maple.expectation.global.error.exception.ExternalServiceException  # Issue #202: 외부 서비스 장애 시 재시도
+      likeSyncRetry:  # P1-2: ResilienceConfig → YAML 이관
+        maxAttempts: 3             # 최대 3번 시도 (처음 1번 + 재시도 2번)
+        waitDuration: 1s           # 1초부터 시작
+        enableExponentialBackoff: true
+        exponentialBackoffMultiplier: 2.0
+        retryExceptions:           # P1-9: 명시적 재시도 대상 (LikeSyncCircuitOpenException 제외)
+          - org.springframework.dao.DataAccessException
+          - org.springframework.jdbc.BadSqlGrammarException
+          - java.sql.SQLException
       nexonLockRetry:
         maxAttempts: 5             # 최대 5번 시도 (락 경합이 심할 때를 대비해 조금 넓넉히)
         waitDuration: 200ms        # 0.2초 간격으로 다시 시도

--- a/src/test/java/maple/expectation/service/v2/LikeSyncServiceTest.java
+++ b/src/test/java/maple/expectation/service/v2/LikeSyncServiceTest.java
@@ -1,6 +1,5 @@
 package maple.expectation.service.v2;
 
-import io.github.resilience4j.retry.Retry;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -58,7 +57,6 @@ class LikeSyncServiceTest {
     @Mock private DistributionSummary mockSummary;
     @Mock private ApplicationEventPublisher eventPublisher;
 
-    private final Retry likeSyncRetry = Retry.ofDefaults("testRetry");
     private static final String SOURCE_KEY = "{buffer:likes}";
 
     @BeforeEach
@@ -127,7 +125,6 @@ class LikeSyncServiceTest {
                 syncExecutor,
                 redisTemplate,
                 redisBufferRepository,
-                likeSyncRetry,
                 shutdownDataPersistenceService,
                 executor,
                 atomicFetchStrategy,


### PR DESCRIPTION
## 관련 이슈\n5-Agent Council 3차 최종 합의안 (Resilience4j P0/P1)\n\n## 개요\nResilience4j 장애 격리 모듈의 P0(즉시 수정) 5건 + P1(개선) 12건 리팩토링\n\n## 작업 내용\n\n### Phase 1: P0 즉시 수정\n- [x] P0-1: AiSreService 무제한 Virtual Thread → `aiTaskExecutor` Bean + Semaphore(5)\n- [x] P0-2: `likeSyncDb`/`openAiApi` CB에 `baseConfig: default` 추가 (ignoreExceptions 상속)\n- [x] P0-3: `DistributedLockException` cause 파라미터 `super()` 전달 (Exception Chaining 복구)\n- [x] P0-4: `redisLock.recordExceptions`에서 `DistributedLockException` 제거 (IgnoreMarker 모순 해소)\n- [x] P0-5: `ResilientLockStrategy.unwrap()` while(true) 무한루프 → `ExceptionUtils` 대체 (MAX_DEPTH=32)\n\n### Phase 2: P1 순차 작업\n- [x] P1-1: `ExceptionUtils`에 `UndeclaredThrowableException` 지원 + `ResilientNexonApiClient` private unwrap 통합\n- [x] P1-3: `ExceptionTranslator.withErrorGuardAndUnwrap()`에 BaseException pass-through 통합 (7개 팩토리 중복 제거)\n\n### Phase 3: P1 독립 작업\n- [x] P1-2+9: `ResilienceConfig` → YAML 이관 + `retryExceptions` 명시\n- [x] P1-4: fallback `private` → package-private (Resilience4j proxy 호환)\n- [x] P1-5: `CircuitBreakerEventLogger` 신규 (상태 전이 이벤트 로깅)\n- [x] P1-6: Nexon API `@Bulkhead` 추가 (maxConcurrentCalls=50)\n- [x] P1-7: `sendAlertBestEffort` 람다 → `handleAlertFailure()` 추출 (Section 15)\n- [x] P1-8: `GlobalExceptionHandler` `CallNotPermittedException` 핸들러 추가 (503 + Retry-After)\n- [x] P1-10: Dead code `syncWithRetry()`/`likeSyncRetry` 필드 제거\n- [x] P1-11: `failedFuture()` → `CompletableFuture.failedFuture()` (Java 9+ API)\n- [x] P1-12: P0-5 연계 (ResilientLockStrategy unwrap → ExceptionUtils 통일)\n\n## 리뷰 포인트\n1. `ExceptionTranslator.withErrorGuardAndUnwrap()`에 BaseException pass-through 통합 → 기존 inner translator에 BaseException이 도달하지 않으므로 동작 변경 없음 확인\n2. `ResilienceConfig` YAML 이관 시 `retryExceptions` 범위가 적절한지 확인\n3. `aiTaskExecutor` Semaphore permits=5, timeout=10s 값의 적절성\n\n## 트레이드 오프 결정 근거\n- **Semaphore vs ThreadPool**: AI LLM 호출은 Virtual Thread + I/O 대기이므로 Semaphore가 적합\n- **Bulkhead maxConcurrentCalls=50**: t3.small 기준 Nexon API 동시 호출 상한\n- **retryExceptions 명시**: LikeSyncCircuitOpenException(의도적 실패) 재시도 방지\n\n## 체크리스트\n- [x] 브랜치/커밋 규칙 준수 여부\n- [x] 빌드 성공 (`./gradlew clean build -x test`)\n- [x] 테스트 통과 (636/638, 실패 2건 Testcontainers 환경 문제)\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)"