### PR TITLE
feat: #283 Scale-out Sprint 2+3 — P0/P1 Stateful 컴포넌트 분산 전환

### DIFF
--- a/src/main/java/maple/expectation/config/LookupTableInitializer.java
+++ b/src/main/java/maple/expectation/config/LookupTableInitializer.java
@@ -53,13 +53,15 @@ public class LookupTableInitializer implements ApplicationRunner {
     /**
      * 초기화 완료 플래그 (#271 V5 P1 검토 완료)
      *
-     * <h4>Stateless 검토 결과</h4>
+     * <h4>Stateless 검토 결과 (Issue #283 P1-12)</h4>
      * <p>인스턴스별 독립 readiness는 <b>의도된 동작</b>입니다:</p>
      * <ul>
      *   <li>목적: 각 인스턴스가 자신의 Lookup Table 초기화 완료를 추적</li>
-     *   <li>K8s rolling update: 각 Pod가 독립적으로 readiness 판정 → 정상 동작</li>
+     *   <li>K8s rolling update: 각 Pod가 독립적으로 readiness 판정 -> 정상 동작</li>
      *   <li>Redis-backed 전환 불필요: Probe는 인스턴스별 상태를 체크해야 함</li>
+     *   <li>Lookup Table은 읽기 전용 데이터로, 인스턴스마다 동일하게 초기화됨</li>
      * </ul>
+     * <p><b>결론: 인스턴스 로컬 readiness 플래그는 Scale-out 환경에서 올바른 설계. 변환 불필요.</b></p>
      */
     private final AtomicBoolean initialized = new AtomicBoolean(false);
 

--- a/src/main/java/maple/expectation/global/concurrency/DistributedSingleFlightService.java
+++ b/src/main/java/maple/expectation/global/concurrency/DistributedSingleFlightService.java
@@ -1,0 +1,115 @@
+package maple.expectation.global.concurrency;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import maple.expectation.global.executor.LogicExecutor;
+import maple.expectation.global.executor.TaskContext;
+import maple.expectation.global.lock.LockStrategy;
+import org.redisson.api.RBucket;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.function.Supplier;
+
+/**
+ * 분산 Single-Flight 서비스 (Issue #283 P0-4)
+ *
+ * <h3>Scale-out 대응</h3>
+ * <p>기존 SingleFlightExecutor는 인스턴스 레벨에서만 중복 계산을 방지합니다.
+ * 이 서비스는 Redis 기반 분산 락 + 캐시를 사용하여 멀티 인스턴스 환경에서도
+ * 동일 키에 대한 중복 계산을 방지합니다.</p>
+ *
+ * <h4>동작 방식</h4>
+ * <pre>
+ * 1. Redis 캐시 확인 → HIT: 즉시 반환
+ * 2. 분산 락 획득 시도 → 실패: 캐시 재확인 후 대기
+ * 3. 계산 실행 → 결과를 Redis에 캐시 (short TTL)
+ * 4. 락 해제
+ * </pre>
+ *
+ * @see SingleFlightExecutor 인스턴스 레벨 Single-Flight (비동기)
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DistributedSingleFlightService {
+
+    private final RedissonClient redissonClient;
+    private final LockStrategy lockStrategy;
+    private final LogicExecutor executor;
+
+    private static final String CACHE_PREFIX = "{single-flight}:result:";
+    private static final Duration DEFAULT_CACHE_TTL = Duration.ofSeconds(30);
+
+    /**
+     * 분산 Single-Flight 실행
+     *
+     * @param key 계산 식별 키
+     * @param computation 실제 계산 로직
+     * @param cacheTtl 결과 캐시 TTL
+     * @param <T> 결과 타입 (Serializable 필수)
+     * @return 계산 결과
+     */
+    public <T> T executeOrShare(String key, Supplier<T> computation, Duration cacheTtl) {
+        return executor.execute(
+                () -> doExecuteOrShare(key, computation, cacheTtl),
+                TaskContext.of("SingleFlight", "Distributed", key)
+        );
+    }
+
+    /**
+     * 분산 Single-Flight 실행 (기본 TTL 30초)
+     */
+    public <T> T executeOrShare(String key, Supplier<T> computation) {
+        return executeOrShare(key, computation, DEFAULT_CACHE_TTL);
+    }
+
+    private <T> T doExecuteOrShare(String key, Supplier<T> computation, Duration cacheTtl) throws Throwable {
+        String cacheKey = CACHE_PREFIX + key;
+
+        // Step 1: Check Redis cache
+        T cached = getCachedResult(cacheKey);
+        if (cached != null) {
+            log.debug("[DistributedSingleFlight] Cache HIT: {}", key);
+            return cached;
+        }
+
+        // Step 2: Acquire distributed lock and compute
+        return lockStrategy.executeWithLock(
+                "single-flight:" + key, 5, 30,
+                () -> computeAndCache(key, cacheKey, computation, cacheTtl)
+        );
+    }
+
+    private <T> T getCachedResult(String cacheKey) {
+        return executor.executeOrDefault(
+                () -> {
+                    RBucket<T> bucket = redissonClient.getBucket(cacheKey);
+                    return bucket.get();
+                },
+                null,
+                TaskContext.of("SingleFlight", "CacheGet")
+        );
+    }
+
+    private <T> T computeAndCache(String key, String cacheKey, Supplier<T> computation, Duration cacheTtl) {
+        // Double-check cache after acquiring lock
+        T existing = getCachedResult(cacheKey);
+        if (existing != null) {
+            log.debug("[DistributedSingleFlight] Cache HIT after lock: {}", key);
+            return existing;
+        }
+
+        T result = computation.get();
+
+        // Cache result with TTL
+        executor.executeVoid(
+                () -> redissonClient.<T>getBucket(cacheKey).set(result, cacheTtl),
+                TaskContext.of("SingleFlight", "CacheSet", key)
+        );
+
+        log.debug("[DistributedSingleFlight] Computed and cached: {}", key);
+        return result;
+    }
+}

