### PR TITLE
[V5] PostgreSQL Migration - Infrastructure Layer

### DIFF
--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/batch/AdaptiveMicroBatchUserService.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/batch/AdaptiveMicroBatchUserService.kt
@@ -24,7 +24,6 @@ import maple.expectation.infrastructure.executor.LogicExecutor
 import maple.expectation.infrastructure.executor.TaskContext
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.cache.Cache
-import org.springframework.stereotype.Service
 
 private val log = KotlinLogging.logger {}
 
@@ -70,7 +69,8 @@ private val log = KotlinLogging.logger {}
  * @see AdaptiveMicroBatchProperties
  * @see BatchRequest
  */
-@Service
+// Note: @Service removed - this is a generic class that must be instantiated manually with specific loaders
+// Used only in tests and specialized configurations
 @EnableConfigurationProperties(AdaptiveMicroBatchProperties::class)
 class AdaptiveMicroBatchUserService<T : Any>(
     private val properties: AdaptiveMicroBatchProperties,

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/batch/listener/BatchOptimisticLockListener.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/batch/listener/BatchOptimisticLockListener.kt
@@ -51,7 +51,7 @@ import org.springframework.stereotype.Component
  * </ul>
  */
 @Component
-@ConditionalOnBean(BatchCharacterViewService::class)
+@ConditionalOnBean(name = ["batchCharacterViewService"])
 class BatchOptimisticLockListener(
     private val batchViewService: BatchCharacterViewService,
     private val executor: LogicExecutor,

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/config/BatchConfig.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/config/BatchConfig.kt
@@ -10,6 +10,7 @@ import org.springframework.batch.core.repository.JobRepository
 import org.springframework.batch.core.step.builder.StepBuilder
 import org.springframework.batch.item.ItemReader
 import org.springframework.batch.item.ItemWriter
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.transaction.PlatformTransactionManager
@@ -53,6 +54,7 @@ import org.springframework.transaction.PlatformTransactionManager
  * @see maple.expectation.infrastructure.batch.listener.BatchOptimisticLockListener
  */
 @Configuration
+@ConditionalOnBean(name = ["batchCharacterViewService"])
 class BatchConfig(
     private val jobRepository: JobRepository,
     private val recoveryListener: BatchJobRecoveryListener,

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/config/CacheConfig.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/config/CacheConfig.kt
@@ -12,6 +12,7 @@ import maple.expectation.infrastructure.cache.TieredCacheManager
 import maple.expectation.infrastructure.executor.LogicExecutor
 import maple.expectation.infrastructure.external.dto.v2.TotalExpectationResponse
 import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.EnableCaching
@@ -41,10 +42,16 @@ import org.springframework.data.redis.serializer.StringRedisSerializer
  *   <li>cache.l2.enabled=false 시 L2 비활성화</li>
  *   <li>CaffeineOnlyCacheManager로 L2 대체</li>
  * </ul>
+ *
+ * <h4>PostgreSQL-only mode</h4>
+ *
+ * <p>Redis가 비활성화된 경우 이 설정은 로드되지 않음.
+ * 대신 CaffeineOnlyCacheConfig가 Caffeine-only 캐시 매니저를 제공.
  */
 @Configuration
 @EnableCaching
 @EnableConfigurationProperties(CacheProperties::class)
+@ConditionalOnProperty(name = ["spring.data.redis.host"])
 class CacheConfig {
 
     /**

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/config/CaffeineOnlyCacheConfig.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/config/CaffeineOnlyCacheConfig.kt
@@ -1,0 +1,117 @@
+package maple.expectation.infrastructure.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.github.benmanes.caffeine.cache.Caffeine
+import java.util.concurrent.TimeUnit
+import maple.expectation.infrastructure.cache.CaffeineOnlyCacheManager
+import maple.expectation.infrastructure.external.dto.v2.TotalExpectationResponse
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.cache.caffeine.CaffeineCacheManager
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer
+import org.springframework.data.redis.serializer.RedisSerializer
+
+/**
+ * Caffeine-only Cache Configuration (PostgreSQL-only mode)
+ *
+ * <h3>Purpose</h3>
+ *
+ * <p>Provides cache management when Redis is disabled.
+ * Uses Caffeine for all caching needs without L2 distributed cache.
+ *
+ * <h3>Activation</h3>
+ *
+ * <p>Only active when `spring.data.redis.host` is not configured (Redis disabled).
+ *
+ * @see CacheProperties
+ * @see CaffeineOnlyCacheManager
+ */
+@Configuration
+@EnableCaching
+@EnableConfigurationProperties(CacheProperties::class)
+@ConditionalOnMissingBean(CacheConfig::class)
+class CaffeineOnlyCacheConfig {
+
+    /**
+     * Primary CacheManager (Caffeine-only for PostgreSQL mode)
+     */
+    @Bean
+    @Primary
+    fun cacheManager(cacheProperties: CacheProperties): CacheManager {
+        val l1Manager = CaffeineCacheManager()
+
+        cacheProperties
+            .specs
+            .forEach { (name, spec) ->
+                l1Manager.registerCustomCache(
+                    name,
+                    Caffeine.newBuilder()
+                        .expireAfterWrite(spec.l1TtlMinutes.toLong(), TimeUnit.MINUTES)
+                        .maximumSize(spec.l1MaxSize.toLong())
+                        .recordStats()
+                        .build(),
+                )
+            }
+
+        return l1Manager
+    }
+
+    /**
+     * Expectation 전용 L1 CacheManager (Caffeine)
+     */
+    @Bean(name = ["expectationL1CacheManager"])
+    fun expectationL1CacheManager(cacheProperties: CacheProperties): CacheManager {
+        val l1Manager = CaffeineCacheManager()
+
+        // Expectation 결과 캐시
+        l1Manager.registerCustomCache(
+            "expectationResult",
+            Caffeine.newBuilder()
+                .expireAfterWrite(5L, TimeUnit.MINUTES)
+                .maximumSize(1000L)
+                .recordStats()
+                .build(),
+        )
+
+        // equipment L1-only 캐시
+        val equipmentSpec = cacheProperties.specs["equipment"]
+        if (equipmentSpec != null) {
+            l1Manager.registerCustomCache(
+                "equipment",
+                Caffeine.newBuilder()
+                    .expireAfterWrite(equipmentSpec.l1TtlMinutes.toLong(), TimeUnit.MINUTES)
+                    .maximumSize(equipmentSpec.l1MaxSize.toLong())
+                    .recordStats()
+                    .build(),
+            )
+        }
+
+        return l1Manager
+    }
+
+    /**
+     * Expectation 전용 Serializer (for compatibility with existing code)
+     */
+    @Bean
+    @Qualifier("expectationCacheSerializer")
+    fun expectationCacheSerializer(objectMapper: ObjectMapper): RedisSerializer<Any> {
+        val serializer =
+            Jackson2JsonRedisSerializer(objectMapper, TotalExpectationResponse::class.java)
+
+        @Suppress("UNCHECKED_CAST", "rawtypes")
+        val casted: RedisSerializer<Any> = serializer as RedisSerializer<Any>
+        return casted
+    }
+
+    /**
+     * L2 Cache Manager for Expectation (Caffeine-only fallback)
+     */
+    @Bean(name = ["expectationL2CacheManager"])
+    fun expectationL2CacheManager(): CacheManager = CaffeineOnlyCacheManager()
+}

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/config/LikeRealtimeSyncConfig.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/config/LikeRealtimeSyncConfig.kt
@@ -12,6 +12,7 @@ import maple.expectation.infrastructure.queue.like.realtime.ReliableRedisLikeEve
 import org.redisson.api.RedissonClient
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -44,6 +45,7 @@ import org.springframework.context.annotation.Configuration
     havingValue = "true",
     matchIfMissing = true,
 )
+@ConditionalOnProperty(name = ["spring.data.redis.host"])
 class LikeRealtimeSyncConfig(
     @Value("\${app.instance-id:\${HOSTNAME:unknown}}") private val instanceId: String,
 ) {
@@ -63,6 +65,7 @@ class LikeRealtimeSyncConfig(
         havingValue = "rtopic",
         matchIfMissing = true,
     )
+    @ConditionalOnBean(TieredCacheManager::class)
     class RTopicConfig(
         private val redissonClient: RedissonClient,
         private val cacheManager: TieredCacheManager,
@@ -99,6 +102,7 @@ class LikeRealtimeSyncConfig(
      */
     @Configuration
     @ConditionalOnProperty(name = ["like.realtime.transport"], havingValue = "reliable-topic")
+    @ConditionalOnBean(TieredCacheManager::class)
     class ReliableTopicConfig(
         private val redissonClient: RedissonClient,
         private val cacheManager: TieredCacheManager,

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/config/LockHikariConfig.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/config/LockHikariConfig.kt
@@ -11,9 +11,9 @@ import org.springframework.context.annotation.Profile
 import org.springframework.jdbc.core.JdbcTemplate
 
 /**
- * MySQL Named Lock 전용 HikariCP 설정
+ * PostgreSQL Advisory Lock 전용 HikariCP 설정
  *
- * <p>[목적] - Redis 장애 시 MySQL Named Lock을 사용할 때 메인 커넥션 풀이 고갈되는 것을 방지 - 락 전용 커넥션 풀을 별도로 운영하여 애플리케이션
+ * <p>[목적] - PostgreSQL Advisory Lock을 사용할 때 메인 커넥션 풀이 고갈되는 것을 방지 - 락 전용 커넥션 풀을 별도로 운영하여 애플리케이션
  * 안정성 확보
  *
  * <p>[설계 원칙] - Fixed Pool Size: Min과 Max를 동일하게 설정하여 연결 비용(Handshake) 제거 - Size 30: RPS 235 트래픽이
@@ -47,7 +47,7 @@ class LockHikariConfig(
         config.jdbcUrl = jdbcUrl
         config.username = username
         config.password = password
-        config.driverClassName = "com.mysql.cj.jdbc.Driver"
+        config.driverClassName = "org.postgresql.Driver"
 
         // [핵심 수정 1] Pool Size 증설 (10 -> 30) 및 고정 (Fixed Pool)
         // Redis가 죽으면 트래픽이 몰리므로 10개로는 부족함.
@@ -59,7 +59,7 @@ class LockHikariConfig(
         config.connectionTimeout = 5000 // 5초 안에 연결 못 얻으면 에러 (스레드 보호)
         config.idleTimeout = 300000
         config.maxLifetime = 600000
-        config.poolName = "MySQLLockPool"
+        config.poolName = "PostgreSQLLockPool"
 
         // 검증 설정 (JDBC4 isValid 사용으로 쿼리 비용 절감)
         config.validationTimeout = 3000
@@ -68,7 +68,7 @@ class LockHikariConfig(
         // 주요 HikariPool 메트릭은 기본 DataSource에서 충분히 수집 가능
 
         log.info(
-            "[Lock Pool] Initialized dedicated MySQL lock connection pool (Fixed Size: {}, Metrics: disabled)",
+            "[Lock Pool] Initialized dedicated PostgreSQL lock connection pool (Fixed Size: {}, Metrics: disabled)",
             poolSize,
         )
 

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/event/outbox/EventOutboxProcessor.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/event/outbox/EventOutboxProcessor.kt
@@ -6,7 +6,7 @@ import maple.expectation.infrastructure.aop.annotation.ObservedTransaction
 import maple.expectation.infrastructure.config.OutboxProperties
 import maple.expectation.infrastructure.executor.LogicExecutor
 import maple.expectation.infrastructure.executor.TaskContext
-import maple.expectation.infrastructure.messaging.RedisStreamPublisher
+import maple.expectation.infrastructure.messaging.PgmqStreamPublisher
 import maple.expectation.infrastructure.metrics.EventOutboxMetrics
 import maple.expectation.infrastructure.persistence.repository.EventOutboxRepository
 import org.slf4j.LoggerFactory
@@ -44,7 +44,7 @@ class EventOutboxProcessor(
     private val transactionTemplate: TransactionTemplate,
     private val properties: OutboxProperties,
     private val eventOutboxRepository: EventOutboxRepository,
-    private val redisStreamPublisher: RedisStreamPublisher,
+    private val pgmqStreamPublisher: PgmqStreamPublisher,
 ) : EventProcessorPort {
 
     private val log = LoggerFactory.getLogger(javaClass)
@@ -128,7 +128,7 @@ class EventOutboxProcessor(
             return false
         }
 
-        publishToRedisStream(entry)
+        publishToPgmqQueue(entry)
         entry.markCompleted()
         eventOutboxRepository.save(entry)
         metrics.incrementProcessed()
@@ -172,24 +172,24 @@ class EventOutboxProcessor(
         dlqHandler.handleDeadLetter(entry, "Integrity verification failed")
     }
 
-    /** Redis Stream에 이벤트 발행 */
-    private fun publishToRedisStream(entry: EventOutbox) {
+    /** PGMQ Queue에 이벤트 발행 */
+    private fun publishToPgmqQueue(entry: EventOutbox) {
         val eventId = entry.id?.toString() ?: "unknown"
         val context = TaskContext.of("EventOutbox", "Publish", eventId)
 
         executor.executeOrCatch(
             {
-                redisStreamPublisher.publish(
+                pgmqStreamPublisher.publish(
                     streamName = entry.targetStream ?: "default",
                     eventId = eventId,
                     eventType = entry.eventType ?: "unknown",
                     payload = entry.payload ?: "{}",
                 )
-                log.info("[EventOutbox] Redis Stream 발행 완료: eventId={}, stream={}", eventId, entry.targetStream)
+                log.info("[EventOutbox] PGMQ 발행 완료: eventId={}, queue={}", eventId, entry.targetStream)
                 metrics.incrementPublished()
             },
             { e ->
-                log.error("[EventOutbox] Redis Stream 발행 실패: eventId={}", eventId, e)
+                log.error("[EventOutbox] PGMQ 발행 실패: eventId={}", eventId, e)
                 throw e // Re-throw for retry logic
             },
             context,

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/lock/MySqlNamedLockStrategy.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/lock/MySqlNamedLockStrategy.kt
@@ -11,6 +11,7 @@ import maple.expectation.infrastructure.executor.TaskContext
 import maple.expectation.infrastructure.executor.strategy.ExceptionTranslator
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.jdbc.core.ConnectionCallback
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.jdbc.datasource.SingleConnectionDataSource
@@ -18,9 +19,13 @@ import org.springframework.stereotype.Component
 
 /**
  * MySQL Named Lock 전략
+ *
+ * Note: MySQL 데이터베이스에서만 활성화됨
+ * PostgreSQL 모드에서는 PostgresAdvisoryLockStrategy 사용
  */
 @Component
 @ConditionalOnBean(name = ["lockJdbcTemplate"])
+@ConditionalOnProperty(name = ["maple.database.type"], havingValue = "mysql", matchIfMissing = false)
 class MySqlNamedLockStrategy(
     @Qualifier("lockJdbcTemplate")
     private val lockJdbcTemplate: JdbcTemplate,

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/lock/PostgresAdvisoryLockStrategy.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/lock/PostgresAdvisoryLockStrategy.kt
@@ -2,9 +2,11 @@ package maple.expectation.infrastructure.lock
 
 import java.sql.Connection
 import maple.expectation.common.function.ThrowingSupplier
+import maple.expectation.error.exception.DistributedLockException
 import maple.expectation.infrastructure.executor.LogicExecutor
 import maple.expectation.infrastructure.executor.TaskContext
 import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Primary
 import org.springframework.jdbc.core.ConnectionCallback
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.stereotype.Component
@@ -26,12 +28,17 @@ import org.springframework.stereotype.Component
  *
  * <h3>Session Scoped Locks</h3>
  * <p>Advisory locks are automatically released when the database session ends.
+ *
+ * <h3>PostgreSQL-only Mode</h3>
+ * <p>When Redis is disabled, this becomes the primary lock strategy.
  */
+@Primary
 @Component
 class PostgresAdvisoryLockStrategy(
     private val jdbcTemplate: JdbcTemplate,
     private val executor: LogicExecutor,
-) : LeaderElectionStrategy {
+) : LockStrategy,
+    LeaderElectionStrategy {
 
     override fun <T> executeWithLeaderElection(
         key: String,
@@ -47,6 +54,80 @@ class PostgresAdvisoryLockStrategy(
                 executeWithConnectionLock(conn, lockId, key, waitTimeSeconds, leaderTask, followerTask, context)
             },
         )!!
+    }
+
+    // ==================== LockStrategy Implementation ====================
+
+    override fun <T> executeWithLock(key: String, waitTime: Long, leaseTime: Long, task: ThrowingSupplier<T>): T {
+        val lockId = generateLockId(key)
+        val context = TaskContext.of("AdvisoryLock", "ExecuteWithLock", key)
+
+        return jdbcTemplate.execute(
+            ConnectionCallback { conn ->
+                executeWithAdvisoryLock(conn, lockId, key, waitTime, task, context)
+            },
+        )!!
+    }
+
+    override fun <T> executeWithLock(key: String, task: ThrowingSupplier<T>): T = executeWithLock(key, 10, 20, task)
+
+    override fun tryLockImmediately(key: String, leaseTime: Long): Boolean {
+        val lockId = generateLockId(key)
+        return jdbcTemplate.queryForObject(
+            "SELECT pg_try_advisory_lock(?)",
+            Boolean::class.java,
+            lockId,
+        ) ?: false
+    }
+
+    override fun unlock(key: String) {
+        val lockId = generateLockId(key)
+        jdbcTemplate.queryForObject(
+            "SELECT pg_advisory_unlock(?)",
+            Boolean::class.java,
+            lockId,
+        )
+        log.debug("🔓 [AdvisoryLock] Unlocked key: {}", key)
+    }
+
+    private fun <T> executeWithAdvisoryLock(
+        conn: Connection,
+        lockId: Long,
+        key: String,
+        waitTime: Long,
+        task: ThrowingSupplier<T>,
+        context: TaskContext,
+    ): T {
+        // Try to acquire lock with timeout
+        val startTime = System.currentTimeMillis()
+        val timeoutMs = waitTime * 1000L
+        val pollIntervalMs = 100L
+        var acquired = false
+
+        while (System.currentTimeMillis() - startTime < timeoutMs) {
+            if (tryAcquireLock(conn, lockId)) {
+                acquired = true
+                break
+            }
+            try {
+                Thread.sleep(pollIntervalMs)
+            } catch (e: InterruptedException) {
+                Thread.currentThread().interrupt()
+                throw DistributedLockException("Interrupted while waiting for lock: $key", e)
+            }
+        }
+
+        if (!acquired) {
+            throw DistributedLockException("Failed to acquire lock within timeout: $key")
+        }
+
+        log.debug("🔒 [AdvisoryLock] Acquired lock for key: {}", key)
+
+        return executor.executeWithFinally(
+            { task.get() },
+            { releaseLock(conn, lockId, key) },
+            context,
+        )
     }
 
     // ==================== Private Methods ====================

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/lock/RedisDistributedLockStrategy.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/lock/RedisDistributedLockStrategy.kt
@@ -5,6 +5,7 @@ import maple.expectation.core.port.out.redis.RedisOperationPort
 import maple.expectation.infrastructure.executor.LogicExecutor
 import maple.expectation.infrastructure.executor.TaskContext
 import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
 
 /**
@@ -14,9 +15,13 @@ import org.springframework.stereotype.Component
  *
  * <h4>ADR-012: DIP 준수</h4>
  * <p>RedissonClient 대신 RedisOperationPort에 의존하여 DIP 준수.
+ *
+ * <h4>Redis 비활성화 시 자동 비활성화</h4>
+ * <p>app.data.redis.enabled=false인 경우 이 빈은 생성되지 않습니다.
  */
 @Component
 @Qualifier("redisDistributedLockStrategy")
+@ConditionalOnProperty(name = ["spring.data.redis.host"], matchIfMissing = false)
 class RedisDistributedLockStrategy(
     private val redisOperationPort: RedisOperationPort,
     executor: LogicExecutor,

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/lock/ResilientLockStrategy.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/lock/ResilientLockStrategy.kt
@@ -16,16 +16,17 @@ import org.redisson.client.RedisException
 import org.redisson.client.RedisTimeoutException
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
-import org.springframework.context.annotation.Primary
 import org.springframework.lang.Nullable
 import org.springframework.stereotype.Component
 
 /**
  * 회복력 있는 락 전략 (Redis 우선, 실패 시 MySQL로 복구)
+ *
+ * Note: @Primary 제거됨 - Redis 모드에서만 활성화됨
+ * PostgreSQL-only 모드에서는 PostgresAdvisoryLockStrategy가 Primary
  */
-@Primary
 @Component
-@ConditionalOnProperty(name = ["lock.impl"], havingValue = "redis", matchIfMissing = true)
+@ConditionalOnProperty(name = ["lock.impl"], havingValue = "redis", matchIfMissing = false)
 class ResilientLockStrategy(
     @Qualifier("redisDistributedLockStrategy")
     private val redisLockStrategy: LockStrategy,

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/messaging/PgmqStreamPublisher.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/messaging/PgmqStreamPublisher.kt
@@ -1,0 +1,96 @@
+package maple.expectation.infrastructure.messaging
+
+import maple.expectation.infrastructure.executor.LogicExecutor
+import maple.expectation.infrastructure.executor.TaskContext
+import maple.expectation.infrastructure.pgmq.PgmqClient
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+
+/**
+ * PGMQ-based Stream Publisher (Redis Stream 대체)
+ *
+ * <h3>Redis Stream → PGMQ Migration</h3>
+ * <p>Redis Stream 대신 PostgreSQL PGMQ를 사용하여 이벤트를 발행합니다.
+ *
+ * <h3>장점</h3>
+ * <ul>
+ *   <li>PostgreSQL 통합: 단일 DB로 관리
+ *   <li>트랜잭션 지원: DB 작업과 메시지 발행이 원자적
+ *   <li>운영 단순화: Redis 의존성 제거
+ * </ul>
+ *
+ * @see PgmqClient
+ * @see maple.expectation.infrastructure.event.outbox.EventOutboxProcessor
+ */
+@Component
+@ConditionalOnProperty(
+    prefix = "app.event-publisher",
+    name = ["type"],
+    havingValue = "postgres",
+    matchIfMissing = false,
+)
+class PgmqStreamPublisher(
+    private val pgmqClient: PgmqClient,
+    private val executor: LogicExecutor,
+) {
+
+    companion object {
+        private val log = LoggerFactory.getLogger(PgmqStreamPublisher::class.java)
+    }
+
+    /**
+     * Publishes event to PGMQ queue.
+     *
+     * @param streamName Target queue name (maps to PGMQ queue)
+     * @param eventId Unique event identifier
+     * @param eventType Event type identifier
+     * @param payload JSON-serialized event payload
+     * @return Message ID if successful, null otherwise
+     */
+    fun publish(streamName: String, eventId: String, eventType: String, payload: String): Long? {
+        val context = TaskContext.of("PgmqStreamPublisher", "Publish", eventId)
+
+        return executor.executeOrDefault(
+            { publishInternal(streamName, eventId, eventType, payload) },
+            null,
+            context,
+        )
+    }
+
+    /** Internal publish logic */
+    private fun publishInternal(
+        streamName: String,
+        eventId: String,
+        eventType: String,
+        payload: String,
+    ): Long {
+        val message = StreamMessage(
+            eventId = eventId,
+            eventType = eventType,
+            payload = payload,
+            timestamp = java.time.Instant.now().toEpochMilli(),
+        )
+
+        val messageId = pgmqClient.send(streamName, message)
+
+        log.info(
+            "[PgmqStreamPublisher] Published event: queue={}, eventId={}, messageId={}",
+            streamName,
+            eventId,
+            messageId,
+        )
+
+        return messageId
+    }
+
+    /**
+     * Data class for stream message.
+     */
+    data class StreamMessage(
+        val eventId: String,
+        val eventType: String,
+        val payload: String,
+        val timestamp: Long,
+    )
+}

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/mongodb/BatchCharacterViewService.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/mongodb/BatchCharacterViewService.kt
@@ -5,6 +5,7 @@ import java.time.Instant
 import maple.expectation.infrastructure.executor.LogicExecutor
 import maple.expectation.infrastructure.executor.TaskContext
 import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.data.mongodb.core.MongoTemplate
 import org.springframework.data.mongodb.core.query.Criteria
 import org.springframework.data.mongodb.core.query.Query
@@ -47,6 +48,7 @@ import org.springframework.stereotype.Service
  * </ul>
  */
 @Service
+@ConditionalOnBean(MongoTemplate::class)
 class BatchCharacterViewService(
     private val mongoTemplate: MongoTemplate,
     private val executor: LogicExecutor,

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/mongodb/CharacterViewQueryService.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/mongodb/CharacterViewQueryService.kt
@@ -5,6 +5,7 @@ import java.time.Duration
 import maple.expectation.infrastructure.executor.LogicExecutor
 import maple.expectation.infrastructure.executor.TaskContext
 import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.data.mongodb.core.MongoTemplate
 import org.springframework.data.mongodb.core.query.Criteria
 import org.springframework.data.mongodb.core.query.Query
@@ -24,6 +25,7 @@ import org.springframework.stereotype.Service
  * </ul>
  */
 @Service
+@ConditionalOnBean(MongoTemplate::class)
 class CharacterViewQueryService(
     private val repository: CharacterValuationRepository,
     private val mongoTemplate: MongoTemplate,

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/mongodb/MongoDBConfig.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/mongodb/MongoDBConfig.kt
@@ -6,6 +6,7 @@ import jakarta.annotation.PostConstruct
 import java.util.concurrent.TimeUnit
 import lombok.RequiredArgsConstructor
 import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.domain.Sort
@@ -37,6 +38,7 @@ import org.springframework.data.mongodb.repository.config.EnableMongoRepositorie
  */
 @Configuration
 @RequiredArgsConstructor
+@ConditionalOnBean(MongoTemplate::class)
 @ConditionalOnProperty(name = ["v5.enabled"], havingValue = "true", matchIfMissing = false)
 @EnableMongoRepositories(basePackages = ["maple.expectation.infrastructure.mongodb"])
 class MongoDBConfig(

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/mongodb/MongoDBHealthIndicator.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/mongodb/MongoDBHealthIndicator.kt
@@ -2,6 +2,7 @@ package maple.expectation.infrastructure.mongodb
 
 import org.springframework.boot.actuate.health.Health
 import org.springframework.boot.actuate.health.HealthIndicator
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
 
@@ -21,6 +22,7 @@ import org.springframework.stereotype.Component
  * Only active when v5.enabled=true
  */
 @Component
+@ConditionalOnBean(MongoDBConfig::class)
 @ConditionalOnProperty(name = ["v5.enabled"], havingValue = "true", matchIfMissing = false)
 class MongoDBHealthIndicator(
     private val mongoConfig: MongoDBConfig,

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/CharacterViewQueryServicePostgres.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/CharacterViewQueryServicePostgres.kt
@@ -1,0 +1,193 @@
+package maple.expectation.infrastructure.persistence
+
+import io.micrometer.core.instrument.MeterRegistry
+import java.time.Duration
+import maple.expectation.infrastructure.executor.LogicExecutor
+import maple.expectation.infrastructure.executor.TaskContext
+import maple.expectation.infrastructure.persistence.entity.CharacterValuationViewEntity
+import maple.expectation.infrastructure.persistence.repository.CharacterValuationViewJpaRepository
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * V5 CQRS Query Side Service - PostgreSQL Read Operations
+ *
+ * MongoDB CharacterViewQueryService의 PostgreSQL 마이그레이션
+ *
+ * <h3>Responsibilities</h3>
+ * <ul>
+ *   <li>Fast read from character_valuation_views table
+ *   <li>LogicExecutor pattern for exception handling
+ *   <li>Micrometer metrics for monitoring
+ * </ul>
+ *
+ * @see maple.expectation.infrastructure.mongodb.CharacterViewQueryService
+ */
+@Service
+@ConditionalOnProperty(name = ["app.v5.enabled"], havingValue = "true", matchIfMissing = false)
+class CharacterViewQueryServicePostgres(
+    private val repository: CharacterValuationViewJpaRepository,
+    private val executor: LogicExecutor,
+    private val meterRegistry: MeterRegistry,
+) {
+    private val log = LoggerFactory.getLogger(CharacterViewQueryServicePostgres::class.java)
+
+    /** Find character valuation view by user IGN (O(1) indexed lookup) */
+    fun findByUserIgn(userIgn: String): CharacterValuationViewEntity? {
+        val context = TaskContext.of("PostgresQuery", "FindByUserIgn", userIgn)
+
+        return executor.executeOrDefault(
+            {
+                val result = repository.findByUserIgn(userIgn)
+                if (result != null) {
+                    meterRegistry
+                        .timer("postgres.query.latency", "operation", "hit")
+                        .record(Duration.ofMillis(1))
+                    result
+                } else {
+                    meterRegistry
+                        .timer("postgres.query.latency", "operation", "miss")
+                        .record(Duration.ofMillis(1))
+                    null
+                }
+            },
+            null,
+            context,
+        )
+    }
+
+    /**
+     * Upsert character valuation view
+     *
+     * @param entity The entity to upsert
+     */
+    @Transactional
+    fun upsert(entity: CharacterValuationViewEntity) {
+        val context = TaskContext.of("PostgresQuery", "Upsert", entity.userIgn)
+
+        executor.executeVoid(
+            {
+                val existing = repository.findByUserIgn(entity.userIgn)
+
+                if (existing != null) {
+                    // Update existing
+                    val incomingVersion = entity.version ?: 0L
+                    val currentVersion = existing.version ?: 0L
+
+                    if (incomingVersion > currentVersion) {
+                        // Incoming update is newer - apply update
+                        val updated = CharacterValuationViewEntity(
+                            id = existing.id,
+                            userIgn = entity.userIgn,
+                            messageId = entity.messageId,
+                            characterOcid = entity.characterOcid,
+                            characterClass = entity.characterClass,
+                            characterLevel = entity.characterLevel,
+                            calculatedAt = entity.calculatedAt,
+                            lastApiSyncAt = entity.lastApiSyncAt,
+                            version = incomingVersion + 1,
+                            lastAppliedVersion = incomingVersion,
+                            totalExpectedCost = entity.totalExpectedCost,
+                            maxPresetNo = entity.maxPresetNo,
+                            presets = entity.presets,
+                            fromCache = entity.fromCache,
+                        )
+                        repository.save(updated)
+                        meterRegistry.counter("postgres.optimistic_lock.updated").increment()
+                        log.debug(
+                            "[OptimisticLock] Updated: userIgn={}, version={}->{}",
+                            entity.userIgn,
+                            currentVersion,
+                            incomingVersion + 1,
+                        )
+                    } else {
+                        // Incoming update is older or same - skip
+                        meterRegistry.counter("postgres.optimistic_lock.skipped").increment()
+                        log.debug(
+                            "[OptimisticLock] Skipped: userIgn={}, incoming={}, current={}",
+                            entity.userIgn,
+                            incomingVersion,
+                            currentVersion,
+                        )
+                    }
+                } else {
+                    // Insert new
+                    val newEntity = CharacterValuationViewEntity(
+                        id = null,
+                        userIgn = entity.userIgn,
+                        messageId = entity.messageId,
+                        characterOcid = entity.characterOcid,
+                        characterClass = entity.characterClass,
+                        characterLevel = entity.characterLevel,
+                        calculatedAt = entity.calculatedAt,
+                        lastApiSyncAt = entity.lastApiSyncAt,
+                        version = 1L,
+                        lastAppliedVersion = entity.version ?: 1L,
+                        totalExpectedCost = entity.totalExpectedCost,
+                        maxPresetNo = entity.maxPresetNo,
+                        presets = entity.presets,
+                        fromCache = entity.fromCache,
+                    )
+                    repository.save(newEntity)
+                    meterRegistry.counter("postgres.optimistic_lock.inserted").increment()
+                    log.debug("[OptimisticLock] Inserted: userIgn={}, version=1", entity.userIgn)
+                }
+            },
+            context,
+        )
+    }
+
+    /** Delete by user IGN (for invalidation) */
+    @Transactional
+    fun deleteByUserIgn(userIgn: String) {
+        val context = TaskContext.of("PostgresQuery", "Delete", userIgn)
+
+        executor.executeVoid(
+            { repository.deleteByUserIgn(userIgn) },
+            context,
+        )
+    }
+
+    /** Delete all documents (for testing) */
+    @Transactional
+    fun deleteAll() {
+        val context = TaskContext.of("PostgresQuery", "DeleteAll", "all")
+
+        executor.executeVoid(
+            { repository.deleteAll() },
+            context,
+        )
+    }
+
+    /** Count all documents for a specific user IGN */
+    fun countByUserIgn(userIgn: String): Long {
+        val context = TaskContext.of("PostgresQuery", "Count", userIgn)
+
+        return executor.executeOrDefault(
+            { if (repository.findByUserIgn(userIgn) != null) 1L else 0L },
+            0L,
+            context,
+        )
+    }
+
+    /**
+     * Get the last applied event version for a user
+     *
+     * @param userIgn User in-game name
+     * @return Last applied version, or 0L if no document exists
+     */
+    fun getLastAppliedVersion(userIgn: String): Long {
+        val context = TaskContext.of("PostgresQuery", "GetLastAppliedVersion", userIgn)
+
+        return executor.executeOrDefault(
+            {
+                val entity = repository.findByUserIgn(userIgn)
+                entity?.lastAppliedVersion ?: 0L
+            },
+            0L,
+            context,
+        )
+    }
+}

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/entity/CharacterValuationViewEntity.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/entity/CharacterValuationViewEntity.kt
@@ -1,0 +1,102 @@
+package maple.expectation.infrastructure.persistence.entity
+
+import jakarta.persistence.*
+import java.time.Instant
+import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.type.SqlTypes
+
+/**
+ * V5 CQRS: PostgreSQL Read Model for Character Valuation Views
+ *
+ * MongoDB CharacterValuationView의 PostgreSQL 마이그레이션
+ *
+ * @see maple.expectation.infrastructure.mongodb.CharacterValuationView
+ */
+@Entity
+@Table(
+    name = "character_valuation_views",
+    indexes = [
+        Index(name = "idx_character_valuation_user_ign", columnList = "user_ign"),
+        Index(name = "idx_character_valuation_message_id", columnList = "message_id", unique = true),
+        Index(name = "idx_character_valuation_calculated_at", columnList = "calculated_at"),
+    ],
+)
+class CharacterValuationViewEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+
+    @Column(name = "user_ign", nullable = false, length = 100)
+    var userIgn: String,
+
+    @Column(name = "message_id", unique = true, length = 100)
+    var messageId: String? = null,
+
+    @Column(name = "character_ocid", length = 100)
+    var characterOcid: String? = null,
+
+    @Column(name = "character_class", length = 50)
+    var characterClass: String? = null,
+
+    @Column(name = "character_level")
+    var characterLevel: Int? = null,
+
+    @Column(name = "calculated_at")
+    var calculatedAt: Instant? = null,
+
+    @Column(name = "last_api_sync_at")
+    var lastApiSyncAt: Instant? = null,
+
+    /**
+     * Event version for causal consistency
+     */
+    @Column(name = "version")
+    var version: Long? = null,
+
+    /**
+     * Last applied event version for ordering validation
+     */
+    @Column(name = "last_applied_version")
+    var lastAppliedVersion: Long? = null,
+
+    @Column(name = "total_expected_cost")
+    var totalExpectedCost: Long? = null,
+
+    @Column(name = "max_preset_no")
+    var maxPresetNo: Int? = null,
+
+    /**
+     * Preset data stored as JSONB
+     */
+    @Column(name = "presets", columnDefinition = "jsonb")
+    @JdbcTypeCode(SqlTypes.JSON)
+    var presets: List<PresetView>? = null,
+
+    @Column(name = "from_cache")
+    var fromCache: Boolean? = null,
+) {
+    /**
+     * Preset view data (embedded in JSONB)
+     */
+    data class PresetView(
+        val presetNo: Int? = null,
+        val totalExpectedCost: Long? = null,
+        val totalCostText: String? = null,
+        val costBreakdown: CostBreakdownView? = null,
+        val items: List<ItemExpectationView>? = null,
+    )
+
+    data class CostBreakdownView(
+        val blackCubeCost: Long? = null,
+        val redCubeCost: Long? = null,
+        val additionalCubeCost: Long? = null,
+        val starforceCost: Long? = null,
+        val flameCost: Long? = null,
+    )
+
+    data class ItemExpectationView(
+        val itemName: String? = null,
+        val expectedCost: Long? = null,
+        val costText: String? = null,
+    )
+}

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/repository/CharacterValuationViewJpaRepository.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/repository/CharacterValuationViewJpaRepository.kt
@@ -1,0 +1,38 @@
+package maple.expectation.infrastructure.persistence.repository
+
+import maple.expectation.infrastructure.persistence.entity.CharacterValuationViewEntity
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * V5 CQRS: PostgreSQL Repository for Character Valuation Views
+ *
+ * MongoDB CharacterValuationRepository의 PostgreSQL 마이그레이션
+ *
+ * @see maple.expectation.infrastructure.mongodb.CharacterValuationRepository
+ */
+@Repository
+interface CharacterValuationViewJpaRepository : JpaRepository<CharacterValuationViewEntity, Long> {
+
+    /**
+     * userIgn으로 조회 (O(1) indexed lookup)
+     */
+    fun findByUserIgn(userIgn: String): CharacterValuationViewEntity?
+
+    /**
+     * messageId으로 조회
+     */
+    fun findByMessageId(messageId: String): CharacterValuationViewEntity?
+
+    /**
+     * userIgn으로 삭제
+     */
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM CharacterValuationViewEntity e WHERE e.userIgn = :userIgn")
+    fun deleteByUserIgn(@Param("userIgn") userIgn: String): Int
+}

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/scheduler/EventOutboxScheduler.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/scheduler/EventOutboxScheduler.kt
@@ -10,6 +10,7 @@ import maple.expectation.infrastructure.executor.TaskContext
 import maple.expectation.infrastructure.metrics.EventOutboxMetrics
 import maple.expectation.infrastructure.persistence.repository.EventOutboxRepository
 import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.data.domain.PageRequest
 import org.springframework.scheduling.annotation.Scheduled
@@ -32,6 +33,7 @@ import org.springframework.stereotype.Component
  * @see maple.expectation.infrastructure.metrics.EventOutboxMetrics
  */
 @Component
+@ConditionalOnBean(EventOutboxProperties::class)
 @ConditionalOnProperty(
     name = ["scheduler.event-outbox.enabled"],
     havingValue = "true",

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/scheduler/NexonApiCollectorScheduler.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/scheduler/NexonApiCollectorScheduler.kt
@@ -16,6 +16,7 @@ import maple.expectation.infrastructure.queue.pgmq.NexonDataQueueProducer
 import maple.expectation.infrastructure.ratelimit.PostgresRateLimiter
 import maple.expectation.infrastructure.ratelimit.RateLimiter
 import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
@@ -47,6 +48,7 @@ import org.springframework.stereotype.Component
  * @see NexonDataQueueProducer
  */
 @Component
+@ConditionalOnBean(RateLimiter::class)
 @ConditionalOnProperty(
     name = ["scheduler.nexon-api-collector.enabled"],
     havingValue = "true",


### PR DESCRIPTION
## Summary
- PostgreSQL migration을 위한 infrastructure layer 변경사항
- Redis/Redisson 의존성 제거 준비 및 PostgreSQL 대체 구현 추가
- MongoDB 의존성 제거 준비 및 PostgreSQL 대체 구현 추가

## Changes
### New Files
- `CaffeineOnlyCacheConfig.kt`: Redis 없이 Caffeine만 사용하는 로컬 개발용 설정
- `PgmqStreamPublisher.kt`: PostgreSQL 기반 메시지 큐 (PGMQ) 구현
- `CharacterViewQueryServicePostgres.kt`: PostgreSQL 기반 CharacterView 쿼리 서비스
- `CharacterValuationViewEntity.kt`: PostgreSQL JPA 엔티티
- `CharacterValuationViewJpaRepository.kt`: JPA Repository

### Modified Files
- Lock 전략들 (`@ConditionalOnProperty` 추가)
- MongoDB 관련 설정 (조건부 활성화)
- Batch 및 스케줄러 설정

## Related Issues
- #589: [V5 Migration] Redis/Redisson 의존성 완전 제거
- #590: [V5 Migration] MongoDB 의존성 완전 제거
- #591: [V5 Migration] MySQL 의존성 완전 제거
- #592: [V5 Migration] 임시 조건부 어노테이션 정리

## Test Plan
- [ ] 로컬 환경에서 Spring Boot 기동 확인
- [ ] PostgreSQL 연결 확인
- [ ] 기존 API 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)