### PR TITLE
refactor: AOP+Async 비동기 파이프라인 P0/P1 리팩토링

### DIFF
--- a/docs/04_Reports/aop-async-pipeline-p0-p1-refactoring-report.md
+++ b/docs/04_Reports/aop-async-pipeline-p0-p1-refactoring-report.md
@@ -1,0 +1,242 @@
+# AOP+Async 비동기 파이프라인 P0/P1 리팩토링 리포트
+
+> **상위 문서:** [CLAUDE.md](../../CLAUDE.md)
+> **관련 가이드:** [async-concurrency.md](../02_Technical_Guides/async-concurrency.md)
+> **일자:** 2026-01-30
+> **5-Agent Council 합의 기반**
+
+---
+
+## 1. 분석 범위
+
+Two-Phase Snapshot (Light/Full) 비동기 파이프라인 및 관련 AOP 모듈의 동시성, 대규모 트래픽, Scale-out 관점 P0/P1 전수 분석.
+
+### 분석 대상 파일
+
+| 카테고리 | 파일 | 핵심 역할 |
+|---------|------|----------|
+| **Service** | `EquipmentService.java` | Two-Phase Snapshot + CompletableFuture 오케스트레이션 |
+| **Config** | `ExecutorConfig.java` | ThreadPool 설정 (alert, expectation, ai) |
+| **AOP** | `TraceAspect.java` | 호출 추적 (MDC 기반 Stateless) |
+| **AOP** | `NexonDataCacheAspect.java` | Leader/Follower 분산 캐싱 |
+| **AOP** | `ObservabilityAspect.java` | 메트릭 수집 |
+| **Concurrency** | `SingleFlightExecutor.java` | 동시 중복 계산 방지 |
+| **Context** | `SkipEquipmentL2CacheContext.java` | MDC 기반 L2 캐시 스킵 |
+
+---
+
+## 2. 발견된 P0/P1 이슈
+
+### P0 (CRITICAL)
+
+| ID | 이슈 | 심각도 | 영향 |
+|----|------|--------|------|
+| **P0-1** | `handleAsyncException()`에서 `RuntimeException` 직접 사용 | CRITICAL | CLAUDE.md 섹션 11 위반. GlobalExceptionHandler에서 무의미한 500 응답 |
+| **P0-2** | Two-Phase Snapshot 중복 DB 조회 | CRITICAL | 캐시 MISS 시 동일 사용자에 대해 DB 2회 조회. 대규모 트래픽 시 DB 부하 2배 |
+
+### P1 (HIGH/MEDIUM)
+
+| ID | 이슈 | 심각도 | 영향 |
+|----|------|--------|------|
+| **P1-1** | `@Deprecated` 메서드 `streamEquipmentData()` 존재 | HIGH | CLAUDE.md 섹션 5 위반 ("No Deprecated" 정책) |
+| **P1-2** | `LightSnapshot`/`FullSnapshot` 동일 필드 구조 중복 | MEDIUM | 불필요한 코드 복잡성, 유지보수 비용 |
+| **P1-3** | `computeAndCacheAsync()`에서 `thenApplyAsync()` 불필요 사용 | MEDIUM | 이미 비동기 스레드에서 불필요한 컨텍스트 스위칭 발생 |
+
+---
+
+## 3. 5-Agent Council 합의
+
+### Blue (Architect)
+- P0-2 수정으로 **파이프라인 단계 3개 → 2개로 단순화**
+- `validateAndResolveCacheKey()` 제거로 코드 복잡도 감소
+- `LightSnapshot`/`FullSnapshot` → 단일 `CharacterSnapshot`으로 SRP 개선
+
+### Green (Performance)
+- **DB 조회 50% 감소** (2회 → 1회)
+- `thenApplyAsync` → `thenApply`로 **스레드 컨텍스트 스위칭 1회 제거**
+- 비동기 파이프라인 단계 감소로 **GC 압력 감소** (CompletableFuture 객체 1개 감소)
+
+### Yellow (Quality)
+- `RuntimeException` → `EquipmentDataProcessingException`으로 **섹션 11 준수**
+- `@Deprecated` 메서드 제거로 **섹션 5 준수**
+- 메서드 참조 `this::processAfterSnapshot` 적용 (섹션 15)
+
+### Purple (Data)
+- `CharacterSnapshot` record로 **불변성 보장**
+- 데이터 일관성: `readOnlyTx` 트랜잭션 내 단일 조회로 **Snapshot Isolation** 강화
+- `equipmentUpdatedAt` 변경 감지는 `EquipmentDataResolver` DB TTL(15분)로 보장
+
+### Red (SRE)
+- Scale-out 안전: MDC 기반 Stateless + `whenComplete()` 복원
+- 장애 복구: `SingleFlightExecutor` fallback 캐시 재조회
+- 로그 보안: `maskOcid()`/`maskKey()` 유지
+
+---
+
+## 4. 수정 내용
+
+### P0-1: RuntimeException 직접 사용 제거
+
+```java
+// Before (CLAUDE.md 섹션 11 위반)
+throw new RuntimeException("Async expectation calculation failed", cause);
+
+// After
+throw new EquipmentDataProcessingException(
+        String.format("Async expectation calculation failed for: %s", userIgn), cause);
+```
+
+### P0-2: Two-Phase → Single-Phase Snapshot
+
+```java
+// Before: DB 2회 조회
+return CompletableFuture
+    .supplyAsync(() -> fetchLightSnapshot(userIgn), executor)     // DB 1회
+    .thenCompose(light -> {
+        if (cacheHit) return cached;
+        return supplyAsync(() -> fetchFullSnapshot(userIgn), executor)  // DB 2회 (동일 쿼리!)
+            .thenCompose(full -> compute(full));
+    });
+
+// After: DB 1회 조회
+return CompletableFuture
+    .supplyAsync(() -> fetchCharacterSnapshot(userIgn), executor)  // DB 1회 (통합)
+    .thenCompose(this::processAfterSnapshot);                      // 바로 계산
+```
+
+**제거된 코드:**
+- `LightSnapshot` record → `CharacterSnapshot`으로 통합
+- `FullSnapshot` record → 제거
+- `fetchFullSnapshot()` → 제거
+- `validateAndResolveCacheKey()` → 제거
+- `processAfterFullSnapshot()` → 제거
+
+### P1-1: @Deprecated 메서드 제거
+
+```java
+// Before
+@Deprecated(since = "v3.1", forRemoval = true)
+public void streamEquipmentData(String userIgn, OutputStream outputStream) { ... }
+
+// After: 완전 제거
+```
+
+### P1-3: thenApplyAsync → thenApply
+
+```java
+// Before (불필요한 스레드 전환)
+.thenApplyAsync(targetData -> { ... }, expectationComputeExecutor);
+
+// After (동일 스레드에서 후속 처리)
+.thenApply(targetData -> { ... });
+```
+
+---
+
+## 5. 모니터링 — Prometheus 메트릭 및 Grafana 쿼리
+
+### 5.1 개선 효과 측정용 Prometheus 쿼리
+
+애플리케이션 실행 후 다음 PromQL 쿼리로 개선 전/후를 비교합니다.
+
+#### DB 부하 감소 확인 (P0-2)
+```promql
+# HikariCP 활성 커넥션 수 (개선 전 대비 감소 예상)
+hikaricp_connections_active{pool="HikariPool-1"}
+
+# DB 쿼리 실행 횟수 (Spring Data JPA)
+spring_data_repository_invocations_seconds_count{method="findByUserIgn"}
+
+# 트랜잭션 수 (readOnly=true)
+# 개선 전: 캐시 MISS 1건당 2 트랜잭션
+# 개선 후: 캐시 MISS 1건당 1 트랜잭션
+rate(spring_data_repository_invocations_seconds_count[5m])
+```
+
+#### Executor 스레드 사용량 (P1-3)
+```promql
+# expectation.compute Executor 활성 스레드 수
+executor_active{name="expectation.compute"}
+
+# 큐 대기 작업 수
+executor_queued{name="expectation.compute"}
+
+# 거부된 작업 수
+executor_rejected_total{name="expectation.compute"}
+
+# 완료된 작업 수
+executor_completed_total{name="expectation.compute"}
+```
+
+#### 캐시 히트율 (전후 비교)
+```promql
+# 캐시 히트율
+sum(rate(cache_hit_total[5m])) / (sum(rate(cache_hit_total[5m])) + sum(rate(cache_miss_total[5m])))
+
+# L1/L2 레이어별 히트
+rate(cache_hit_total{layer="L1"}[5m])
+rate(cache_hit_total{layer="L2"}[5m])
+```
+
+### 5.2 Grafana 대시보드
+
+기존 대시보드 파일 위치:
+- `docker/grafana/provisioning/dashboards/prometheus-metrics.json` — 시스템 메트릭
+- `docker/grafana/provisioning/dashboards/application.json` — 애플리케이션 로그
+- `grafana/dashboards/cache-monitoring.json` — 캐시 모니터링
+
+### 5.3 Loki 로그 쿼리
+
+```logql
+# P0-2 효과: "비활성 캐릭터 감지" 로그 (단일 조회 확인)
+{app="maple-expectation"} |= "비활성 캐릭터 감지"
+
+# 캐시 HIT 로그 (Single-Phase 확인)
+{app="maple-expectation"} |= "Cache HIT for"
+
+# Follower timeout fallback 로그
+{app="maple-expectation"} |= "Follower timeout, fallback"
+
+# Executor rejected 로그
+{app="maple-expectation"} |= "Task rejected"
+```
+
+### 5.4 예상 개선 수치
+
+| 메트릭 | 개선 전 | 개선 후 | 변화 |
+|--------|---------|---------|------|
+| **DB 조회 (캐시 MISS)** | 2회/요청 | 1회/요청 | **-50%** |
+| **스레드 전환 (계산)** | 3회/요청 | 2회/요청 | **-33%** |
+| **CompletableFuture 객체** | 4개/요청 | 3개/요청 | **-25%** |
+| **코드 복잡도** | 메서드 7개 | 메서드 4개 | **-43%** |
+| **Record 수** | 2개 (중복) | 1개 | **-50%** |
+
+---
+
+## 6. CLAUDE.md 준수 검증
+
+| 섹션 | 규칙 | 준수 여부 |
+|------|------|----------|
+| 4 | SOLID, Modern Java | PASS (Record, Pattern Matching, Method Reference) |
+| 5 | No Deprecated | PASS (streamEquipmentData 제거) |
+| 6 | Design Patterns | PASS (Facade, Factory, Strategy) |
+| 11 | Custom Exception | PASS (RuntimeException → EquipmentDataProcessingException) |
+| 12 | LogicExecutor | PASS (processCalculation, processLegacyCalculation) |
+| 14 | Anti-Pattern | PASS (Catch-and-Ignore 없음) |
+| 15 | Lambda 3-Line Rule | PASS (computeAndCacheAsync 람다 3줄 이내) |
+| 21 | Async Non-Blocking | PASS (orTimeout, thenCompose, whenComplete) |
+| 22 | Thread Pool Backpressure | PASS (AbortPolicy, rejected Counter) |
+
+---
+
+## 7. 5-Agent Council 최종 판정
+
+| Agent | 역할 | 판정 | 비고 |
+|-------|------|------|------|
+| Blue (Architect) | 아키텍처 | **PASS** | SRP, Single-Phase 단순화 |
+| Green (Performance) | 성능 | **PASS** | DB -50%, 스레드 전환 -33% |
+| Yellow (Quality) | 품질 | **PASS** | 섹션 5, 11, 15 준수 |
+| Purple (Data) | 데이터 | **PASS** | Snapshot Isolation 강화 |
+| Red (SRE) | 운영 | **PASS** | Stateless, Graceful Degradation |
+
+**결론: 만장일치 PASS — P0/P1 잔존 이슈 없음**

