### PR TITLE
test: add ArchUnit tests for module dependency verification

### DIFF
--- a/module-app/src/test/java/architecture/ModuleDependencyTest.java
+++ b/module-app/src/test/java/architecture/ModuleDependencyTest.java
@@ -165,6 +165,97 @@ class ModuleDependencyTest {
     }
 
     /**
+     * module-web must NOT depend on module-infra.
+     *
+     * <p><strong>Phase 6 Finding:</strong> module-web currently has 12 imports from module-infra:
+     *
+     * <ul>
+     *   <li>ValidCorsOrigin, MDCFilter (config)
+     *   <li>AuthenticatedUser (security)
+     *   <li>LogicExecutor, TaskContext (executor)
+     *   <li>CharacterValuationView (mongodb view)
+     *   <li>RateLimitExceededException (exception handling)
+     * </ul>
+     *
+     * <p>See ADR-039 for future refactoring plans.
+     */
+    @Test
+    @DisplayName("module-web must NOT depend on module-infra (temporarily disabled)")
+    @Disabled(
+        "Phase 6 - module-web has 12 imports from module-infra. Requires refactoring to remove dependency.")
+    void moduleWebMustNotDependOnInfra() {
+      noClasses()
+          .that()
+          .resideInAPackage("..web..")
+          .should()
+          .dependOnClassesThat()
+          .resideInAPackage("..infrastructure..")
+          .because(
+              """
+                            Web layer must not depend on infrastructure layer.
+                            Use port interfaces from module-core instead.
+                            Infrastructure implementations are injected at runtime by module-app.
+                            """)
+          .allowEmptyShould(true)
+          .check(classes);
+    }
+
+    /**
+     * Comprehensive module dependency matrix validation.
+     *
+     * <p>Enforces the complete dependency direction: app → web/infra → core → common
+     */
+    @Test
+    @DisplayName("No forbidden module dependencies (comprehensive matrix)")
+    void noForbiddenModuleDependencies() {
+      // core must not depend on infra, web, app
+      noClasses()
+          .that()
+          .resideInAPackage("..core..")
+          .should()
+          .dependOnClassesThat()
+          .resideInAPackage("..infrastructure..")
+          .because("Core must not depend on infrastructure (DIP violation)")
+          .allowEmptyShould(true)
+          .check(classes);
+
+      noClasses()
+          .that()
+          .resideInAPackage("..core..")
+          .should()
+          .dependOnClassesThat()
+          .resideInAPackage("..application..")
+          .because("Core must not depend on application layer")
+          .allowEmptyShould(true)
+          .check(classes);
+
+      // common must not depend on any other module
+      noClasses()
+          .that()
+          .resideInAPackage("..common..")
+          .should()
+          .dependOnClassesThat()
+          .resideInAPackage("..core..")
+          .because("Common is the foundation and must not depend on higher modules")
+          .allowEmptyShould(true)
+          .check(classes);
+
+      // infra must not depend on app, web
+      noClasses()
+          .that()
+          .resideInAPackage("..infrastructure..")
+          .should()
+          .dependOnClassesThat()
+          .resideInAPackage("..application..")
+          .because("Infrastructure must not depend on application layer")
+          .allowEmptyShould(true)
+          .check(classes);
+
+      // Note: web → infra dependency is documented technical debt (12 imports)
+      // See moduleWebMustNotDependOnInfra() test for details
+    }
+
+    /**
      * module-common must not depend on any other module.
      *
      * <p><strong>Correct:</strong> common (foundation)


### PR DESCRIPTION
## 관련 이슈
Phase 6 Implementation

## 개요
Add ArchUnit tests to enforce clean module dependency direction and document technical debt.

## 작업 내용
- [x] Add `moduleWebMustNotDependOnInfra()` test (disabled with technical debt documentation)
- [x] Add `noForbiddenModuleDependencies()` comprehensive dependency matrix test
- [x] Document 12 infrastructure imports in module-web as technical debt

## 리뷰 포인트
- **Critical Finding**: Original plan assumption was incorrect. module-web has 12 actual imports from module-infra:
  - `LogicExecutor`, `TaskContext` (executor)
  - `AuthenticatedUser` (security)
  - `CharacterValuationView` (mongodb view)
  - `RateLimitExceededException` (exception handling)
  - `ValidCorsOrigin`, `MDCFilter` (config)
- The `module-web → module-infra` dependency cannot be removed without significant refactoring

## 트레이드 오프 결정 근거
- Added `@Disabled` test to document technical debt rather than asserting false invariant
- Comprehensive test uses `.allowEmptyShould(true)` to avoid false positives
- Web→infra check commented out with clear documentation

## 체크리스트
- [x] 브랜치/커밋 규칙 준수 여부
- [x] 테스트 통과 여부 (ArchUnit tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)