### PR TITLE
docs: 포트폴리오 다이어그램 TD+LR 혼합 레이아웃 적용

### DIFF
--- a/docs/05_Reports/PORTFOLIO_TECHNICAL_DEEP_DIVE.md
+++ b/docs/05_Reports/PORTFOLIO_TECHNICAL_DEEP_DIVE.md
@@ -24,32 +24,33 @@
 ### 아키텍처 다이어그램
 
 ```mermaid
-flowchart TB
+flowchart TD
+    subgraph Analysis["EXPLAIN 분석 결과"]
+        direction LR
+        TYPE["type: ALL → ref"]
+        ROWS["rows: 1.2M → 847"]
+        KEY["key: NULL → idx_equipment_search"]
+    end
+
     subgraph Before["Before: Full Table Scan"]
-        Q1[Query: SELECT * FROM equipment] --> SCAN[Full Table Scan<br/>1.2M rows]
-        SCAN --> FILTER[WHERE 조건 필터링]
-        FILTER --> RESULT1[결과 반환<br/>0.98s]
+        direction LR
+        B1["SELECT * FROM equipment"] --> B2["Full Scan<br/>1.2M rows"]
+        B2 --> B3["0.98s"]
     end
 
     subgraph After["After: Composite Index"]
-        Q2[Query: SELECT * FROM equipment] --> IDX[Composite Index<br/>idx_equipment_search]
-        IDX --> SEEK[Index Seek]
-        SEEK --> RESULT2[결과 반환<br/>20ms]
+        direction LR
+        A1["SELECT * FROM equipment"] --> A2["Index Seek<br/>847 rows"]
+        A2 --> A3["20ms"]
     end
 
-    subgraph EXPLAIN["EXPLAIN 분석"]
-        ANALYZE[EXPLAIN SELECT...] --> TYPE[type: ALL → ref]
-        ANALYZE --> ROWS[rows: 1.2M → 847]
-        ANALYZE --> KEY[key: NULL → idx_equipment_search]
-    end
+    Before --> Analysis
+    Analysis --> After
 
-    Before --> EXPLAIN
-    EXPLAIN --> After
-
-    style SCAN fill:#FF5722,color:white
-    style IDX fill:#4CAF50,color:white
-    style RESULT1 fill:#F44336,color:white
-    style RESULT2 fill:#2196F3,color:white
+    style B2 fill:#FF5722,color:white
+    style B3 fill:#F44336,color:white
+    style A2 fill:#4CAF50,color:white
+    style A3 fill:#2196F3,color:white
 ```
 
 ### 문제 (Problem)
@@ -210,30 +211,38 @@ Cache Hit Rate >99% 달성, Chaos Test N01에서 DB Query Ratio 0.3% 유지.
 ### 아키텍처 다이어그램
 
 ```mermaid
-flowchart TB
+flowchart TD
     subgraph Before["Before: 환경 불일치"]
+        direction LR
         LOCAL[로컬: H2 DB] --> TEST1[테스트 통과]
         CI[CI: MySQL 5.7] --> TEST2[테스트 실패]
         TEST2 --> FLAKY[Flaky Tests<br/>47건 발생]
     end
 
     subgraph After["After: Testcontainers 표준화"]
-        TC[Testcontainers<br/>MySQL 8.0 Container] --> LOCAL2[로컬 테스트]
+        direction LR
+        TC[Testcontainers<br/>MySQL 8.0] --> LOCAL2[로컬 테스트]
         TC --> CI2[CI 테스트]
-        LOCAL2 --> PASS[모든 환경 동일 결과]
+        LOCAL2 --> PASS[모든 환경<br/>동일 결과]
         CI2 --> PASS
+    end
+
+    subgraph Result["결과"]
+        direction LR
         PASS --> STABLE[Flaky Tests 0건<br/>CI Pass Rate 99.7%]
     end
 
     subgraph Container["Container Lifecycle"]
+        direction LR
         START[컨테이너 시작] --> REUSE[싱글톤 재사용]
-        REUSE --> TESTS[498개 테스트 실행]
+        REUSE --> TESTS[498개 테스트]
         TESTS --> CLEAN[데이터 정리]
         CLEAN --> REUSE
     end
 
     Before --> After
-    After --> Container
+    After --> Result
+    Result --> Container
 
     style FLAKY fill:#F44336,color:white
     style STABLE fill:#4CAF50,color:white
@@ -485,46 +494,41 @@ class OutboxPoller(
 ### 아키텍처 다이어그램
 
 ```mermaid
