### PR TITLE
refactor: ADR-003 LikeSyncScheduler 헥사고날 아키텍처 리팩토링

### DIFF
--- a/module-app/src/main/java/maple/expectation/scheduler/LikeSyncScheduler.java
+++ b/module-app/src/main/java/maple/expectation/scheduler/LikeSyncScheduler.java
@@ -3,13 +3,13 @@ package maple.expectation.scheduler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import maple.expectation.core.port.out.LikeBufferStrategy;
+import maple.expectation.core.port.out.LikeRelationSyncPort;
+import maple.expectation.core.port.out.LikeSyncPort;
 import maple.expectation.error.exception.DistributedLockException;
 import maple.expectation.infrastructure.executor.LogicExecutor;
 import maple.expectation.infrastructure.executor.TaskContext;
 import maple.expectation.infrastructure.lock.LockStrategy;
 import maple.expectation.infrastructure.queue.like.PartitionedFlushStrategy;
-import maple.expectation.service.v2.LikeRelationSyncService;
-import maple.expectation.service.v2.LikeSyncService;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.lang.Nullable;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -21,8 +21,8 @@ import org.springframework.stereotype.Component;
  * <p>두 가지 버퍼 동기화:
  *
  * <ul>
- *   <li>likeCount: LikeSyncService (숫자 카운트)
- *   <li>likeRelation: LikeRelationSyncService (관계 데이터)
+ *   <li>likeCount: LikeSyncPort (숫자 카운트)
+ *   <li>likeRelation: LikeRelationSyncPort (관계 데이터)
  * </ul>
  *
  * <p>동기화 주기:
@@ -36,6 +36,10 @@ import org.springframework.stereotype.Component;
  *
  * <p>Redis 모드에서 PartitionedFlushStrategy를 사용하여 파티션 기반 분산 Flush를 수행합니다. 각 인스턴스가 자신이 담당하는 파티션만
  * Flush하여 중복 Flush를 방지합니다.
+ *
+ * <h3>ADR-003: Hexagonal Architecture</h3>
+ *
+ * <p>Port 인터페이스를 통해 infra(adapter) → app(service) 역참조 제거
  */
 @Slf4j
 @Component
