### PR TITLE
test: ADR-005 CubeCostPolicyTest PolicyPort 호환성 수정 (#435)

### DIFF
--- a/module-app/src/test/java/maple/expectation/service/v2/policy/CubeCostPolicyTest.java
+++ b/module-app/src/test/java/maple/expectation/service/v2/policy/CubeCostPolicyTest.java
@@ -3,8 +3,9 @@ package maple.expectation.service.v2.policy;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import maple.expectation.core.port.out.PolicyPort;
 import maple.expectation.domain.v2.CubeType;
-import maple.expectation.error.exception.InvalidPotentialGradeException;
+import maple.expectation.infrastructure.adapter.policy.PolicyAdapter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -20,12 +21,12 @@ import org.junit.jupiter.params.provider.CsvSource;
 class CubeCostPolicyTest {
 
   private CubeCostPolicy cubeCostPolicy;
-  private CostCalculationStrategy costStrategy;
+  private PolicyPort policyPort;
 
   @BeforeEach
   void setUp() {
-    costStrategy = new TableBasedCostStrategy();
-    cubeCostPolicy = new CubeCostPolicy(costStrategy);
+    policyPort = new PolicyAdapter();
+    cubeCostPolicy = new CubeCostPolicy(policyPort);
   }
 
   @Nested
@@ -80,7 +81,7 @@ class CubeCostPolicyTest {
     void getCubeCost_blackCube_invalidGrades_throws(int level, String grade) {
       // When & Then
       assertThatThrownBy(() -> cubeCostPolicy.getCubeCost(CubeType.BLACK, level, grade))
-          .isInstanceOf(InvalidPotentialGradeException.class);
+          .isInstanceOf(IllegalArgumentException.class);
     }
 
     @ParameterizedTest(name = "ADDITIONAL 큐브, 레벨 {0}, 등급 {1} -> 예외 발생")
@@ -94,7 +95,7 @@ class CubeCostPolicyTest {
     void getCubeCost_additionalCube_invalidGrades_throws(int level, String grade) {
       // When & Then
       assertThatThrownBy(() -> cubeCostPolicy.getCubeCost(CubeType.ADDITIONAL, level, grade))
-          .isInstanceOf(InvalidPotentialGradeException.class);
+          .isInstanceOf(IllegalArgumentException.class);
     }
   }
 }


### PR DESCRIPTION
## 관련 이슈
#435

## 개요
module-common 모듈 검증 및 CubeCostPolicyTest 호환성 수정

## 작업 내용
- [x] module-common Spring 의존성 검증 (0개 확인)
- [x] ErrorCode/CommonErrorCode 구조 확인
- [x] 예외 계층 구조 확인 (48개 예외 + base + marker)
- [x] CubeCostPolicyTest PolicyPort 호환성 수정

## 분석 결과
**module-common은 이미 ADR-005/ADR-014 완벽 준수:**
- Spring 의존성 0개 (verifyNoSpringDependency 태스크 있음)
- 공통 예외 계층: BaseException, ClientBaseException, ServerBaseException
- CircuitBreaker Marker: RecordMarker, IgnoreMarker
- 공통 응답: ApiResponse, ErrorResponse
- 유틸리티: ExceptionUtils, GzipUtils, InterruptUtils, StringMaskingUtils

## 버그 수정
Policy 도메인 이관(PR #459) 후 누락된 테스트 수정:
- `CostCalculationStrategy` → `PolicyPort` 의존성 변경
- `InvalidPotentialGradeException` → `IllegalArgumentException` 예외 타입 반영

## 체크리스트
- [x] 브랜치/커밋 규칙 준수 여부
- [x] 테스트 통과 여부 (745 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)