### PR TITLE
feat: Event Contract Standards and Port Signature ArchUnit Test

### DIFF
--- a/docs/events/compatibility.md
+++ b/docs/events/compatibility.md
@@ -1,0 +1,316 @@
+# Event Backward Compatibility Rules
+
+> **Version:** 1.0.0
+> **Status:** Active
+> **Related Issues:** #503
+> **Last Updated:** 2025-03-10
+
+## Purpose
+
+Define rules for making changes to event schemas while maintaining backward compatibility. This ensures existing consumers continue to work when event structures evolve.
+
+---
+
+## Core Principles
+
+1. **Consumers drive compatibility:** Events are produced once but consumed by many services
+2. **Explicit breaking changes:** Major version bumps signal incompatible changes
+3. **Graceful degradation:** Consumers should handle unknown fields gracefully
+4. **Documentation required:** All schema changes must be documented
+
+---
+
+## Compatibility Matrix
+
+| Change Type | Compatibility | Action Required | Example |
+|-------------|---------------|-----------------|---------|
+| Add optional field | ✅ ALLOWED | None | Add `nickname?: string` |
+| Add required field | ❌ BREAKING | New major version | Add `userId: string` (required) |
+| Remove field | ❌ BREAKING | New major version | Remove `oldField` |
+| Rename field | ❌ BREAKING | New major version | `userName` → `username` |
+| Change field type | ❌ BREAKING | New major version | `count: number` → `count: string` |
+| Required → Optional | ✅ ALLOWED | None | `name: string` → `name?: string` |
+| Optional → Required | ❌ BREAKING | New major version | `name?: string` → `name: string` |
+| Add enum value | ⚠️ CAUTION | Consumer update | Add `FAILED` to status enum |
+| Remove enum value | ❌ BREAKING | New major version | Remove `PENDING` from status |
+| Change field format | ⚠️ CAUTION | Consumer update | ISO date → epoch millis |
+
+### Legend
+
+- ✅ **ALLOWED:** No version change needed, safe to deploy
+- ⚠️ **CAUTION:** May work but requires consumer coordination
+- ❌ **BREAKING:** Requires new major version (`v1` → `v2`)
+
+---
+
+## Detailed Rules
+
+### 1. Adding Fields
+
+#### Optional Fields (ALLOWED)
+
+```json
+// v1
+{
+  "userId": "u123",
+  "name": "John"
+}
+
+// v1 (compatible addition)
+{
+  "userId": "u123",
+  "name": "John",
+  "nickname": "Johnny"  // NEW optional field
+}
+```
+
+**Consumer behavior:** Old consumers ignore the new field. New consumers can use it.
+
+#### Required Fields (BREAKING)
+
+```json
+// v1
+{
+  "userId": "u123"
+}
+
+// v2 (BREAKING - new required field)
+{
+  "userId": "u123",
+  "email": "john@example.com"  // NEW required field
+}
+```
+
+**Why breaking:** Old consumers expect events without `email`. New producers always include it.
+
+**Solution:** Add as optional first, then deprecate old version after migration.
+
+---
+
+### 2. Removing Fields
+
+```json
+// v1
+{
+  "userId": "u123",
+  "legacyField": "old data"
+}
+
+// v2 (BREAKING - field removed)
+{
+  "userId": "u123"
+}
+```
+
+**Why breaking:** Consumers may depend on the removed field.
+
+**Migration path:**
+1. Add new field alongside old field
+2. Update consumers to use new field
+3. Wait for consumer migration (monitor usage)
+4. Remove old field with new major version
+
+---
+
+### 3. Changing Field Types
+
+```json
+// v1
+{
+  "count": 42  // number
+}
+
+// v2 (BREAKING - type changed)
+{
+  "count": "42"  // string
+}
+```
+
+**Why breaking:** Type expectations in consumers will fail.
+
+**Solution:** Add new field with new type, deprecate old field.
+
+---
+
+### 4. Enum Changes
+
+#### Adding Values (CAUTION)
+
+```json
+// v1
+{
+  "status": "ACTIVE" | "INACTIVE"
+}
+
+// v1 (cautious addition)
+{
+  "status": "ACTIVE" | "INACTIVE" | "PENDING"  // NEW value
+}
+```
+
+**Risk:** Consumers using `switch`/`if-else` may hit default case unexpectedly.
+
+**Mitigation:** Ensure consumers handle unknown enum values gracefully.
+
+#### Removing Values (BREAKING)
+
+```json
+// v1
+{
+  "status": "ACTIVE" | "PENDING" | "INACTIVE"
+}
+
+// v2 (BREAKING - enum value removed)
+{
+  "status": "ACTIVE" | "INACTIVE"  // PENDING removed
+}
+```
+
+**Why breaking:** Consumers may produce events with `PENDING`. Old events may exist with `PENDING`.
+
+---
+
+### 5. Required ↔ Optional
+
+#### Required → Optional (ALLOWED)
+
+```json
+// v1
+{
+  "name": "John"  // required
+}
+
+// v1 (compatible change)
+{
+  "name": "John" | null  // now optional
+}
+```
+
+**Consumer behavior:** Consumers already expect the field. Making it optional is safe.
+
+#### Optional → Required (BREAKING)
+
+```json
+// v1
+{
+  "name": "John" | null  // optional
+}
+
+// v2 (BREAKING - now required)
+{
+  "name": "John"  // required
+}
+```
+
+**Why breaking:** Old events may have `null`. Consumers may not handle missing field.
+
+---
+
+## Version Bumping Guide
+
+### When to Bump Major Version
+
+- Remove any field
+- Add required field
+- Change field type
+- Rename field
+- Remove enum value
+- Make optional field required
+
+### When NOT to Bump
+
+- Add optional field with default
+- Make required field optional
+- Add documentation/comments
+- Internal implementation changes
+
+---
+
+## Consumer Implementation Guidelines
+
+### Robust Field Access
+
+```kotlin
+// Good: Handle missing/null fields
+val name = event.payload.name ?: "Unknown"
+val count = event.payload.count ?: 0
+
+// Bad: Assume field exists
+val name = event.payload.name  // NPE risk
+```
+
+### Enum Handling
+
+```kotlin
+// Good: Handle unknown values
+enum class Status { ACTIVE, INACTIVE }
+fun parseStatus(value: String): Status =
+    try { Status.valueOf(value) }
+    catch (e: IllegalArgumentException) {
+        log.warn("Unknown status: $value")
+        Status.INACTIVE  // Safe default
+    }
+```
+
+### Version Negotiation
+
+```kotlin
+fun handle(event: IntegrationEvent<*>) {
+    when (event.version) {
+        "1" -> handleV1(event)
+        "2" -> handleV2(event)
+        else -> log.warn("Unknown event version: ${event.version}")
+    }
+}
+```
+
+---
+
+## Change Checklist
+
+Before making event schema changes:
+
+- [ ] Identify change type (allowed, caution, or breaking)
+- [ ] If breaking, create new major version
+- [ ] Update event documentation
+- [ ] Notify consumer teams
+- [ ] Deploy producers first (for additions)
+- [ ] Deploy consumers (for removals)
+- [ ] Monitor for errors
+- [ ] Deprecate old version after migration
+
+---
+
+## Deprecation Policy
+
+### Timeline
+
+| Phase | Duration | Actions |
+|-------|----------|---------|
+| Announcement | Day 0 | Announce deprecation, provide migration guide |
+| Warning Period | 90 days | Log warnings for old version usage |
+| Sunset Period | 30 days | Reject new events with old version |
+| Removal | Day 120 | Delete old version support |
+
+### Deprecation Notice Format
+
+```markdown
+## Deprecation Notice
+
+**Event:** `character.calculated.v1`
+**Deprecated:** 2025-03-10
+**Sunset:** 2025-06-10
+**Replacement:** `character.calculated.v2`
+
+**Migration:**
+- Replace `characterClass` with `characterClassCode`
+- `totalExpectedCost` is now `expectedCostMeso`
+```
+
+---
+
+## References
+
+- [Event Contract v1](./contract-v1.md) - Event structure and naming
+- [Sample Events](./samples/) - Example event definitions
+- [ADR-018](../adr/ADR-018-strategy-pattern-for-acl.md) - Anti-Corruption Layer strategy