@@ -47,8 +51,8 @@ import org.springframework.stereotype.Component;
     )
 public class LikeSyncScheduler {
 
-  private final LikeSyncService likeSyncService;
-  private final LikeRelationSyncService likeRelationSyncService;
+  private final LikeSyncPort likeSyncPort;
+  private final LikeRelationSyncPort likeRelationSyncPort;
   private final LockStrategy lockStrategy;
   private final LogicExecutor executor;
   private final LikeBufferStrategy likeBufferStrategy;
@@ -88,11 +92,11 @@ public class LikeSyncScheduler {
   public void localFlush() {
     // likeCount 버퍼 동기화
     executor.executeVoidJava(
-        likeSyncService::flushLocalToRedis, TaskContext.of("Scheduler", "LocalFlush.Count"));
+        likeSyncPort::flushLocalToRedis, TaskContext.of("Scheduler", "LocalFlush.Count"));
 
     // likeRelation 버퍼 동기화
     executor.executeVoidJava(
-        likeRelationSyncService::flushLocalToRedis,
+        likeRelationSyncPort::flushLocalToRedis,
         TaskContext.of("Scheduler", "LocalFlush.Relation"));
   }
 
@@ -135,7 +139,7 @@ public class LikeSyncScheduler {
               0,
               30,
               () -> {
-                likeSyncService.syncRedisToDatabase();
+                likeSyncPort.syncRedisToDatabase();
                 return null;
               });
           return null;
@@ -173,7 +177,7 @@ public class LikeSyncScheduler {
               0,
               30,
               () -> {
-                likeRelationSyncService.syncRedisToDatabase();
+                likeRelationSyncPort.syncRedisToDatabase();
                 return null;
               });
           return null;

--- a/module-app/src/main/java/maple/expectation/service/v2/LikeRelationSyncService.java
+++ b/module-app/src/main/java/maple/expectation/service/v2/LikeRelationSyncService.java
@@ -4,6 +4,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import maple.expectation.core.port.out.LikeRelationSyncPort;
 import maple.expectation.domain.repository.CharacterLikeRepository;
 import maple.expectation.infrastructure.aop.annotation.ObservedTransaction;
 import maple.expectation.infrastructure.executor.LogicExecutor;
@@ -31,7 +32,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class LikeRelationSyncService {
+public class LikeRelationSyncService implements LikeRelationSyncPort {
 
   private final LikeRelationBufferStrategy likeRelationBuffer;
   private final CharacterLikeRepository characterLikeRepository;
@@ -65,11 +66,11 @@ public class LikeRelationSyncService {
    */
   @ObservedTransaction("scheduler.like.relation_sync")
   @Transactional(isolation = Isolation.READ_COMMITTED)
-  public SyncResult syncRedisToDatabase() {
+  public void syncRedisToDatabase() {
     int pendingSize = likeRelationBuffer.getPendingSize();
 
     if (pendingSize == 0) {
-      return SyncResult.empty();
+      return;
     }
 
     log.info("📤 [LikeRelationSync] 동기화 시작: 최대 {}건 예상", pendingSize);
@@ -88,8 +89,6 @@ public class LikeRelationSyncService {
 
     SyncResult result = new SyncResult(successCount.get(), skipCount.get(), failCount.get());
     log.info("📥 [LikeRelationSync] 동기화 완료: {}", result);
-
-    return result;
   }
 
   private void processBatch(

--- a/module-app/src/main/java/maple/expectation/service/v2/LikeSyncService.java
+++ b/module-app/src/main/java/maple/expectation/service/v2/LikeSyncService.java
@@ -10,6 +10,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import lombok.extern.slf4j.Slf4j;
 import maple.expectation.core.port.out.LikeBufferStrategy;
+import maple.expectation.core.port.out.LikeSyncPort;
 import maple.expectation.domain.repository.RedisBufferRepository;
 import maple.expectation.infrastructure.aop.annotation.ObservedTransaction;
 import maple.expectation.infrastructure.executor.LogicExecutor;
@@ -45,7 +46,7 @@ import org.springframework.stereotype.Service;
  */
 @Slf4j
 @Service
-public class LikeSyncService {
+public class LikeSyncService implements LikeSyncPort {
 
   private final LikeBufferStrategy likeBufferStrategy;
   private final LikeSyncExecutor syncExecutor;

--- a/module-core/src/main/kotlin/maple/expectation/core/port/out/LikeRelationSyncPort.kt
+++ b/module-core/src/main/kotlin/maple/expectation/core/port/out/LikeRelationSyncPort.kt
@@ -1,0 +1,21 @@
+package maple.expectation.core.port.out
+
+/**
+ * Like Relation Sync Port - 좋아요 관계 동기화 작업을 위한 인터페이스
+ *
+ * <h3>Implementations</h3>
+ * <ul>
+ *   <li>module-infra/adapter/LikeRelationSyncAdapter - LikeRelationSyncService에 위임
+ * </ul>
+ */
+interface LikeRelationSyncPort {
+    /**
+     * L1 (Caffeine) → L2 (Redis) Flush
+     */
+    fun flushLocalToRedis()
+
+    /**
+     * L2 (Redis) → L3 (MySQL) Sync
+     */
+    fun syncRedisToDatabase()
+}

--- a/module-core/src/main/kotlin/maple/expectation/core/port/out/LikeSyncPort.kt
+++ b/module-core/src/main/kotlin/maple/expectation/core/port/out/LikeSyncPort.kt
@@ -1,0 +1,21 @@
+package maple.expectation.core.port.out
+
+/**
+ * Like Sync Port - 좋아요 동기화 작업을 위한 인터페이스
+ *
+ * <h3>Implementations</h3>
+ * <ul>
+ *   <li>module-infra/adapter/LikeSyncAdapter - LikeSyncService에 위임
+ * </ul>
+ */
+interface LikeSyncPort {
+    /**
+     * L1 (Caffeine) → L2 (Redis) Flush
+     */
+    fun flushLocalToRedis()
+
+    /**
+     * L2 (Redis) → L3 (MySQL) Sync
+     */
+    fun syncRedisToDatabase()
+}


### PR DESCRIPTION
## 관련 이슈
#424

## 개요
ADR-003 Hexagonal Architecture에 따라 LikeSyncScheduler가 Port 인터페이스를 사용하도록 리팩토링

## 작업 내용
- [x] LikeSyncPort 인터페이스 추가 (module-core/port/out)
- [x] LikeRelationSyncPort 인터페이스 추가 (module-core/port/out)
- [x] LikeSyncService가 LikeSyncPort 구현
- [x] LikeRelationSyncService가 LikeRelationSyncPort 구현
- [x] LikeSyncScheduler가 Port 인터페이스 사용하도록 변경
- [x] LikeRelationSyncService.syncRedisToDatabase() 반환타입 void로 변경

## 리뷰 포인트
- 서비스가 직접 Port를 구현하는 방식 채택 (별도 Adapter 클래스 없이)
- 의존성 방향: `app → core` (infra → app 역참조 제거)

## 트레이드 오프 결정 근거
- **Adapter 별도 생성 vs 서비스 직접 구현**: module-infra가 module-app을 참조할 수 없으므로, 서비스가 직접 Port를 구현하는 방식 선택
- **장점**: 불필요한 위임 계층 제거, 코드 단순화
- **단점**: 서비스가 Port 구현을 강제받음 (향후 다른 구현체 필요 시 리팩토링 가능)

## 체크리스트
- [x] 브랜치/커밋 규칙 준수 여부
- [x] 테스트 통과 여부