### PR TITLE
refactor: ADR-004 Policy 도메인 이관 (Issue #419)

### DIFF
--- a/docs/adr/ADR-004-module-core-migration.md
+++ b/docs/adr/ADR-004-module-core-migration.md
@@ -280,12 +280,40 @@ class CoreMigrationVerificationTest {
 - CLAUDE.md: Section 4 (Implementation Logic & SOLID), Section 16 (Proactive Refactoring)
 - docs/plans/2026-02-27-module-separation-design.md: 전체 모듈 분리 계획
 
+## Phase 1: Facade 이관 분석 (2026-02-28)
+
+### 결정: **DEFERRED** (유예)
+
+**분석 결과**: `service/v2/facade/` 패키지 이관을 **유예**하고 ADR-003 Port 기반 리팩토링 선행 권장.
+
+### 차단 요인 (Blockers)
+
+| 차단 요인 | 심각도 | 해결 방안 |
+|----------|--------|----------|
+| GameCharacterService 의존 | P0 | ADR-003 리팩토링 후 CharacterPort 추출 |
+| RedissonClient 직접 사용 | P0 | DistributedLockPort 정의 필요 |
+| Infra 패키지 의존 (LogicExecutor 등) | P1 | Port 추출 또는 module-app 유지 |
+| 순환 의존성 위험 | P0 | 서비스 계층 리팩토링 선행 |
+
+### 권장사항
+
+1. **Facade는 Application Layer 패턴**: `module-app`에 유지하는 것이 Clean Layered Architecture에 부합
+2. **Port 기반 리팩토링 선행**: `GameCharacterService` → `CharacterPort` 변환 후 재검토
+3. **동시성 제어 분리**: `DistributedLockPort` 정의하여 Core의 Infra 의존 제거
+
+### 상세 분석 보고서
+
+- 문서: `docs/adr/facade-migration-analysis.md`
+- 분석일: 2026-02-28
+- 결론: Phase 2 (GameCharacterService 리팩토링) 완료 후 재검토
+
 ## 이력
 
 | 날짜 | 상태 | 변경 사항 |
 |------|------|-----------|
 | 2026-02-28 | Proposed | 초기 초안 작성, Port-Based Architecture 설계 |
 | 2026-02-28 | Approved | 의존성 분리 전략 검증 |
+| 2026-02-28 | Updated | Facade 이관 분석 완료, 유예 결정 (Phase 1) |
 
 ---
 

--- a/docs/adr/facade-migration-analysis.md
+++ b/docs/adr/facade-migration-analysis.md
@@ -1,0 +1,232 @@
+# Facade Migration Analysis Report (ADR-004 Phase 1)
+
+**Date**: 2026-02-28
+**Status**: Analysis Complete - DEFERRED to Phase 2
+
+---
+
+## Executive Summary
+
+Facade 패키지(`service/v2/facade/`)의 **이관을 유예**하고, **ADR-003 Port 기반 리팩토링 선행**을 권장합니다.
+
+---
+
+## 1. Current State
+
+### 1.1 Files in Facade Package
+```
+module-app/src/main/java/maple/expectation/service/v2/facade/
+├── GameCharacterFacade.java       (152 lines)
+└── GameCharacterSynchronizer.java (87 lines)
+```
+
+### 1.2 Dependency Analysis
+
+#### GameCharacterFacade Dependencies
+| Dependency | Type | Module | Port Available? |
+|------------|------|--------|-----------------|
+| `GameCharacterService` | Service | app | ❌ NO |
+| `MessageTopic<String>` | Port | core (out) | ✅ YES |
+| `MessageQueue<String>` | Port | core (out) | ✅ YES |
+| `LogicExecutor` | Infra | infra | ✅ YES (via package) |
+| `TaskContext` | Infra | infra | ✅ YES (via package) |
+| `AsyncUtils` | Infra | infra | ✅ YES (via package) |
+
+#### GameCharacterSynchronizer Dependencies
+| Dependency | Type | Module | Port Available? |
+|------------|------|--------|-----------------|
+| `GameCharacterService` | Service | app | ❌ NO |
+| `RedissonClient` | External API | infra | ❌ NO |
+| `LogicExecutor` | Infra | infra | ✅ YES (via package) |
+| `RCountDownLatch` | Redisson API | infra | ❌ NO |
+
+---
+
+## 2. Critical Blocking Issues
+
+### Issue #1: GameCharacterService Dependency (P0 - BLOCKER)
+
+**Problem**: Facade 클래스들은 `GameCharacterService`에 강하게 의존합니다.
+
+```java
+// GameCharacterFacade.java:25
+private final GameCharacterService gameCharacterService;
+
+// GameCharacterSynchronizer.java:20
+private final GameCharacterService gameCharacterService;
+```
+
+**Impact**:
+- `GameCharacterService`는 `module-app`에 위치한 서비스 클래스
+- Repository, NexonApiClient, CacheManager 등 인프라 의존성이 심함
+- Facade를 이관하려면 `GameCharacterService`도 함께 이관하거나 Port 추출 필요
+
+### Issue #2: RedissonClient Direct Dependency (P0 - BLOCKER)
+
+**Problem**: `GameCharacterSynchronizer`는 `RedissonClient`를 직접 사용합니다.
+
+```java
+// GameCharacterSynchronizer.java:21
+private final org.redisson.api.RedissonClient redissonClient;
+
+// GameCharacterSynchronizer.java:35
+RCountDownLatch latch = redissonClient.getCountDownLatch("latch:char:" + cleanUserIgn);
+```
+
+**Impact**:
+- 순수 비즈니스 로직이 아닌 **동시성 제어 인프라 로직**
+- Hexagonal Architecture 원칙상 **Core는 Redisson API를 직접 알면 안 됨**
+- `DistributedLockPort` 등의 Port 추출이 선행되어야 함
+
+### Issue #3: Infra Package Dependencies (P1 - HIGH)
+
+**Problem**: Facade는 `infrastructure` 패키지의 클래스들을 직접 사용합니다.
+
+```java
+import maple.expectation.infrastructure.executor.LogicExecutor;
+import maple.expectation.infrastructure.executor.TaskContext;
+import maple.expectation.infrastructure.util.AsyncUtils;
+import org.redisson.api.RCountDownLatch;
+```
+
+**Current Situation**:
+- `module-app`은 `module-infra`에 의존 가능
+- `module-core`는 `module-infra`에 의존할 수 없음 (**DIP 위반**)
+
+---
+
+## 3. Architecture Violation Risk
+
+### Risk #1: Dependency Inversion Violation
+
+```
+Current (Facade in app):
+module-app → module-infra ✅ (허용)
+
+Proposed (Facade in core):
+module-core → module-infra ❌ (DIP 위반)
+```
+
+### Risk #2: Circular Dependency
+
+```
+GameCharacterService (app)
+    ↓ depends on
+GameCharacterFacade (core) ❌
+    ↓ depends on
+GameCharacterService (app) 💥 CYCLE!
+```
+
+### Risk #3: Infrastructure Leakage
+
+```kotlin
+// BAD: Core가 Infra 구현을 알게 됨
+class GameCharacterFacade(
+    private val redissonClient: RedissonClient  // ❌ Infra 구현 노출
+)
+
+// GOOD: Core가 Port만 알게 됨
+class GameCharacterFacade(
+    private val distributedLockPort: DistributedLockPort  // ✅ Port 추상화
+)
+```
+
+---
+
+## 4. Recommendations
+
+### Recommendation #1: DEFER Facade Migration (PRIORITY)
+
+**Rationale**:
+1. **ADR-003 Port 기반 리팩토링이 선행**되어야 함
+2. `GameCharacterService`가 Port/Adapter 패턴으로 리팩토링되면 Facade 이관이 자연스러워짐
+3. 현재 단계에서 Facade를 강제 이관하면 **순환 의존성 발생**
+
+**Timeline**:
+- **Phase 1 (Current)**: Calculator, Flame, Starforce 도메인 이관
+- **Phase 2**: `GameCharacterService` → `CharacterPort` 리팩토링
+- **Phase 3**: Facade 이관 (의존성 해결 후)
+
+### Recommendation #2: Port Interface Extraction (PRE-REQUISITE)
+
+Facade 이관 전 다음 Port가 필요합니다:
+
+```kotlin
+// module-core/src/main/kotlin/maple/expectation/core/port/out/
+interface CharacterQueryPort {
+    fun findCharacter(userIgn: String): GameCharacter?
+    fun isNonExistent(userIgn: String): Boolean
+}
+
+interface CharacterCreationPort {
+    fun createNewCharacter(userIgn: String): GameCharacter
+    fun enrichBasicInfo(character: GameCharacter): GameCharacter
+}
+
+interface DistributedLockPort {
+    fun tryAcquireLeadership(latchKey: String): Boolean
+    fun awaitCompletion(latchKey: String, timeoutSeconds: Long): Boolean
+    fun releaseAndDelete(latchKey: String)
+}
+```
+
+### Recommendation #3: Layer Refactoring (ALTERNATIVE)
+
+Facade를 **Application Service**로 재정의하여 `module-app`에 유지:
+
+```
+module-app/src/main/java/maple/expectation/application/
+├── character/
+│   ├── CharacterQueryService.java      # (was GameCharacterFacade)
+│   └── CharacterSynchronizationService.java  # (was GameCharacterSynchronizer)
+└── equipment/
+    └── EquipmentCalculationService.java
+```
+
+**Rationale**:
+- Facade는 본질적으로 **여러 서비스를 조율하는 Application Layer**
+- 순수 비즈니스 로직이 아닌 **코디네이션(Coordination) 로직**
+- `module-app`에 유지하는 것이 **Clean Layered Architecture**에 부합
+
+---
+
+## 5. Migration Blocker Summary
+
+| Blocker | Severity | Resolution |
+|---------|----------|------------|
+| GameCharacterService 의존 | P0 | ADR-003 리팩토링 완료 후 Port 추출 |
+| RedissonClient 직접 사용 | P0 | DistributedLockPort 정의 필요 |
+| Infra 패키지 의존 | P1 | Port 인터페이스 추출 또는 유예 |
+| 순환 의존성 위험 | P0 | 서비스 계층 리팩토링 선행 |
+
+---
+
+## 6. Conclusion
+
+### Status: **DEFERRED** (유예)
+
+**Reasoning**:
+1. **술익기 전에 술 따르기**: ADR-003 Port 기반 리팩토링이 선행되어야 함
+2. **순환 의존성 방지**: 현재 상태에서 이관 시 DIP 위반 발생
+3. **아키텍처 정합성**: Facade는 Application Layer 패턴이므로 `module-app` 유지가 타당
+
+**Next Steps**:
+1. ✅ Calculator, Flame, Starforce 도메인 이관 (Phase 1)
+2. ⏳ `GameCharacterService` → `CharacterPort` 리팩토링 (Phase 2)
+3. ⏳ `DistributedLockPort` 정의 및 Adapter 구현 (Phase 2)
+4. ⏳ Facade 이관 재검토 (Phase 3)
+
+---
+
+## 7. Related Documents
+
+- ADR-003: Hexagonal Architecture (Ports & Adapters) 채택
+- ADR-004: Module-Core 도메인 이관
+- docs/04_Sequence_Diagrams/character-lookup-sequence.md
+- docs/03_Technical_Guides/service-modules.md
+
+---
+
+**Report Version**: 1.0.0
+**Author**: Claude (Executor Agent)
+**Reviewed By**: Pending

--- a/module-app/src/main/java/maple/expectation/service/v2/policy/CubeCostPolicy.java
+++ b/module-app/src/main/java/maple/expectation/service/v2/policy/CubeCostPolicy.java
@@ -1,6 +1,7 @@
 package maple.expectation.service.v2.policy;
 
 import lombok.RequiredArgsConstructor;
+import maple.expectation.core.port.out.PolicyPort;
 import maple.expectation.domain.v2.CubeType;
 import org.springframework.stereotype.Component;
 
@@ -17,7 +18,7 @@ import org.springframework.stereotype.Component;
  * <p>OCP (Open-Closed Principle) 준수:
  *
  * <ul>
- *   <li>확장: {@link CostCalculationStrategy} 구현체로 새로운 계산 방식 추가
+ *   <li>확장: {@link PolicyPort} 구현체로 새로운 계산 방식 추가
  *   <li>수정 방지: 전략 교체로 동작 변경 (코드 수정 불필요)
  * </ul>
  *
@@ -26,13 +27,14 @@ import org.springframework.stereotype.Component;
  * <ul>
  *   <li>hard-coded 테이블을 {@link TableBasedCostStrategy}로 분리
  *   <li>전략 패턴 도입으로 동적 전략 교체 가능
+ *   <li>ADR-004: PolicyPort 기반 헥사고날 아키텍처로 이관
  * </ul>
  */
 @Component
 @RequiredArgsConstructor
 public class CubeCostPolicy {
 
-  private final CostCalculationStrategy costStrategy;
+  private final PolicyPort policyPort;
 
   /**
    * 큐브 비용을 조회합니다.
@@ -45,6 +47,17 @@ public class CubeCostPolicy {
    * @throws IllegalStateException 유효하지 않은 CubeType인 경우
    */
   public long getCubeCost(CubeType type, int level, String grade) {
-    return costStrategy.calculateCost(type, level, grade);
+    // Convert v2 CubeType to core CubeType
+    maple.expectation.core.domain.model.CubeType coreType = convertToCoreCubeType(type);
+    return policyPort.getCubeCost(coreType, level, grade);
+  }
+
+  /** Convert v2 CubeType to core CubeType. */
+  private maple.expectation.core.domain.model.CubeType convertToCoreCubeType(CubeType v2Type) {
+    return switch (v2Type) {
+      case BLACK -> maple.expectation.core.domain.model.CubeType.BLACK;
+      case RED -> maple.expectation.core.domain.model.CubeType.RED;
+      case ADDITIONAL -> maple.expectation.core.domain.model.CubeType.ADDITIONAL;
+    };
   }
 }

--- a/module-core/src/main/kotlin/maple/expectation/core/domain/model/PotentialGrade.kt
+++ b/module-core/src/main/kotlin/maple/expectation/core/domain/model/PotentialGrade.kt
@@ -1,0 +1,32 @@
+package maple.expectation.core.domain.model
+
+/**
+ * Potential grade enum for cube potential options.
+ *
+ * <p>Domain model - no external dependencies.
+ */
+enum class PotentialGrade(val koreanName: String) {
+    RARE("레어"),
+    EPIC("에픽"),
+    UNIQUE("유니크"),
+    LEGENDARY("레전드리");
+
+    companion object {
+        private val KOREAN_MAP = entries.associateBy { it.koreanName }
+
+        /**
+         * Lookup PotentialGrade by Korean name.
+         *
+         * @param korean Korean grade name (e.g., "레어", "에픽", "유니크", "레전드리")
+         * @return Matching PotentialGrade
+         * @throws IllegalArgumentException if Korean name is invalid
+         */
+        fun fromKorean(korean: String?): PotentialGrade {
+            if (korean == null) {
+                throw IllegalArgumentException("Potential grade cannot be null")
+            }
+            return KOREAN_MAP[korean.trim()]
+                ?: throw IllegalArgumentException("Invalid potential grade: $korean")
+        }
+    }
+}

--- a/module-core/src/main/kotlin/maple/expectation/core/policy/CostCalculationStrategy.kt
+++ b/module-core/src/main/kotlin/maple/expectation/core/policy/CostCalculationStrategy.kt
@@ -1,0 +1,37 @@
+package maple.expectation.core.policy
+
+import maple.expectation.core.domain.model.CubeType
+import maple.expectation.core.domain.model.PotentialGrade
+
+/**
+ * Cost calculation strategy interface (Strategy Pattern).
+ *
+ * <p>OCP (Open-Closed Principle) compliance via Strategy Pattern:
+ * - Open for extension: Add new cost calculation strategies
+ * - Closed for modification: No need to modify existing code
+ *
+ * <p>Usage examples:
+ * ```kotlin
+ * // 1. Default strategy (hardcoded table)
+ * val defaultStrategy = TableBasedCostStrategy()
+ *
+ * // 2. Dynamic strategy (loaded from DB/config)
+ * val dynamicStrategy = DynamicCostStrategy(repository)
+ *
+ * // 3. Cached strategy
+ * val cachedStrategy = CachedCostStrategy(delegate)
+ * ```
+ */
+fun interface CostCalculationStrategy {
+
+    /**
+     * Calculate cube cost.
+     *
+     * @param type Cube type (BLACK, RED, ADDITIONAL)
+     * @param level Equipment level
+     * @param grade Potential grade (Korean: "레어", "에픽", "유니크", "레전드리")
+     * @return Cost for single cube use
+     * @throws IllegalArgumentException if parameters are invalid
+     */
+    fun calculateCost(type: CubeType, level: Int, grade: String): Long
+}

--- a/module-core/src/main/kotlin/maple/expectation/core/policy/TableBasedCostStrategy.kt
+++ b/module-core/src/main/kotlin/maple/expectation/core/policy/TableBasedCostStrategy.kt
@@ -1,0 +1,93 @@
+package maple.expectation.core.policy
+
+import maple.expectation.core.domain.model.CubeType
+import maple.expectation.core.domain.model.PotentialGrade
+import java.util.EnumMap
+import java.util.NavigableMap
+import java.util.TreeMap
+
+/**
+ * Table-based cost calculation strategy (default implementation).
+ *
+ * <p>Responsibilities (Single Responsibility Principle):
+ * - Lookup cost from static table
+ * - O(1) lookup performance using EnumMap
+ *
+ * <p>OCP Compliance:
+ * - Extension: Implements {@link CostCalculationStrategy} interface
+ * - Modification prevention: New cube types added without code changes
+ */
+class TableBasedCostStrategy : CostCalculationStrategy {
+
+    private val costMasterTable: Map<CubeType, NavigableMap<Int, EnumMap<PotentialGrade, Long>>>
+
+    init {
+        this.costMasterTable = initializeCostTable()
+    }
+
+    override fun calculateCost(type: CubeType, level: Int, grade: String): Long {
+        // Fail-Fast: Immediate exception on invalid input (prevent Silent Failure)
+        val validGrade = PotentialGrade.fromKorean(grade)
+
+        val typeTable = costMasterTable[type]
+            ?: throw IllegalStateException("Unknown CubeType: $type")
+
+        // Find closest lower bracket key for level (e.g., level 210 -> key 200)
+        val levelKey = typeTable.floorKey(level) ?: typeTable.firstKey()
+
+        // O(1) EnumMap lookup
+        return typeTable[levelKey]!![validGrade]!!
+    }
+
+    /**
+     * Initialize cost table (called from constructor).
+     *
+     * @return Cost master table
+     */
+    private fun initializeCostTable(): Map<CubeType, NavigableMap<Int, EnumMap<PotentialGrade, Long>>> {
+        val table = mutableMapOf<CubeType, NavigableMap<Int, EnumMap<PotentialGrade, Long>>>()
+
+        // 1. Black Cube (upper potential) cost table
+        val blackTable: NavigableMap<Int, EnumMap<PotentialGrade, Long>> = TreeMap<Int, EnumMap<PotentialGrade, Long>>().apply {
+            put(0, createGradeMap(4_000_000L, 16_000_000L, 34_000_000L, 40_000_000L))
+            put(160, createGradeMap(4_250_000L, 17_000_000L, 36_125_000L, 42_500_000L))
+            put(200, createGradeMap(4_500_000L, 18_000_000L, 38_250_000L, 45_000_000L))
+            put(250, createGradeMap(5_000_000L, 20_000_000L, 42_500_000L, 50_000_000L))
+        }
+        table[CubeType.BLACK] = blackTable
+
+        // 2. Additional Cube (lower potential) cost table
+        val addiTable: NavigableMap<Int, EnumMap<PotentialGrade, Long>> = TreeMap<Int, EnumMap<PotentialGrade, Long>>().apply {
+            put(0, createGradeMap(13_000_000L, 36_400_000L, 44_200_000L, 52_000_000L))
+            put(160, createGradeMap(13_812_500L, 38_675_000L, 46_962_500L, 55_250_000L))
+            put(200, createGradeMap(14_625_000L, 40_950_000L, 49_725_000L, 58_500_000L))
+            put(250, createGradeMap(16_250_000L, 45_500_000L, 55_250_000L, 65_000_000L))
+        }
+        table[CubeType.ADDITIONAL] = addiTable
+
+        // 3. Red Cube - no level distinction, returns 1 to treat as 'count'
+        val redTable: NavigableMap<Int, EnumMap<PotentialGrade, Long>> = TreeMap<Int, EnumMap<PotentialGrade, Long>>().apply {
+            put(0, createGradeMap(1L, 1L, 1L, 1L))
+        }
+        table[CubeType.RED] = redTable
+
+        return table
+    }
+
+    /**
+     * Create EnumMap helper - maps costs in RARE, EPIC, UNIQUE, LEGENDARY order.
+     */
+    private fun createGradeMap(
+        rare: Long,
+        epic: Long,
+        unique: Long,
+        legendary: Long
+    ): EnumMap<PotentialGrade, Long> {
+        val map = EnumMap<PotentialGrade, Long>(PotentialGrade::class.java)
+        map[PotentialGrade.RARE] = rare
+        map[PotentialGrade.EPIC] = epic
+        map[PotentialGrade.UNIQUE] = unique
+        map[PotentialGrade.LEGENDARY] = legendary
+        return map
+    }
+}

--- a/module-core/src/main/kotlin/maple/expectation/core/port/out/PolicyPort.kt
+++ b/module-core/src/main/kotlin/maple/expectation/core/port/out/PolicyPort.kt
@@ -1,0 +1,26 @@
+package maple.expectation.core.port.out
+
+import maple.expectation.core.domain.model.CubeType
+
+/**
+ * Policy outbound port for cost calculation.
+ *
+ * <p>Follows hexagonal architecture pattern:
+ * - Core defines the port interface
+ * - Infrastructure provides the implementation
+ * - Application layer depends only on this port
+ */
+interface PolicyPort {
+
+    /**
+     * Get cube cost for given parameters.
+     *
+     * @param type Cube type (BLACK, RED, ADDITIONAL)
+     * @param level Equipment level
+     * @param grade Potential grade (Korean: "레어", "에픽", "유니크", "레전드리")
+     * @return Cost for single cube use
+     * @throws IllegalArgumentException if parameters are invalid
+     * @throws IllegalStateException if cube type is unknown
+     */
+    fun getCubeCost(type: CubeType, level: Int, grade: String): Long
+}

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/adapter/policy/PolicyAdapter.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/adapter/policy/PolicyAdapter.kt
@@ -1,0 +1,22 @@
+package maple.expectation.infrastructure.adapter.policy
+
+import maple.expectation.core.domain.model.CubeType
+import maple.expectation.core.port.out.PolicyPort
+import maple.expectation.core.policy.TableBasedCostStrategy
+import org.springframework.stereotype.Component
+
+/**
+ * Policy infrastructure adapter.
+ *
+ * <p>Implements PolicyPort using TableBasedCostStrategy from core.
+ * Bridges module-app to module-core policy domain.
+ */
+@Component
+class PolicyAdapter : PolicyPort {
+
+    private val costStrategy = TableBasedCostStrategy()
+
+    override fun getCubeCost(type: CubeType, level: Int, grade: String): Long {
+        return costStrategy.calculateCost(type, level, grade)
+    }
+}


### PR DESCRIPTION
## 관련 이슈
#419

## 개요
ADR-004에 따라 Policy 도메인을 module-core로 이관

## 작업 내용
- [x] CostCalculationStrategy 인터페이스 이관 (Kotlin fun interface)
- [x] TableBasedCostStrategy 구현체 이관
- [x] PotentialGrade enum 이관
- [x] PolicyPort 인터페이스 정의
- [x] PolicyAdapter 구현 (module-infra)

## 구조 변경
```
module-core/
├── domain/model/PotentialGrade.kt
├── policy/
│   ├── CostCalculationStrategy.kt
│   └── TableBasedCostStrategy.kt
└── port/out/PolicyPort.kt

module-infra/
└── adapter/policy/PolicyAdapter.kt
```

## 검증
- 빌드 성공
- 의존성 방향: app → core ← infra

## 체크리스트
- [x] 브랜치/커밋 규칙 준수
- [x] 빌드 통과