--- a/docs/events/contract-v1.md
+++ b/docs/events/contract-v1.md
@@ -1,0 +1,182 @@
+# Event Contract v1
+
+> **Version:** 1.0.0
+> **Status:** Active
+> **Related Issues:** #501, #502, #503
+> **Last Updated:** 2025-03-10
+
+## Purpose
+
+Define a standardized contract for all integration events in the MapleExpectation system. This ensures:
+
+- **Consistency:** All events follow the same structure and naming conventions
+- **Interoperability:** Events can be processed by any consumer without custom parsing logic
+- **Evolvability:** Changes can be made safely with clear backward compatibility rules
+- **Traceability:** Events can be traced across distributed systems
+
+---
+
+## Event Naming Convention
+
+### Format
+
+```
+{domain}.{action}.v{version}
+```
+
+### Components
+
+| Component | Description | Examples |
+|-----------|-------------|----------|
+| `domain` | The bounded context or aggregate | `character`, `donation`, `cache`, `user` |
+| `action` | Past-tense verb describing what happened | `calculated`, `created`, `invalidated`, `updated` |
+| `version` | Semantic version (major only for events) | `v1`, `v2` |
+
+### Naming Rules
+
+1. **Use lowercase with dots:** `character.calculated.v1` (not `CharacterCalculatedV1`)
+2. **Past tense for actions:** `created` not `create`, `calculated` not `calculate`
+3. **Single version number:** Events use `v1`, `v2` (not `v1.0.0` or `v1.2`)
+4. **Domain-first grouping:** Events are grouped by domain for subscription patterns
+
+### Examples
+
+```
+character.calculated.v1      # Character expectation calculation completed
+character.updated.v1         # Character data updated
+donation.created.v1          # New donation record created
+cache.invalidated.v1         # Cache entry invalidated
+user.logged_in.v1            # User login event
+```
+
+---
+
+## Common Fields
+
+All events MUST include the following fields in the envelope:
+
+### Required Fields
+
+| Field | Type | Description | Example |
+|-------|------|-------------|---------|
+| `eventId` | String (UUID) | Unique identifier for this event instance. Used for deduplication and tracing. | `"550e8400-e29b-41d4-a716-446655440000"` |
+| `eventType` | String | Event type identifier following naming convention | `"character.calculated.v1"` |
+| `occurredAt` | String (ISO-8601) | When the event occurred in the domain (not when it was published) | `"2025-03-10T14:30:00.123Z"` |
+| `version` | String | Event schema version (matches eventType version) | `"1"` |
+| `producer` | String | Service/module that produced the event | `"expectation-calculator"` |
+| `idempotencyKey` | String | Key for idempotent processing (often derived from aggregate ID + action) | `"char-abc123-calc-20250310"` |
+
+### Field Constraints
+
+- `eventId`: MUST be a valid UUID v4, globally unique
+- `occurredAt`: MUST be in UTC, ISO-8601 format with milliseconds
+- `version`: MUST be a string (not number) to allow "1", "2", etc.
+- `producer`: SHOULD be the module/service name, not hostname or instance ID
+
+---
+
+## Event Envelope Structure
+
+### JSON Schema
+
+```json
+{
+  "eventId": "550e8400-e29b-41d4-a716-446655440000",
+  "eventType": "character.calculated.v1",
+  "occurredAt": "2025-03-10T14:30:00.123Z",
+  "version": "1",
+  "producer": "expectation-calculator",
+  "idempotencyKey": "char-abc123-calc-20250310",
+  "payload": {
+    // Domain-specific fields
+  }
+}
+```
+
+### Kotlin Implementation
+
+```kotlin
+data class IntegrationEvent<T>(
+    val eventId: String,           // UUID
+    val eventType: String,         // "character.calculated.v1"
+    val occurredAt: String,        // ISO-8601 timestamp
+    val version: String,           // "1"
+    val producer: String,          // "expectation-calculator"
+    val idempotencyKey: String,    // Deduplication key
+    val payload: T                 // Domain-specific payload
+)
+```
+
+---
+
+## Payload Guidelines
+
+### Principles
+
+1. **Minimal payload:** Include only data needed by consumers
+2. **Denormalization OK:** Include computed values if commonly needed
+3. **No sensitive data:** Never include passwords, tokens, or PII
+4. **Stable identifiers:** Use IDs that don't change (not names, emails)
+
+### Payload Versioning
+
+When payload structure changes:
+
+| Change Type | Action | Example |
+|-------------|--------|---------|
+| Add optional field | Create new minor version | `v1` → `v1.1` (internal) |
+| Remove field | Create new major version | `v1` → `v2` |
+| Change field type | Create new major version | `v1` → `v2` |
+| Add required field | Create new major version | `v1` → `v2` |
+
+---
+
+## Producer Responsibilities
+
+1. **Generate unique eventId:** Use UUID v4
+2. **Set accurate occurredAt:** When the event happened, not when publishing
+3. **Include idempotencyKey:** Enable consumers to deduplicate safely
+4. **Version correctly:** Increment version only for breaking changes
+5. **Order within aggregate:** Events for same aggregate should be ordered
+
+## Consumer Responsibilities
+
+1. **Idempotent processing:** Use eventId or idempotencyKey to deduplicate
+2. **Handle version negotiation:** Support current and N-1 versions
+3. **Fail gracefully:** Unknown event types should not crash consumers
+4. **Acknowledge after processing:** Only ack after successful handling
+
+---
+
+## Event Flow
+
+```
+┌─────────────┐    ┌──────────────┐    ┌─────────────┐
+│   Domain    │───▶│   Event      │───▶│  Message    │
+│   Service   │    │   Publisher  │    │  Broker     │
+└─────────────┘    └──────────────┘    └─────────────┘
+                          │                   │
+                    Creates event         Routes to
+                    with contract         consumers
+                          │                   │
+                          ▼                   ▼
+                   ┌─────────────────────────────┐
+                   │     IntegrationEvent<T>     │
+                   │  - eventId (UUID)           │
+                   │  - eventType (domain.action)│
+                   │  - occurredAt (ISO-8601)    │
+                   │  - version ("1")            │
+                   │  - producer                 │
+                   │  - idempotencyKey           │
+                   │  - payload (domain data)    │
+                   └─────────────────────────────┘
+```
+
+---
+
+## References
+
+- [Event Compatibility Rules](./compatibility.md) - Backward compatibility guidelines
+- [Sample Events](./samples/) - Example event definitions
+- [IntegrationEvent.kt](../../module-core/src/main/kotlin/maple/expectation/core/domain/event/IntegrationEvent.kt) - Core implementation
+- [ADR-018](../adr/ADR-018-strategy-pattern-for-acl.md) - Anti-Corruption Layer strategy

