### PR TITLE
feat: Add ChatGPT integration and AI-powered incident analysis

### DIFF
--- a/src/main/java/maple/expectation/config/LockHikariConfig.java
+++ b/src/main/java/maple/expectation/config/LockHikariConfig.java
@@ -44,8 +44,9 @@ public class LockHikariConfig {
     @Autowired
     private MeterRegistry meterRegistry;
 
-    // Issue #284 DoD: Pool Size 외부화 (기본 30, prod에서 150으로 오버라이드)
-    @Value("${lock.datasource.pool-size:30}")
+    // Issue #284 DoD: Pool Size 외부화 (기본 40, prod에서 150으로 오버라이드)
+    // AI SRE 제안 (INC-29506518): Lock Pool 병목 방지를 위해 최댓값 증가
+    @Value("${lock.datasource.pool-size:40}")
     private int poolSize;
 
     @Bean(name = "lockDataSource")

--- a/src/main/java/maple/expectation/monitoring/ai/AiSreService.java
+++ b/src/main/java/maple/expectation/monitoring/ai/AiSreService.java
@@ -623,8 +623,25 @@ public class AiSreService {
      * JSON 응답 파싱 (간단 구현)
      */
     private MitigationPlan parseMitigationPlanJson(String jsonResponse, String incidentId) {
-        // 실제 구현에서는 Jackson ObjectMapper 사용 권장
-        // 여기서는 간단한 텍스트 파싱으로 대체
+        // Markdown 코드 블록 제거 (ChatGPT가 ```json ... ```으로 감싼는 경우 대응)
+        String cleanedResponse = jsonResponse;
+        if (cleanedResponse.contains("```")) {
+            // 첫 번째 ``` 이후부터 마지막 ``` 이전까지 추출
+            int firstBacktick = cleanedResponse.indexOf("```");
+            if (firstBacktick != -1) {
+                // 첫 번째 라인 끝나는 개행 문자 찾기
+                int newlineAfterFirstBlock = cleanedResponse.indexOf("\n", firstBacktick);
+                if (newlineAfterFirstBlock != -1) {
+                    cleanedResponse = cleanedResponse.substring(newlineAfterFirstBlock + 1);
+                }
+
+                // 마지막 ``` 제거
+                int lastBacktick = cleanedResponse.lastIndexOf("```");
+                if (lastBacktick != -1) {
+                    cleanedResponse = cleanedResponse.substring(0, lastBacktick);
+                }
+            }
+        }
 
         try {
             // Jackson ObjectMapper로 파싱 (가장 안전한 방식)
@@ -632,7 +649,7 @@ public class AiSreService {
                     new com.fasterxml.jackson.databind.ObjectMapper();
 
             // JSON에서 레코드로 변환을 위한 TypeReference
-            var planNode = mapper.readTree(jsonResponse);
+            var planNode = mapper.readTree(cleanedResponse);
 
             // hypotheses 파싱
             List<Hypothesis> hypotheses = mapper.convertValue(

--- a/src/main/java/maple/expectation/monitoring/ai/config/OpenAIConfiguration.java
+++ b/src/main/java/maple/expectation/monitoring/ai/config/OpenAIConfiguration.java
@@ -1,0 +1,77 @@
+package maple.expectation.monitoring.ai.config;
+
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+/**
+ * OpenAI GPT Configuration for AI SRE (Issue #251)
+ *
+ * <h3>OpenAI API</h3>
+ * <ul>
+ *   <li>Base URL: https://api.openai.com/v1</li>
+ *   <li>Model: gpt-4o-mini (default) or gpt-4o</li>
+ *   <li>Protocol: OpenAI Chat Completions API</li>
+ * </ul>
+ *
+ * <h4>LangChain4j Integration</h4>
+ * <pre>
+ * OpenAiChatModel.builder()
+ *     .apiKey("${OPENAI_API_KEY}")
+ *     .modelName("gpt-4o-mini")
+ *     .timeout(60s)
+ *     .build()
+ * </pre>
+ *
+ * @see <a href="https://platform.openai.com/docs/api-reference/chat/create">OpenAI API Reference</a>
+ */
+@Slf4j
+@Configuration
+@ConditionalOnProperty(name = "ai.sre.enabled", havingValue = "true")
+public class OpenAIConfiguration {
+
+    @Value("${langchain4j.open-ai.chat-model.api-key:}")
+    private String apiKey;
+
+    @Value("${langchain4j.open-ai.chat-model.model-name:gpt-4o-mini}")
+    private String modelName;
+
+    @Value("${langchain4j.open-ai.chat-model.timeout:60s}")
+    private String timeout;
+
+    @Value("${langchain4j.open-ai.chat-model.log-requests:false}")
+    private boolean logRequests;
+
+    @Value("${langchain4j.open-ai.chat-model.log-responses:false}")
+    private boolean logResponses;
+
+    /**
+     * OpenAI GPT ChatLanguageModel (Primary)
+     *
+     * <p>OpenAI의 GPT-4o-mini 모델을 사용합니다.</p>
+     *
+     * <p><strong>주의:</strong> API 키가 미설정이면 빈 문자열로 초기화되며,
+     * AiSreService의 Fallback 체인으로 연결됩니다.</p>
+     *
+     * @return OpenAI GPT ChatLanguageModel
+     */
+    @Bean
+    @Primary
+    @ConditionalOnProperty(name = "langchain4j.open-ai.chat-model.api-key", matchIfMissing = false)
+    public ChatLanguageModel openAIChatModel() {
+        log.info("[OpenAI] GPT 모델 초기화: model={}", modelName);
+
+        return OpenAiChatModel.builder()
+                .apiKey(apiKey)
+                .modelName(modelName)
+                .timeout(java.time.Duration.parse("PT" + timeout))
+                .logRequests(logRequests)
+                .logResponses(logResponses)
+                .build();
+    }
+}


### PR DESCRIPTION
## 요약
ChatGPT(GPT-4o-mini) 기반 AI SRE 기능을 추가하여 인시던트 분석과 자동 완화 제안을 제공합니다.

## 주요 변경사항

### 1. OpenAI 통합
- **OpenAIConfiguration.java**: GPT-4o-mini 모델 지원 추가
- ZAiConfiguration 비활성화 (잔액 부족 문제)
- 환경 변수로 API 키 설정 (`OPENAI_API_KEY`)

### 2. AI SRE 서비스 개선
- **AiSreService.java Markdown 파싱 수정**: ChatGPT가 `````json 코드 블록으로 감싼 응답 처리
- 변수명 버그 수정 (`newlineAfterBlock` → `newlineAfterFirstBlock`)
- 인시던트 분석 후 Hypotheses, Actions, Clarifying Questions 반환

### 3. Discord 알림
- AI가 생성한 가설(Hypotheses)과 행동 계획(Actions)을 Discord로 실시간 전송
- 환경 변수로 Webhook URL 설정 (`DISCORD_WEBHOOK_URL`)

### 4. MySQL Lock Pool 최적화
- AI SRE 권장에 따라 Pool Size 증가: 30 → 40
- Lock Pool 병목 방지

### 5. 인시던트 중복 방지
- Deduplication 윈도우: 5분 (과도한 알림 방지)

## 테스트 결과
- ✅ OpenAI 초기화 성공
- ✅ ChatGPT가 실시간 인시던트 분석 (confidence: HIGH)
- ✅ Discord webhook 정상 작동
- ✅ Markdown JSON 파싱 정상 작동

## 기술 스택
- Java 21
- Spring Boot 3.5.4
- LangChain4j
- OpenAI GPT-4o-mini
- Discord Webhook

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>