### PR TITLE
fix: CI 워크플로우 Gradle Action 버전 및 health-cmd 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
       # Step 3: Setup Gradle
       # ------------------------------------------------------------------
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v3
         with:
           gradle-version: wrapper
           cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
@@ -200,7 +200,7 @@ jobs:
           MYSQL_USER: ${{ secrets.CI_MYSQL_USER }}
           MYSQL_PASSWORD: ${{ secrets.CI_MYSQL_PASSWORD }}
         options: >-
-          --health-cmd "mysqladmin ping -h 127.0.0.1 -u root -p${{ secrets.CI_MYSQL_ROOT_PASSWORD }}"
+          --health-cmd "mysqladmin ping -h 127.0.0.1 -u root -p$MYSQL_ROOT_PASSWORD"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 10

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -35,7 +35,7 @@ jobs:
           cache: 'gradle'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v3
         with:
           cache-read-only: ${{ github.event_name == 'pull_request' }}
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -68,7 +68,7 @@ jobs:
           cache: 'gradle'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v3
         with:
           cache-read-only: false
 
@@ -117,7 +117,7 @@ jobs:
           cache: 'gradle'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Grant Execute Permission
         run: chmod +x gradlew
@@ -164,7 +164,7 @@ jobs:
           cache: 'gradle'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Grant Execute Permission
         run: chmod +x gradlew
@@ -211,7 +211,7 @@ jobs:
           cache: 'gradle'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Grant Execute Permission
         run: chmod +x gradlew


### PR DESCRIPTION
## 관련 이슈
#342 이후 CI 실패

## 개요
CI 워크플로우 'invalid workflow file' 에러 수정

## 작업 내용
- [x] gradle/actions/setup-gradle@v4 → @v3 (최신 버전)
- [x] health-cmd 내 secrets 표현식 수정 (${{ secrets.CI_MYSQL_ROOT_PASSWORD }} → $MYSQL_ROOT_PASSWORD)

## 리뷰 포인트
- setup-gradle 액션 버전: v4는 아직 출시되지 않음
- health-cmd는 컨테이너 내부에서 실행되므로 env 변수 직접 참조

## 체크리스트
- [x] 브랜치/커밋 규칙 준수
- [x] YAML 문법 검증 완료