### PR TITLE
feat(pgmq): Phase 4 - Cleanup deprecated ports, drop outbox tables, add archive cleanup

### DIFF
--- a/docker/postgres/init.sql
+++ b/docker/postgres/init.sql
@@ -8,15 +8,6 @@
 CREATE EXTENSION IF NOT EXISTS pgmq CASCADE;
 
 -- Create PGMQ Queues
--- V4 Buffer Queue: Equipment expectation write-back buffer
-SELECT pgmq.create('v4_buffer_queue');
-
--- V5 Event Queue: Domain event stream
-SELECT pgmq.create('v5_event_queue');
-
--- Donation Outbox Queue: Donation transaction outbox
-SELECT pgmq.create('donation_outbox_queue');
-
 -- Nexon API Retry Queue: Failed API call retry via PGMQ (Phase 3)
 SELECT pgmq.create('nexon_retry_queue');
 
@@ -86,5 +77,5 @@ GRANT ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA pgmq TO maple;
 DO $$
 BEGIN
     RAISE NOTICE 'PostgreSQL + PGMQ initialized successfully';
-    RAISE NOTICE 'Created queues: v4_buffer_queue, v5_event_queue, donation_outbox_queue';
+    RAISE NOTICE 'Created queues: nexon_retry_queue';
 END $$;

--- a/module-app/src/main/resources/application-pglocal.yml
+++ b/module-app/src/main/resources/application-pglocal.yml
@@ -115,20 +115,6 @@ scheduler:
   popular-character-warmup:
     enabled: false
 
-# PGMQ Configuration (for future migration)
-pgmq:
-  enabled: true
-  queues:
-    v4-buffer:
-      name: v4_buffer_queue
-      retention: 86400  # 24 hours
-    v5-event:
-      name: v5_event_queue
-      retention: 604800  # 7 days
-    donation-outbox:
-      name: donation_outbox_queue
-      retention: 86400
-
 # Z.ai LangChain4j Configuration
 langchain4j:
   glm-4:

--- a/module-app/src/test/kotlin/maple/expectation/testinfra/ContainerSingletonTest.kt
+++ b/module-app/src/test/kotlin/maple/expectation/testinfra/ContainerSingletonTest.kt
@@ -45,8 +45,6 @@ class ContainerSingletonTest : IntegrationTestBase() {
         )
 
         // init-pgmq.sql에서 생성한 큐들
-        assertThat(queues).contains("v4_buffer_queue")
-        assertThat(queues).contains("v5_event_queue")
-        assertThat(queues).contains("donation_outbox_queue")
+        assertThat(queues).contains("nexon_retry_queue")
     }
 }

--- a/module-app/src/test/resources/sql/init-pgmq.sql
+++ b/module-app/src/test/resources/sql/init-pgmq.sql
@@ -5,7 +5,4 @@
 CREATE EXTENSION IF NOT EXISTS pgmq CASCADE;
 
 -- Create application queues
-SELECT pgmq.create('v4_buffer_queue');
-SELECT pgmq.create('v5_event_queue');
-SELECT pgmq.create('donation_outbox_queue');
 SELECT pgmq.create('nexon_retry_queue');

--- a/module-core/src/main/kotlin/maple/expectation/core/port/out/NexonApiOutboxMetricsPort.kt
+++ b/module-core/src/main/kotlin/maple/expectation/core/port/out/NexonApiOutboxMetricsPort.kt
@@ -8,11 +8,12 @@ package maple.expectation.core.port.out
  *
  * <h3>구현체</h3>
  * <ul>
- *   <li>module-app/service/v2/outbox/NexonApiOutboxMetrics
+ *   <li>module-infra/nexon/pgmq/NexonApiPgmqMetrics (PGMQ 기반)
  * </ul>
  *
  * @see NexonApiOutboxProcessorPort
  */