--- a/src/main/java/maple/expectation/global/concurrency/SingleFlightExecutor.java
+++ b/src/main/java/maple/expectation/global/concurrency/SingleFlightExecutor.java
@@ -34,6 +34,7 @@ import java.util.function.Supplier;
  * }</pre>
  *
  * @param <T> 계산 결과 타입
+ * @see DistributedSingleFlightService 분산 환경에서의 Single-Flight (Issue #283 P0-4)
  * @see <a href="https://github.com/issue/158">Issue #158: Single-flight 패턴</a>
  */
 @Slf4j

--- a/src/main/java/maple/expectation/global/shutdown/GracefulShutdownCoordinator.java
+++ b/src/main/java/maple/expectation/global/shutdown/GracefulShutdownCoordinator.java
@@ -56,6 +56,21 @@ public class GracefulShutdownCoordinator implements SmartLifecycle {
     private final Counter shutdownSuccessCounter;
     private final Counter shutdownFailureCounter;
 
+    /**
+     * SmartLifecycle 실행 상태 플래그
+     *
+     * <h4>Issue #283 P1-14: Scale-out 분산 안전성</h4>
+     * <p>이 플래그는 Spring {@link SmartLifecycle} 계약의 일부로,
+     * <b>인스턴스 로컬 lifecycle</b>을 관리합니다:</p>
+     * <ul>
+     *   <li>start(): 이 인스턴스의 Coordinator가 활성화되었음을 표시</li>
+     *   <li>stop(): 이 인스턴스의 4단계 순차 종료를 실행 후 false로 전환</li>
+     *   <li>isRunning(): Spring이 이 인스턴스의 lifecycle 상태를 확인</li>
+     * </ul>
+     * <p>각 인스턴스는 독립적으로 SIGTERM을 수신하고 자신의 종료 절차를 실행합니다.
+     * DB 동기화 단계에서는 {@link LockStrategy} 분산 락으로 중복 실행을 방지합니다.</p>
+     * <p><b>결론: SmartLifecycle 계약에 의한 인스턴스 로컬 상태. Redis 전환 불필요.</b></p>
+     */
     private volatile boolean running = false;
 
     public GracefulShutdownCoordinator(

--- a/src/main/java/maple/expectation/monitoring/throttle/AlertThrottler.java
+++ b/src/main/java/maple/expectation/monitoring/throttle/AlertThrottler.java
@@ -1,37 +1,53 @@
 package maple.expectation.monitoring.throttle;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import maple.expectation.global.executor.LogicExecutor;
+import maple.expectation.global.executor.TaskContext;
+import org.redisson.api.RAtomicLong;
+import org.redisson.api.RMap;
+import org.redisson.api.RedissonClient;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.time.Instant;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 /**
- * 알림 스로틀러 (Issue #251)
+ * 알림 스로틀러 (Issue #251) - Redis 기반 분산 상태 관리
  *
  * <h3>[P0-Green] 비용 제한 메커니즘</h3>
  * <ul>
- *   <li>일일 LLM 호출 한도 제한</li>
- *   <li>동일 에러 패턴 스로틀링</li>
+ *   <li>일일 LLM 호출 한도 제한 (Redis RAtomicLong)</li>
+ *   <li>동일 에러 패턴 스로틀링 (Redis RMap)</li>
  *   <li>Rate Limiting (Decorator 패턴)</li>
  * </ul>
  *
  * <h4>CLAUDE.md 준수사항</h4>
  * <ul>
- *   <li>Section 6 (Design Patterns): Decorator 패턴</li>
- *   <li>Section 12 (LogicExecutor): 상태 관리 Stateless</li>
+ *   <li>Section 6 (Design Patterns): Decorator 패턴, Constructor Injection</li>
+ *   <li>Section 12 (LogicExecutor): executeOrDefault 패턴</li>
+ *   <li>Section 8-1 (Redis): Hash Tag ({ai-throttle}) for Cluster</li>
+ * </ul>
+ *
+ * <h4>Redis 키 구조</h4>
+ * <ul>
+ *   <li>일일 카운터: {ai-throttle}:daily-count:2026-02-01 (TTL 25시간)</li>
+ *   <li>패턴 타임스탬프: {ai-throttle}:pattern-times (TTL 10배 스로틀링)</li>
  * </ul>
  */
 @Slf4j
 @Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "ai.sre.enabled", havingValue = "true")
 public class AlertThrottler {
 
-    private final AtomicInteger dailyAiCallCount = new AtomicInteger(0);
-    private final Map<String, Instant> lastAlertTimeByPattern = new ConcurrentHashMap<>();
+    private final RedissonClient redissonClient;
+    private final LogicExecutor executor;
 
     @Value("${ai.sre.daily-limit:100}")
     private int dailyLimit;
@@ -40,49 +56,122 @@ public class AlertThrottler {
     private int throttleSeconds;
 
     /**
-     * 매일 자정에 일일 카운터 리셋
+     * Redis 키 생성 헬퍼
      */
-    @Scheduled(cron = "0 0 0 * * *")
-    public void resetDailyCount() {
-        int previousCount = dailyAiCallCount.getAndSet(0);
-        log.info("[AlertThrottler] 일일 AI 호출 카운터 리셋: {} -> 0", previousCount);
+    private String buildDailyCountKey() {
+        return "{ai-throttle}:daily-count:" + LocalDate.now();
+    }
+
+    private String buildPatternTimesKey() {
+        return "{ai-throttle}:pattern-times";
     }
 
     /**
-     * AI 분석 호출 가능 여부 확인
+     * 일일 카운터 Redis 객체 조회
+     */
+    private RAtomicLong getDailyCounter() {
+        RAtomicLong counter = redissonClient.getAtomicLong(buildDailyCountKey());
+        // 25시간 TTL 설정 (자정 넘어가도 안전하게 만료)
+        executor.executeVoid(
+                () -> this.setCounterExpiry(counter),
+                TaskContext.of("AlertThrottler", "SetDailyTTL")
+        );
+        return counter;
+    }
+
+    private void setCounterExpiry(RAtomicLong counter) {
+        if (!counter.isExists() || counter.remainTimeToLive() < 0) {
+            counter.expire(25, TimeUnit.HOURS);
+        }
+    }
+
+    /**
+     * 패턴별 타임스탬프 Redis Map 조회
+     */
+    private RMap<String, Long> getPatternTimesMap() {
+        RMap<String, Long> map = redissonClient.getMap(buildPatternTimesKey());
+        // TTL: 스로틀링 시간의 10배
+        executor.executeVoid(
+                () -> this.setMapExpiry(map),
+                TaskContext.of("AlertThrottler", "SetPatternMapTTL")
+        );
+        return map;
+    }
+
+    private void setMapExpiry(RMap<String, Long> map) {
+        if (!map.isExists() || map.remainTimeToLive() < 0) {
+            map.expire(throttleSeconds * 10L, TimeUnit.SECONDS);
+        }
+    }
+
+    /**
+     * 매일 자정에 일일 카운터 리셋 (Redis TTL 기반 자동 만료)
+     * Redis 키는 TTL로 자동 삭제되므로 로그 출력만 수행
+     */
+    @Scheduled(cron = "0 0 0 * * *")
+    public void resetDailyCount() {
+        log.info("[AlertThrottler] 일일 AI 호출 카운터 리셋 (Redis TTL 기반 자동 만료)");
+    }
+
+    /**
+     * AI 분석 호출 가능 여부 확인 (Redis 분산 상태)
      *
      * @return 호출 가능하면 true
      */
     public boolean canSendAiAnalysis() {
-        int current = dailyAiCallCount.incrementAndGet();
+        return executor.executeOrDefault(
+                this::checkAndIncrementDailyCount,
+                false,
+                TaskContext.of("AlertThrottler", "CanSendAI")
+        );
+    }
+
+    private boolean checkAndIncrementDailyCount() {
+        RAtomicLong counter = getDailyCounter();
+        long current = counter.incrementAndGet();
+
         if (current > dailyLimit) {
             log.warn("[AlertThrottler] 일일 AI 호출 한도 초과: {}/{}", current, dailyLimit);
-            dailyAiCallCount.decrementAndGet(); // 롤백
+            counter.decrementAndGet(); // 롤백
             return false;
         }
         return true;
     }
 
     /**
-     * 동일 에러 패턴 스로틀링 확인
+     * 동일 에러 패턴 스로틀링 확인 (Redis 분산 상태)
      *
      * @param errorPattern 에러 패턴 (예: 예외 클래스명)
      * @return 전송 가능하면 true
      */
     public boolean shouldSendAlert(String errorPattern) {
-        Instant now = Instant.now();
-        Instant lastTime = lastAlertTimeByPattern.get(errorPattern);
+        return executor.executeOrDefault(
+                () -> this.checkPatternThrottle(errorPattern),
+                false,
+                TaskContext.of("AlertThrottler", "ShouldSend", errorPattern)
+        );
+    }
 
-        if (lastTime != null) {
-            long secondsSinceLast = now.getEpochSecond() - lastTime.getEpochSecond();
-            if (secondsSinceLast < throttleSeconds) {
-                log.debug("[AlertThrottler] 스로틀링: {} ({}초 후 재전송 가능)",
-                        errorPattern, throttleSeconds - secondsSinceLast);
-                return false;
-            }
+    private boolean checkPatternThrottle(String errorPattern) {
+        long nowEpochSeconds = Instant.now().getEpochSecond();
+        RMap<String, Long> patternTimes = getPatternTimesMap();
+
+        return Optional.ofNullable(patternTimes.get(errorPattern))
+                .map(lastTime -> this.evaluateThrottle(errorPattern, lastTime, nowEpochSeconds, patternTimes))
+                .orElseGet(() -> this.allowAndRecord(errorPattern, nowEpochSeconds, patternTimes));
+    }
+
+    private boolean evaluateThrottle(String pattern, long lastTime, long now, RMap<String, Long> map) {
+        long elapsed = now - lastTime;
+        if (elapsed < throttleSeconds) {
+            log.debug("[AlertThrottler] 스로틀링: {} ({}초 후 재전송 가능)", pattern, throttleSeconds - elapsed);
+            return false;
         }
+        return allowAndRecord(pattern, now, map);
+    }
 
-        lastAlertTimeByPattern.put(errorPattern, now);
+    private boolean allowAndRecord(String pattern, long now, RMap<String, Long> map) {
+        map.put(pattern, now);
         return true;
     }
 
@@ -97,12 +186,20 @@ public class AlertThrottler {
     }
 
     /**
-     * 현재 일일 사용량 조회
+     * 현재 일일 사용량 조회 (Redis 기반)
      *
      * @return 오늘 사용된 AI 호출 수
      */
     public int getDailyUsage() {
-        return dailyAiCallCount.get();
+        return executor.executeOrDefault(
+                this::fetchDailyUsage,
+                0,
+                TaskContext.of("AlertThrottler", "GetUsage")
+        );
+    }
+
+    private int fetchDailyUsage() {
+        return (int) getDailyCounter().get();
     }
 
     /**
@@ -111,16 +208,15 @@ public class AlertThrottler {
      * @return 남은 호출 가능 수
      */
     public int getRemainingCalls() {
-        return Math.max(0, dailyLimit - dailyAiCallCount.get());
+        return Math.max(0, dailyLimit - getDailyUsage());
     }
 
     /**
-     * 스로틀 캐시 정리 (오래된 항목 제거)
+     * 스로틀 캐시 정리 (Redis TTL 기반 자동 만료)
+     * Redis Map은 TTL로 자동 삭제되므로 명시적 정리 불필요
      */
     @Scheduled(fixedRate = 3600000) // 1시간마다
     public void cleanupThrottleCache() {
-        Instant cutoff = Instant.now().minusSeconds(throttleSeconds * 10L);
-        lastAlertTimeByPattern.entrySet().removeIf(entry -> entry.getValue().isBefore(cutoff));
-        log.debug("[AlertThrottler] 스로틀 캐시 정리 완료. 현재 항목 수: {}", lastAlertTimeByPattern.size());
+        log.debug("[AlertThrottler] 스로틀 캐시는 Redis TTL로 자동 관리됨 ({}초)", throttleSeconds * 10);
     }
 }

--- a/src/main/java/maple/expectation/scheduler/ExpectationBatchWriteScheduler.java
+++ b/src/main/java/maple/expectation/scheduler/ExpectationBatchWriteScheduler.java
@@ -37,6 +37,17 @@ import java.util.List;
  *   <li>expectation.buffer.flushed: 플러시된 작업 수</li>
  * </ul>
  *
+ * <h3>Issue #283 P1-10: Scale-out 분산 안전성 분석</h3>
+ * <p>이 스케줄러는 자체적으로 volatile/in-memory shutdown 플래그를 보유하지 않습니다.
+ * Shutdown 상태는 {@link ExpectationWriteBackBuffer#isShuttingDown()}에 위임하며,
+ * 분산 락({@code expectation-batch-sync-lock})으로 다중 인스턴스 간 중복 실행을 방지합니다.</p>
+ * <ul>
+ *   <li>분산 락: {@link LockStrategy}를 통한 Redis 기반 분산 락 사용 -> Scale-out 안전</li>
+ *   <li>Shutdown 플래그: 버퍼에 위임 -> 각 인스턴스가 독립적으로 자신의 shutdown 관리</li>
+ *   <li>@Scheduled: 각 인스턴스에서 독립 실행되나, 분산 락이 한 번에 하나만 flush 허용</li>
+ * </ul>
+ * <p><b>결론: Redis 분산 락 기반으로 이미 Scale-out 안전. 추가 변환 불필요.</b></p>
+ *
  * @see ExpectationWriteBackBuffer 메모리 버퍼
  * @see LikeSyncScheduler 참조 패턴
  */

--- a/src/main/java/maple/expectation/scheduler/OutboxScheduler.java
+++ b/src/main/java/maple/expectation/scheduler/OutboxScheduler.java
@@ -23,10 +23,22 @@ import org.springframework.stereotype.Component;
  * <p>기존: OutboxProcessor.pollAndProcess() 내부에서 호출 (배치 트랜잭션 내 추가 쿼리)</p>
  * <p>수정: 스케줄러에서 독립적으로 호출 (배치 처리 시간 단축)</p>
  *
- * <h3>분산 환경 안전</h3>
- * <p>SKIP LOCKED 쿼리로 분산 락 없이 중복 처리 방지</p>
+ * <h3>분산 환경 안전 (Issue #283 P1-9)</h3>
+ * <p><b>분산 락 미적용 사유</b>: {@link DonationOutboxRepository}의
+ * {@code findPendingWithLock()} 및 {@code findStalledProcessing()} 메서드는
+ * {@code PESSIMISTIC_WRITE} + {@code SKIP LOCKED} 쿼리를 사용하여 DB 레벨에서
+ * 중복 처리를 방지합니다.</p>
+ *
+ * <p><b>SKIP LOCKED 동작 원리</b>:</p>
+ * <ul>
+ *   <li>다중 인스턴스가 동시에 폴링 시, 잠긴 행은 건너뛰고 다음 행 처리</li>
+ *   <li>대기 없이 병렬 처리 가능 (높은 처리량 보장)</li>
+ *   <li>Redis 분산 락 대비 장점: Redis 장애 시에도 독립 동작</li>
+ * </ul>
  *
  * @see OutboxProcessor
+ * @see DonationOutboxRepository#findPendingWithLock
+ * @see DonationOutboxRepository#findStalledProcessing
  */
 @Slf4j
 @Component

--- a/src/main/java/maple/expectation/service/v2/shutdown/EquipmentPersistenceTracker.java
+++ b/src/main/java/maple/expectation/service/v2/shutdown/EquipmentPersistenceTracker.java
@@ -21,6 +21,18 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * <h3>#271 V5 Stateless Architecture</h3>
  * <p>PersistenceTrackerStrategy 인터페이스 구현체 (In-Memory 모드)</p>
  *
+ * <h3>Issue #283 P1-15: Scale-out 분산 안전성</h3>
+ * <p>이 구현체는 {@code @ConditionalOnProperty(name = "app.buffer.redis.enabled", havingValue = "false")}로
+ * In-Memory 모드에서만 활성화됩니다. Scale-out 환경에서는 Redis 구현체
+ * ({@code RedisEquipmentPersistenceTracker})가 대신 로드됩니다.</p>
+ * <ul>
+ *   <li>{@code shutdownInProgress}: AtomicBoolean - 인스턴스 로컬 shutdown 상태.
+ *       각 인스턴스가 독립적으로 자신의 비동기 작업 완료를 대기하므로 분산화 불필요.</li>
+ *   <li>{@code pendingOperations}: ConcurrentHashMap - 이 인스턴스에서 시작된 비동기 작업만 추적.
+ *       CompletableFuture는 본질적으로 로컬이므로 분산화 불가.</li>
+ * </ul>
+ * <p><b>결론: 이미 Strategy 패턴으로 In-Memory/Redis 분리 완료. 추가 변환 불필요.</b></p>
+ *
  * @see PersistenceTrackerStrategy 전략 인터페이스
  * @see maple.expectation.global.queue.persistence.RedisEquipmentPersistenceTracker Redis 구현체
  */

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -348,6 +348,7 @@ ai:
     enabled: ${AI_SRE_ENABLED:false}  # 기본 비활성화 (prod에서 true)
     daily-limit: 100  # [P0-Green] 일일 LLM 호출 한도
     throttle-seconds: 60  # 동일 에러 패턴 스로틀링 간격
+    max-concurrent-threads: 10  # Issue #283 P0-5: 동시 LLM 호출 최대 개수
 
 # Spring Batch 설정 - spring.batch는 상단 spring: 블록에 병합됨
 

--- a/src/test/java/maple/expectation/support/AbstractContainerBaseTest.java
+++ b/src/test/java/maple/expectation/support/AbstractContainerBaseTest.java
@@ -96,6 +96,13 @@ public abstract class AbstractContainerBaseTest {
             // Best-effort: 정리 실패 시 로그만 남기고 계속 진행
             System.err.println("[globalProxyReset] Cleanup failed (best-effort): " + e.getMessage());
         }
+
+        // 3. Redis 데이터 초기화 (Proxy 복구 후 실행하여 연결 확보)
+        try {
+            REDIS.execInContainer("redis-cli", "FLUSHDB");
+        } catch (Exception e) {
+            System.err.println("[globalProxyReset] Redis FLUSHDB failed (best-effort): " + e.getMessage());
+        }
     }
 
     /**

--- a/src/test/java/maple/expectation/support/SimpleRedisContainerBase.java
+++ b/src/test/java/maple/expectation/support/SimpleRedisContainerBase.java
@@ -1,7 +1,10 @@
 package maple.expectation.support;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+
+import java.io.IOException;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.GenericContainer;
@@ -71,6 +74,21 @@ public abstract class SimpleRedisContainerBase {
     static {
         // 병렬 시작으로 컨테이너 초기화 시간 단축
         Startables.deepStart(Stream.of(MYSQL, REDIS)).join();
+    }
+
+    /**
+     * 테스트 간 데이터 격리를 위한 Redis 초기화
+     *
+     * <p>Singleton Container 패턴에서 테스트 간 데이터 누수를 방지합니다.
+     * 서브클래스에서 override하여 추가 정리 로직(DB cleanup 등)을 수행할 수 있습니다.
+     */
+    @AfterEach
+    protected void cleanupTestData() {
+        try {
+            REDIS.execInContainer("redis-cli", "FLUSHDB");
+        } catch (IOException | InterruptedException e) {
+            System.err.println("[cleanupTestData] Redis FLUSHDB failed (best-effort): " + e.getMessage());
+        }
     }
 
     @DynamicPropertySource


### PR DESCRIPTION
## 관련 이슈
#283

## 개요
Scale-out 조건부 빈 로딩 Sprint 2+3 완료. P0 8개 + P1 14개 = 22개 항목 중 Sprint 1(PR #301)에서 처리된 인프라 기반 위에, 나머지 전체 Stateful 컴포넌트의 분산 전환 및 안전성 문서화를 완료합니다.

## 작업 내용

### P0 — 분산 상태 전환 (6개)
- [x] **P0-1**: AlertThrottler → Redis `RAtomicLong` + `RMap` 기반 분산 스로틀링
- [x] **P0-4**: `DistributedSingleFlightService` 신규 생성 (Redis Lock + Cache 패턴)
- [x] **P0-5**: ExecutorConfig `aiTaskExecutor` Semaphore 동시성 제한
- [x] **P0-6**: LoggingAspect shutdown guard 추가
- [x] **P0-7**: CompensationLogService `HOSTNAME + UUID` 기반 unique instanceId
- [x] **P0-8**: DynamicTTLManager → `lockStrategy.executeWithLock()` 전환

### P1 — 분산 락 + 문서화 (8개)
- [x] **P1-7**: BufferRecoveryScheduler 분산 락 적용 (waitTime=0, leaseTime=30/60)
- [x] **P1-8**: LikeSyncScheduler `@Nullable` 생성자 주입 전환
- [x] **P1-9**: OutboxScheduler `SKIP LOCKED` Javadoc
- [x] **P1-10~17**: Instance-local 상태 안전성 Javadoc 문서화 (7개 파일)

### 테스트 안정화
- [x] `@AfterEach` Redis FLUSHDB + DB TRUNCATE 데이터 초기화 (Singleton Container Flaky 방지)
- [x] `AlertThrottlerTest` Mock 기반 전면 재작성 (Redis 의존 제거)
- [x] `LikeSyncSchedulerTest` 생성자 주입 반영 + 파티션 Flush 검증 추가

## 리뷰 포인트
1. **AlertThrottler Redis 전환** — `{ai-throttle}:daily-count:YYYY-MM-DD` 키 구조, TTL 25시간
2. **DynamicTTLManager** — 기존 RLock 직접 사용 → LockStrategy 위임으로 단순화
3. **BufferRecoveryScheduler** — `waitTime=0` 전략 (락 획득 실패 시 스킵)
4. **테스트 데이터 초기화** — `INFORMATION_SCHEMA.TABLES` 기반 동적 TRUNCATE

## 트레이드 오프 결정 근거
- **P1-10~17 Javadoc만 추가**: `volatile boolean running`, `AtomicLong` 등 SmartLifecycle/인스턴스별 상태는 Redis 전환 불필요. Scale-out 시 각 인스턴스가 독립적으로 관리하는 것이 올바른 설계
- **DistributedSingleFlightService**: 기존 `SingleFlightExecutor`는 Caffeine 기반 로컬 중복 방지. 분산 환경에서는 Redis Lock + Cache 기반 `DistributedSingleFlightService`로 보완
- **테스트 @AfterEach 초기화**: Testcontainers는 이미 Singleton 패턴. 컨텍스트 재사용 시 데이터 잔존 방지를 위해 각 테스트 후 Redis/DB 초기화

## 체크리스트
- [x] 브랜치/커밋 규칙 준수 여부
- [x] 테스트 통과 여부 (661 tests, 0 new failures)
- [x] CLAUDE.md Section 6 (생성자 주입), Section 12 (LogicExecutor) 준수
- [x] Redis Hash Tag `{ai-throttle}` Cluster 호환 (Section 8-1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)