### PR TITLE
feat: ADR-005 GameCharacterControllerV1 이관

### DIFF
--- a/module-web/src/main/java/maple/expectation/controller/v1/GameCharacterControllerV1.java
+++ b/module-web/src/main/java/maple/expectation/controller/v1/GameCharacterControllerV1.java
@@ -1,10 +1,10 @@
-package maple.expectation.controller;
+package maple.expectation.controller.v1;
 
 import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
+import maple.expectation.core.port.out.GameCharacterPort;
 import maple.expectation.domain.model.character.GameCharacter;
-import maple.expectation.dto.response.CharacterResponse;
-import maple.expectation.service.v2.facade.GameCharacterFacade;
+import maple.expectation.web.dto.response.CharacterResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,33 +13,31 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * 캐릭터 API V1 (레거시)
+ * 캐릭터 API V1 (레거시) - ADR-005 이관
  *
  * <p>Note: 좋아요 API는 V2로 이관됨 (인증 필요, Self-Like/중복 방지)
  *
- * <p>Issue #128: Entity 직접 노출 방지, DTO로 응답 크기 최적화
+ * <p>ADR-005 Hexagonal Architecture:
  *
- * @see maple.expectation.controller.GameCharacterControllerV2
+ * <ul>
+ *   <li>GameCharacterPort: 캐릭터 조회
+ * </ul>
  */
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/characters")
 public class GameCharacterControllerV1 {
 
-  private final GameCharacterFacade gameCharacterFacade;
+  private final GameCharacterPort gameCharacterPort;
 
-  /**
-   * 캐릭터 정보 조회
-   *
-   * <p>Issue #128: Entity → DTO 변환으로 응답 크기 최적화 (350KB → 4KB)
-   */
+  /** 캐릭터 정보 조회 */
   @GetMapping("/{userIgn}")
   @PreAuthorize("hasRole('ADMIN') or hasRole('USER')")
   public CompletableFuture<ResponseEntity<CharacterResponse>> findCharacterByUserIgn(
       @PathVariable String userIgn) {
     return CompletableFuture.supplyAsync(
         () -> {
-          GameCharacter character = gameCharacterFacade.findCharacterByUserIgn(userIgn);
+          GameCharacter character = gameCharacterPort.getCharacterOrThrow(userIgn);
           return ResponseEntity.ok(CharacterResponse.fromDomainModel(character));
         });
   }

--- a/module-web/src/main/kotlin/maple/expectation/web/dto/response/CharacterResponse.kt
+++ b/module-web/src/main/kotlin/maple/expectation/web/dto/response/CharacterResponse.kt
@@ -1,0 +1,43 @@
+package maple.expectation.web.dto.response
+
+import maple.expectation.domain.model.character.GameCharacter
+
+/**
+ * Character response DTO (Issue #128)
+ *
+ * <p>Prevents direct Entity exposure and optimizes API response size (350KB → 4KB)
+ *
+ * @param userIgn character nickname
+ * @param ocid character unique ID
+ * @param likeCount like count
+ * @param worldName world name
+ * @param characterClass class name
+ * @param characterImage character image URL
+ */
+data class CharacterResponse(
+    val userIgn: String?,
+    val ocid: String?,
+    val likeCount: Long?,
+    val worldName: String?,
+    val characterClass: String?,
+    val characterImage: String?,
+) {
+    companion object {
+        /**
+         * Convert Domain Model to DTO
+         *
+         * @param character GameCharacter domain model
+         * @return CharacterResponse DTO
+         */
+        @JvmStatic
+        @JvmName("fromDomainModel")
+        fun from(character: GameCharacter): CharacterResponse = CharacterResponse(
+            userIgn = character.userIgn.value,
+            ocid = character.characterId.value,
+            likeCount = character.likeCount,
+            worldName = character.worldName,
+            characterClass = character.characterClass,
+            characterImage = character.characterImage,
+        )
+    }
+}


### PR DESCRIPTION
## 관련 이슈
#349 (ADR-005 Hexagonal Architecture)

## 개요
GameCharacterControllerV1 module-web 이관

## 작업 내용
- [x] GameCharacterControllerV1 → GameCharacterPort 사용
- [x] CharacterResponse DTO module-web 추가

## 체크리스트
- [x] 빌드 통과 (`./gradlew build -x test`)
- [x] 브랜치/커밋 규칙 준수

🤖 Generated with [Claude Code](https://claude.com/claude-code)