### PR TITLE
refactor: ADR-003 MonitoringReportJob 헥사고날 아키텍처 리팩토링

### DIFF
--- a/module-app/src/main/java/maple/expectation/batch/MonitoringReportJob.java
+++ b/module-app/src/main/java/maple/expectation/batch/MonitoringReportJob.java
@@ -2,18 +2,16 @@ package maple.expectation.batch;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import maple.expectation.core.domain.model.AlertMessage;
+import maple.expectation.core.port.out.AlertPort;
 import maple.expectation.infrastructure.executor.LogicExecutor;
 import maple.expectation.infrastructure.executor.TaskContext;
 import maple.expectation.infrastructure.lock.LockStrategy;
 import maple.expectation.infrastructure.monitoring.collector.MetricCategory;
 import maple.expectation.monitoring.context.SystemContextProvider;
-import maple.expectation.service.v2.alert.DiscordAlertService;
-import maple.expectation.service.v2.alert.dto.DiscordMessage;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -25,7 +23,7 @@ import org.springframework.stereotype.Component;
  *
  * <ul>
  *   <li>매시간 정기 모니터링 리포트 생성
- *   <li>Discord로 시스템 상태 요약 전송
+ *   <li>AlertPort를 통한 시스템 상태 요약 전송 (Hexagonal Architecture)
  *   <li>Leader Election으로 단일 인스턴스 실행
  * </ul>
  *
@@ -34,9 +32,11 @@ import org.springframework.stereotype.Component;
  * <ul>
  *   <li>Section 12 (LogicExecutor): 배치 작업도 executor 패턴
  *   <li>Section 12-1 (Resilience): 분산 락으로 중복 실행 방지
+ *   <li>ADR-003: Hexagonal Architecture - AlertPort (outbound port) 사용
  * </ul>
  *
  * @see SystemContextProvider
+ * @see AlertPort
  */
 @Slf4j
 @Component
