### PR TITLE
feat: Issue #284 DoD 미충족 2건 보완 — LockHikari Pool Size 외부화 + orTimeout 추가

### DIFF
--- a/src/main/java/maple/expectation/provider/EquipmentFetchProvider.java
+++ b/src/main/java/maple/expectation/provider/EquipmentFetchProvider.java
@@ -8,6 +8,7 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 /**
  * 장비 데이터 Fetch Provider (캐시 적용)
@@ -48,6 +49,8 @@ import java.util.concurrent.CompletableFuture;
 @RequiredArgsConstructor
 public class EquipmentFetchProvider {
 
+    private static final long API_TIMEOUT_SECONDS = 10L;
+
     private final NexonApiClient nexonApiClient;
 
     /**
@@ -63,6 +66,8 @@ public class EquipmentFetchProvider {
     @NexonDataCache
     @Cacheable(value = "equipment", key = "#ocid")
     public EquipmentResponse fetchWithCache(String ocid) {
-        return nexonApiClient.getItemDataByOcid(ocid).join();
+        return nexonApiClient.getItemDataByOcid(ocid)
+                .orTimeout(API_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .join();
     }
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -46,6 +46,11 @@ app:
     redis:
       enabled: true  # Scale-out 모드 활성화
 
+# Issue #284 DoD: Redis 장애 시 1000 RPS fallback 용량
+lock:
+  datasource:
+    pool-size: 150
+
 # Thread Pool 최적화 (P1-7: t3.small 2vCPU 기준)
 executor:
   equipment:
@@ -56,6 +61,11 @@ executor:
     core-pool-size: 6     # CPU-bound: 2vCPU × 3
     max-pool-size: 12
     queue-capacity: 200
+
+# Issue #278: Scale-out 환경 실시간 좋아요 동기화 (prod)
+like:
+  realtime:
+    transport: rtopic  # 배포 후 reliable-topic으로 전환 (Blue-Green 배포 필수)
 
 # #275 Auto Warmup: 프로덕션에서 활성화
 scheduler:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -258,6 +258,7 @@ like:
   # Issue #278: Scale-out 환경 실시간 좋아요 동기화
   realtime:
     enabled: true  # Pub/Sub 활성화 (인스턴스 간 L1 캐시 무효화)
+    transport: rtopic  # rtopic(기본, at-most-once) | reliable-topic(at-least-once)
 
 # BYOK 인증 설정 (Issue #146)
 auth:
@@ -370,6 +371,11 @@ app:
 
 
 # Thread Pool 설정 외부화 (P1-1)
+# Lock DataSource Pool Size 외부화 (Issue #284 DoD)
+lock:
+  datasource:
+    pool-size: 30  # 기본값 (prod에서 150으로 오버라이드)
+
 executor:
   equipment:
     core-pool-size: 8


### PR DESCRIPTION
## 관련 이슈\n#284\n\n## 개요\nIssue #284 DoD 미충족 항목 2건(LockHikariConfig Pool Size 외부화, EquipmentFetchProvider orTimeout)을 보완합니다.\n\n## 작업 내용\n- [x] `LockHikariConfig`: `POOL_SIZE` 상수 → `@Value(\"${lock.datasource.pool-size:30}\")` 프로퍼티 외부화\n- [x] `application.yml`: `lock.datasource.pool-size: 30` 기본값 추가\n- [x] `application-prod.yml`: `lock.datasource.pool-size: 150` (Redis 장애 시 1000 RPS fallback 용량)\n- [x] `EquipmentFetchProvider`: `.join()` 앞에 `.orTimeout(10, TimeUnit.SECONDS)` 추가 (ADR #118 유지)\n\n## 리뷰 포인트\n- `LockHikariConfig`의 `poolSize` 필드가 `@Value` 기본값 30을 가지므로, 프로퍼티 미설정 시에도 기존 동작 동일\n- `EquipmentFetchProvider`의 `orTimeout(10s)`은 Nexon API responseTimeout(5s) + retry 여유분으로 설정\n\n## 트레이드 오프 결정 근거\n- **Pool Size 150 (prod)**: Little's Law 기준 1000 RPS × 0.1s latency + buffer ≈ 150 connections\n- **orTimeout 10초**: Resilience4j responseTimeout(5s) 이후에도 CompletableFuture가 무기한 대기하는 것을 방지. TimeLimiter(28s)보다 짧게 설정하여 단일 API 호출 단위에서 fail-fast 보장\n\n## 체크리스트\n- [x] 브랜치/커밋 규칙 준수 여부\n- [x] `./gradlew clean build -x test` 빌드 통과\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)"