### PR TITLE
refactor: TieredCache P0/P1 리팩토링 — 동시성·Scale-out·메트릭 개선

### DIFF
--- a/src/main/java/maple/expectation/config/CacheProperties.java
+++ b/src/main/java/maple/expectation/config/CacheProperties.java
@@ -1,0 +1,144 @@
+package maple.expectation.config;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import java.util.Map;
+
+/**
+ * TieredCache 외부 설정 프로퍼티 (P1-2, P1-5, P0-4)
+ *
+ * <h4>설계 의도</h4>
+ * <ul>
+ *   <li>P1-2: CacheConfig TTL/Size 하드코딩 제거 → YAML 외부화</li>
+ *   <li>P1-5: Lock timeout 하드코딩 제거 → YAML 외부화</li>
+ *   <li>P0-4: lockWaitSeconds 30초 → 5초 (cold cache burst 스레드 고갈 방지)</li>
+ * </ul>
+ *
+ * <h4>NexonApiProperties 패턴 참조</h4>
+ * <p>{@code @ConfigurationProperties} + {@code @Validated}로 타입 안전 바인딩</p>
+ *
+ * @see CacheConfig
+ */
+@Validated
+@ConfigurationProperties(prefix = "cache")
+public class CacheProperties {
+
+    /**
+     * 캐시별 L1/L2 스펙 설정
+     * <p>key: 캐시 이름 (equipment, cubeTrials, ocidCache, characterBasic, expectationV4)</p>
+     */
+    @NotNull
+    @Valid
+    private Map<String, CacheSpec> specs = Map.of();
+
+    /**
+     * Singleflight (분산 락) 설정
+     */
+    @NotNull
+    @Valid
+    private Singleflight singleflight = new Singleflight();
+
+    public Map<String, CacheSpec> getSpecs() {
+        return specs;
+    }
+
+    public void setSpecs(Map<String, CacheSpec> specs) {
+        this.specs = specs;
+    }
+
+    public Singleflight getSingleflight() {
+        return singleflight;
+    }
+
+    public void setSingleflight(Singleflight singleflight) {
+        this.singleflight = singleflight;
+    }
+
+    /**
+     * 캐시별 L1/L2 스펙
+     *
+     * <ul>
+     *   <li>l1TtlMinutes: L1(Caffeine) TTL (분)</li>
+     *   <li>l1MaxSize: L1 최대 엔트리 수</li>
+     *   <li>l2TtlMinutes: L2(Redis) TTL (분)</li>
+     *   <li>l2Serializer: L2 직렬화 방식 (json | jdk)</li>
+     * </ul>
+     */
+    public static class CacheSpec {
+
+        @Min(1)
+        @Max(1440)
+        private int l1TtlMinutes = 10;
+
+        @Min(100)
+        @Max(100000)
+        private int l1MaxSize = 5000;
+
+        @Min(1)
+        @Max(1440)
+        private int l2TtlMinutes = 15;
+
+        @NotNull
+        private String l2Serializer = "json";
+
+        public int getL1TtlMinutes() {
+            return l1TtlMinutes;
+        }
+
+        public void setL1TtlMinutes(int l1TtlMinutes) {
+            this.l1TtlMinutes = l1TtlMinutes;
+        }
+
+        public int getL1MaxSize() {
+            return l1MaxSize;
+        }
+
+        public void setL1MaxSize(int l1MaxSize) {
+            this.l1MaxSize = l1MaxSize;
+        }
+
+        public int getL2TtlMinutes() {
+            return l2TtlMinutes;
+        }
+
+        public void setL2TtlMinutes(int l2TtlMinutes) {
+            this.l2TtlMinutes = l2TtlMinutes;
+        }
+
+        public String getL2Serializer() {
+            return l2Serializer;
+        }
+
+        public void setL2Serializer(String l2Serializer) {
+            this.l2Serializer = l2Serializer;
+        }
+    }
+
+    /**
+     * Singleflight (분산 락) 설정
+     *
+     * <h4>P0-4 Fix: lockWaitSeconds 기본값 5초</h4>
+     * <p>캐시 valueLoader는 보통 100-500ms. 5초면 충분하고,
+     * 5초 초과 시 fallback 직접 실행이 합리적.</p>
+     * <p>기존 30초 → 5초로 변경하여 cold cache burst 시 스레드 고갈 방지</p>
+     */
+    public static class Singleflight {
+
+        @Min(1)
+        @Max(60)
+        private int lockWaitSeconds = 5;
+
+        public int getLockWaitSeconds() {
+            return lockWaitSeconds;
+        }
+
+        public void setLockWaitSeconds(int lockWaitSeconds) {
+            this.lockWaitSeconds = lockWaitSeconds;
+        }
+    }
+}

--- a/src/main/java/maple/expectation/global/cache/TieredCache.java
+++ b/src/main/java/maple/expectation/global/cache/TieredCache.java
@@ -1,7 +1,7 @@
 package maple.expectation.global.cache;
 
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import maple.expectation.global.cache.invalidation.CacheInvalidationEvent;
 import maple.expectation.global.executor.LogicExecutor;
@@ -15,6 +15,7 @@ import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /**
  * 2층 구조 캐시 (L1: Caffeine, L2: Redis)
@@ -26,21 +27,71 @@ import java.util.function.Consumer;
  *   <li>Watchdog 모드: leaseTime 생략으로 자동 연장</li>
  * </ul>
  *
+ * <h4>P0/P1 리팩토링</h4>
+ * <ul>
+ *   <li>P0-1: put() 시 Pub/Sub 이벤트 발행 (원격 인스턴스 L1 무효화)</li>
+ *   <li>P0-3: evict() 순서 L2→L1→Pub/Sub (stale backfill 방지)</li>
+ *   <li>P0-4: lockWaitSeconds 외부화 (30초→5초, cold burst 방지)</li>
+ *   <li>P1-1: 메트릭에 cacheName 태그 추가</li>
+ *   <li>P1-6: Supplier 기반 lazy resolution (instanceId, callback)</li>
+ *   <li>P1-7: Counter pre-registration (hot-path 할당 제거)</li>
+ * </ul>
+ *
  * @see <a href="https://github.com/issue/148">Issue #148</a>
  */
 @Slf4j
