### PR TITLE
feat: ADR-005 SystemMetricsPort 인터페이스 추가

### DIFF
--- a/module-app/src/main/java/maple/expectation/monitoring/context/SystemContextProvider.java
+++ b/module-app/src/main/java/maple/expectation/monitoring/context/SystemContextProvider.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import maple.expectation.core.port.out.SystemMetricsPort;
 import maple.expectation.infrastructure.executor.LogicExecutor;
 import maple.expectation.infrastructure.executor.TaskContext;
 import maple.expectation.infrastructure.monitoring.collector.MetricCategory;
@@ -41,7 +42,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class SystemContextProvider {
+public class SystemContextProvider implements SystemMetricsPort {
 
   private final List<MetricsCollectorStrategy> collectors;
   private final LogicExecutor executor;

--- a/module-core/src/main/kotlin/maple/expectation/core/port/out/SystemMetricsPort.kt
+++ b/module-core/src/main/kotlin/maple/expectation/core/port/out/SystemMetricsPort.kt
@@ -1,0 +1,21 @@
+package maple.expectation.core.port.out
+
+/**
+ * 시스템 메트릭 수집 Port 인터페이스 (ADR-005)
+ *
+ * <p>책임: 시스템 상태 메트릭 수집
+ *
+ * <p>구현체:
+ * <ul>
+ *   <li>module-app/monitoring/context/SystemContextProvider
+ * </ul>
+ */
+interface SystemMetricsPort {
+
+    /**
+     * 전체 시스템 메트릭 수집
+     *
+     * @return 카테고리별 메트릭 맵
+     */
+    fun collectAllMetrics(): Map<*, Map<String, Any>>
+}


### PR DESCRIPTION
## 관련 이슈
#441

## 개요
MonitoringReportJob 이관을 위한 SystemMetricsPort 인터페이스 추출

## 작업 내용
- [x] SystemMetricsPort 인터페이스 생성 (module-core/port/out)
- [x] SystemContextProvider가 SystemMetricsPort 구현

## 체크리스트
- [x] 브랜치/커밋 규칙 준수 여부
- [x] ADR-005 Hexagonal Architecture 준수

🤖 Generated with [Claude Code](https://claude.com/claude-code)