-flowchart TB
+flowchart TD
     subgraph Client["클라이언트"]
+        direction LR
         REQ[락 요청]
     end
 
     subgraph Tier0["Tier 0: ResilientLockStrategy"]
-        RLS[ResilientLockStrategy]
-        CB[Circuit Breaker]
-        FH[Fallback Handler]
+        direction LR
+        RLS[ResilientLockStrategy] --> CB[Circuit Breaker]
+        CB --> FH[Fallback Handler]
     end
 
     subgraph Tier1["Tier 1: Redis (Primary)"]
-        RDS[RedisDistributedLockStrategy]
-        RL[Redisson RLock]
-        WD[Watchdog 자동 갱신]
+        direction LR
+        RDS[RedisDistributedLockStrategy] --> RL[Redisson RLock]
+        RL --> WD[Watchdog 자동 갱신]
     end
 
     subgraph Tier2["Tier 2: MySQL (Fallback)"]
-        MLS[MySqlNamedLockStrategy]
-        GL[GET_LOCK / RELEASE_LOCK]
+        direction LR
+        MLS[MySqlNamedLockStrategy] --> GL[GET_LOCK / RELEASE_LOCK]
     end
 
     subgraph AI["AI SRE 자율 루프"]
-        DETECT[장애 감지<br/>MTTD 30s]
-        CLASSIFY[예외 분류]
-        MITIGATE[자동 완화<br/>MTTR 2min]
+        direction LR
+        DETECT[장애 감지<br/>MTTD 30s] --> CLASSIFY[예외 분류]
+        CLASSIFY --> MITIGATE[자동 완화<br/>MTTR 2min]
     end
 
     REQ --> RLS
-    RLS --> CB
     CB -->|정상| RDS
     CB -->|OPEN/실패| FH
-    RDS --> RL
-    RL --> WD
     FH --> MLS
-    MLS --> GL
 
     RLS -.->|메트릭| DETECT
-    DETECT --> CLASSIFY
-    CLASSIFY --> MITIGATE
     MITIGATE -.->|Pool 확장| MLS
 
     style RLS fill:#4CAF50,color:white


### PR DESCRIPTION
## 관련 이슈
- 포트폴리오 문서 가독성 개선

## 개요
포트폴리오 문서의 Mermaid 다이어그램에 TD+LR 혼합 레이아웃을 적용하여 16:9 비율 최적화

## 작업 내용
- [x] Testcontainers 다이어그램: TB → TD+LR 서브그래프 구조로 변경
- [x] ResilientLockStrategy 다이어그램: TB → TD+LR 서브그래프 구조로 변경
- [x] MySQL 다이어그램: 이미 TD+LR 적용됨 (이전 커밋)

## 리뷰 포인트
- `flowchart TD` 메인 흐름 + `direction LR` 서브그래프 조합으로 가로형 레이아웃 구현
- 16:9 화면 비율에서 가독성 향상

## 트레이드 오프 결정 근거
- sequenceDiagram과 mindmap은 고유 레이아웃 규칙이 있어 변경하지 않음
- flowchart만 TD+LR 패턴 적용

## 체크리스트
- [x] 브랜치/커밋 규칙 준수 여부
- [x] Spotless 포맷팅 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)