--- a/docs/events/samples/cache-invalidated.v1.md
+++ b/docs/events/samples/cache-invalidated.v1.md
@@ -1,0 +1,219 @@
+# Sample Event: cache.invalidated.v1
+
+> **Event Type:** `cache.invalidated.v1`
+> **Version:** 1
+> **Domain:** Cache
+> **Related Issues:** #502
+
+## Purpose
+
+Published when a cache entry is invalidated (explicitly removed or expired). This event enables cache invalidation propagation across multiple application instances in a distributed environment, ensuring cache consistency.
+
+---
+
+## Event Envelope
+
+```json
+{
+  "eventId": "770e8400-e29b-41d4-a716-446655440002",
+  "eventType": "cache.invalidated.v1",
+  "occurredAt": "2025-03-10T16:00:00.789Z",
+  "version": "1",
+  "producer": "cache-manager",
+  "idempotencyKey": "cache-user-preferences-u67890",
+  "payload": {
+    "cacheName": "user-preferences",
+    "key": "u67890",
+    "invalidationType": "EXPLICIT",
+    "sourceInstanceId": "app-instance-01",
+    "reason": "USER_UPDATE",
+    "invalidatedAt": "2025-03-10T16:00:00.000Z"
+  }
+}
+```
+
+---
+
+## Field Definitions
+
+### Common Fields (Envelope)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `eventId` | String (UUID) | Yes | Unique event identifier for tracing/deduplication |
+| `eventType` | String | Yes | Always `"cache.invalidated.v1"` |
+| `occurredAt` | String (ISO-8601) | Yes | When invalidation occurred |
+| `version` | String | Yes | Event schema version: `"1"` |
+| `producer` | String | Yes | Service that produced: `"cache-manager"` |
+| `idempotencyKey` | String | Yes | Key: `cache-{cacheName}-{key}` |
+
+### Payload Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `cacheName` | String | Yes | Name of the cache (e.g., `user-preferences`, `character-data`) |
+| `key` | String | Yes | Cache key that was invalidated |
+| `invalidationType` | String | Yes | Type: `EXPLICIT`, `EXPIRED`, `EVICTED`, `CLEARED` |
+| `sourceInstanceId` | String | Yes | Instance that triggered the invalidation |
+| `reason` | String | No | Reason code for invalidation (e.g., `USER_UPDATE`, `DATA_REFRESH`) |
+| `invalidatedAt` | String (ISO-8601) | Yes | When the invalidation happened |
+
+---
+
+## Payload Schema (JSON Schema)
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["cacheName", "key", "invalidationType", "sourceInstanceId", "invalidatedAt"],
+  "properties": {
+    "cacheName": {
+      "type": "string",
+      "description": "Cache name/region"
+    },
+    "key": {
+      "type": "string",
+      "description": "Cache key that was invalidated"
+    },
+    "invalidationType": {
+      "type": "string",
+      "enum": ["EXPLICIT", "EXPIRED", "EVICTED", "CLEARED"],
+      "description": "How the invalidation occurred"
+    },
+    "sourceInstanceId": {
+      "type": "string",
+      "description": "Application instance that triggered invalidation"
+    },
+    "reason": {
+      "type": "string",
+      "description": "Optional reason code for invalidation"
+    },
+    "invalidatedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "When the invalidation occurred"
+    }
+  }
+}
+```
+
+---
+
+## Invalidation Types
+
+| Type | Description | Example Trigger |
+|------|-------------|-----------------|
+| `EXPLICIT` | Intentional removal via API call | User updates profile, cache cleared |
+| `EXPIRED` | TTL-based expiration | Cache entry TTL reached |
+| `EVICTED` | Memory pressure eviction | Cache size limit reached |
+| `CLEARED` | Full cache clear | Application deployment, admin action |
+
+---
+
+## Consumer Usage
+
+### L1 Cache Invalidation (Caffeine)
+
+```kotlin
+fun handle(event: IntegrationEvent<CacheInvalidatedPayload>) {
+    val payload = event.payload
+
+    // Skip if this instance triggered the invalidation (already handled locally)
+    if (payload.sourceInstanceId == instanceId) {
+        return
+    }
+
+    // Invalidate local L1 cache
+    l1CacheManager.invalidate(payload.cacheName, payload.key)
+
+    log.info("Invalidated L1 cache: {} - {}", payload.cacheName, payload.key)
+}
+```
+
+### Metrics Collection
+
+```kotlin
+fun handle(event: IntegrationEvent<CacheInvalidatedPayload>) {
+    val payload = event.payload
+
+    metrics.counter("cache.invalidation",
+        "cacheName" to payload.cacheName,
+        "type" to payload.invalidationType
+    ).increment()
+}
+```
+
+---
+
+## Flow Diagram
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│               Distributed Cache Invalidation                 │
+├─────────────────────────────────────────────────────────────┤
+│                                                              │
+│  ┌─────────────────┐                                         │
+│  │  Instance A     │                                         │
+│  │  (Source)       │───┐                                     │
+│  │  L1: key=value  │   │                                     │
+│  └─────────────────┘   │                                     │
+│                        ▼                                      │
+│              Event: cache.invalidated.v1                      │
+│                        │                                      │
+│         ┌──────────────┼──────────────┐                      │
+│         │              │              │                       │
+│         ▼              ▼              ▼                       │
+│  ┌─────────────┐ ┌─────────────┐ ┌─────────────┐            │
+│  │ Instance B  │ │ Instance C  │ │ Instance D  │            │
+│  │ L1: REMOVE  │ │ L1: REMOVE  │ │ L1: REMOVE  │            │
+│  │ key         │ │ key         │ │ key         │            │
+│  └─────────────┘ └─────────────┘ └─────────────┘            │
+│                                                              │
+│  All instances now have consistent L1 cache state            │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Integration with TieredCache
+
+This event is part of the TieredCache invalidation strategy:
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                      TieredCache Flow                         │
+├──────────────────────────────────────────────────────────────┤
+│                                                               │
+│  1. Read: L1 (Caffeine) → L2 (PostgreSQL UNLOGGED) → Loader  │
+│                                                               │
+│  2. Write: L1 → L2 → PostgreSQL NOTIFY                       │
+│             │                                                 │
+│             ▼                                                 │
+│  3. Invalidate: Publish cache.invalidated.v1                  │
+│             │                                                 │
+│             ▼                                                 │
+│  4. Propagate: Other instances receive event, clear L1        │
+│                                                               │
+└──────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Notes
+
+### Source Instance Filtering
+
+Consumers MUST skip processing if `sourceInstanceId` matches their own instance ID. The source instance has already handled the invalidation locally, and processing it again would be redundant.
+
+### Idempotency
+
+The `idempotencyKey` format (`cache-{cacheName}-{key}`) ensures that multiple invalidation events for the same cache entry can be deduplicated if needed.
+
+---
+
+## Version History
+
+| Version | Date | Changes |
+|---------|------|---------|
+| v1 | 2025-03-10 | Initial definition |

--- a/docs/events/samples/character-calculated.v1.md
+++ b/docs/events/samples/character-calculated.v1.md
@@ -1,0 +1,167 @@
+# Sample Event: character.calculated.v1
+
+> **Event Type:** `character.calculated.v1`
+> **Version:** 1
+> **Domain:** Character
+> **Related Issues:** #502
+
+## Purpose
+
+Published when a character's equipment expectation calculation is completed. This event notifies downstream systems (MongoDB sync, analytics, notifications) that new calculation results are available.
+
+---
+
+## Event Envelope
+
+```json
+{
+  "eventId": "550e8400-e29b-41d4-a716-446655440000",
+  "eventType": "character.calculated.v1",
+  "occurredAt": "2025-03-10T14:30:00.123Z",
+  "version": "1",
+  "producer": "expectation-calculator",
+  "idempotencyKey": "char-ocid-abc123-20250310-143000",
+  "payload": {
+    "characterOcid": "abc123",
+    "userIgn": "MapleStory",
+    "characterClass": "ARCH_MAGE_FP",
+    "characterLevel": 275,
+    "totalExpectedCost": "150000000000",
+    "maxPresetNo": 2,
+    "calculatedAt": "2025-03-10T14:30:00.000Z"
+  }
+}
+```
+
+---
+
+## Field Definitions
+
+### Common Fields (Envelope)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `eventId` | String (UUID) | Yes | Unique event identifier for tracing/deduplication |
+| `eventType` | String | Yes | Always `"character.calculated.v1"` |
+| `occurredAt` | String (ISO-8601) | Yes | When calculation completed |
+| `version` | String | Yes | Event schema version: `"1"` |
+| `producer` | String | Yes | Service that produced: `"expectation-calculator"` |
+| `idempotencyKey` | String | Yes | Key: `char-ocid-{ocid}-{date}-{time}` |
+
+### Payload Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `characterOcid` | String | Yes | Nexon OCID (unique character identifier) |
+| `userIgn` | String | Yes | In-game name for display purposes |
+| `characterClass` | String | Yes | Character class enum (e.g., `ARCH_MAGE_FP`) |
+| `characterLevel` | Integer | Yes | Character level (1-300) |
+| `totalExpectedCost` | String | Yes | Total expected meso cost as string (avoid precision loss) |
+| `maxPresetNo` | Integer | Yes | Maximum preset number available |
+| `calculatedAt` | String (ISO-8601) | Yes | Timestamp of calculation (may differ from occurredAt) |
+
+---
+
+## Payload Schema (JSON Schema)
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["characterOcid", "userIgn", "characterClass", "characterLevel", "totalExpectedCost", "maxPresetNo", "calculatedAt"],
+  "properties": {
+    "characterOcid": {
+      "type": "string",
+      "description": "Nexon OCID identifier"
+    },
+    "userIgn": {
+      "type": "string",
+      "description": "In-game character name"
+    },
+    "characterClass": {
+      "type": "string",
+      "enum": ["ARCH_MAGE_FP", "ARCH_MAGE_TC", "BISHOP", "HERO", "PALADIN", "DARK_KNIGHT", "..."],
+      "description": "Character class enum"
+    },
+    "characterLevel": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 300,
+      "description": "Character level"
+    },
+    "totalExpectedCost": {
+      "type": "string",
+      "pattern": "^\\d+$",
+      "description": "Total expected cost in meso (as string for precision)"
+    },
+    "maxPresetNo": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Maximum equipment preset number"
+    },
+    "calculatedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "When the calculation was performed"
+    }
+  }
+}
+```
+
+---
+
+## Consumer Usage
+
+### MongoDB Sync Worker
+
+```kotlin
+fun handle(event: IntegrationEvent<CharacterCalculatedPayload>) {
+    val payload = event.payload
+    characterValuationViewRepository.upsert(
+        ocid = payload.characterOcid,
+        totalExpectedCost = BigDecimal(payload.totalExpectedCost),
+        calculatedAt = Instant.parse(payload.calculatedAt)
+    )
+}
+```
+
+### Analytics Consumer
+
+```kotlin
+fun handle(event: IntegrationEvent<CharacterCalculatedPayload>) {
+    metrics.counter("character.calculated",
+        "class" to event.payload.characterClass,
+        "levelRange" to event.payload.characterLevel / 10 * 10
+    ).increment()
+}
+```
+
+---
+
+## Flow Diagram
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                   Expectation Calculation                    │
+├─────────────────────────────────────────────────────────────┤
+│                                                              │
+│  User Request ──▶ Calculator Service ──▶ Event Publisher    │
+│                                              │               │
+│                                              ▼               │
+│                              character.calculated.v1         │
+│                                              │               │
+│                    ┌─────────────────────────┼────────────┐ │
+│                    │                         │            │ │
+│                    ▼                         ▼            ▼ │
+│              MongoDB Sync            Analytics       Notifications│
+│              (Materialized View)     (Metrics)      (Optional)   │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Version History
+
+| Version | Date | Changes |
+|---------|------|---------|
+| v1 | 2025-03-10 | Initial definition |

