### PR TITLE
refactor: ADR-003 OcidReader 헥사고날 아키텍처 리팩토링

### DIFF
--- a/module-app/src/main/java/maple/expectation/batch/reader/OcidReader.java
+++ b/module-app/src/main/java/maple/expectation/batch/reader/OcidReader.java
@@ -3,16 +3,14 @@ package maple.expectation.batch.reader;
 import java.util.Iterator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import maple.expectation.core.domain.model.Page;
+import maple.expectation.core.domain.model.PageRequest;
+import maple.expectation.core.port.out.OcidQueryPort;
 import maple.expectation.infrastructure.executor.LogicExecutor;
 import maple.expectation.infrastructure.executor.TaskContext;
-import maple.expectation.infrastructure.persistence.entity.GameCharacterJpaEntity;
-import maple.expectation.infrastructure.persistence.jpa.GameCharacterJpaRepository;
 import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.core.annotation.BeforeStep;
 import org.springframework.batch.item.ItemReader;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 /**
@@ -32,17 +30,16 @@ import org.springframework.stereotype.Component;
  *   <li>Section 12: LogicExecutor.executeOrDefault (Zero Try-Catch)
  *   <li>Section 15: 람다 3줄 초과 시 Private Method 추출
  *   <li>Stateless: Iterator 사용, 상태 저장 최소화
- *   <li>Method Reference: GameCharacterJpaEntity::getOcid
  * </ul>
  *
- * @see maple.expectation.infrastructure.persistence.jpa.GameCharacterJpaRepository
+ * @see maple.expectation.core.port.out.OcidQueryPort
  */
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class OcidReader implements ItemReader<String> {
 
-  private final GameCharacterJpaRepository repository;
+  private final OcidQueryPort ocidQuery;
   private final LogicExecutor executor;
 
   // Chunk-based fetch for memory efficiency
@@ -96,19 +93,18 @@ public class OcidReader implements ItemReader<String> {
   }
 
   /**
-   * Fetch next chunk of OCIDs using JPA pagination
+   * Fetch next chunk of OCIDs using OcidQueryPort
    *
    * <p>Section 15: 람다 3줄 초과 시 Private Method 추출
    */
   private void fetchNextChunk() {
-    Pageable pageable = PageRequest.of(currentPage, FETCH_SIZE);
-    Page<GameCharacterJpaEntity> page = repository.findAll(pageable);
+    PageRequest pageRequest = PageRequest.Companion.of(currentPage, FETCH_SIZE);
+    Page<String> page = ocidQuery.findAllOcids(pageRequest);
 
-    hasNextPage = page.hasNext();
+    hasNextPage = page.getHasNext();
     currentPage++;
 
-    // Method Reference: GameCharacterJpaEntity::getOcid
-    ocidIterator = page.getContent().stream().map(GameCharacterJpaEntity::getOcid).iterator();
+    ocidIterator = page.getContent().iterator();
 
     log.debug("[OcidReader] Fetched chunk: page={}, hasMore={}", currentPage, hasNextPage);
   }

--- a/module-app/src/test/java/maple/expectation/batch/reader/OcidReaderTest.java
+++ b/module-app/src/test/java/maple/expectation/batch/reader/OcidReaderTest.java
@@ -10,10 +10,11 @@ import static org.mockito.Mockito.when;
 import java.util.ArrayList;
 import java.util.List;
 import maple.expectation.common.function.ThrowingSupplier;
+import maple.expectation.core.domain.model.Page;
+import maple.expectation.core.domain.model.PageRequest;
+import maple.expectation.core.port.out.OcidQueryPort;
 import maple.expectation.infrastructure.executor.LogicExecutor;
 import maple.expectation.infrastructure.executor.TaskContext;
-import maple.expectation.infrastructure.persistence.entity.GameCharacterJpaEntity;
-import maple.expectation.infrastructure.persistence.jpa.GameCharacterJpaRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -22,10 +23,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.batch.core.StepExecution;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
 
 /**
  * OcidReader 단위 테스트
@@ -38,7 +35,7 @@ class OcidReaderTest {
 
   private static final int FETCH_SIZE = 1000;
 
-  @Mock private GameCharacterJpaRepository repository;
+  @Mock private OcidQueryPort ocidQuery;
   @Mock private LogicExecutor executor;
   @Mock private StepExecution stepExecution;
 
@@ -46,7 +43,7 @@ class OcidReaderTest {
 
   @BeforeEach
   void setUp() {
-    reader = new OcidReader(repository, executor);
+    reader = new OcidReader(ocidQuery, executor);
     lenient().when(stepExecution.getJobExecutionId()).thenReturn(1L);
   }
 
@@ -58,11 +55,11 @@ class OcidReaderTest {
     @DisplayName("마지막 페이지 OCID가 모두 반환되어야 함 (2500개: 1000, 1000, 500)")
     void lastPageOcids_ShouldAllBeReturned() {
       // Given: 총 2500개 OCID (3페이지: 1000, 1000, 500)
-      when(repository.findAll(any(PageRequest.class)))
+      when(ocidQuery.findAllOcids(any(PageRequest.class)))
           .thenReturn(createPage(0, 1000, true))
           .thenReturn(createPage(1, 1000, true))
           .thenReturn(createPage(2, 500, false))
-          .thenReturn(new PageImpl<>(List.of())); // Empty page after all data consumed
+          .thenReturn(createEmptyPage()); // Empty page after all data consumed
 
       when(executor.executeOrDefault(any(), any(), any(TaskContext.class)))
           .thenAnswer(
@@ -87,20 +84,20 @@ class OcidReaderTest {
       // Then: 2500개 OCID 모두 반환됨 (마지막 500개 포함)
       assertThat(ocids).hasSize(2500);
       // Page 0, 1, 2 fetched + 1 empty page after exhaustion = 4 calls total
-      verify(repository, times(4)).findAll(any(PageRequest.class));
-      verify(repository).findAll(PageRequest.of(0, FETCH_SIZE));
-      verify(repository).findAll(PageRequest.of(1, FETCH_SIZE));
-      verify(repository).findAll(PageRequest.of(2, FETCH_SIZE));
-      verify(repository).findAll(PageRequest.of(3, FETCH_SIZE));
+      verify(ocidQuery, times(4)).findAllOcids(any(PageRequest.class));
+      verify(ocidQuery).findAllOcids(PageRequest.Companion.of(0, FETCH_SIZE));
+      verify(ocidQuery).findAllOcids(PageRequest.Companion.of(1, FETCH_SIZE));
+      verify(ocidQuery).findAllOcids(PageRequest.Companion.of(2, FETCH_SIZE));
+      verify(ocidQuery).findAllOcids(PageRequest.Companion.of(3, FETCH_SIZE));
     }
 
     @Test
     @DisplayName("정확히 한 페이지 분량의 데이터가 있을 때 모두 반환되어야 함")
     void exactOnePage_ShouldReturnAllOcids() {
       // Given: 정확히 1000개 OCID (1페이지)
-      when(repository.findAll(any(PageRequest.class)))
+      when(ocidQuery.findAllOcids(any(PageRequest.class)))
           .thenReturn(createPage(0, 1000, false))
-          .thenReturn(new PageImpl<>(List.of())); // Empty page after all data consumed
+          .thenReturn(createEmptyPage()); // Empty page after all data consumed
 
       when(executor.executeOrDefault(any(), any(), any(TaskContext.class)))
           .thenAnswer(
@@ -125,16 +122,16 @@ class OcidReaderTest {
       // Then: 1000개 OCID 모두 반환됨
       assertThat(ocids).hasSize(1000);
       // Page 0 fetched + 1 empty page after exhaustion = 2 calls total
-      verify(repository, times(2)).findAll(any(PageRequest.class));
-      verify(repository).findAll(PageRequest.of(0, FETCH_SIZE));
-      verify(repository).findAll(PageRequest.of(1, FETCH_SIZE));
+      verify(ocidQuery, times(2)).findAllOcids(any(PageRequest.class));
+      verify(ocidQuery).findAllOcids(PageRequest.Companion.of(0, FETCH_SIZE));
+      verify(ocidQuery).findAllOcids(PageRequest.Companion.of(1, FETCH_SIZE));
     }
 
     @Test
     @DisplayName("데이터가 없을 때 null을 반환해야 함")
     void noData_ShouldReturnNull() {
       // Given: 빈 페이지
-      when(repository.findAll(any(PageRequest.class))).thenReturn(new PageImpl<>(List.of()));
+      when(ocidQuery.findAllOcids(any(PageRequest.class))).thenReturn(createEmptyPage());
 
       when(executor.executeOrDefault(any(), any(), any(TaskContext.class)))
           .thenAnswer(
@@ -164,9 +161,9 @@ class OcidReaderTest {
     @DisplayName("@BeforeStep에서 상태가 초기화되어야 함")
     void beforeStep_ShouldInitializeState() {
       // Given: 이전 실행으로 상태가 변경됨
-      when(repository.findAll(any(PageRequest.class)))
+      when(ocidQuery.findAllOcids(any(PageRequest.class)))
           .thenReturn(createPage(0, 1000, false))
-          .thenReturn(new PageImpl<>(List.of())); // Empty page after all data consumed
+          .thenReturn(createEmptyPage()); // Empty page after all data consumed
 
       when(executor.executeOrDefault(any(), any(), any(TaskContext.class)))
           .thenAnswer(
@@ -190,9 +187,9 @@ class OcidReaderTest {
 
       // When: @BeforeStep 호출 (새로운 mock 설정 필요)
       // 상태 초기화 후 다시 읽을 때 새로운 데이터 반환하도록 mock 재설정
-      when(repository.findAll(any(PageRequest.class)))
+      when(ocidQuery.findAllOcids(any(PageRequest.class)))
           .thenReturn(createPage(0, 1000, false))
-          .thenReturn(new PageImpl<>(List.of())) // 첫 실행의 두 번째 호출
+          .thenReturn(createEmptyPage()) // 첫 실행의 두 번째 호출
           .thenReturn(createPage(0, 100, false)); // 초기화 후 다시 읽을 때
 
       reader.initializeState(stepExecution);
@@ -206,11 +203,11 @@ class OcidReaderTest {
     @DisplayName("초기화 없이 재실행하면 데이터 누락 발생")
     void reexecuteWithoutInitialization_ShouldMissData() {
       // Given: 2500개 OCID (3페이지)
-      when(repository.findAll(any(PageRequest.class)))
+      when(ocidQuery.findAllOcids(any(PageRequest.class)))
           .thenReturn(createPage(0, 1000, true))
           .thenReturn(createPage(1, 1000, true))
           .thenReturn(createPage(2, 500, false))
-          .thenReturn(new PageImpl<>(List.of())); // Empty page after all data consumed
+          .thenReturn(createEmptyPage()); // Empty page after all data consumed
 
       when(executor.executeOrDefault(any(), any(), any(TaskContext.class)))
           .thenAnswer(
@@ -247,22 +244,20 @@ class OcidReaderTest {
 
   // ==================== Helper Methods ====================
 
-  private Page<GameCharacterJpaEntity> createPage(int pageNumber, int size, boolean hasNext) {
-    List<GameCharacterJpaEntity> entities = new ArrayList<>();
+  private Page<String> createPage(int pageNumber, int size, boolean hasNext) {
+    List<String> ocids = new ArrayList<>();
     long startOcid = (long) pageNumber * FETCH_SIZE;
 
     for (long i = 0; i < size; i++) {
-      String ocid = "ocid-" + (startOcid + i);
-      GameCharacterJpaEntity entity =
-          new GameCharacterJpaEntity(
-              maple.expectation.domain.model.character.UserIgn.of("testUser"),
-              maple.expectation.domain.model.character.CharacterId.of(ocid));
-      entities.add(entity);
+      ocids.add("ocid-" + (startOcid + i));
     }
 
-    return new PageImpl<>(
-        entities,
-        PageRequest.of(pageNumber, FETCH_SIZE, Sort.unsorted()),
-        hasNext ? (pageNumber + 1) * FETCH_SIZE + 1 : (long) pageNumber * FETCH_SIZE + size);
+    long totalElements =
+        hasNext ? (pageNumber + 1) * FETCH_SIZE + 1 : (long) pageNumber * FETCH_SIZE + size;
+    return new Page<>(ocids, pageNumber, FETCH_SIZE, totalElements, hasNext);
+  }
+
+  private Page<String> createEmptyPage() {
+    return new Page<>(List.of(), 0, 0, 0, false);
   }
 }

--- a/module-core/src/main/kotlin/maple/expectation/core/domain/model/Page.kt
+++ b/module-core/src/main/kotlin/maple/expectation/core/domain/model/Page.kt
@@ -1,0 +1,96 @@
+package maple.expectation.core.domain.model
+
+/**
+ * 간단한 페이지네이션 결과 컨테이너
+ *
+ * <p>Spring Data의 Page/Pageable 의존성을 제거하기 위한 순수 도메인 타입입니다.
+ * module-core는 Spring Framework에 의존하지 않도록 설계되었습니다 (ADR-017).
+ *
+ * @property T 페이지에 포함될 요소의 타입
+ * @property content 현재 페이지의 컨텐츠 목록
+ * @property pageNumber 현재 페이지 번호 (0-based)
+ * @property pageSize 페이지 크기
+ * @property totalElements 전체 요소 개수
+ * @property hasNext 다음 페이지가 존재하는지 여부
+ */
+data class Page<T>(
+    val content: List<T>,
+    val pageNumber: Int,
+    val pageSize: Int,
+    val totalElements: Long,
+    val hasNext: Boolean
+) {
+    /**
+     * 전체 페이지 수 계산
+     */
+    val totalPages: Int
+        get() = if (pageSize == 0) 0 else ((totalElements / pageSize).toInt() + if (totalElements % pageSize != 0L) 1 else 0)
+
+    /**
+     * 현재 페이지가 첫 번째 페이지인지 여부
+     */
+    val isFirst: Boolean
+        get() = pageNumber == 0
+
+    /**
+     * 현재 페이지가 마지막 페이지인지 여부
+     */
+    val isLast: Boolean
+        get() = !hasNext
+
+    /**
+     * 빈 페이지 생성 (결과가 없는 경우)
+     */
+    companion object {
+        fun <T> empty(): Page<T> = Page(
+            content = emptyList(),
+            pageNumber = 0,
+            pageSize = 0,
+            totalElements = 0,
+            hasNext = false
+        )
+    }
+
+    /**
+     * 현재 페이지에 요소가 없는지 확인
+     */
+    fun isEmpty(): Boolean = content.isEmpty()
+
+    /**
+     * 현재 페이지에 요소가 있는지 확인
+     */
+    fun isNotEmpty(): Boolean = content.isNotEmpty()
+}
+
+/**
+ * 페이지네이션 요청 파라미터
+ *
+ * @property page 페이지 번호 (0-based)
+ * @property size 페이지 크기
+ */
+data class PageRequest(
+    val page: Int = 0,
+    val size: Int = 10
+) {
+    init {
+        require(page >= 0) { "Page index must not be less than zero" }
+        require(size > 0) { "Page size must be greater than zero" }
+    }
+
+    /**
+     * 첫 번째 페이지 요청 생성
+     */
+    fun first(): PageRequest = PageRequest(page = 0, size = size)
+
+    /**
+     * 다음 페이지 요청 생성
+     */
+    fun next(): PageRequest = PageRequest(page = page + 1, size = size)
+
+    companion object {
+        /**
+         * 기본 페이지 요청 생성 (page=0, size=10)
+         */
+        fun of(page: Int = 0, size: Int = 10): PageRequest = PageRequest(page, size)
+    }
+}

--- a/module-core/src/main/kotlin/maple/expectation/core/port/out/OcidQueryPort.kt
+++ b/module-core/src/main/kotlin/maple/expectation/core/port/out/OcidQueryPort.kt
@@ -1,0 +1,32 @@
+package maple.expectation.core.port.out
+
+import maple.expectation.core.domain.model.Page
+import maple.expectation.core.domain.model.PageRequest
+
+/**
+ * OCID Query Port - 배치 작업이 OCID를 조회하는 인터페이스
+ *
+ * <p>이 인터페이스는 페이지네이션을 통해 OCID 목록을 조회하는 기능을 제공합니다.
+ * 주로 배치 작업에서 대량의 OCID를 처리할 때 사용됩니다.
+ *
+ * <h3>Usage</h3>
+ *
+ * <p>module-infra 어댑터에 의해 구현되어 underlying data store(DB 등)에서
+ * OCID 목록을 페이지 단위로 조회합니다.
+ *
+ * @see maple.expectation.core.domain.model.Page
+ * @see maple.expectation.core.domain.model.PageRequest
+ */
+interface OcidQueryPort {
+
+    /**
+     * 페이지네이션으로 모든 OCID 조회
+     *
+     * <p>배치 작업에서 대량의 OCID를 효율적으로 처리하기 위해
+     * 페이지 단위로 조회합니다.
+     *
+     * @param pageRequest 페이지네이션 요청 정보 (page, size)
+     * @return OCID 목록이 담긴 페이지
+     */
+    fun findAllOcids(pageRequest: PageRequest): Page<String>
+}

--- a/module-infra/src/main/kotlin/maple/expectation/infra/adapter/OcidQueryAdapter.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infra/adapter/OcidQueryAdapter.kt
@@ -1,0 +1,36 @@
+package maple.expectation.infra.adapter
+
+import maple.expectation.core.domain.model.Page
+import maple.expectation.core.domain.model.PageRequest
+import maple.expectation.core.port.out.OcidQueryPort
+import maple.expectation.infrastructure.persistence.jpa.GameCharacterJpaRepository
+import org.springframework.data.domain.PageRequest as SpringPageRequest
+import org.springframework.stereotype.Component
+
+/**
+ * OcidQueryPort의 JPA 기반 구현체
+ *
+ * <h3>Wiring</h3>
+ * module-infra의 GameCharacterJpaRepository에 위임하여 OCID 목록을 페이지 단위로 조회합니다.
+ *
+ * <h3>Usage</h3>
+ * 배치 작업에서 대량의 OCID를 효율적으로 처리하기 위해 페이지네이션을 지원합니다.
+ */
+@Component
+class OcidQueryAdapter(
+    private val repository: GameCharacterJpaRepository
+) : OcidQueryPort {
+
+    override fun findAllOcids(pageRequest: PageRequest): Page<String> {
+        val springPageable = SpringPageRequest.of(pageRequest.page, pageRequest.size)
+        val springPage = repository.findAll(springPageable)
+        
+        return Page(
+            content = springPage.content.mapNotNull { it.ocid },
+            pageNumber = springPage.number,
+            pageSize = springPage.size,
+            totalElements = springPage.totalElements,
+            hasNext = springPage.hasNext()
+        )
+    }
+}


### PR DESCRIPTION
## 관련 이슈
#424

## 개요
OcidReader에 Hexagonal Architecture (Ports & Adapters) 패턴 적용

## 작업 내용
- [x] OcidQueryPort 인터페이스 추출 (module-core)
- [x] OcidQueryAdapter 구현 (module-infra)
- [x] OcidReader가 Port를 통해 OCID 조회하도록 변경
- [x] core.domain.model.Page/PageRequest 사용으로 Spring 의존성 제거
- [x] 테스트 코드 업데이트

## 리뷰 포인트
- Java에서 Kotlin companion object 호출 시 `PageRequest.Companion.of()` 사용
- Adapter에서 Spring Data Page → Core Page 매핑 처리

## 트레이드 오프 결정 근거
- Spring Data Page 대신 Core Page 사용 → module-core의 Spring 의존성 제거
- 배치 Reader가 Port 인터페이스에만 의존 → DIP 준수

## 체크리스트
- [x] 브랜치/커밋 규칙 준수 여부
- [x] 테스트 통과 여부
- [x] Spotless 포맷팅 통과

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)