+@Deprecated("Outbox 제거 완료. PGMQ Worker로 대체됨. 다음 릴리즈에서 삭제 예정.")
 interface NexonApiOutboxMetricsPort {
     /**
      * Pending 카운트 업데이트

--- a/module-core/src/main/kotlin/maple/expectation/core/port/out/NexonApiOutboxProcessorPort.kt
+++ b/module-core/src/main/kotlin/maple/expectation/core/port/out/NexonApiOutboxProcessorPort.kt
@@ -8,11 +8,12 @@ package maple.expectation.core.port.out
  *
  * <h3>구현체</h3>
  * <ul>
- *   <li>module-app/service/v2/outbox/NexonApiOutboxProcessor
+ *   <li>module-infra/nexon/pgmq/NexonApiPgmqProcessor (PGMQ 기반)
  * </ul>
  *
  * @see NexonApiOutboxMetricsPort
  */
+@Deprecated("Outbox 제거 완료. PGMQ Worker로 대체됨. 다음 릴리즈에서 삭제 예정.")
 interface NexonApiOutboxProcessorPort {
     /**
      * Outbox 폴링 및 처리

--- a/module-core/src/test/java/maple/expectation/arch/CoreDependencyRuleTest.java
+++ b/module-core/src/test/java/maple/expectation/arch/CoreDependencyRuleTest.java
@@ -349,7 +349,7 @@ public class CoreDependencyRuleTest {
      * <p><strong>Rationale:</strong> External API integration is an infrastructure concern. Core
      * should define port interfaces, not concrete client implementations.
      *
-     * <p><strong>Allowed:</strong> Port interfaces (e.g., NexonApiOutboxProcessorPort).
+     * <p><strong>Allowed:</strong> Port interfaces (e.g., @Deprecated NexonApiOutboxProcessorPort — pending removal).
      *
      * <p><strong>Forbidden:</strong> WebClient, RestTemplate, HttpClient, external client impls.
      */

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/nexon/pgmq/NexonApiPgmqMetrics.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/nexon/pgmq/NexonApiPgmqMetrics.kt
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Component
  * </ul>
  */
 @Component
+@Suppress("DEPRECATION")
 class NexonApiPgmqMetrics(
     private val registry: MeterRegistry,
     private val pgmqClient: PgmqClient,

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/nexon/pgmq/NexonApiPgmqProcessor.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/nexon/pgmq/NexonApiPgmqProcessor.kt
@@ -45,6 +45,7 @@ import kotlin.math.pow
  * @see NexonApiPgmqMetrics
  */
 @Component
+@Suppress("DEPRECATION")
 class NexonApiPgmqProcessor(
     private val pgmqClient: PgmqClient,
     private val executor: LogicExecutor,

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/entity/CharacterValuationEntity.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/entity/CharacterValuationEntity.kt
@@ -19,7 +19,7 @@ import java.time.Instant
  * <ul>
  *   <li><b>Query Side:</b> This entity (PostgreSQL JSONB)
  *   <li><b>Command Side:</b> MySQL game_character, character_equipment
- *   <li><b>Sync:</b> PGMQ v5_event_queue topic
+ *   <li><b>Sync:</b> PGMQ event queue (direct publish)
  * </ul>
  *
  * <h3>JSONB Strategy</h3>

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/scheduler/PgmqArchiveCleanupScheduler.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/scheduler/PgmqArchiveCleanupScheduler.kt
@@ -1,0 +1,51 @@
+package maple.expectation.infrastructure.scheduler
+
+import maple.expectation.infrastructure.executor.LogicExecutor
+import maple.expectation.infrastructure.executor.TaskContext
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+/**
+ * PGMQ Archive Cleanup Scheduler (Phase 4)
+ *
+ * PGMQ의 `pgmq.archive()`로 이동된 메시지 중 30일이 경과한 것을 삭제.
+ * pg_cron이 프로덕션 DB에 설치되어 있지 않으므로 애플리케이션 스케줄러로 대체.
+ *
+ * @see maple.expectation.infrastructure.pgmq.PgmqClient
+ */
+@Component
+@ConditionalOnProperty(name = ["pgmq.archive.cleanup.enabled"], havingValue = "true", matchIfMissing = true)
+class PgmqArchiveCleanupScheduler(
+    private val jdbcTemplate: JdbcTemplate,
+    private val executor: LogicExecutor,
+) {
+    companion object {
+        private val log = LoggerFactory.getLogger(PgmqArchiveCleanupScheduler::class.java)
+        private const val RETENTION_DAYS = 30
+        private val QUEUES = listOf(
+            "calculation_queue",
+            "donation_queue",
+            "nexon_retry_queue",
+            "like_sync_queue",
+            "expectation_calc_high",
+            "expectation_calc_low",
+        )
+    }
+
+    @Scheduled(cron = "\${pgmq.archive.cleanup.cron:0 0 3 * * *}")
+    fun cleanupArchived() {
+        val context = TaskContext.of("PgmqArchive", "Cleanup", "scheduled")
+        executor.executeVoid({
+            QUEUES.forEach { queue ->
+                val sql = "DELETE FROM pgmq.a_${queue} WHERE created_at < NOW() - INTERVAL '$RETENTION_DAYS days'"
+                val deleted = jdbcTemplate.update(sql)
+                if (deleted > 0) {
+                    log.info("[ArchiveCleanup] Purged {} archived messages from {}", deleted, queue)
+                }
+            }
+        }, context)
+    }
+}

--- a/module-infra/src/main/resources/db/migration/V106__drop_outbox_tables.sql
+++ b/module-infra/src/main/resources/db/migration/V106__drop_outbox_tables.sql
@@ -1,0 +1,6 @@
+-- Phase 4: Drop outbox tables replaced by PGMQ
+-- donation_outbox: Phase 2에서 PGMQ donation_queue로 대체
+-- event_outbox, nexon_api_outbox: MySQL 잔여 테이블 (PostgreSQL에 존재할 수도 있음)
+DROP TABLE IF EXISTS donation_outbox;
+DROP TABLE IF EXISTS event_outbox;
+DROP TABLE IF EXISTS nexon_api_outbox;

--- a/module-infra/src/test/resources/sql/init-pgmq.sql
+++ b/module-infra/src/test/resources/sql/init-pgmq.sql
@@ -6,7 +6,4 @@ CREATE EXTENSION IF NOT EXISTS pgmq CASCADE;
 
 -- Create application queues
 SELECT pgmq.create('calculation_queue');
-SELECT pgmq.create('v4_buffer_queue');
-SELECT pgmq.create('v5_event_queue');
-SELECT pgmq.create('donation_outbox_queue');
 SELECT pgmq.create('nexon_retry_queue');

--- a/module-web/src/main/kotlin/maple/expectation/web/controller/v5/GameCharacterControllerV5.kt
+++ b/module-web/src/main/kotlin/maple/expectation/web/controller/v5/GameCharacterControllerV5.kt
@@ -27,7 +27,7 @@ import org.springframework.web.bind.annotation.RestController
  * **CQRS Pattern**
  * - Query Side: PostgreSQL CharacterValuationViewEntity (fast read 1-10ms)
  * - Command Side: Priority Queue + Calculation Worker
- * - Sync: PGMQ v5_event_queue → PostgreSQL upsert
+ * - Sync: PGMQ event queue → PostgreSQL upsert
  *
  * **ADR-005 Hexagonal Architecture**
  * - CharacterViewQueryPort: PostgreSQL 조회


### PR DESCRIPTION
## Summary
- `@Deprecated` NexonApiOutboxProcessorPort/MetricsPort (2주 운영 검증 후 삭제 예정)
- Remove unused queues: `v4_buffer_queue`, `v5_event_queue`, `donation_outbox_queue`
- V106 migration: DROP TABLE `donation_outbox`, `event_outbox`, `nexon_api_outbox`
- New `PgmqArchiveCleanupScheduler`: purges archived PGMQ messages older than 30 days (cron: 3am daily)

## Files Changed (14)
- **New (2)**: `PgmqArchiveCleanupScheduler`, `V106__drop_outbox_tables.sql`
- **Modified (12)**: Deprecated ports, implementing classes, init.sql, configs, test assertions, Javadoc comments

## Test plan
- [x] `./gradlew compileKotlin compileJava --continue` passes
- [x] `./gradlew test -x :module-app:test` passes
- [ ] Verify V106 migration runs cleanly on server startup
- [ ] Verify deprecated port warnings appear in build logs as expected
- [ ] Verify archive cleanup scheduler runs at scheduled time

🤖 Generated with [Claude Code](https://claude.com/claude-code)