@@ -47,17 +47,15 @@ public class MonitoringReportJob {
   private final LockStrategy lockStrategy;
   private final LogicExecutor executor;
 
-  // Discord 서비스 (Optional)
+  // Alert Port (Optional - hexagonal architecture adapter)
   @org.springframework.beans.factory.annotation.Autowired(required = false)
-  private DiscordAlertService discordAlertService;
+  private AlertPort alertPort;
 
   @Value("${ai.sre.enabled:false}")
   private boolean aiSreEnabled;
 
   private static final String REPORT_LOCK_KEY = "monitoring-report-lock";
   private static final int LOCK_LEASE_SECONDS = 60; // 리포트 생성 최대 시간
-
-  private static final int INFO_COLOR = 3447003; // 파란색
 
   /** 매시간 정기 리포트 (정각 실행) */
   @Scheduled(cron = "0 0 * * * *")
@@ -107,65 +105,64 @@ public class MonitoringReportJob {
     Map<MetricCategory, Map<String, Object>> allMetrics = contextProvider.collectAllMetrics();
 
     // 2. 리포트 메시지 생성
-    DiscordMessage report = createReportMessage(reportType, allMetrics);
+    AlertMessage report = createReportMessage(reportType, allMetrics);
 
-    // 3. Discord 전송
-    if (discordAlertService != null) {
-      sendReportToDiscord(report);
+    // 3. Alert 전송 (AlertPort via hexagonal architecture)
+    if (alertPort != null) {
+      sendReport(report);
     }
 
     log.info("[MonitoringReport] {} 리포트 생성 완료", reportType);
   }
 
-  /** 리포트 Discord 메시지 생성 */
-  private DiscordMessage createReportMessage(
+  /** 리포트 AlertMessage 생성 (Hexagonal Architecture용 포맷) */
+  private AlertMessage createReportMessage(
       String reportType, Map<MetricCategory, Map<String, Object>> metrics) {
     String title = reportType.equals("daily") ? "📊 일간 시스템 리포트" : "📈 시간별 시스템 리포트";
     String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
 
-    List<DiscordMessage.Field> fields = new ArrayList<>();
+    // 모든 메트릭을 텍스트 포맷으로 조합
+    StringBuilder message = new StringBuilder();
+    message.append("**시스템 상태 정기 리포트** (").append(timestamp).append(")\\n\\n");
 
     // Golden Signals 요약
-    Map<String, Object> goldenSignals =
-        metrics.getOrDefault(MetricCategory.GOLDEN_SIGNALS, Map.of());
-    fields.add(
-        new DiscordMessage.Field("🎯 Golden Signals", formatGoldenSignals(goldenSignals), false));
+    message.append("### 🎯 Golden Signals\\n");
+    message.append(
+        formatGoldenSignals(metrics.getOrDefault(MetricCategory.GOLDEN_SIGNALS, Map.of())));
+    message.append("\\n");
 
     // JVM 상태
-    Map<String, Object> jvmMetrics = metrics.getOrDefault(MetricCategory.JVM, Map.of());
-    fields.add(new DiscordMessage.Field("☕ JVM Status", formatJvmStatus(jvmMetrics), true));
+    message.append("### ☕ JVM Status\\n");
+    message.append(formatJvmStatus(metrics.getOrDefault(MetricCategory.JVM, Map.of())));
+    message.append("\\n");
 
     // Circuit Breaker 상태
-    Map<String, Object> cbMetrics = metrics.getOrDefault(MetricCategory.CIRCUIT_BREAKER, Map.of());
-    fields.add(
-        new DiscordMessage.Field("🔌 Circuit Breakers", formatCircuitBreakers(cbMetrics), true));
+    message.append("### 🔌 Circuit Breakers\\n");
+    message.append(
+        formatCircuitBreakers(metrics.getOrDefault(MetricCategory.CIRCUIT_BREAKER, Map.of())));
+    message.append("\\n");
 
     // Database 상태
-    Map<String, Object> dbMetrics = metrics.getOrDefault(MetricCategory.DATABASE, Map.of());
-    fields.add(new DiscordMessage.Field("🗄️ Database", formatDatabaseStatus(dbMetrics), true));
+    message.append("### 🗄️ Database\\n");
+    message.append(formatDatabaseStatus(metrics.getOrDefault(MetricCategory.DATABASE, Map.of())));
+    message.append("\\n");
 
     // Redis 상태
-    Map<String, Object> redisMetrics = metrics.getOrDefault(MetricCategory.REDIS, Map.of());
-    fields.add(new DiscordMessage.Field("📦 Redis Buffer", formatRedisStatus(redisMetrics), true));
+    message.append("### 📦 Redis Buffer\\n");
+    message.append(formatRedisStatus(metrics.getOrDefault(MetricCategory.REDIS, Map.of())));
 
-    return new DiscordMessage(
-        List.of(
-            new DiscordMessage.Embed(
-                title,
-                "시스템 상태 정기 리포트 (" + timestamp + ")",
-                INFO_COLOR,
-                fields,
-                new DiscordMessage.Footer("MapleExpectation Monitoring"),
-                java.time.ZonedDateTime.now().format(DateTimeFormatter.ISO_INSTANT))));
+    return AlertMessage.of(title, message.toString());
   }
 
   private String formatGoldenSignals(Map<String, Object> metrics) {
     StringBuilder sb = new StringBuilder();
-    sb.append("Latency p95: ").append(metrics.getOrDefault("latency_p95_ms", "N/A")).append("ms\n");
-    sb.append("Error Rate: ")
+    sb.append("- Latency p95: ")
+        .append(metrics.getOrDefault("latency_p95_ms", "N/A"))
+        .append("ms\\n");
+    sb.append("- Error Rate: ")
         .append(metrics.getOrDefault("error_rate_percent", "0.0"))
-        .append("%\n");
-    sb.append("DB Saturation: ")
+        .append("%\\n");
+    sb.append("- DB Saturation: ")
         .append(metrics.getOrDefault("db_pool_saturation_percent", "N/A"))
         .append("%");
     return sb.toString();
@@ -173,9 +170,9 @@ public class MonitoringReportJob {
 
   private String formatJvmStatus(Map<String, Object> metrics) {
     StringBuilder sb = new StringBuilder();
-    sb.append("Heap: ").append(metrics.getOrDefault("heap_used_mb", "?")).append("/");
-    sb.append(metrics.getOrDefault("heap_max_mb", "?")).append("MB\n");
-    sb.append("Threads: ").append(metrics.getOrDefault("threads_live", "?"));
+    sb.append("- Heap: ").append(metrics.getOrDefault("heap_used_mb", "?")).append("/");
+    sb.append(metrics.getOrDefault("heap_max_mb", "?")).append("MB\\n");
+    sb.append("- Threads: ").append(metrics.getOrDefault("threads_live", "?"));
     return sb.toString();
   }
 
@@ -186,12 +183,13 @@ public class MonitoringReportJob {
 
     String status = openCount > 0 ? "⚠️ DEGRADED" : "✅ HEALTHY";
     return String.format(
-        "%s\nOpen: %d, Half-Open: %d/%d", status, openCount, halfOpenCount, totalCount);
+        "- Status: %s\\n- Open: %d, Half-Open: %d/%d",
+        status, openCount, halfOpenCount, totalCount);
   }
 
   private String formatDatabaseStatus(Map<String, Object> metrics) {
     return String.format(
-        "Active: %s/%s\nSaturation: %s%%",
+        "- Active: %s/%s\\n- Saturation: %s%%",
         metrics.getOrDefault("connections_active", "?"),
         metrics.getOrDefault("connections_max", "?"),
         metrics.getOrDefault("saturation_percent", "0"));
@@ -199,16 +197,20 @@ public class MonitoringReportJob {
 
   private String formatRedisStatus(Map<String, Object> metrics) {
     return String.format(
-        "Pending: %s\nSaturation: %s%%",
+        "- Pending: %s\\n- Saturation: %s%%",
         metrics.getOrDefault("buffer_pending_count", "0"),
         metrics.getOrDefault("buffer_saturation_percent", "0"));
   }
 
-  /** Discord로 리포트 전송 */
-  private void sendReportToDiscord(DiscordMessage report) {
-    // DiscordAlertService의 내부 send 메서드 대신 직접 WebClient 사용하거나
-    // send를 public으로 변경해야 함. 여기서는 로그만 남김.
-    log.info("[MonitoringReport] Discord 리포트 전송 (embeds: {})", report.embeds().size());
+  /** AlertPort로 리포트 전송 */
+  private void sendReport(AlertMessage report) {
+    log.info("[MonitoringReport] Alert 전송 시작: {}", report.getTitle());
+    boolean sent = alertPort.sendAlert(report);
+    if (sent) {
+      log.info("[MonitoringReport] Alert 전송 성공");
+    } else {
+      log.warn("[MonitoringReport] Alert 전송 실패");
+    }
   }
 
   /** 리포트 실패 처리 */


### PR DESCRIPTION
## 관련 이슈
#424

## 개요
MonitoringReportJob에 Hexagonal Architecture (Ports & Adapters) 패턴 적용

## 작업 내용
- [x] DiscordAlertService → AlertPort로 의존성 역전
- [x] DiscordMessage → AlertMessage로 변경
- [x] 복잡한 embed 구조를 텍스트 포맷으로 단순화
- [x] AlertPort가 optional로 주입되어 미설정 시 graceful degradation

## 리뷰 포인트
- 기존 AlertPort 인터페이스 재사용
- AlertPort 미설정 시 로그만 남기고 정상 종료

## 트레이드 오프 결정 근거
- 새 Port 생성 대신 기존 AlertPort 재사용 → 일관성 유지
- 텍스트 포맷 사용 → AlertPort 인터페이스 단순화

## 체크리스트
- [x] 브랜치/커밋 규칙 준수 여부
- [x] 테스트 통과 여부
- [x] Spotless 포맷팅 통과

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)