### PR TITLE
fix: Kotlin nullable receiver 컴파일 에러 수정

### DIFF
--- a/module-app/src/main/kotlin/maple/expectation/dto/CubeCalculationInput.kt
+++ b/module-app/src/main/kotlin/maple/expectation/dto/CubeCalculationInput.kt
@@ -136,7 +136,7 @@ data class CubeCalculationInput(
 
         // 3. 옵션 내용 체크: 전부 null이거나 빈 문자열이면 계산 불가
         return options.any { opt ->
-            opt.trim().isNotEmpty() && !"null".equals(opt, ignoreCase = true)
+            opt?.trim()?.isNotEmpty() == true && !"null".equals(opt, ignoreCase = true)
         }
     }
 


### PR DESCRIPTION
## 관련 이슈
검증 작업 중 발견된 P0 CRITICAL 이슈 수정

## 개요
`CubeCalculationInput.kt`에서 nullable receiver로 인한 Kotlin 컴파일 에러 수정

## 작업 내용
- [x] `opt.trim().isNotEmpty()` → `opt?.trim()?.isNotEmpty() == true` 변경
- [x] 컴파일 검증 완료

## 변경 전
```kotlin
return options.any { opt ->
    opt.trim().isNotEmpty() && !"null".equals(opt, ignoreCase = true)
}
```

## 변경 후
```kotlin
return options.any { opt ->
    opt?.trim()?.isNotEmpty() == true && !"null".equals(opt, ignoreCase = true)
}
```

## 검증 결과
```
./gradlew :module-app:compileKotlin
BUILD SUCCESSFUL in 1m 23s
```

## 체크리스트
- [x] 브랜치/커밋 규칙 준수 여부
- [x] 컴파일 통과 여부

🤖 Generated with [Claude Code](https://claude.com/claude-code)