--- a/docs/events/samples/donation-created.v1.md
+++ b/docs/events/samples/donation-created.v1.md
@@ -1,0 +1,184 @@
+# Sample Event: donation.created.v1
+
+> **Event Type:** `donation.created.v1`
+> **Version:** 1
+> **Domain:** Donation
+> **Related Issues:** #502
+
+## Purpose
+
+Published when a new donation record is created in the system. This event notifies downstream systems (analytics, notifications, audit logging) about new donation activity.
+
+---
+
+## Event Envelope
+
+```json
+{
+  "eventId": "660e8400-e29b-41d4-a716-446655440001",
+  "eventType": "donation.created.v1",
+  "occurredAt": "2025-03-10T15:00:00.456Z",
+  "version": "1",
+  "producer": "donation-service",
+  "idempotencyKey": "donation-d12345",
+  "payload": {
+    "donationId": "d12345",
+    "userId": "u67890",
+    "amount": "10000",
+    "currency": "KRW",
+    "donationType": "ONE_TIME",
+    "status": "COMPLETED",
+    "createdAt": "2025-03-10T15:00:00.000Z"
+  }
+}
+```
+
+---
+
+## Field Definitions
+
+### Common Fields (Envelope)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `eventId` | String (UUID) | Yes | Unique event identifier for tracing/deduplication |
+| `eventType` | String | Yes | Always `"donation.created.v1"` |
+| `occurredAt` | String (ISO-8601) | Yes | When donation was recorded |
+| `version` | String | Yes | Event schema version: `"1"` |
+| `producer` | String | Yes | Service that produced: `"donation-service"` |
+| `idempotencyKey` | String | Yes | Key: `donation-{donationId}` |
+
+### Payload Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `donationId` | String | Yes | Unique donation identifier |
+| `userId` | String | Yes | User who made the donation |
+| `amount` | String | Yes | Donation amount as string (avoid precision loss) |
+| `currency` | String | Yes | ISO 4217 currency code |
+| `donationType` | String | Yes | Type: `ONE_TIME`, `RECURRING`, `SPONSOR` |
+| `status` | String | Yes | Status: `PENDING`, `COMPLETED`, `FAILED`, `REFUNDED` |
+| `createdAt` | String (ISO-8601) | Yes | When donation was created in database |
+
+---
+
+## Payload Schema (JSON Schema)
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["donationId", "userId", "amount", "currency", "donationType", "status", "createdAt"],
+  "properties": {
+    "donationId": {
+      "type": "string",
+      "description": "Unique donation identifier"
+    },
+    "userId": {
+      "type": "string",
+      "description": "User identifier"
+    },
+    "amount": {
+      "type": "string",
+      "pattern": "^\\d+(\\.\\d{1,2})?$",
+      "description": "Donation amount (as string for precision)"
+    },
+    "currency": {
+      "type": "string",
+      "pattern": "^[A-Z]{3}$",
+      "description": "ISO 4217 currency code"
+    },
+    "donationType": {
+      "type": "string",
+      "enum": ["ONE_TIME", "RECURRING", "SPONSOR"],
+      "description": "Type of donation"
+    },
+    "status": {
+      "type": "string",
+      "enum": ["PENDING", "COMPLETED", "FAILED", "REFUNDED"],
+      "description": "Current donation status"
+    },
+    "createdAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "When donation was created"
+    }
+  }
+}
+```
+
+---
+
+## Consumer Usage
+
+### Analytics Consumer
+
+```kotlin
+fun handle(event: IntegrationEvent<DonationCreatedPayload>) {
+    val payload = event.payload
+    if (payload.status == "COMPLETED") {
+        donationMetrics.recordDonation(
+            amount = BigDecimal(payload.amount),
+            currency = payload.currency,
+            type = payload.donationType
+        )
+    }
+}
+```
+
+### Notification Consumer
+
+```kotlin
+fun handle(event: IntegrationEvent<DonationCreatedPayload>) {
+    val payload = event.payload
+    if (payload.status == "COMPLETED") {
+        notificationService.sendThankYou(
+            userId = payload.userId,
+            amount = payload.amount,
+            currency = payload.currency
+        )
+    }
+}
+```
+
+---
+
+## Flow Diagram
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    Donation Processing                       │
+├─────────────────────────────────────────────────────────────┤
+│                                                              │
+│  Payment Gateway ──▶ Donation Service ──▶ Event Publisher   │
+│                                           │                  │
+│                                           ▼                  │
+│                            donation.created.v1               │
+│                                           │                  │
+│                   ┌───────────────────────┼──────────────┐  │
+│                   │                       │              │  │
+│                   ▼                       ▼              ▼  │
+│             Analytics              Notifications      Audit Log│
+│             (Metrics)              (Thank You)        (Compliance)│
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Notes
+
+### Amount as String
+
+Amount is stored as string to avoid floating-point precision issues with monetary values. Consumers should convert to `BigDecimal` for calculations.
+
+### Status Transitions
+
+This event is published for the initial creation. Status changes (`COMPLETED`, `FAILED`, `REFUNDED`) may trigger additional events like `donation.updated.v1` in future versions.
+
+---
+
+## Version History
+
+| Version | Date | Changes |
+|---------|------|---------|
+| v1 | 2025-03-10 | Initial definition |

--- a/module-app/src/test/java/architecture/PortSignatureRuleTest.java
+++ b/module-app/src/test/java/architecture/PortSignatureRuleTest.java
@@ -1,0 +1,276 @@
+package architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Port signature enforcement tests.
+ *
+ * <p><strong>Core Principle:</strong> Port interfaces (inbound/outbound) must be
+ * framework-agnostic. They should only use domain types, not Spring/Servlet/HTTP framework types.
+ *
+ * <p><strong>References:</strong>
+ *
+ * <ul>
+ *   <li>docs/adr/ADR-004-port-based-architecture.md - Port-Based Architecture
+ *   <li>CLAUDE.md - Section: Clean Architecture & DIP
+ *   <li>Issue #500 - Create ArchUnit test to prevent forbidden types in Port interfaces
+ * </ul>
+ *
+ * <p><strong>Forbidden Types:</strong>
+ *
+ * <ul>
+ *   <li>{@code org.springframework.http.ResponseEntity} - Use domain DTOs instead
+ *   <li>{@code org.springframework.data.domain.Pageable} - Use domain pagination types
+ *   <li>{@code jakarta.servlet.http.HttpServletRequest} - Use domain request objects
+ *   <li>{@code jakarta.servlet.http.HttpServletResponse} - Use domain response objects
+ * </ul>
+ *
+ * <p><strong>Rationale:</strong> Port interfaces define the boundary between the core domain and
+ * external systems. Using framework types creates tight coupling to specific technologies and
+ * violates the Dependency Inversion Principle (DIP). This prevents:
+ *
+ * <ul>
+ *   <li>Framework lock-in (cannot switch from Spring to another framework)
+ *   <li>Testability issues (requires mock HTTP infrastructure)
+ *   <li>Violation of Clean Architecture (domain depends on infrastructure concerns)
+ * </ul>
+ */
+@DisplayName("Port Signature: Framework-Agnostic Interfaces")
+class PortSignatureRuleTest {
+
+  private final JavaClasses classes =
+      new ClassFileImporter()
+          .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+          .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_JARS)
+          .importPackages("maple.expectation.core");
+
+  // ========================================
+  // Rule 1: No ResponseEntity in Port Methods
+  // ========================================
+
+  @Nested
+  @DisplayName("ResponseEntity: Not Allowed in Port Interfaces")
+  class ResponseEntityTests {
+
+    /**
+     * Port interfaces must not use ResponseEntity.
+     *
+     * <p><strong>Problem:</strong> ResponseEntity is a Spring framework type that couples the port
+     * to HTTP concerns.
+     *
+     * <p><strong>Solution:</strong> Return domain DTOs directly. Let the adapter layer handle HTTP
+     * response wrapping.
+     */
+    @Test
+    @DisplayName("Port interfaces should not use ResponseEntity")
+    void portsShouldNotUseResponseEntity() {
+      noClasses()
+          .that()
+          .resideInAPackage("..port..")
+          .and()
+          .areInterfaces()
+          .should()
+          .dependOnClassesThat()
+          .areAssignableTo("org.springframework.http.ResponseEntity")
+          .because(
+              """
+                            Port interfaces must be framework-agnostic.
+                            ResponseEntity couples the port to Spring HTTP concerns.
+                            Use domain DTOs instead. Let adapters handle HTTP wrapping.
+                            """)
+          .allowEmptyShould(true)
+          .check(classes);
+    }
+  }
+
+  // ========================================
+  // Rule 2: No Pageable in Port Methods
+  // ========================================
+
+  @Nested
+  @DisplayName("Pageable: Not Allowed in Port Interfaces")
+  class PageableTests {
+
+    /**
+     * Port interfaces must not use Spring Data Pageable.
+     *
+     * <p><strong>Problem:</strong> Pageable is a Spring Data type that couples the port to Spring's
+     * pagination abstraction.
+     *
+     * <p><strong>Solution:</strong> Define domain pagination types (e.g., PageRequest, PageResult)
+     * in the core module.
+     */
+    @Test
+    @DisplayName("Port interfaces should not use Pageable")
+    void portsShouldNotUsePageable() {
+      noClasses()
+          .that()
+          .resideInAPackage("..port..")
+          .and()
+          .areInterfaces()
+          .should()
+          .dependOnClassesThat()
+          .areAssignableTo("org.springframework.data.domain.Pageable")
+          .because(
+              """
+                            Port interfaces must be framework-agnostic.
+                            Pageable couples the port to Spring Data pagination.
+                            Define domain pagination types in core module instead.
+                            """)
+          .allowEmptyShould(true)
+          .check(classes);
+    }
+  }
+
+  // ========================================
+  // Rule 3: No HttpServletRequest/Response in Port Methods
+  // ========================================
+
+  @Nested
+  @DisplayName("Servlet Types: Not Allowed in Port Interfaces")
+  class ServletTypesTests {
+
+    /**
+     * Port interfaces must not use HttpServletRequest.
+     *
+     * <p><strong>Problem:</strong> HttpServletRequest is a Servlet API type that couples the port
+     * to HTTP request handling.
+     *
+     * <p><strong>Solution:</strong> Extract required data into domain request objects in the
+     * controller/adapter layer.
+     */
+    @Test
+    @DisplayName("Port interfaces should not use HttpServletRequest")
+    void portsShouldNotUseHttpServletRequest() {
+      noClasses()
+          .that()
+          .resideInAPackage("..port..")
+          .and()
+          .areInterfaces()
+          .should()
+          .dependOnClassesThat()
+          .areAssignableTo("jakarta.servlet.http.HttpServletRequest")
+          .because(
+              """
+                            Port interfaces must be framework-agnostic.
+                            HttpServletRequest couples the port to Servlet API.
+                            Extract required data into domain request objects instead.
+                            """)
+          .allowEmptyShould(true)
+          .check(classes);
+    }
+
+    /**
+     * Port interfaces must not use HttpServletResponse.
+     *
+     * <p><strong>Problem:</strong> HttpServletResponse is a Servlet API type that couples the port
+     * to HTTP response handling.
+     *
+     * <p><strong>Solution:</strong> Return domain response objects. Let the controller handle HTTP
+     * response building.
+     */
+    @Test
+    @DisplayName("Port interfaces should not use HttpServletResponse")
+    void portsShouldNotUseHttpServletResponse() {
+      noClasses()
+          .that()
+          .resideInAPackage("..port..")
+          .and()
+          .areInterfaces()
+          .should()
+          .dependOnClassesThat()
+          .areAssignableTo("jakarta.servlet.http.HttpServletResponse")
+          .because(
+              """
+                            Port interfaces must be framework-agnostic.
+                            HttpServletResponse couples the port to Servlet API.
+                            Return domain response objects instead.
+                            """)
+          .allowEmptyShould(true)
+          .check(classes);
+    }
+  }
+
+  // ========================================
+  // Rule 4: No javax.servlet Types (Legacy)
+  // ========================================
+
+  @Nested
+  @DisplayName("Legacy Servlet Types: Not Allowed in Port Interfaces")
+  class LegacyServletTypesTests {
+
+    /**
+     * Port interfaces must not use legacy javax.servlet types.
+     *
+     * <p><strong>Problem:</strong> javax.servlet is the pre-Jakarta EE namespace. While deprecated,
+     * some older dependencies may still use it.
+     */
+    @Test
+    @DisplayName("Port interfaces should not use javax.servlet types")
+    void portsShouldNotUseJavaxServlet() {
+      noClasses()
+          .that()
+          .resideInAPackage("..port..")
+          .and()
+          .areInterfaces()
+          .should()
+          .dependOnClassesThat()
+          .resideInAPackage("javax.servlet..")
+          .because(
+              """
+                            Port interfaces must be framework-agnostic.
+                            javax.servlet types are legacy Servlet API.
+                            Use domain request/response objects instead.
+                            """)
+          .allowEmptyShould(true)
+          .check(classes);
+    }
+  }
+
+  // ========================================
+  // Summary: Combined Check
+  // ========================================
+
+  @Nested
+  @DisplayName("Summary: All Forbidden Types Check")
+  class SummaryTests {
+
+    /**
+     * Combined check for all forbidden types in port interfaces.
+     *
+     * <p>This provides a single test that catches all violations at once, useful for CI/CD
+     * pipelines.
+     */
+    @Test
+    @DisplayName("Port interfaces should not depend on any forbidden framework types")
+    void portsShouldNotDependOnForbiddenTypes() {
+      noClasses()
+          .that()
+          .resideInAPackage("..port..")
+          .and()
+          .areInterfaces()
+          .should()
+          .dependOnClassesThat()
+          .resideInAnyPackage(
+              "org.springframework.http..",
+              "org.springframework.data.domain..",
+              "jakarta.servlet..",
+              "javax.servlet..")
+          .because(
+              """
+                            Port interfaces must be framework-agnostic for Clean Architecture compliance.
+                            Forbidden: ResponseEntity, Pageable, HttpServletRequest, HttpServletResponse.
+                            Use domain types only. Adapters handle framework-specific concerns.
+                            """)
+          .allowEmptyShould(true)
+          .check(classes);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements 4 related issues for event standardization and architecture enforcement:

- **#500 [P0]**: Create ArchUnit test to prevent forbidden types in Port interfaces
- **#501 [P1]**: Define event naming and common fields standard documentation
- **#502 [P1]**: Define 3 sample event definitions (depends on #501)
- **#503 [P1]**: Define event backward compatibility rules (depends on #501)

## Changes

### Issue #500 - Port Signature ArchUnit Test
- `module-app/src/test/java/architecture/PortSignatureRuleTest.java`
- Validates port interfaces are framework-agnostic
- Checks for forbidden types: `ResponseEntity`, `Pageable`, `HttpServletRequest`, `HttpServletResponse`
- Ensures Clean Architecture compliance (Dependency Inversion Principle)

### Issue #501 - Event Contract v1 Standard
- `docs/events/contract-v1.md`
- Naming convention: `{domain}.{action}.v{version}` (e.g., `character.calculated.v1`)
- Common fields: `eventId`, `eventType`, `occurredAt`, `version`, `producer`, `idempotencyKey`
- JSON envelope structure and producer/consumer responsibilities

### Issue #502 - Sample Event Definitions
- `docs/events/samples/character-calculated.v1.md` - Character expectation calculation completed
- `docs/events/samples/donation-created.v1.md` - New donation record created  
- `docs/events/samples/cache-invalidated.v1.md` - Distributed cache invalidation propagation

### Issue #503 - Event Compatibility Rules
- `docs/events/compatibility.md`
- Compatibility matrix for field changes (add/remove/type change)
- Version bumping guide (when to bump major version)
- Deprecation policy and migration checklist

## Test plan

- [x] `./gradlew :module-app:test --tests "architecture.PortSignatureRuleTest"` passes
- [x] `./gradlew compileKotlin compileJava` passes
- [x] All 6 ArchUnit tests pass (no violations in existing port interfaces)

Fixes #500, #501, #502, #503

🤖 Generated with [Claude Code](https://claude.com/claude-code)