### PR TITLE
refactor: ADR-003 OutboxScheduler 헥사고날 아키텍처 리팩토링

### DIFF
--- a/module-app/src/main/java/maple/expectation/scheduler/OutboxScheduler.java
+++ b/module-app/src/main/java/maple/expectation/scheduler/OutboxScheduler.java
@@ -2,11 +2,11 @@ package maple.expectation.scheduler;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import maple.expectation.core.port.out.OutboxMetricsPort;
+import maple.expectation.core.port.out.OutboxProcessorPort;
 import maple.expectation.infrastructure.config.OutboxProperties;
 import maple.expectation.infrastructure.executor.LogicExecutor;
 import maple.expectation.infrastructure.executor.TaskContext;
-import maple.expectation.service.v2.donation.outbox.OutboxMetrics;
-import maple.expectation.service.v2.donation.outbox.OutboxProcessor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -54,8 +54,8 @@ import org.springframework.stereotype.Component;
     matchIfMissing = true)
 public class OutboxScheduler {
 
-  private final OutboxProcessor outboxProcessor;
-  private final OutboxMetrics outboxMetrics;
+  private final OutboxProcessorPort outboxProcessor;
+  private final OutboxMetricsPort outboxMetrics;
   private final LogicExecutor executor;
   private final OutboxProperties properties;
 

--- a/module-app/src/main/java/maple/expectation/service/v2/donation/outbox/OutboxMetrics.java
+++ b/module-app/src/main/java/maple/expectation/service/v2/donation/outbox/OutboxMetrics.java
@@ -6,6 +6,7 @@ import jakarta.annotation.PostConstruct;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 import lombok.RequiredArgsConstructor;
+import maple.expectation.core.port.out.OutboxMetricsPort;
 import maple.expectation.domain.v2.DonationOutbox.OutboxStatus;
 import maple.expectation.infrastructure.config.OutboxProperties;
 import maple.expectation.infrastructure.persistence.repository.DonationOutboxRepository;
@@ -30,7 +31,7 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Component
 @RequiredArgsConstructor
-public class OutboxMetrics {
+public class OutboxMetrics implements OutboxMetricsPort {
 
   private final MeterRegistry registry;
   private final DonationOutboxRepository repository;
@@ -132,6 +133,7 @@ public class OutboxMetrics {
    * <p>스케줄러에서 주기적으로 호출
    */
   @Transactional(readOnly = true)
+  @Override
   public void updatePendingCount() {
     long count = repository.countByStatusIn(List.of(OutboxStatus.PENDING, OutboxStatus.FAILED));
     pendingCount.set(count);
@@ -144,6 +146,7 @@ public class OutboxMetrics {
    *
    * <p>스케줄러에서 주기적으로 호출 (30초)
    */
+  @Override
   public void updateTotalCount() {
     long count = repository.count();
     totalCount.set(count);
@@ -163,6 +166,7 @@ public class OutboxMetrics {
    *
    * @return 전체 Outbox 항목 수
    */
+  @Override
   public long getCurrentSize() {
     return totalCount.get();
   }

--- a/module-app/src/main/java/maple/expectation/service/v2/donation/outbox/OutboxProcessor.java
+++ b/module-app/src/main/java/maple/expectation/service/v2/donation/outbox/OutboxProcessor.java
@@ -3,6 +3,7 @@ package maple.expectation.service.v2.donation.outbox;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
+import maple.expectation.core.port.out.OutboxProcessorPort;
 import maple.expectation.domain.v2.DonationOutbox;
 import maple.expectation.infrastructure.aop.annotation.ObservedTransaction;
 import maple.expectation.infrastructure.config.OutboxProperties;
@@ -48,7 +49,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 @Slf4j
 @Service
 @EnableConfigurationProperties(OutboxProperties.class)
-public class OutboxProcessor {
+public class OutboxProcessor implements OutboxProcessorPort {
 
   private final OutboxFetchFacade fetchFacade;
   private final DlqHandler dlqHandler;
@@ -86,6 +87,7 @@ public class OutboxProcessor {
    * </ol>
    */
   @ObservedTransaction("scheduler.outbox.poll")
+  @Override
   public void pollAndProcess() {
     TaskContext context = TaskContext.of("Outbox", "PollAndProcess", properties.getInstanceId());
 
@@ -244,6 +246,7 @@ public class OutboxProcessor {
    */
   @ObservedTransaction("scheduler.outbox.recover_stalled")
   @Transactional
+  @Override
   public void recoverStalled() {
     LocalDateTime staleTime = LocalDateTime.now().minus(properties.getStaleThreshold());
     List<DonationOutbox> stalledEntries =

--- a/module-core/src/main/kotlin/maple/expectation/core/port/out/OutboxMetricsPort.kt
+++ b/module-core/src/main/kotlin/maple/expectation/core/port/out/OutboxMetricsPort.kt
@@ -1,0 +1,33 @@
+package maple.expectation.core.port.out
+
+/**
+ * Outbox Metrics Port - Outbox 메트릭 조회를 위한 인터페이스
+ *
+ * <h3>역할</h3>
+ * <p>Outbox 상태 모니터링을 위한 메트릭 조회를 정의합니다.
+ *
+ * <h3>구현체</h3>
+ * <ul>
+ *   <li>module-app/service/v2/donation/outbox/OutboxMetrics
+ * </ul>
+ *
+ * @see OutboxProcessorPort
+ */
+interface OutboxMetricsPort {
+    /**
+     * Pending 카운트 업데이트
+     */
+    fun updatePendingCount()
+
+    /**
+     * 전체 카운트 업데이트
+     */
+    fun updateTotalCount()
+
+    /**
+     * 현재 Outbox 크기 조회
+     *
+     * @return 현재 처리 대기 중인 메시지 수
+     */
+    fun getCurrentSize(): Long
+}

--- a/module-core/src/main/kotlin/maple/expectation/core/port/out/OutboxProcessorPort.kt
+++ b/module-core/src/main/kotlin/maple/expectation/core/port/out/OutboxProcessorPort.kt
@@ -1,0 +1,30 @@
+package maple.expectation.core.port.out
+
+/**
+ * Outbox Processor Port - Outbox 패턴 처리를 위한 인터페이스
+ *
+ * <h3>역할</h3>
+ * <p>Outbox 패턴의 폴링 및 처리, 복구 작업을 정의합니다.
+ *
+ * <h3>구현체</h3>
+ * <ul>
+ *   <li>module-app/service/v2/donation/outbox/OutboxProcessor
+ * </ul>
+ *
+ * @see OutboxMetricsPort
+ */
+interface OutboxProcessorPort {
+    /**
+     * Outbox 폴링 및 처리
+     *
+     * <p>PENDING 상태의 메시지를 조회하여 처리 후 COMPLETED로 변경
+     */
+    fun pollAndProcess()
+
+    /**
+     * Stalled 상태 복구
+     *
+     * <p>JVM 크래시 등으로 PROCESSING 상태에서 멈춘 항목을 PENDING으로 복원
+     */
+    fun recoverStalled()
+}


### PR DESCRIPTION
## 관련 이슈
#424

## 개요
OutboxScheduler가 Port 인터페이스를 사용하도록 리팩토링

## 작업 내용
- [x] OutboxProcessorPort 인터페이스 추가
- [x] OutboxMetricsPort 인터페이스 추가
- [x] OutboxProcessor, OutboxMetrics가 Port 구현
- [x] OutboxScheduler가 Port 인터페이스 사용

## 체크리스트
- [x] 브랜치/커밋 규칙 준수 여부
- [x] 테스트 통과 여부