--- a/src/test/java/maple/expectation/service/v2/EquipmentServiceTest.java
+++ b/src/test/java/maple/expectation/service/v2/EquipmentServiceTest.java
@@ -41,12 +41,6 @@ class EquipmentServiceTest extends IntegrationTestSupport {
         gameCharacterRepository.deleteAllInBatch();
     }
 
-    @Test
-    @DisplayName("Stream API: GZIP 데이터 압축 해제 검증")
-    void streamEquipmentData_Gzip_Success() throws Exception {
-        // Given/When/Then 로직 유지 (부모의 Mock 사용)
-    }
-
     // ==================== Issue #118: 비동기 파이프라인 테스트 ====================
 
     @Test


### PR DESCRIPTION
## 관련 이슈\n5-Agent Council P0/P1 전수 분석\n\n## 개요\nTwo-Phase Snapshot(Light/Full) 비동기 파이프라인을 Single-Phase CharacterSnapshot으로 통합하여 DB 조회 50% 감소, 불필요한 스레드 전환 제거\n\n## 작업 내용\n- [x] P0-1: RuntimeException → EquipmentDataProcessingException (CLAUDE.md 섹션 11)\n- [x] P0-2: Two-Phase → Single-Phase Snapshot (DB 2회→1회)\n- [x] P1-1: @Deprecated streamEquipmentData() 제거 (섹션 5)\n- [x] P1-2: LightSnapshot/FullSnapshot → CharacterSnapshot 단일화\n- [x] P1-3: thenApplyAsync → thenApply (스레드 전환 제거)\n\n## 리뷰 포인트\n- CharacterSnapshot record 통합으로 파이프라인 단순화 여부\n- processAfterSnapshot 메서드 참조 적용\n\n## 트레이드 오프 결정 근거\n- Single-Phase로 캐시 MISS 시 DB 조회 1회로 감소 (기존 2회)\n- thenApply 사용으로 동일 스레드 후속 처리 (불필요한 컨텍스트 스위칭 제거)\n\n## 체크리스트\n- [x] 브랜치/커밋 규칙 준수\n- [x] 테스트 통과 (fastTest BUILD SUCCESSFUL)\n- [x] 5-Agent Council 만장일치 PASS\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)