-@RequiredArgsConstructor
 public class TieredCache implements Cache {
     private final Cache l1; // Caffeine (Local)
     private final Cache l2; // Redis (Distributed)
     private final LogicExecutor executor;
     private final RedissonClient redissonClient; // 분산 락용
-    private final MeterRegistry meterRegistry;   // 메트릭 수집용
-    private final String instanceId;             // Issue #278: Self-skip용 (P0-2)
-    private final Consumer<CacheInvalidationEvent> invalidationCallback; // Issue #278: Cache Coherence (P0-4)
+    private final int lockWaitSeconds;           // P0-4: 외부 설정 (기본 5초)
+    private final Supplier<String> instanceIdSupplier;                        // P1-6: Lazy Resolution
+    private final Supplier<Consumer<CacheInvalidationEvent>> callbackSupplier; // P1-6: Lazy Resolution
 
-    /** 락 획득 대기 타임아웃 (초) */
-    private static final int LOCK_WAIT_SECONDS = 30;
+    // P1-7: Counter pre-registration (hot-path 할당 제거)
+    private final Counter l1HitCounter;
+    private final Counter l2HitCounter;
+    private final Counter missCounter;
+    private final Counter lockFailureCounter;
+    private final Counter l2FailureCounter;
+
+    public TieredCache(
+            Cache l1,
+            Cache l2,
+            LogicExecutor executor,
+            RedissonClient redissonClient,
+            MeterRegistry meterRegistry,
+            int lockWaitSeconds,
+            Supplier<String> instanceIdSupplier,
+            Supplier<Consumer<CacheInvalidationEvent>> callbackSupplier
+    ) {
+        this.l1 = l1;
+        this.l2 = l2;
+        this.executor = executor;
+        this.redissonClient = redissonClient;
+        this.lockWaitSeconds = lockWaitSeconds;
+        this.instanceIdSupplier = instanceIdSupplier;
+        this.callbackSupplier = callbackSupplier;
+
+        // P1-7 + P1-1: 생성자에서 Counter pre-register (cacheName 태그 포함)
+        String cacheName = l2.getName();
+        this.l1HitCounter = Counter.builder("cache.hit")
+                .tag("layer", "L1").tag("cache", cacheName)
+                .register(meterRegistry);
+        this.l2HitCounter = Counter.builder("cache.hit")
+                .tag("layer", "L2").tag("cache", cacheName)
+                .register(meterRegistry);
+        this.missCounter = Counter.builder("cache.miss")
+                .tag("cache", cacheName)
+                .register(meterRegistry);
+        this.lockFailureCounter = Counter.builder("cache.lock.failure")
+                .tag("cache", cacheName)
+                .register(meterRegistry);
+        this.l2FailureCounter = Counter.builder("cache.l2.failure")
+                .tag("cache", cacheName)
+                .register(meterRegistry);
+    }
 
     @Override
     public String getName() { return l2.getName(); }
@@ -83,7 +134,8 @@ public class TieredCache implements Cache {
     /**
      * 캐시 저장 (L2 → L1 순서 - 일관성 보장)
      *
-     * <p><b>Issue #148:</b> L2 저장 성공 시에만 L1 저장</p>
+     * <h4>Issue #148: L2 저장 성공 시에만 L1 저장</h4>
+     * <h4>P0-1: put() 성공 시 Pub/Sub 이벤트 발행 (원격 인스턴스 L1 무효화)</h4>
      */
     @Override
     public void put(Object key, Object value) {
@@ -97,14 +149,18 @@ public class TieredCache implements Cache {
 
         if (l2Success) {
             executor.executeVoid(() -> l1.put(key, value), context);
+            publishEvictEvent(key); // P0-1: 원격 인스턴스 L1 evict
         } else {
             log.warn("[TieredCache] L2 put failed, skipping L1 for consistency: key={}", key);
-            recordL2Failure();
+            l2FailureCounter.increment();
         }
     }
 
     /**
-     * 캐시 키 무효화 (L1 → L2 → Pub/Sub 전파)
+     * 캐시 키 무효화 (L2 → L1 → Pub/Sub 전파)
+     *
+     * <h4>P0-3 Fix: evict() 순서 L2→L1→Pub/Sub</h4>
+     * <p>L2가 source of truth. L2 먼저 제거해야 backfill 시 stale data 불가.</p>
      *
      * <h4>Issue #278: L1 Cache Coherence (P0-1)</h4>
      * <p>evict 후 다른 인스턴스의 L1 캐시도 무효화하도록 이벤트 발행</p>
@@ -112,23 +168,24 @@ public class TieredCache implements Cache {
     @Override
     public void evict(Object key) {
         executor.executeVoid(() -> {
-            l1.evict(key);
-            l2.evict(key);
-            publishEvictEvent(key);
+            l2.evict(key);    // P0-3: L2 먼저 (원본 제거)
+            l1.evict(key);    // L1 다음 (로컬 제거)
+            publishEvictEvent(key);  // Pub/Sub 마지막
         }, TaskContext.of("Cache", "Evict", key.toString()));
     }
 
     /**
-     * 캐시 전체 무효화 (L1 → L2 → Pub/Sub 전파)
+     * 캐시 전체 무효화 (L2 → L1 → Pub/Sub 전파)
      *
+     * <h4>P0-3 일관성: L2 → L1 순서</h4>
      * <h4>Issue #278: L1 Cache Coherence (P0-1)</h4>
      * <p>clear 후 다른 인스턴스의 L1 캐시도 전체 무효화하도록 이벤트 발행</p>
      */
     @Override
     public void clear() {
         executor.executeVoid(() -> {
-            l1.clear();
             l2.clear();
+            l1.clear();
             publishClearAllEvent();
         }, TaskContext.of("Cache", "Clear"));
     }
@@ -137,8 +194,8 @@ public class TieredCache implements Cache {
      * EVICT 이벤트 발행 (Section 15: 메서드 추출)
      */
     private void publishEvictEvent(Object key) {
-        invalidationCallback.accept(
-                CacheInvalidationEvent.evict(getName(), key.toString(), instanceId)
+        callbackSupplier.get().accept(
+                CacheInvalidationEvent.evict(getName(), key.toString(), instanceIdSupplier.get())
         );
     }
 
@@ -146,8 +203,8 @@ public class TieredCache implements Cache {
      * CLEAR_ALL 이벤트 발행 (Section 15: 메서드 추출)
      */
     private void publishClearAllEvent() {
-        invalidationCallback.accept(
-                CacheInvalidationEvent.clearAll(getName(), instanceId)
+        callbackSupplier.get().accept(
+                CacheInvalidationEvent.clearAll(getName(), instanceIdSupplier.get())
         );
     }
 
@@ -215,7 +272,7 @@ public class TieredCache implements Cache {
         // L1 조회 (로컬 캐시 - 장애 없음)
         ValueWrapper l1Result = l1.get(key);
         if (l1Result != null) {
-            recordCacheHit("L1");
+            l1HitCounter.increment();
             return (T) l1Result.get();
         }
 
@@ -228,7 +285,7 @@ public class TieredCache implements Cache {
 
         if (l2Result != null) {
             l1.put(key, l2Result.get());
-            recordCacheHit("L2");
+            l2HitCounter.increment();
             return (T) l2Result.get();
         }
 
@@ -248,7 +305,7 @@ public class TieredCache implements Cache {
 
         // Graceful Degradation: 락 획득 시도도 Redis 장애 허용 (CLAUDE.md 섹션 12 패턴 3)
         boolean acquired = executor.executeOrDefault(
-                () -> lock.tryLock(LOCK_WAIT_SECONDS, TimeUnit.SECONDS),
+                () -> lock.tryLock(lockWaitSeconds, TimeUnit.SECONDS),
                 false,  // Redis 장애 시 락 획득 실패로 처리
                 TaskContext.of("Cache", "AcquireLock", keyStr)
         );
@@ -256,7 +313,7 @@ public class TieredCache implements Cache {
         // 락 획득 실패 또는 Redis 장애 → Fallback
         if (!acquired) {
             log.warn("[TieredCache] Lock acquisition failed, executing directly: {}", lockKey);
-            recordLockFailure();
+            lockFailureCounter.increment();
             return executeAndCache(key, valueLoader);
         }
 
@@ -300,7 +357,7 @@ public class TieredCache implements Cache {
         }
 
         // 캐시 미스 → valueLoader 실행 (직접 호출 - 예외 자연 전파)
-        recordCacheMiss();
+        missCounter.increment();
         return executeAndCache(key, valueLoader);
     }
 
@@ -320,7 +377,7 @@ public class TieredCache implements Cache {
             l1.put(key, value);
         } else {
             log.warn("[TieredCache] L2 put failed, skipping L1: key={}", key);
-            recordL2Failure();
+            l2FailureCounter.increment();
         }
 
         return value;
@@ -336,25 +393,11 @@ public class TieredCache implements Cache {
      * Tap 패턴: 값 반환하며 캐시 히트 메트릭 기록
      */
     private ValueWrapper tapCacheHit(ValueWrapper wrapper, String layer) {
-        recordCacheHit(layer);
+        if ("L1".equals(layer)) {
+            l1HitCounter.increment();
+        } else {
+            l2HitCounter.increment();
+        }
         return wrapper;
-    }
-
-    // ==================== Metrics (Micrometer 소문자 점 표기법) ====================
-
-    private void recordCacheHit(String layer) {
-        meterRegistry.counter("cache.hit", "layer", layer).increment();
-    }
-
-    private void recordCacheMiss() {
-        meterRegistry.counter("cache.miss").increment();
-    }
-
-    private void recordLockFailure() {
-        meterRegistry.counter("cache.lock.failure").increment();
-    }
-
-    private void recordL2Failure() {
-        meterRegistry.counter("cache.l2.failure").increment();
     }
 }

--- a/src/main/java/maple/expectation/service/v2/cache/EquipmentCacheService.java
+++ b/src/main/java/maple/expectation/service/v2/cache/EquipmentCacheService.java
@@ -10,13 +10,21 @@ import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Service;
 
+import java.util.Objects;
 import java.util.Optional;
 
+/**
+ * Equipment 캐시 서비스
+ *
+ * <h4>P1-4: Cache 필드 캐싱</h4>
+ * <p>매 호출마다 cacheManager.getCache() 반복 호출 대신
+ * 생성자에서 1회 조회하여 필드에 캐싱</p>
+ */
 @Slf4j
 @Service
 public class EquipmentCacheService {
-    private final CacheManager cacheManager;          // Tiered (L1+L2)
-    private final CacheManager l1CacheManager;        // L1 Only (Expectation 경로 전용)
+    private final Cache tieredEquipmentCache;     // P1-4: Tiered (L1+L2) 필드 캐싱
+    private final Cache l1OnlyEquipmentCache;     // P1-4: L1 Only 필드 캐싱
     private final EquipmentDbWorker dbWorker;
     private final LogicExecutor executor;
 
@@ -29,62 +37,58 @@ public class EquipmentCacheService {
             @Qualifier("expectationL1CacheManager") CacheManager l1CacheManager,
             EquipmentDbWorker dbWorker,
             LogicExecutor executor) {
-        this.cacheManager = cacheManager;
-        this.l1CacheManager = l1CacheManager;
+        this.tieredEquipmentCache = Objects.requireNonNull(
+                cacheManager.getCache(CACHE_NAME),
+                "Tiered equipment cache must not be null");
+        this.l1OnlyEquipmentCache = Objects.requireNonNull(
+                l1CacheManager.getCache(CACHE_NAME),
+                "L1-only equipment cache must not be null");
         this.dbWorker = dbWorker;
         this.executor = executor;
     }
 
     /**
-     * ✅ [관측성 확보] 캐시 조회 로직 평탄화
+     * 캐시 조회 로직 (P1-4: 필드 캐싱 적용)
      */
     public Optional<EquipmentResponse> getValidCache(String ocid) {
-        return executor.execute(() -> { //
-            Cache cache = cacheManager.getCache("equipment");
-            if (cache == null) return Optional.<EquipmentResponse>empty();
-
-            EquipmentResponse cached = cache.get(ocid, EquipmentResponse.class);
+        return executor.execute(() -> {
+            EquipmentResponse cached = tieredEquipmentCache.get(ocid, EquipmentResponse.class);
             if (cached != null && !"NEGATIVE_MARKER".equals(cached.getCharacterClass())) {
                 return Optional.of(cached);
             }
             return Optional.empty();
-        }, TaskContext.of("EquipmentCache", "GetValid", ocid)); //
+        }, TaskContext.of("EquipmentCache", "GetValid", ocid));
     }
 
     public boolean hasNegativeCache(String ocid) {
-        return executor.executeOrDefault(() -> { //
-            Cache cache = cacheManager.getCache("equipment");
-            EquipmentResponse cached = (cache != null) ? cache.get(ocid, EquipmentResponse.class) : null;
+        return executor.executeOrDefault(() -> {
+            EquipmentResponse cached = tieredEquipmentCache.get(ocid, EquipmentResponse.class);
             return cached != null && "NEGATIVE_MARKER".equals(cached.getCharacterClass());
         }, false, TaskContext.of("EquipmentCache", "CheckNegative", ocid));
     }
 
     /**
-     * ✅  try-catch 및 비동기 예외 처리 평탄화
+     * 캐시 저장 및 비동기 DB persist (P1-4: 필드 캐싱 적용)
      */
     public void saveCache(String ocid, EquipmentResponse response) {
-        TaskContext context = TaskContext.of("EquipmentCache", "Save", ocid); //
+        TaskContext context = TaskContext.of("EquipmentCache", "Save", ocid);
 
-        // [패턴 5] executeWithRecovery: 정상 흐름과 셧다운 복구 시나리오를 분리
         executor.executeOrCatch(
                 () -> {
-                    performCaching(ocid, response);  // 1. 캐시 저장 로직
-                    triggerAsyncPersist(ocid, response); // 2. 비동기 저장 트리거
+                    performCaching(ocid, response);
+                    triggerAsyncPersist(ocid, response);
                     return null;
                 },
-                e -> handleSaveFailure(ocid, e), // 3. 장애 및 셧다운 대응 로직 격리
+                e -> handleSaveFailure(ocid, e),
                 context
         );
     }
 
     /**
-     * 헬퍼 1: 캐시 저장 로직 (Null Marker 처리 포함)
+     * 헬퍼 1: 캐시 저장 로직 (Null Marker 처리 포함, P1-4: 필드 캐싱)
      */
     private void performCaching(String ocid, EquipmentResponse response) {
-        Cache cache = cacheManager.getCache("equipment");
-        if (cache != null) {
-            cache.put(ocid, (response == null) ? NULL_MARKER : response);
-        }
+        tieredEquipmentCache.put(ocid, (response == null) ? NULL_MARKER : response);
     }
 
     /**
@@ -94,7 +98,7 @@ public class EquipmentCacheService {
         if (response == null) return;
 
         dbWorker.persist(ocid, response)
-                .exceptionally(ex -> observeAsyncError(ocid, ex)); //
+                .exceptionally(ex -> observeAsyncError(ocid, ex));
     }
 
     /**
@@ -112,34 +116,21 @@ public class EquipmentCacheService {
      * 헬퍼 4: 셧다운 및 공통 예외 핸들러
      */
     private EquipmentResponse handleSaveFailure(String ocid, Throwable e) {
-        // Shutdown 진행 중인 경우(IllegalStateException)는 정상적인 흐름으로 간주하여 복구
         if (e instanceof IllegalStateException) {
-            log.warn("⚠️ [Equipment Cache] Shutdown 진행 중 - DB 저장 스킵(캐시만 유지): {}", ocid);
+            log.warn("[Equipment Cache] Shutdown 진행 중 - DB 저장 스킵(캐시만 유지): {}", ocid);
             return null;
         }
-        // 그 외의 런타임 예외는 그대로 전파
         throw (RuntimeException) e;
     }
 
     // ==================== L1-only API (Expectation 경로 전용) ====================
 
     /**
-     * L1 캐시에서만 조회 (Expectation 경로 전용 - L2 우회)
-     *
-     * <p>Blocker C: Expectation 경로에서 EquipmentResponse L2 저장/조회를 구조적으로 차단</p>
-     *
-     * @param ocid 캐릭터 OCID
-     * @return L1 캐시된 결과 (없으면 empty)
+     * L1 캐시에서만 조회 (Expectation 경로 전용 - L2 우회, P1-4: 필드 캐싱)
      */
     public Optional<EquipmentResponse> getValidCacheL1Only(String ocid) {
         return executor.execute(() -> {
-            Cache cache = l1CacheManager.getCache(CACHE_NAME);
-            if (cache == null) {
-                log.warn("[EquipmentCache] L1 cache missing: {}", CACHE_NAME);
-                return Optional.<EquipmentResponse>empty();
-            }
-
-            EquipmentResponse cached = cache.get(ocid, EquipmentResponse.class);
+            EquipmentResponse cached = l1OnlyEquipmentCache.get(ocid, EquipmentResponse.class);
             if (cached != null && !"NEGATIVE_MARKER".equals(cached.getCharacterClass())) {
                 return Optional.of(cached);
             }
@@ -148,22 +139,12 @@ public class EquipmentCacheService {
     }
 
     /**
-     * L1 캐시에만 저장 (Expectation 경로 전용 - L2 우회, DB 저장도 스킵)
-     *
-     * <p>Blocker C: Expectation 경로에서 EquipmentResponse L2 저장을 구조적으로 차단</p>
-     *
-     * @param ocid 캐릭터 OCID
-     * @param response 저장할 응답
+     * L1 캐시에만 저장 (Expectation 경로 전용 - L2 우회, DB 저장도 스킵, P1-4: 필드 캐싱)
      */
     public void saveCacheL1Only(String ocid, EquipmentResponse response) {
         executor.executeVoid(() -> {
-            Cache cache = l1CacheManager.getCache(CACHE_NAME);
-            if (cache != null) {
-                cache.put(ocid, (response == null) ? NULL_MARKER : response);
-                log.debug("[EquipmentCache] L1-only save: {}", ocid);
-            } else {
-                log.warn("[EquipmentCache] L1 cache missing: {}", CACHE_NAME);
-            }
+            l1OnlyEquipmentCache.put(ocid, (response == null) ? NULL_MARKER : response);
+            log.debug("[EquipmentCache] L1-only save: {}", ocid);
         }, TaskContext.of("EquipmentCache", "SaveL1Only", ocid));
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -212,8 +212,37 @@ springdoc:
   default-consumes-media-type: application/json
   default-produces-media-type: application/json
 
-# Cache Invalidation 설정 (Issue #278: L1 Cache Coherence)
+# Cache 설정 (P1-2: TTL/Size 외부화, P0-4: lockWaitSeconds)
 cache:
+  specs:
+    equipment:
+      l1-ttl-minutes: 5
+      l1-max-size: 5000
+      l2-ttl-minutes: 10
+      l2-serializer: json
+    cubeTrials:
+      l1-ttl-minutes: 10
+      l1-max-size: 5000
+      l2-ttl-minutes: 20
+      l2-serializer: jdk
+    ocidCache:
+      l1-ttl-minutes: 30
+      l1-max-size: 5000
+      l2-ttl-minutes: 60
+      l2-serializer: json
+    characterBasic:
+      l1-ttl-minutes: 15
+      l1-max-size: 5000
+      l2-ttl-minutes: 15
+      l2-serializer: json
+    expectationV4:
+      l1-ttl-minutes: 60
+      l1-max-size: 5000
+      l2-ttl-minutes: 60
+      l2-serializer: jdk
+  singleflight:
+    lock-wait-seconds: 5  # P0-4 Fix: 30초 → 5초 (cold burst 스레드 고갈 방지)
+  # Cache Invalidation 설정 (Issue #278: L1 Cache Coherence)
   invalidation:
     pubsub:
       enabled: true  # Scale-out 환경 L1 캐시 무효화 Pub/Sub 활성화

--- a/src/test/java/maple/expectation/cache/TieredCacheRaceConditionTest.java
+++ b/src/test/java/maple/expectation/cache/TieredCacheRaceConditionTest.java
@@ -294,14 +294,14 @@ class TieredCacheRaceConditionTest extends AbstractContainerBaseTest {
             String testKey = "metrics-hit-test-" + UUID.randomUUID();
             cache.put(testKey, "cached-value");
 
-            // 메트릭 초기값 기록
-            double initialL1Hits = getCounterValue("cache.hit", "layer", "L1");
+            // P1-1: cache 태그 포함 조회
+            double initialL1Hits = getCounterValue("cache.hit", "layer", "L1", "cache", "equipment");
 
             // when: L1 히트 발생
             cache.get(testKey, String.class);
 
             // then
-            double finalL1Hits = getCounterValue("cache.hit", "layer", "L1");
+            double finalL1Hits = getCounterValue("cache.hit", "layer", "L1", "cache", "equipment");
             assertThat(finalL1Hits).isGreaterThan(initialL1Hits);
         }
 
@@ -310,13 +310,14 @@ class TieredCacheRaceConditionTest extends AbstractContainerBaseTest {
         void shouldRecordMissMetrics() {
             // given
             String testKey = "metrics-miss-test-" + UUID.randomUUID();
-            double initialMisses = getCounterValue("cache.miss");
+            // P1-1: cache 태그 포함 조회
+            double initialMisses = getCounterValue("cache.miss", "cache", "equipment");
 
             // when: 캐시 미스 발생 (valueLoader 호출)
             cache.get(testKey, () -> "new-value");
 
             // then
-            double finalMisses = getCounterValue("cache.miss");
+            double finalMisses = getCounterValue("cache.miss", "cache", "equipment");
             assertThat(finalMisses).isGreaterThan(initialMisses);
         }
 

--- a/src/test/java/maple/expectation/cache/TieredCacheWriteOrderP0Test.java
+++ b/src/test/java/maple/expectation/cache/TieredCacheWriteOrderP0Test.java
@@ -177,7 +177,8 @@ class TieredCacheWriteOrderP0Test extends AbstractContainerBaseTest {
         void shouldRecordL2FailureMetric_whenL2Fails() {
             // given
             String testKey = "l2-metric-test-" + UUID.randomUUID();
-            double initialL2Failures = getCounterValue("cache.l2.failure");
+            // P1-1: cache 태그 포함 조회
+            double initialL2Failures = getCounterValue("cache.l2.failure", "cache", "equipment");
 
             // when: Redis 연결 끊기
             redisProxy.setConnectionCut(true);
@@ -190,7 +191,7 @@ class TieredCacheWriteOrderP0Test extends AbstractContainerBaseTest {
                         .atMost(java.time.Duration.ofSeconds(5))
                         .pollInterval(java.time.Duration.ofMillis(200))
                         .untilAsserted(() -> {
-                            double finalL2Failures = getCounterValue("cache.l2.failure");
+                            double finalL2Failures = getCounterValue("cache.l2.failure", "cache", "equipment");
                             assertThat(finalL2Failures)
                                     .as("L2 실패 시 cache.l2.failure 메트릭이 증가해야 함")
                                     .isGreaterThan(initialL2Failures);

--- a/src/test/java/maple/expectation/global/cache/TieredCacheTest.java
+++ b/src/test/java/maple/expectation/global/cache/TieredCacheTest.java
@@ -3,6 +3,7 @@ package maple.expectation.global.cache;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import maple.expectation.global.cache.invalidation.CacheInvalidationEvent;
 import maple.expectation.global.common.function.ThrowingSupplier;
 import maple.expectation.global.executor.function.ThrowingRunnable;
 import maple.expectation.global.executor.LogicExecutor;
@@ -13,13 +14,16 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
 import org.springframework.cache.Cache;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
+import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
@@ -32,12 +36,13 @@ import static org.mockito.Mockito.*;
  * <h4>경량 테스트 (CLAUDE.md Section 25)</h4>
  * <p>Spring Context 없이 Mockito만으로 2층 캐시를 검증합니다.</p>
  *
- * <h4>테스트 범위</h4>
+ * <h4>P0/P1 리팩토링 반영</h4>
  * <ul>
- *   <li>L1 → L2 순차 조회 및 Backfill</li>
- *   <li>L2 → L1 순서 저장 (일관성)</li>
- *   <li>Single-flight 패턴 (분산 락)</li>
- *   <li>Graceful Degradation (L2 장애 시)</li>
+ *   <li>생성자 시그니처 변경 (lockWaitSeconds, Supplier)</li>
+ *   <li>P0-1: put() Pub/Sub 이벤트 발행 검증</li>
+ *   <li>P0-3: evict() L2→L1 순서 InOrder 검증</li>
+ *   <li>P1-1: cache.hit 메트릭에 cache 태그 포함 검증</li>
+ *   <li>P1-7: Counter pre-registration 검증</li>
  * </ul>
  */
 @Tag("unit")
@@ -46,12 +51,14 @@ class TieredCacheTest {
     private static final String CACHE_NAME = "testCache";
     private static final Object KEY = "testKey";
     private static final String VALUE = "testValue";
+    private static final int LOCK_WAIT_SECONDS = 5;
 
     private Cache l1;
     private Cache l2;
     private LogicExecutor executor;
     private RedissonClient redissonClient;
     private MeterRegistry meterRegistry;
+    private List<CacheInvalidationEvent> publishedEvents;
     private TieredCache tieredCache;
 
     @BeforeEach
@@ -61,10 +68,18 @@ class TieredCacheTest {
         executor = createMockLogicExecutor();
         redissonClient = mock(RedissonClient.class);
         meterRegistry = new SimpleMeterRegistry();
+        publishedEvents = new ArrayList<>();
 
         given(l2.getName()).willReturn(CACHE_NAME);
 
-        tieredCache = new TieredCache(l1, l2, executor, redissonClient, meterRegistry, "test-instance", event -> { });
+        Consumer<CacheInvalidationEvent> callback = publishedEvents::add;
+
+        tieredCache = new TieredCache(
+                l1, l2, executor, redissonClient, meterRegistry,
+                LOCK_WAIT_SECONDS,
+                () -> "test-instance",
+                () -> callback
+        );
     }
 
     @Nested
@@ -157,13 +172,49 @@ class TieredCacheTest {
         void shouldSkipL1WhenL2Fails() {
             // given - L2 저장 실패 시뮬레이션
             executor = createFailingL2Executor();
-            tieredCache = new TieredCache(l1, l2, executor, redissonClient, meterRegistry, "test-instance", event -> { });
+            Consumer<CacheInvalidationEvent> callback = publishedEvents::add;
+            tieredCache = new TieredCache(
+                    l1, l2, executor, redissonClient, meterRegistry,
+                    LOCK_WAIT_SECONDS, () -> "test-instance", () -> callback
+            );
 
             // when
             tieredCache.put(KEY, VALUE);
 
             // then
             verify(l1, never()).put(KEY, VALUE);
+        }
+
+        @Test
+        @DisplayName("P0-1: put() 성공 시 Pub/Sub 이벤트 발행")
+        void shouldPublishEvictEventAfterSuccessfulPut() {
+            // when
+            tieredCache.put(KEY, VALUE);
+
+            // then
+            assertThat(publishedEvents).hasSize(1);
+            CacheInvalidationEvent event = publishedEvents.getFirst();
+            assertThat(event.cacheName()).isEqualTo(CACHE_NAME);
+            assertThat(event.key()).isEqualTo(KEY.toString());
+            assertThat(event.sourceInstanceId()).isEqualTo("test-instance");
+        }
+
+        @Test
+        @DisplayName("P0-1: L2 실패 시 Pub/Sub 미발행")
+        void shouldNotPublishEventWhenL2Fails() {
+            // given
+            executor = createFailingL2Executor();
+            Consumer<CacheInvalidationEvent> callback = publishedEvents::add;
+            tieredCache = new TieredCache(
+                    l1, l2, executor, redissonClient, meterRegistry,
+                    LOCK_WAIT_SECONDS, () -> "test-instance", () -> callback
+            );
+
+            // when
+            tieredCache.put(KEY, VALUE);
+
+            // then
+            assertThat(publishedEvents).isEmpty();
         }
     }
 
@@ -180,6 +231,29 @@ class TieredCacheTest {
             // then
             verify(l1).evict(KEY);
             verify(l2).evict(KEY);
+        }
+
+        @Test
+        @DisplayName("P0-3: evict() L2→L1 순서 InOrder 검증")
+        void shouldEvictL2BeforeL1() {
+            // when
+            tieredCache.evict(KEY);
+
+            // then
+            InOrder inOrder = inOrder(l2, l1);
+            inOrder.verify(l2).evict(KEY);
+            inOrder.verify(l1).evict(KEY);
+        }
+
+        @Test
+        @DisplayName("evict 시 Pub/Sub 이벤트 발행")
+        void shouldPublishEvictEventOnEvict() {
+            // when
+            tieredCache.evict(KEY);
+
+            // then
+            assertThat(publishedEvents).hasSize(1);
+            assertThat(publishedEvents.getFirst().cacheName()).isEqualTo(CACHE_NAME);
         }
 
         @Test
@@ -303,9 +377,12 @@ class TieredCacheTest {
 
             // then
             assertThat(result).isEqualTo("fallbackValue");
-            // 락 실패 메트릭 확인
-            Counter lockFailure = meterRegistry.find("cache.lock.failure").counter();
+            // P1-7: pre-registered counter 검증
+            Counter lockFailure = meterRegistry.find("cache.lock.failure")
+                    .tag("cache", CACHE_NAME)
+                    .counter();
             assertThat(lockFailure).isNotNull();
+            assertThat(lockFailure.count()).isGreaterThan(0);
         }
 
         @Test
@@ -336,8 +413,8 @@ class TieredCacheTest {
     class MetricsTest {
 
         @Test
-        @DisplayName("L1 히트 시 메트릭 기록")
-        void shouldRecordL1HitMetric() {
+        @DisplayName("P1-1: L1 히트 시 cache 태그 포함 메트릭 기록")
+        void shouldRecordL1HitMetricWithCacheTag() {
             // given
             Cache.ValueWrapper wrapper = () -> VALUE;
             given(l1.get(KEY)).willReturn(wrapper);
@@ -348,14 +425,15 @@ class TieredCacheTest {
             // then
             Counter l1HitCounter = meterRegistry.find("cache.hit")
                     .tag("layer", "L1")
+                    .tag("cache", CACHE_NAME)
                     .counter();
             assertThat(l1HitCounter).isNotNull();
             assertThat(l1HitCounter.count()).isGreaterThan(0);
         }
 
         @Test
-        @DisplayName("L2 히트 시 메트릭 기록")
-        void shouldRecordL2HitMetric() {
+        @DisplayName("P1-1: L2 히트 시 cache 태그 포함 메트릭 기록")
+        void shouldRecordL2HitMetricWithCacheTag() {
             // given
             given(l1.get(KEY)).willReturn(null);
             given(l2.get(KEY)).willReturn(() -> VALUE);
@@ -366,9 +444,54 @@ class TieredCacheTest {
             // then
             Counter l2HitCounter = meterRegistry.find("cache.hit")
                     .tag("layer", "L2")
+                    .tag("cache", CACHE_NAME)
                     .counter();
             assertThat(l2HitCounter).isNotNull();
             assertThat(l2HitCounter.count()).isGreaterThan(0);
+        }
+
+        @Test
+        @DisplayName("P0-4: lockWaitSeconds=5 적용 확인")
+        void shouldUseLockWaitSecondsFromConfig() throws Exception {
+            // given
+            given(l1.get(KEY)).willReturn(null);
+            given(l2.get(KEY)).willReturn(null);
+
+            RLock lock = createMockLock(true);
+            given(redissonClient.getLock(anyString())).willReturn(lock);
+
+            // when
+            tieredCache.get(KEY, () -> "value");
+
+            // then: lockWaitSeconds=5 확인
+            verify(lock).tryLock(eq((long) LOCK_WAIT_SECONDS), eq(TimeUnit.SECONDS));
+        }
+    }
+
+    @Nested
+    @DisplayName("P1-6: TieredCacheManager CAS 초기화")
+    class CASInitializationTest {
+
+        @Test
+        @DisplayName("initializeInstanceId() 중복 호출 시 false 반환")
+        void shouldReturnFalseOnDuplicateInitialization() {
+            // given
+            TieredCacheManager manager = new TieredCacheManager(
+                    mock(org.springframework.cache.CacheManager.class),
+                    mock(org.springframework.cache.CacheManager.class),
+                    executor,
+                    redissonClient,
+                    meterRegistry,
+                    LOCK_WAIT_SECONDS
+            );
+
+            // when
+            boolean first = manager.initializeInstanceId("instance-1");
+            boolean second = manager.initializeInstanceId("instance-2");
+
+            // then
+            assertThat(first).isTrue();
+            assertThat(second).isFalse();
         }
     }
 

--- a/src/test/java/maple/expectation/global/cache/invalidation/CacheInvalidationIntegrationTest.java
+++ b/src/test/java/maple/expectation/global/cache/invalidation/CacheInvalidationIntegrationTest.java
@@ -112,9 +112,12 @@ class CacheInvalidationIntegrationTest extends IntegrationTestSupport {
             AtomicReference<CacheInvalidationEvent> receivedEvent = new AtomicReference<>();
 
             RTopic topic = redissonClient.getTopic(RedisKey.CACHE_INVALIDATION_TOPIC.getKey());
+            // EVICT 타입만 필터링 (setUp의 cache.clear()가 CLEAR_ALL 이벤트를 발행하므로)
             int listenerId = topic.addListener(CacheInvalidationEvent.class, (channel, event) -> {
-                receivedEvent.set(event);
-                latch.countDown();
+                if (event.type() == InvalidationType.EVICT) {
+                    receivedEvent.set(event);
+                    latch.countDown();
+                }
             });
 
             // When
@@ -141,9 +144,12 @@ class CacheInvalidationIntegrationTest extends IntegrationTestSupport {
             AtomicReference<CacheInvalidationEvent> receivedEvent = new AtomicReference<>();
 
             RTopic topic = redissonClient.getTopic(RedisKey.CACHE_INVALIDATION_TOPIC.getKey());
+            // sourceInstanceId로 테스트 발행 이벤트만 필터링 (setUp의 clear()가 CLEAR_ALL을 발행하므로)
             int listenerId = topic.addListener(CacheInvalidationEvent.class, (channel, event) -> {
-                receivedEvent.set(event);
-                latch.countDown();
+                if ("test-publisher".equals(event.sourceInstanceId())) {
+                    receivedEvent.set(event);
+                    latch.countDown();
+                }
             });
 
             // When

--- a/src/test/java/maple/expectation/global/cache/invalidation/RedisCacheInvalidationPublisherTest.java
+++ b/src/test/java/maple/expectation/global/cache/invalidation/RedisCacheInvalidationPublisherTest.java
@@ -58,6 +58,9 @@ class RedisCacheInvalidationPublisherTest {
     void setUp() {
         meterRegistry = new SimpleMeterRegistry();
 
+        // P1-3: RTopic 필드 캐싱을 위해 생성자 호출 전에 mock 설정
+        when(redissonClient.getTopic(RedisKey.CACHE_INVALIDATION_TOPIC.getKey())).thenReturn(topic);
+
         // LogicExecutor.executeOrDefault: task 직접 실행 stub
         when(executor.executeOrDefault(any(), any(), any())).thenAnswer(invocation -> {
             maple.expectation.global.common.function.ThrowingSupplier<?> task = invocation.getArgument(0);
@@ -69,7 +72,6 @@ class RedisCacheInvalidationPublisherTest {
         });
 
         publisher = new RedisCacheInvalidationPublisher(redissonClient, executor, meterRegistry);
-        when(redissonClient.getTopic(RedisKey.CACHE_INVALIDATION_TOPIC.getKey())).thenReturn(topic);
     }
 
     @Nested

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -106,6 +106,37 @@ cors:
   allow-credentials: true
   max-age: 3600
 
+# Cache 설정 (테스트 환경)
+cache:
+  specs:
+    equipment:
+      l1-ttl-minutes: 5
+      l1-max-size: 5000
+      l2-ttl-minutes: 10
+      l2-serializer: json
+    cubeTrials:
+      l1-ttl-minutes: 10
+      l1-max-size: 5000
+      l2-ttl-minutes: 20
+      l2-serializer: jdk
+    ocidCache:
+      l1-ttl-minutes: 30
+      l1-max-size: 5000
+      l2-ttl-minutes: 60
+      l2-serializer: json
+    characterBasic:
+      l1-ttl-minutes: 15
+      l1-max-size: 5000
+      l2-ttl-minutes: 15
+      l2-serializer: json
+    expectationV4:
+      l1-ttl-minutes: 60
+      l1-max-size: 5000
+      l2-ttl-minutes: 60
+      l2-serializer: jdk
+  singleflight:
+    lock-wait-seconds: 5
+
 # Expectation Buffer 설정 (테스트 환경 - 작은 값으로 테스트 용이성 확보)
 expectation:
   buffer:


### PR DESCRIPTION
## 관련 이슈\n5-Agent Council TieredCache 분석 합의안\n\n## 개요\nTieredCache (L1/L2) + Singleflight 모듈의 P0 4건, P1 7건을 리팩토링하여 동시성 안전성, Scale-out L1 coherence, 메트릭 가시성을 개선합니다.\n\n## 작업 내용\n\n### P0 (CRITICAL)\n- [x] P0-1: `put()` Pub/Sub 미발행 → Scale-out 시 최대 60분 stale data 방지\n- [x] P0-2: `TotalExpectationCacheService` L1→L2 순서 위반 → L2→L1 수정\n- [x] P0-3: `evict()` L1→L2 순서 race condition → L2→L1→Pub/Sub 수정\n- [x] P0-4: `LOCK_WAIT_SECONDS=30` → CacheProperties 외부화 (기본 5초)\n\n### P1 (HIGH/MEDIUM)\n- [x] P1-1: Metrics cacheName 태그 추가 (cache별 모니터링 가능)\n- [x] P1-3: RTopic 필드 캐싱 (매 호출 생성 제거)\n- [x] P1-4: EquipmentCacheService Cache 필드 캐싱 + Objects.requireNonNull fail-fast\n- [x] P1-5: Lock timeout CacheProperties 외부화\n- [x] P1-6: TieredCacheManager @Setter → AtomicReference CAS 패턴\n- [x] P1-7: Counter hot-path 할당 → 필드 pre-registration\n- [x] P1-9: CacheConfig 동적 등록 (하드코딩 5개 → specs.forEach)\n\n### 신규 파일\n- `CacheProperties.java`: @ConfigurationProperties 기반 캐시 설정 외부화\n\n## 리뷰 포인트\n- `TieredCache.evict()` L2→L1 순서 변경이 기존 동작에 미치는 영향\n- `TieredCacheManager` AtomicReference CAS 패턴의 thread-safety\n- `CacheProperties` 기본값이 운영 환경에 적합한지\n\n## 트레이드 오프 결정 근거\n- lockWaitSeconds 30→5초: 캐시 valueLoader는 100-500ms이므로 5초 충분, 초과 시 fallback 직접 실행이 합리적\n- P0-2 L1 항상 저장: L2 실패 시에도 로컬 성능 보장 (가용성 우선)\n- Counter pre-registration: 메모리 소폭 증가 vs hot-path 할당 제거 (throughput 우선)\n\n## 체크리스트\n- [x] 브랜치/커밋 규칙 준수\n- [x] 81개 캐시 관련 테스트 전체 통과\n- [x] 신규 테스트 7건 추가 (P0-1, P0-3, P0-4, P1-1, P1-6 검증)\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)