### PR TITLE
feat: #283 Scale-out 조건부 빈 로딩 + Docker 29.x 호환

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ dependencies {
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
     }
-    testImplementation platform('org.testcontainers:testcontainers-bom:1.19.3')
+    testImplementation platform('org.testcontainers:testcontainers-bom:1.21.3')
     testImplementation "org.testcontainers:testcontainers"
     testImplementation "org.testcontainers:junit-jupiter"
     testImplementation "org.testcontainers:mysql"

--- a/src/main/java/maple/expectation/config/LockHikariConfig.java
+++ b/src/main/java/maple/expectation/config/LockHikariConfig.java
@@ -2,6 +2,7 @@ package maple.expectation.config;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import com.zaxxer.hikari.metrics.micrometer.MicrometerMetricsTrackerFactory;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -73,7 +74,7 @@ public class LockHikariConfig {
         config.setValidationTimeout(3000);
 
         // Issue #284: Micrometer 메트릭 등록 (hikaricp.connections.active{pool=MySQLLockPool})
-        config.setMetricRegistry(meterRegistry);
+        config.setMetricsTrackerFactory(new MicrometerMetricsTrackerFactory(meterRegistry));
 
         log.info("[Lock Pool] Initialized dedicated MySQL lock connection pool (Fixed Size: {})", poolSize);
 

--- a/src/main/java/maple/expectation/config/RedisBufferConfig.java
+++ b/src/main/java/maple/expectation/config/RedisBufferConfig.java
@@ -21,7 +21,7 @@ import org.springframework.context.annotation.Primary;
  *
  * <h3>활성화 조건</h3>
  * <p>{@code app.buffer.redis.enabled=true} 설정 시 활성화됩니다.
- * 기본값은 false이며, 기존 In-Memory 버퍼가 사용됩니다.</p>
+ * 기본값은 true이며, Redis 기반 버퍼가 사용됩니다. In-Memory는 local/test 전용.</p>
  *
  * <h3>5-Agent Council 합의</h3>
  * <ul>
@@ -31,7 +31,7 @@ import org.springframework.context.annotation.Primary;
  * </ul>
  */
 @Configuration
-@ConditionalOnProperty(name = "app.buffer.redis.enabled", havingValue = "true", matchIfMissing = false)
+@ConditionalOnProperty(name = "app.buffer.redis.enabled", havingValue = "true", matchIfMissing = true)
 public class RedisBufferConfig {
 
     private static final int DEFAULT_MAX_RETRIES = 3;

--- a/src/main/java/maple/expectation/global/lock/MySqlNamedLockStrategy.java
+++ b/src/main/java/maple/expectation/global/lock/MySqlNamedLockStrategy.java
@@ -8,6 +8,7 @@ import maple.expectation.global.executor.LogicExecutor;
 import maple.expectation.global.executor.TaskContext;
 import maple.expectation.global.executor.strategy.ExceptionTranslator;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.jdbc.core.ConnectionCallback;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.SingleConnectionDataSource;
@@ -31,10 +32,17 @@ import java.util.Deque;
  *   <li>P1-BLUE-03: LockOrderMetrics 의존성 주입</li>
  * </ul>
  *
+ * <h3>Conditional Bean Loading</h3>
+ * <p>이 빈은 lockJdbcTemplate이 존재할 때만 로드됩니다.
+ * LockHikariConfig는 @Profile({"!test", "container"})이므로,
+ * test 프로필만 활성화된 환경에서는 이 빈이 생성되지 않습니다.
+ * ResilientLockStrategy는 Optional로 주입받아 Redis-only 모드로 동작합니다.</p>
+ *
  * @see LockOrderMetrics
  */
 @Slf4j
 @Component
+@ConditionalOnBean(name = "lockJdbcTemplate")
 public class MySqlNamedLockStrategy implements LockStrategy {
 
     private final JdbcTemplate lockJdbcTemplate;

--- a/src/main/java/maple/expectation/service/v2/cache/LikeBufferStorage.java
+++ b/src/main/java/maple/expectation/service/v2/cache/LikeBufferStorage.java
@@ -6,6 +6,7 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import java.util.HashMap;
@@ -30,6 +31,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * @see LikeBufferStrategy 전략 인터페이스
  */
 @Slf4j
+@ConditionalOnProperty(name = "app.buffer.redis.enabled", havingValue = "false")
 @Component
 public class LikeBufferStorage implements LikeBufferStrategy {
 

--- a/src/main/java/maple/expectation/service/v2/cache/LikeRelationBuffer.java
+++ b/src/main/java/maple/expectation/service/v2/cache/LikeRelationBuffer.java
@@ -10,6 +10,7 @@ import maple.expectation.global.executor.LogicExecutor;
 import maple.expectation.global.executor.TaskContext;
 import org.redisson.api.RSet;
 import org.redisson.api.RedissonClient;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import java.util.HashSet;
@@ -41,6 +42,7 @@ import java.util.concurrent.TimeUnit;
  * @see LikeRelationBufferStrategy 전략 인터페이스
  */
 @Slf4j
+@ConditionalOnProperty(name = "app.buffer.redis.enabled", havingValue = "false")
 @Component
 public class LikeRelationBuffer implements LikeRelationBufferStrategy {
 

--- a/src/main/java/maple/expectation/service/v2/shutdown/EquipmentPersistenceTracker.java
+++ b/src/main/java/maple/expectation/service/v2/shutdown/EquipmentPersistenceTracker.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import maple.expectation.global.executor.LogicExecutor;
 import maple.expectation.global.executor.TaskContext;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
@@ -24,6 +25,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * @see maple.expectation.global.queue.persistence.RedisEquipmentPersistenceTracker Redis 구현체
  */
 @Slf4j
+@ConditionalOnProperty(name = "app.buffer.redis.enabled", havingValue = "false")
 @Component
 @RequiredArgsConstructor
 public class EquipmentPersistenceTracker implements PersistenceTrackerStrategy {

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -48,3 +48,10 @@ cors:
     - "http://127.0.0.1:3000"
     - "http://127.0.0.1:3001"
     - "http://127.0.0.1:5173"
+
+# Issue #283 P0-2: 로컬 환경에서만 In-Memory 버퍼 사용
+# prod/default에서는 Redis 버퍼가 기본 활성화 (Scale-out 지원)
+app:
+  buffer:
+    redis:
+      enabled: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -364,10 +364,7 @@ otel:
 
 # Redis 기반 Write-Behind 버퍼 (P1-2: Scale-out 지원)
 # true: Redis Reliable Queue, false: In-Memory ConcurrentLinkedQueue
-app:
-  buffer:
-    redis:
-      enabled: false  # prod 프로필에서 true로 설정
+# → app.buffer.redis.enabled는 상단 app: 블록(line 184)에서 관리
 
 
 # Thread Pool 설정 외부화 (P1-1)

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -72,6 +72,9 @@ app:
   aop:
     trace:
       enabled: false
+  buffer:
+    redis:
+      enabled: false
 
 # BYOK 인증 설정 (테스트용)
 auth:

--- a/src/test/resources/docker-java.properties
+++ b/src/test/resources/docker-java.properties
@@ -1,0 +1,1 @@
+api.version=1.44

--- a/src/test/resources/testcontainers.properties
+++ b/src/test/resources/testcontainers.properties
@@ -1,1 +1,2 @@
 testcontainers.reuse.enable=true
+docker.client.api.version=1.44


### PR DESCRIPTION
## 관련 이슈
#283

## 개요
Scale-out 지원을 위한 조건부 빈 로딩 전략 구현 및 Docker 29.x Testcontainers 호환성 수정

## 작업 내용
- [x] Redis 버퍼 기본 활성화 (matchIfMissing=true), In-Memory는 local/test 전용
- [x] LikeBufferStorage, LikeRelationBuffer, EquipmentPersistenceTracker @ConditionalOnProperty 추가
- [x] MySqlNamedLockStrategy @ConditionalOnBean 적용 (test 프로필 빈 충돌 방지)
- [x] ResilientLockStrategy MySQL Optional 주입 (@Nullable) + Redis-only 모드 지원
- [x] LockHikariConfig setMetricRegistry → MicrometerMetricsTrackerFactory (deprecated API 제거)
- [x] Testcontainers BOM 1.19.3 → 1.21.3 업그레이드
- [x] docker-java.properties api.version=1.44 추가 (Docker 29.x 호환)

## 리뷰 포인트
1. **프로필 매트릭스 검증**: prod/local/test/container 4개 프로필 조합에서 빈 로딩 정합성
2. **ResilientLockStrategy Redis-only 모드**: MySQL 전략 null 시 DistributedLockException 전파 경로
3. **CLAUDE.md 준수**: @Nullable 패턴, unlockMySqlIfAvailable() Optional 체이닝, Lambda 3-Line Rule

## 트레이드 오프 결정 근거
- @Autowired(required=false) 대신 @Nullable: Spring Boot 3.x 생성자 주입 모범 사례 + CLAUDE.md Section 6 준수
- Testcontainers BOM 2.x 대신 1.21.3 유지: docker-java.properties로 API 버전만 오버라이드하는 보수적 접근

## 체크리스트
- [x] 브랜치/커밋 규칙 준수
- [x] fastTest 통과 (chaos/nightmare 제외 전부 통과)
- [x] 빌드 성공 (BUILD SUCCESSFUL)