### PR TITLE
refactor: ADR-003 ExpectationCalculationScheduler QueueWriterPort 사용

### DIFF
--- a/module-app/src/main/java/maple/expectation/scheduler/ExpectationCalculationScheduler.java
+++ b/module-app/src/main/java/maple/expectation/scheduler/ExpectationCalculationScheduler.java
@@ -2,10 +2,10 @@ package maple.expectation.scheduler;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import maple.expectation.core.port.out.QueueWriterPort;
 import maple.expectation.domain.repository.GameCharacterRepository;
 import maple.expectation.infrastructure.executor.LogicExecutor;
 import maple.expectation.infrastructure.executor.TaskContext;
-import maple.expectation.service.v5.queue.PriorityCalculationQueue;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -48,7 +48,7 @@ import org.springframework.stereotype.Component;
     matchIfMissing = false)
 public class ExpectationCalculationScheduler {
 
-  private final PriorityCalculationQueue queue;
+  private final QueueWriterPort queueWriter;
   private final GameCharacterRepository gameCharacterRepository;
   private final LogicExecutor executor;
 
@@ -134,7 +134,7 @@ public class ExpectationCalculationScheduler {
               "[ExpectationCalculation] Full refresh completed: processed={}, skipped={}, queueSize={}",
               processedCount,
               skippedCount,
-              queue.size());
+              queueWriter.size());
         },
         context);
   }
@@ -145,6 +145,6 @@ public class ExpectationCalculationScheduler {
    * @return true if task was added, false if rejected (backpressure)
    */
   private boolean addTaskForUser(String userIgn) {
-    return queue.addLowPriorityTask(userIgn);
+    return queueWriter.addLowPriorityTask(userIgn);
   }
 }

--- a/module-core/src/main/kotlin/maple/expectation/core/port/out/QueueWriterPort.kt
+++ b/module-core/src/main/kotlin/maple/expectation/core/port/out/QueueWriterPort.kt
@@ -41,4 +41,13 @@ interface QueueWriterPort {
      * @return true: 추가 성공, false: 큐 full
      */
     fun addHighPriorityTask(userIgn: String, forceRecalculation: Boolean): Boolean
+
+    /**
+     * 현재 큐 크기 조회
+     *
+     * <p>모니터링 및 로깅 목적으로 현재 큐에 대기 중인 작업 수를 반환합니다.
+     *
+     * @return 큐에 대기 중인 작업 수
+     */
+    fun size(): Int
 }

--- a/module-infra/src/main/kotlin/maple/expectation/infra/adapter/QueueWriterAdapter.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infra/adapter/QueueWriterAdapter.kt
@@ -22,4 +22,9 @@ class QueueWriterAdapter(
     override fun addHighPriorityTask(userIgn: String, forceRecalculation: Boolean): Boolean {
         return delegate.addHighPriorityTask(userIgn, forceRecalculation)
     }
+
+    override fun size(): Int {
+        val (high, low) = delegate.getQueueSize()
+        return high + low
+    }
 }


### PR DESCRIPTION
## 관련 이슈
#424

## 개요
ExpectationCalculationScheduler가 기존 QueueWriterPort를 사용하도록 리팩토링

## 작업 내용
- [x] QueueWriterPort에 size() 메서드 추가
- [x] QueueWriterAdapter에 size() 구현
- [x] ExpectationCalculationScheduler가 QueueWriterPort 사용

## 리뷰 포인트
- 기존 PR #448에서 생성한 QueueWriterPort 재사용
- 의존성 방향: `app → core` (service 구체타입 의존 제거)

## 체크리스트
- [x] 브랜치/커밋 규칙 준수 여부
- [x] 테스트 통과 여부