### PR TITLE
FEAT : Fan-out batch worker with micro-batch coalescing for Nexon API

### DIFF
--- a/docs/09_Plans/2026-04-01-fanout-batch-worker-with-coalescing.md
+++ b/docs/09_Plans/2026-04-01-fanout-batch-worker-with-coalescing.md
@@ -1,0 +1,318 @@
+# Fan-Out Batch Worker with Request Coalescing (v2 - Consensus-Reviewed)
+
+## Context
+
+### Problem
+현재 V4/V5 컨트롤러는 캐시 미스 시 개별적으로 Nexon API를 호출한다. 동시 다수 요청 시:
+- 동일 OCID에 대한 중복 API 호출
+- Nexon API rate limit (429) 도달 위험
+- 서버 리소스 비효율적 사용
+
+### Key Discovery (Consensus Review)
+**`AdaptiveMicroBatchUserService`**가 이미 구현되어 있음:
+- Request Coalescing (inFlightRequests + CompletableFuture)
+- Adaptive Routing (Fast Lane: semaphore, Batch Lane: Channel)
+- Batch Collection (Channel + 10ms window + max size)
+- Deduplication (uniqueKeys = batch.map { it.key }.distinct())
+- Chunked Processing (chunked(chunkSize))
+- Coroutine-based (CoroutineScope + Dispatchers.IO)
+- Caffeine cache integration + Metrics
+
+**기존 Adapter 패턴**: `GameCharacterMicroBatchAdapter`, `L2CacheMicroBatchAdapter`가 이미 `AdaptiveMicroBatchUserService`를 감싸서 사용 중.
+
+### Scope
+- **대상**: V4/V5 캐릭터 기대값 조회 흐름 개선
+- **캐시**: 기존 TieredCache + Caffeine 유지 (Redis 없음)
+- **동시성**: 기존 `ResilientNexonApiClient`의 Bulkhead(50) + Retry(3) + CB 재사용, 추가 RateLimiter는 불필요
+
+---
+
+## Architecture
+
+```
+V4/V5 Controller (cache miss)
+  |
+  v
+NexonEquipmentMicroBatchAdapter (GameCharacterMicroBatchAdapter pattern)
+  |
+  |-- L1 (Caffeine) HIT -> return immediately
+  |
+  |-- In-Flight (coalescing) -> wait for existing request
+  |
+  |-- Fast Lane (semaphore available)
+  |   +-- EquipmentFetchProvider.fetchWithCache(ocid) -> @Cacheable + ResilientNexonApiClient
+  |
+  +-- Batch Lane (Channel -> 10ms window)
+      +-- NexonFanOutBatchLoader.load(ocids)
+          |-- Concurrent (CompletableFuture.supplyAsync, 30-permit Semaphore)
+          |-- Each -> ResilientNexonApiClient.getItemDataByOcid(ocid).join()
+          |-- Success -> cache.put + archive
+          +-- 429 -> FanOutQueueProducer.enqueue() -> PGMQ
+
+NexonFanOutWorker (extends PgmqWorker)
+  |-- Polls PGMQ (50ms interval)
+  |-- 429 -> setVisibilityTimeout (1~1.3s jitter)
+  |-- retry_count >= 5 -> delete (DLQ)
+  +-- Success -> archive + cache write
+```
+
+---
+
+## Implementation Steps
+
+### Step 1: FanOut 메시지 페이로드
+
+**File: `module-infra/.../pgmq/PgmqMessage.kt`** (기존 파일에 추가)
+```kotlin
+data class FanOutRequest(
+    val ocid: String,
+    val userIgn: String,
+    val retryCount: Int = 0,
+    val requestedAt: String,
+)
+```
+
+### Step 2: FanOutQueuePort (Hexagonal Architecture 준수)
+
+**File: `module-core/.../port/out/FanOutQueuePort.kt`** (신규)
+```kotlin
+interface FanOutQueuePort {
+    fun enqueue(ocid: String, userIgn: String, retryCount: Int = 0): Long
+}
+```
+
+### Step 3: FanOutQueueProducer (Port 구현)
+
+**File: `module-infra/.../queue/pgmq/FanOutQueueProducer.kt`** (신규)
+- `CalculationQueueProducer` 패턴 참고
+- `PgmqClient.send()` 로 메시지 발행
+- **`@Transactional` 필수** (PgmqClient.send() 가 트랜잭션 체크)
+- `LogicExecutor`로 예외 처리 위임 (Zero Try-Catch)
+
+### Step 4: NexonFanOutBatchLoader (Batch Lane의 batchLoader)
+
+**File: `module-infra/.../fanout/NexonFanOutBatchLoader.kt`** (신규)
+- **CompletableFuture 기반** (기존 프로젝트 표준, `EquipmentFetchProvider` .join() ADR과 일치)
+- `java.util.concurrent.Semaphore(30)` (Bulkhead(50)보다 작게 설정 -> 실제 제한 = min(30, 50) = 30)
+- `ExecutorService` (전용, fixed thread pool = 10, `BulkLoaderService.BULK_EXECUTOR` 패턴 참고)
+- 429 시: `FanOutQueuePort.enqueue()` 로 PGMQ에 전달, 해당 OCID는 결과에서 제외
+- **`runBlocking` 없음**, **`Thread.sleep` 없음**
+
+```kotlin
+class NexonFanOutBatchLoader(
+    private val nexonApiClient: NexonApiClient,
+    private val fanOutQueuePort: FanOutQueuePort,
+    private val executor: LogicExecutor,
+) {
+    private val semaphore = java.util.concurrent.Semaphore(30)
+    private val executorService: ExecutorService = Executors.newFixedThreadPool(10)
+
+    fun load(ocids: List<String>): Map<String, EquipmentResponse> {
+        val futures = ocids.map { ocid ->
+            CompletableFuture.supplyAsync({
+                semaphore.acquire()
+                try { fetchOrEnqueueRetry(ocid) } finally { semaphore.release() }
+            }, executorService)
+        }
+        return CompletableFuture.allOf(*futures.toTypedArray()).join()
+            .let { futures.mapNotNull { it.join() }.associate { it } }
+    }
+
+    private fun fetchOrEnqueueRetry(ocid: String): Pair<String, EquipmentResponse>? {
+        return executor.executeOrCatch(
+            task = { ocid to nexonApiClient.getItemDataByOcid(ocid).orTimeout(10, SECONDS).join() },
+            recovery = { e -> if (is429(e)) fanOutQueuePort.enqueue(ocid, "batch", 0); null },
+            context = TaskContext.of("FanOutBatchLoader", "Fetch", ocid),
+        )
+    }
+}
+```
+
+### Step 5: NexonEquipmentMicroBatchAdapter (핵심 - 기존 패턴 재사용)
+
+**File: `module-infra/.../batch/NexonEquipmentMicroBatchAdapter.kt`** (신규)
+- `GameCharacterMicroBatchAdapter` 패턴 그대로 사용
+- `AdaptiveMicroBatchUserService<EquipmentResponse>` 인스턴스 생성
+- `singleLoader`: `EquipmentFetchProvider.fetchWithCache(ocid)` (기존 @Cacheable 경로)
+- `batchLoader`: `NexonFanOutBatchLoader.load(ocids)` (새로운 병렬 실행)
+- `cache`: Caffeine "equipment" cache
+
+```kotlin
+@Service
+class NexonEquipmentMicroBatchAdapter(
+    properties: AdaptiveMicroBatchProperties,
+    logicExecutor: LogicExecutor,
+    meterRegistry: MeterRegistry,
+    cacheManager: CacheManager,
+    private val fetchProvider: EquipmentFetchProvider,
+    private val batchLoader: NexonFanOutBatchLoader,
+) {
+    private val delegate = AdaptiveMicroBatchUserService<EquipmentResponse>(
+        properties = properties,
+        logicExecutor = logicExecutor,
+        meterRegistry = meterRegistry,
+        cache = cacheManager.getCache("equipment"),
+        singleLoader = { key -> fetchProvider.fetchWithCache(key) },
+        batchLoader = { keys -> batchLoader.load(keys) },
+    )
+
+    fun getByKey(ocid: String): EquipmentResponse? = delegate.getByKey(ocid)
+}
+```
+
+### Step 6: PgmqWorkerConfig + NexonFanOutWorker
+
+**File: `module-infra/.../pgmq/PgmqWorkerConfig.kt`** (수정)
+```kotlin
+/** Nexon FanOut Worker 설정 */
+var nexonFanout: WorkerSettings = WorkerSettings()
+```
+
+**File: `module-infra/.../worker/NexonFanOutWorker.kt`** (신규)
+- `PgmqWorker<FanOutRequest>` 상속 (`CalculationWorker` 패턴)
+- 기본 `processMessages()` 사용 (**runBlocking 없음**, 기본 `process()` 위임)
+- 429: `pgmqClient.setVisibilityTimeout()` + 30% jitter
+- `readCount >= 5`: `pgmqClient.delete()` (DLQ)
+- 성공: `pgmqClient.archive()`
+
+### Step 7: PGMQ Queue 생성
+
+**File: `module-app/.../db/migration/V{next}__create_nexon_fanout_queue.sql`** (신규)
+```sql
+SELECT pgmq.create('nexon_fanout_queue');
+```
+
+### Step 8: V5 Controller 통합
+
+**File: `module-web/.../controller/v5/GameCharacterControllerV5.kt`** (수정)
+- `fanout.enabled=true` 시: 캐시 미스 -> `NexonEquipmentMicroBatchAdapter.getByKey(ocid)`
+- `fanout.enabled=false` 시: 기존 `CalculationQueuePort.offerHighPriority()`
+
+### Step 9: V4 Controller 통합 (Optional)
+
+**File: `module-web/.../controller/v4/GameCharacterControllerV4.kt`** (수정)
+- `fanout.enabled=true` 시: 캐시 미스 -> adapter.getByKey() + 300ms polling
+- `fanout.enabled=false` 시: 기존 `AdmissionPort.submitOrWait()` 경로 유지
+
+### Step 10: Configuration
+
+**File: `application.yml`** (수정)
+```yaml
+fanout:
+  enabled: false
+  semaphore-permits: 30
+  batch-size: 50
+  max-retry-count: 5
+  retry-delay-base-ms: 1000
+  jitter-factor: 0.3
+  polling-interval-ms: 50
+  queue-name: nexon_fanout_queue
+
+pgmq:
+  worker:
+    nexon-fanout:
+      enabled: false
+      batch-size: 50
+      max-retries: 5
+```
+
+---
+
+## Files to Create
+
+| File | Module | Description |
+|------|--------|-------------|
+| `core/port/out/FanOutQueuePort.kt` | module-core | Port 인터페이스 (DIP) |
+| `infra/queue/pgmq/FanOutQueueProducer.kt` | module-infra | PGMQ 발행 (@Transactional) |
+| `infra/fanout/NexonFanOutBatchLoader.kt` | module-infra | Batch Lane 병렬 실행 |
+| `infra/batch/NexonEquipmentMicroBatchAdapter.kt` | module-infra | AdaptiveMicroBatch 래퍼 |
+| `infra/worker/NexonFanOutWorker.kt` | module-infra | 429 전용 PGMQ Worker |
+| `db/migration/V{next}__create_nexon_fanout_queue.sql` | module-app | Queue 생성 |
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `PgmqMessage.kt` | `FanOutRequest` data class 추가 |
+| `PgmqWorkerConfig.kt` | `nexonFanout: WorkerSettings` 추가 |
+| `application.yml` | fanout + pgmq.worker.nexon-fanout 설정 |
+| `application-local.yml` | `fanout.enabled=true` 로컬 설정 |
+| `GameCharacterControllerV5.kt` | fanout 경로 추가 (feature flag) |
+| `GameCharacterControllerV4.kt` | fanout 경로 추가 (optional) |
+
+## Existing Code to Reuse
+
+| Component | File Path | Usage |
+|-----------|-----------|-------|
+| **AdaptiveMicroBatchUserService** | `infra/batch/AdaptiveMicroBatchUserService.kt` | **핵심 엔진**: coalescing + dedup + batch + cache |
+| **GameCharacterMicroBatchAdapter** | `infra/batch/GameCharacterMicroBatchAdapter.kt` | **패턴 참고**: 래핑 방식 |
+| `AdaptiveMicroBatchProperties` | `infra/config/AdaptiveMicroBatchProperties.kt` | 설정 재사용 |
+| `EquipmentFetchProvider` | `infra/provider/EquipmentFetchProvider.kt` | `fetchWithCache()` -> @Cacheable |
+| `ResilientNexonApiClient` | `infra/external/impl/ResilientNexonApiClient.kt` | CB + Bulkhead(50) + Retry(3) |
+| `PgmqClient` | `infra/pgmq/PgmqClient.kt` | send, read, archive, delete, setVisibilityTimeout |
+| `PgmqWorker` | `infra/pgmq/PgmqWorker.kt` | Base class |
+| `PgmqWorkerConfig` | `infra/pgmq/PgmqWorkerConfig.kt` | Worker 설정 |
+| `CalculationWorker` | `infra/worker/CalculationWorker.kt` | Worker 패턴 참고 |
+| `CalculationQueueProducer` | `infra/queue/pgmq/CalculationQueueProducer.kt` | Producer 패턴 참고 |
+| `LogicExecutor` | `infra/executor/LogicExecutor.kt` | Zero try-catch |
+| `BulkLoaderService` | `infra/bulk/BulkLoaderService.kt` | Semaphore + ThreadPool 패턴 |
+
+### What We're NOT Building (기존 인프라로 대체)
+
+| Original Plan | Reused Component |
+|---------------|------------------|
+| New FanOutExecutor | `AdaptiveMicroBatchUserService` |
+| New FanOutProperties | `AdaptiveMicroBatchProperties` |
+| New CachePollingHelper | `AdaptiveMicroBatchUserService.getByKey()` |
+| New CoroutineScope | `AdaptiveMicroBatchUserService`가 이미 사용 |
+| New RateLimiter(500/sec) | Bulkhead(50) + PGMQ 429 처리 |
+| `runBlocking()` | 없음 (기본 `processMessages()` 사용) |
+| `Thread.sleep()` | 없음 (`delay()` 또는 `CompletableFuture.get(timeout)`) |
+
+---
+
+## Consensus Review 반영
+
+### P0 해결
+
+| P0 Issue | Resolution |
+|----------|------------|
+| `runBlocking` + Virtual Thread | `AdaptiveMicroBatchUserService`가 이미 `CoroutineScope` 사용. Worker는 기본 `processMessages()` -> `runBlocking` 불필요 |
+| `Thread.sleep()` 금지 | `AdaptiveMicroBatchUserService`가 이미 `delay()` 사용. CachePollingHelper 제거 |
+| `PgmqClient.send()` @Transactional | `FanOutQueueProducer.enqueue()`에 `@Transactional` 추가 |
+
+### P1 해결
+
+| P1 Issue | Resolution |
+|----------|------------|
+| Semaphore(30) + Bulkhead(50) 이중 제한 | 의도적: 실제 처리량 = 30. 초과분은 Batch Lane -> PGMQ 분산 |
+| Cache 충돌 | `singleLoader`는 `@Cacheable` 경로, `batchLoader`는 `cache.put()` 직접. 동일 Caffeine cache에 무해 중복 쓰기 |
+| DIP 위반 | `FanOutQueuePort` 인터페이스를 module-core에 정의 |
+| Feature flag if/else | Phase 1에서는 단순 if 분기. 추후 Strategy 패턴으로 리팩토링 |
+
+---
+
+## Verification
+
+1. `fanout.enabled=false` -> 기존 V4/V5 동작 완전 동일 (no-op)
+2. `fanout.enabled=true` + 캐시 미스 -> `NexonEquipmentMicroBatchAdapter.getByKey()` 호출
+3. 동시 100 요청 -> coalescing + dedup으로 API 호출 수 감소
+4. 429 -> PGMQ에 적재, worker가 1~1.3초 후 재시도
+5. max 5회 초과 -> delete (DLQ)
+6. 컴파일: `./gradlew compileKotlin compileJava --continue`
+7. 테스트: `./gradlew test`
+
+---
+
+## Execution Order
+
+1. Step 1: `FanOutRequest` (PgmqMessage)
+2. Step 2: `FanOutQueuePort` (module-core)
+3. Step 3: `FanOutQueueProducer` (module-infra, @Transactional)
+4. Step 4: `NexonFanOutBatchLoader` (module-infra)
+5. Step 5: `NexonEquipmentMicroBatchAdapter` (핵심)
+6. Step 6: `NexonFanOutWorker` (PgmqWorker 상속)
+7. Step 7: Migration SQL
+8. Step 8-9: V4/V5 Controller 통합
+9. Step 10: Configuration
+10. Verification: 컴파일 + 테스트

--- a/module-app/src/main/resources/application-pglocal.yml
+++ b/module-app/src/main/resources/application-pglocal.yml
@@ -134,6 +134,12 @@ pgmq:
     donation-outbox:
       name: donation_outbox_queue
       retention: 86400
+  worker:
+    nexon-fanout:
+      enabled: true
+      polling-interval-ms: 50
+      batch-size: 50
+      max-retries: 5
 
 # Z.ai LangChain4j Configuration
 langchain4j:

--- a/module-app/src/main/resources/application-pgprod.yml
+++ b/module-app/src/main/resources/application-pgprod.yml
@@ -23,6 +23,11 @@ pgmq:
       polling-interval-ms: 500
       batch-size: 50
       max-retries: 3
+    nexon-fanout:
+      enabled: true
+      polling-interval-ms: 50
+      batch-size: 50
+      max-retries: 5
 
 # PostgreSQL connection pool for scale-out
 spring:

--- a/module-app/src/main/resources/application.yml
+++ b/module-app/src/main/resources/application.yml
@@ -631,3 +631,14 @@ alert:
     capacity: 1000                   # Maximum alerts stored in memory (LRU eviction)
   file:
     path: /var/log/maple-alerts.log  # File-based alert log path
+
+# FanOut Micro-Batch Configuration (Issue #690)
+fanout:
+  enabled: false                     # Phase 1: false (검증 후 true)
+  semaphore-permits: 30              # Batch Lane 동시성 (Bulkhead(50)과 2중 제한, 실제=min(30,50)=30)
+  batch-size: 50                     # Batch Lane 최대 크기
+  max-retry-count: 5                 # 429 재시도 최대 횟수
+  retry-delay-base-ms: 1000          # 429 재시도 기본 지연 (ms)
+  jitter-factor: 0.3                 # 429 재시도 jitter (30%)
+  polling-interval-ms: 50            # PGMQ Worker 폴링 간격 (ms)
+  queue-name: nexon_fanout_queue     # PGMQ 큐 이름

--- a/module-core/src/main/kotlin/maple/expectation/core/port/out/EquipmentFanOutPort.kt
+++ b/module-core/src/main/kotlin/maple/expectation/core/port/out/EquipmentFanOutPort.kt
@@ -1,0 +1,29 @@
+package maple.expectation.core.port.out
+
+/**
+ * Equipment FanOut Port (DIP - Hexagonal Architecture)
+ *
+ * <h3>역할</h3>
+ * <p>Micro-Batch Coalescing을 통한 장비 데이터 프리페치.
+ * V5 Controller에서 PostgreSQL 캐시 미스 시 장비 데이터를 미리 캐시에 적재.
+ *
+ * <h3>작동</h3>
+ * <ul>
+ *   <li>L1 Cache HIT → 즉시 반환 (true)
+ *   <li>In-Flight Coalescing → 기존 요청 대기 후 결과 반환
+ *   <li>Fast Lane → EquipmentFetchProvider.fetchWithCache() (@Cacheable)
+ *   <li>Batch Lane → NexonFanOutBatchLoader.load() (병렬 실행)
+ * </ul>
+ *
+ * @see maple.expectation.infrastructure.batch.NexonEquipmentMicroBatchAdapter
+ */
+interface EquipmentFanOutPort {
+
+    /**
+     * OCID로 장비 데이터 프리페치 (Micro-Batch Coalescing)
+     *
+     * @param ocid 캐릭터 OCID
+     * @return 캐시 적재 성공 여부
+     */
+    fun preFetchByOcid(ocid: String): Boolean
+}

--- a/module-core/src/main/kotlin/maple/expectation/core/port/out/FanOutQueuePort.kt
+++ b/module-core/src/main/kotlin/maple/expectation/core/port/out/FanOutQueuePort.kt
@@ -1,0 +1,25 @@
+package maple.expectation.core.port.out
+
+/**
+ * FanOut 큐 발행 Port (DIP - Hexagonal Architecture)
+ *
+ * <h3>역할</h3>
+ * <p>429 Rate Limit 발생 시 Batch Lane에서 PGMQ로 재시도 메시지를 발행
+ *
+ * <h3>구현체</h3>
+ * <p>module-infra의 FanOutQueueProducer
+ *
+ * @see maple.expectation.infrastructure.queue.pgmq.FanOutQueueProducer
+ */
+interface FanOutQueuePort {
+
+    /**
+     * FanOut 재시도 메시지를 큐에 발행
+     *
+     * @param ocid 캐릭터 OCID
+     * @param userIgn 사용자 IGN
+     * @param retryCount 현재 재시도 횟수 (기본값: 0)
+     * @return 메시지 ID
+     */
+    fun enqueue(ocid: String, userIgn: String, retryCount: Int = 0): Long
+}

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/batch/GameCharacterMicroBatchAdapter.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/batch/GameCharacterMicroBatchAdapter.kt
@@ -4,6 +4,7 @@ import io.micrometer.core.instrument.MeterRegistry
 import maple.expectation.core.domain.model.character.GameCharacter
 import maple.expectation.domain.repository.GameCharacterRepository
 import maple.expectation.infrastructure.config.AdaptiveMicroBatchProperties
+import jakarta.annotation.PostConstruct
 import maple.expectation.infrastructure.executor.LogicExecutor
 import org.springframework.cache.Cache
 import org.springframework.cache.concurrent.ConcurrentMapCache
@@ -41,6 +42,11 @@ class GameCharacterMicroBatchAdapter(
         singleLoader = { key -> repository.findByUserIgn(key) },
         batchLoader = { keys -> repository.findByUserIgnIn(keys) },
     )
+
+    @PostConstruct
+    fun init() {
+        delegate.startBatchWorker()
+    }
 
     /**
      * Get character by user IGN with adaptive micro-batching

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/batch/L2CacheMicroBatchAdapter.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/batch/L2CacheMicroBatchAdapter.kt
@@ -66,7 +66,7 @@ class L2CacheMicroBatchAdapter(
                 cache = cache,
                 singleLoader = { key -> l2Strategy.get(key, type) },
                 batchLoader = { keys -> l2Strategy.getAll(keys, type) },
-            )
+            ).also { it.startBatchWorker() }
         }
     }
 }

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/batch/NexonEquipmentMicroBatchAdapter.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/batch/NexonEquipmentMicroBatchAdapter.kt
@@ -7,6 +7,7 @@ import maple.expectation.infrastructure.executor.LogicExecutor
 import maple.expectation.infrastructure.external.dto.v2.EquipmentResponse
 import maple.expectation.infrastructure.fanout.NexonFanOutBatchLoader
 import maple.expectation.infrastructure.provider.EquipmentFetchProvider
+import jakarta.annotation.PostConstruct
 import org.springframework.cache.Cache
 import org.springframework.cache.concurrent.ConcurrentMapCache
 import org.springframework.stereotype.Service
@@ -55,6 +56,18 @@ class NexonEquipmentMicroBatchAdapter(
         singleLoader = { key -> fetchSingle(key) },
         batchLoader = { keys -> batchLoader.load(keys) },
     )
+
+    /**
+     * Batch Lane 코루틴 워커 시작
+     *
+     * <p>AdaptiveMicroBatchUserService는 Spring Bean이 아니므로 @PostConstruct가 자동 실행되지 않음.
+     * 따라서 이 어댑터의 @PostConstruct에서 명시적으로 호출 필요.
+     * (기존 GameCharacterMicroBatchAdapter, L2CacheMicroBatchAdapter에도 동일한 이슈 존재)
+     */
+    @PostConstruct
+    fun init() {
+        delegate.startBatchWorker()
+    }
 
     /**
      * OCID로 장비 데이터 조회 (Adaptive Micro-Batch)

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/batch/NexonEquipmentMicroBatchAdapter.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/batch/NexonEquipmentMicroBatchAdapter.kt
@@ -1,0 +1,78 @@
+package maple.expectation.infrastructure.batch
+
+import io.micrometer.core.instrument.MeterRegistry
+import maple.expectation.core.port.out.EquipmentFanOutPort
+import maple.expectation.infrastructure.config.AdaptiveMicroBatchProperties
+import maple.expectation.infrastructure.executor.LogicExecutor
+import maple.expectation.infrastructure.external.dto.v2.EquipmentResponse
+import maple.expectation.infrastructure.fanout.NexonFanOutBatchLoader
+import maple.expectation.infrastructure.provider.EquipmentFetchProvider
+import org.springframework.cache.Cache
+import org.springframework.cache.concurrent.ConcurrentMapCache
+import org.springframework.stereotype.Service
+
+/**
+ * Nexon Equipment Micro-Batch Adapter
+ *
+ * <h3>역할</h3>
+ * <p>AdaptiveMicroBatchUserService를 활용한 장비 데이터 조회 어댑터.
+ * Request Coalescing, Adaptive Routing, Batch Collection, Dedup을 자동 처리.
+ *
+ * <h3>Routing Logic (AdaptiveMicroBatchUserService)</h3>
+ * <ul>
+ *   <li>Fast Lane: Semaphore 여유 시 EquipmentFetchProvider.fetchWithCache(ocid) → @Cacheable 경로</li>
+ *   <li>Batch Lane: Channel → 10ms window → NexonFanOutBatchLoader.load(ocids) → 병렬 실행</li>
+ * </ul>
+ *
+ * <h3>Cache</h3>
+ * <p>Caffeine "equipment" 캐시를 공유:
+ * <ul>
+ *   <li>Fast Lane: @Cacheable이 자동으로 put</li>
+ *   <li>Batch Lane: AdaptiveMicroBatchUserService가 cache.put() 호출</li>
+ * </ul>
+ *
+ * @see AdaptiveMicroBatchUserService 핵심 코어스칸 엔진
+ * @see NexonFanOutBatchLoader Batch Lane 병렬 실행기
+ * @see EquipmentFetchProvider Fast Lane @Cacheable 경로
+ */
+@Service
+class NexonEquipmentMicroBatchAdapter(
+    properties: AdaptiveMicroBatchProperties,
+    logicExecutor: LogicExecutor,
+    meterRegistry: MeterRegistry,
+    cacheManager: org.springframework.cache.CacheManager,
+    private val fetchProvider: EquipmentFetchProvider,
+    private val batchLoader: NexonFanOutBatchLoader,
+) : EquipmentFanOutPort {
+    private val cache: Cache = cacheManager.getCache("equipment")
+        ?: ConcurrentMapCache("equipment")
+
+    private val delegate = AdaptiveMicroBatchUserService<EquipmentResponse>(
+        properties = properties,
+        logicExecutor = logicExecutor,
+        meterRegistry = meterRegistry,
+        cache = cache,
+        singleLoader = { key -> fetchSingle(key) },
+        batchLoader = { keys -> batchLoader.load(keys) },
+    )
+
+    /**
+     * OCID로 장비 데이터 조회 (Adaptive Micro-Batch)
+     *
+     * <p>내부 흐름:
+     * <ol>
+     *   <li>L1 Cache HIT → 즉시 반환</li>
+     *   <li>In-Flight Coalescing → 기존 요청 대기</li>
+     *   <li>Fast Lane → EquipmentFetchProvider.fetchWithCache()</li>
+     *   <li>Batch Lane → NexonFanOutBatchLoader.load()</li>
+     * </ol>
+     *
+     * @param ocid 캐릭터 OCID
+     * @return 장비 응답 (캐시 미스 + API 실패 시 null)
+     */
+    fun getByKey(ocid: String): EquipmentResponse? = delegate.getByKey(ocid)
+
+    override fun preFetchByOcid(ocid: String): Boolean = delegate.getByKey(ocid) != null
+
+    private fun fetchSingle(ocid: String): EquipmentResponse? = fetchProvider.fetchWithCache(ocid)
+}

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/fanout/NexonFanOutBatchLoader.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/fanout/NexonFanOutBatchLoader.kt
@@ -5,6 +5,7 @@ import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.Semaphore
 import java.util.concurrent.TimeUnit
+import jakarta.annotation.PreDestroy
 import maple.expectation.core.port.out.FanOutQueuePort
 import maple.expectation.infrastructure.executor.LogicExecutor
 import maple.expectation.infrastructure.executor.TaskContext
@@ -48,6 +49,14 @@ class NexonFanOutBatchLoader(
      * @param ocids 조회할 OCID 목록
      * @return 성공한 OCID → EquipmentResponse 매핑 (429 건은 제외됨)
      */
+    @PreDestroy
+    fun shutdown() {
+        executorService.shutdown()
+        if (!executorService.awaitTermination(5, TimeUnit.SECONDS)) {
+            executorService.shutdownNow()
+        }
+    }
+
     fun load(ocids: List<String>): Map<String, EquipmentResponse> {
         if (ocids.isEmpty()) return emptyMap()
 
@@ -112,7 +121,6 @@ class NexonFanOutBatchLoader(
         fun is429(throwable: Throwable): Boolean {
             var current: Throwable? = throwable
             while (current != null) {
-                if (current.message?.contains("429") == true) return true
                 if (current is org.springframework.web.reactive.function.client.WebClientResponseException &&
                     current.statusCode.value() == 429
                 ) {

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/fanout/NexonFanOutBatchLoader.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/fanout/NexonFanOutBatchLoader.kt
@@ -1,0 +1,126 @@
+package maple.expectation.infrastructure.fanout
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.Semaphore
+import java.util.concurrent.TimeUnit
+import maple.expectation.core.port.out.FanOutQueuePort
+import maple.expectation.infrastructure.executor.LogicExecutor
+import maple.expectation.infrastructure.executor.TaskContext
+import maple.expectation.infrastructure.external.NexonApiClient
+import maple.expectation.infrastructure.external.dto.v2.EquipmentResponse
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+/**
+ * Nexon FanOut Batch Loader
+ *
+ * <h3>역할</h3>
+ * <p>Batch Lane에서 수집된 OCID 목록을 병렬로 Nexon API 호출.
+ * Semaphore(30)로 동시성 제한, 429 발생 시 PGMQ에 재시도 메시지 enqueue.
+ *
+ * <h3>동시성 제어</h3>
+ * <ul>
+ *   <li>Semaphore(30): Bulkhead(50)보다 작게 설정 → 실제 제한 = min(30, 50) = 30</li>
+ *   <li>ExecutorService(10): 전용 fixed thread pool</li>
+ * </ul>
+ *
+ * <h3>429 처리</h3>
+ * <p>429 Rate Limit 발생 시 FanOutQueuePort를 통해 PGMQ에 enqueue.
+ * NexonFanOutWorker가 1~1.3초 jitter 후 재시도.
+ *
+ * @see FanOutQueuePort PGMQ 재시도 발행
+ * @see NexonApiClient Nexon API 클라이언트
+ */
+@Component
+class NexonFanOutBatchLoader(
+    private val nexonApiClient: NexonApiClient,
+    private val fanOutQueuePort: FanOutQueuePort,
+    private val executor: LogicExecutor,
+) {
+    private val semaphore = Semaphore(SEMAPHORE_PERMITS)
+    private val executorService: ExecutorService = Executors.newFixedThreadPool(THREAD_POOL_SIZE)
+
+    /**
+     * OCID 목록을 병렬로 조회
+     *
+     * @param ocids 조회할 OCID 목록
+     * @return 성공한 OCID → EquipmentResponse 매핑 (429 건은 제외됨)
+     */
+    fun load(ocids: List<String>): Map<String, EquipmentResponse> {
+        if (ocids.isEmpty()) return emptyMap()
+
+        val futures = ocids.map { ocid ->
+            CompletableFuture.supplyAsync({
+                semaphore.acquire()
+                try {
+                    fetchOrEnqueueRetry(ocid)
+                } finally {
+                    semaphore.release()
+                }
+            }, executorService)
+        }
+
+        CompletableFuture.allOf(*futures.toTypedArray()).join()
+
+        return futures.mapNotNull { it.join() }.associate { it }
+    }
+
+    /**
+     * 단일 OCID 조회 또는 429 시 PGMQ enqueue
+     *
+     * @param ocid 캐릭터 OCID
+     * @return 성공 시 OCID-Response 쌍, 실패 시 null
+     */
+    private fun fetchOrEnqueueRetry(ocid: String): Pair<String, EquipmentResponse>? {
+        val context = TaskContext.of("FanOutBatchLoader", "Fetch", ocid)
+
+        return executor.executeOrCatch(
+            task = {
+                val response = nexonApiClient.getItemDataByOcid(ocid)
+                    .orTimeout(API_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                    .join()
+                ocid to response
+            },
+            recovery = { e ->
+                if (is429(e)) {
+                    log.warn("[FanOutBatchLoader] 429 Rate Limit, enqueuing retry: ocid={}", ocid)
+                    fanOutQueuePort.enqueue(ocid, BATCH_LANE_USER)
+                } else {
+                    log.error("[FanOutBatchLoader] Failed: ocid={}", ocid, e)
+                }
+                null
+            },
+            context = context,
+        )
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(NexonFanOutBatchLoader::class.java)
+
+        private const val SEMAPHORE_PERMITS = 30
+        private const val THREAD_POOL_SIZE = 10
+        private const val API_TIMEOUT_SECONDS = 10L
+        private const val BATCH_LANE_USER = "batch"
+
+        /**
+         * 429 Rate Limit 에러 여부 확인
+         *
+         * <p>CompletionException으로 래핑될 수 있으므로 cause 체인까지 확인
+         */
+        fun is429(throwable: Throwable): Boolean {
+            var current: Throwable? = throwable
+            while (current != null) {
+                if (current.message?.contains("429") == true) return true
+                if (current is org.springframework.web.reactive.function.client.WebClientResponseException &&
+                    current.statusCode.value() == 429
+                ) {
+                    return true
+                }
+                current = current.cause
+            }
+            return false
+        }
+    }
+}

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/PgmqClient.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/PgmqClient.kt
@@ -134,6 +134,26 @@ class PgmqClient(
     }
 
     /**
+     * 메시지 Visibility Timeout 변경
+     *
+     * <p>이미 읽은 메시지의 VT를 변경. 429 Rate Limit 시 짧은 지연 후 재시도에 사용.
+     *
+     * @param queueName 큐 이름
+     * @param messageId 메시지 ID
+     * @param visibilityTimeoutSec 새 VT (초)
+     * @return 성공 여부
+     */
+    @CircuitBreaker(name = "pgmq", fallbackMethod = "setVisibilityTimeoutFallback")
+    fun setVisibilityTimeout(queueName: String, messageId: Long, visibilityTimeoutSec: Int): Boolean {
+        val context = TaskContext.of("PgmqClient", "SetVT", "$queueName:$messageId")
+        return executor.executeOrDefault(
+            { performSetVisibilityTimeout(queueName, messageId, visibilityTimeoutSec) },
+            false,
+            context,
+        )
+    }
+
+    /**
      * 큐 길이 조회
      *
      * <p>지정된 큐의 현재 대기 중인 메시지 수를 반환.
@@ -233,6 +253,21 @@ class PgmqClient(
         return result
     }
 
+    private fun performSetVisibilityTimeout(queueName: String, messageId: Long, visibilityTimeoutSec: Int): Boolean {
+        val result = jdbcTemplate.queryForObject(
+            "SELECT pgmq.set_visibility_timeout(?, ?, ?) as success",
+            Boolean::class.java,
+            queueName,
+            messageId,
+            visibilityTimeoutSec,
+        ) ?: false
+
+        if (result) {
+            log.debug("⏱️ [PGMQ] Set VT: queue={}, msgId={}, vt={}s", queueName, messageId, visibilityTimeoutSec)
+        }
+        return result
+    }
+
     private fun performQueueLength(queueName: String): Long {
         return jdbcTemplate.queryForObject(
             "SELECT pgmq.queue_length(?)",
@@ -266,6 +301,16 @@ class PgmqClient(
 
     private fun deleteFallback(queueName: String, messageId: Long, e: Throwable): Boolean {
         log.error("⚡ [PGMQ] Circuit Breaker OPEN - delete fallback: queue={}, msgId={}", queueName, messageId, e)
+        return false
+    }
+
+    private fun setVisibilityTimeoutFallback(
+        queueName: String,
+        messageId: Long,
+        visibilityTimeoutSec: Int,
+        e: Throwable,
+    ): Boolean {
+        log.error("⚡ [PGMQ] Circuit Breaker OPEN - setVT fallback: queue={}, msgId={}", queueName, messageId, e)
         return false
     }
 

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/PgmqMessage.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/PgmqMessage.kt
@@ -149,3 +149,21 @@ data class ExpectationCalcMessage(
     val userIgn: String,
     val forceRecalculation: Boolean,
 )
+
+/**
+ * FanOut 배치 처리 재시도 메시지 페이로드
+ *
+ * <p>nexon_fanout_queue로 발행되어 NexonFanOutWorker가 처리.
+ * 429 Rate Limit 발생 시 Batch Lane에서 enqueue.
+ *
+ * @param ocid 캐릭터 OCID
+ * @param userIgn 사용자 IGN
+ * @param retryCount 현재 재시도 횟수
+ * @param requestedAt 요청 시점
+ */
+data class FanOutRequest(
+    val ocid: String,
+    val userIgn: String,
+    val retryCount: Int = 0,
+    val requestedAt: String,
+)

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/PgmqWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/PgmqWorker.kt
@@ -53,6 +53,19 @@ abstract class PgmqWorker<T : Any>(
     protected abstract fun process(message: PgmqMessage<T>): Boolean
 
     /**
+     * 메시지 처리 실패 시 후처리 훅 (선택적 오버라이드)
+     *
+     * <p>process()가 false를 반환하거나 예외 발생 시 호출.
+     * 기본 구현은 no-op.
+     * 429 Rate Limit 시 setVisibilityTimeout()으로 짧은 지연 설정에 사용.
+     *
+     * @param message 처리 실패한 메시지
+     */
+    protected open fun onProcessingFailed(message: PgmqMessage<T>) {
+        // no-op by default
+    }
+
+    /**
      * 메시지 배치 처리
      *
      * <p>1. 큐에서 메시지 읽기
@@ -113,7 +126,8 @@ abstract class PgmqWorker<T : Any>(
                 log.debug("✅ [{}] Archived message: msgId={}", queueName, message.messageId)
             }
             message.isRetryable(maxRetries) -> {
-                // 재시도 가능: 다음 poll에서 다시 처리됨
+                // 재시도 가능: 후처리 훅 호출 후 다음 poll에서 다시 처리됨
+                onProcessingFailed(message)
                 log.warn("⚠️ [{}] Message will be retried: msgId={}, readCount={}", queueName, message.messageId, message.readCount)
             }
             else -> {

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/PgmqWorkerConfig.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/PgmqWorkerConfig.kt
@@ -42,6 +42,9 @@ class PgmqWorkerConfig {
     /** Expectation Calc Low Priority Worker 설정 */
     var expectationCalcLow: WorkerSettings = WorkerSettings()
 
+    /** Nexon FanOut Worker 설정 (429 재시도 전용) */
+    var nexonFanout: WorkerSettings = WorkerSettings()
+
     data class CommonSettings(
         /** 폴링 간격 (ms) */
         var pollingIntervalMs: Long = 1000,

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/queue/pgmq/FanOutQueueProducer.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/queue/pgmq/FanOutQueueProducer.kt
@@ -1,0 +1,59 @@
+package maple.expectation.infrastructure.queue.pgmq
+
+import java.time.Instant
+import maple.expectation.core.port.out.FanOutQueuePort
+import maple.expectation.infrastructure.executor.LogicExecutor
+import maple.expectation.infrastructure.executor.TaskContext
+import maple.expectation.infrastructure.pgmq.FanOutRequest
+import maple.expectation.infrastructure.pgmq.PgmqClient
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * FanOut 큐 프로듀서
+ *
+ * <h3>역할</h3>
+ * <p>429 Rate Limit 발생 시 nexon_fanout_queue에 재시도 메시지를 발행
+ *
+ * <h3>트랜잭션</h3>
+ * <p>PgmqClient.send()가 활성 트랜잭션을 요구하므로 @Transactional 필수
+ *
+ * @see FanOutRequest 메시지 페이로드
+ * @see PgmqClient PGMQ 클라이언트
+ * @see FanOutQueuePort Port 인터페이스
+ */
+@Component
+class FanOutQueueProducer(
+    private val pgmqClient: PgmqClient,
+    private val executor: LogicExecutor,
+) : FanOutQueuePort {
+
+    @Transactional
+    override fun enqueue(ocid: String, userIgn: String, retryCount: Int): Long {
+        val context = TaskContext.of("FanOutQueue", "Enqueue", ocid)
+
+        return executor.execute(
+            {
+                val request = FanOutRequest(
+                    ocid = ocid,
+                    userIgn = userIgn,
+                    retryCount = retryCount,
+                    requestedAt = Instant.now().toString(),
+                )
+
+                val messageId = pgmqClient.send(QUEUE_NAME, request)
+                log.debug("[FanOutQueue] Enqueued: ocid={}, retry={}, msgId={}", ocid, retryCount, messageId)
+                messageId
+            },
+            context,
+        )
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(FanOutQueueProducer::class.java)
+
+        /** 큐 이름 */
+        const val QUEUE_NAME = "nexon_fanout_queue"
+    }
+}

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/NexonFanOutWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/NexonFanOutWorker.kt
@@ -1,0 +1,92 @@
+package maple.expectation.infrastructure.worker
+
+import kotlin.random.Random
+import maple.expectation.infrastructure.executor.LogicExecutor
+import maple.expectation.infrastructure.executor.TaskContext
+import maple.expectation.infrastructure.fanout.NexonFanOutBatchLoader
+import maple.expectation.infrastructure.pgmq.FanOutRequest
+import maple.expectation.infrastructure.pgmq.PgmqClient
+import maple.expectation.infrastructure.pgmq.PgmqMessage
+import maple.expectation.infrastructure.pgmq.PgmqWorker
+import maple.expectation.infrastructure.pgmq.PgmqWorkerConfig
+import maple.expectation.infrastructure.provider.EquipmentFetchProvider
+import maple.expectation.infrastructure.queue.pgmq.FanOutQueueProducer
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Component
+
+/**
+ * Nexon FanOut Worker (429 재시도 전용)
+ *
+ * <h3>역할</h3>
+ * <p>nexon_fanout_queue에서 429 Rate Limit 재시도 메시지를 소비.
+ * Batch Lane에서 enqueue된 FanOutRequest를 처리.
+ *
+ * <h3>처리 흐름</h3>
+ * <ol>
+ *   <li>nexon_fanout_queue에서 메시지 읽기</li>
+ *   <li>EquipmentFetchProvider.fetchWithCache()로 장비 데이터 조회</li>
+ *   <li>성공 → archive (Base class 처리)</li>
+ *   <li>429 → setVisibilityTimeout(1.0~1.3s jitter) 후 재시도</li>
+ *   <li>readCount >= maxRetries → delete (DLQ)</li>
+ * </ol>
+ *
+ * <h3>Jitter</h3>
+ * <p>429 재시도 시 1.0초 ~ 1.3초 (30% jitter) 랜덤 지연.
+ * Thundering Herd 방지.
+ *
+ * @see FanOutQueueProducer 프로듀서
+ * @see EquipmentFetchProvider 캐시 적용 장비 데이터 조회
+ * @see NexonFanOutBatchLoader Batch Lane 병렬 실행기
+ */
+@Component
+@Profile("!test")
+class NexonFanOutWorker(
+    private val pgmqClient: PgmqClient,
+    executor: LogicExecutor,
+    config: PgmqWorkerConfig,
+    private val fetchProvider: EquipmentFetchProvider,
+) : PgmqWorker<FanOutRequest>(pgmqClient, executor, config) {
+
+    override val queueName: String = FanOutQueueProducer.QUEUE_NAME
+    override val payloadClass: Class<FanOutRequest> = FanOutRequest::class.java
+    override val workerSettings: PgmqWorkerConfig.WorkerSettings = config.nexonFanout
+
+    override fun process(message: PgmqMessage<FanOutRequest>): Boolean {
+        val request = message.payload
+        val context = TaskContext.of("NexonFanOutWorker", "Process", request.ocid)
+
+        return executor.executeOrDefault(
+            {
+                fetchProvider.fetchWithCache(request.ocid)
+                log.info("[NexonFanOutWorker] Success: ocid={}, retry={}", request.ocid, request.retryCount)
+                true
+            },
+            false,
+            context,
+        )
+    }
+
+    /**
+     * 429 발생 시 Visibility Timeout을 짧게 설정 (1.0~1.3s jitter)
+     *
+     * <p>Base class의 processSingleMessage에서 process() 실패 후 호출.
+     * 기본 30초 VT 대신 짧은 지연으로 빠른 재시도.
+     */
+    override fun onProcessingFailed(message: PgmqMessage<FanOutRequest>) {
+        val jitterSec = BASE_DELAY_SEC + (Random.nextDouble() * JITTER_FACTOR)
+        val jitterSecInt = jitterSec.toInt().coerceAtLeast(1)
+
+        pgmqClient.setVisibilityTimeout(queueName, message.messageId, jitterSecInt)
+        log.warn(
+            "[NexonFanOutWorker] 429 retry with VT={}s: ocid={}, readCount={}",
+            jitterSecInt, message.payload.ocid, message.readCount,
+        )
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(NexonFanOutWorker::class.java)
+        private const val BASE_DELAY_SEC = 1.0
+        private const val JITTER_FACTOR = 0.3
+    }
+}

--- a/module-infra/src/main/resources/db/migration/V105__nexon_fanout_queue.sql
+++ b/module-infra/src/main/resources/db/migration/V105__nexon_fanout_queue.sql
@@ -1,0 +1,4 @@
+-- V105: Nexon FanOut Queue 생성 (429 재시도 전용)
+-- Batch Lane에서 429 Rate Limit 발생 시 FanOutQueueProducer가 메시지를 발행
+-- NexonFanOutWorker가 소비 후 EquipmentFetchProvider.fetchWithCache()로 재시도
+SELECT pgmq.create('nexon_fanout_queue');

--- a/module-web/src/main/kotlin/maple/expectation/web/controller/v5/GameCharacterControllerV5.kt
+++ b/module-web/src/main/kotlin/maple/expectation/web/controller/v5/GameCharacterControllerV5.kt
@@ -8,9 +8,12 @@ import maple.expectation.core.domain.model.character.CharacterView
 import maple.expectation.core.port.inbound.CalculationQueuePort
 import maple.expectation.core.port.inbound.CharacterViewQueryPort
 import maple.expectation.core.port.inbound.ExecutorPort
+import maple.expectation.core.port.out.CharacterOcidPort
+import maple.expectation.core.port.out.EquipmentFanOutPort
 import maple.expectation.web.dto.v5.EquipmentExpectationResponseV5
 import maple.expectation.web.mapper.CharacterViewMapper
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -32,6 +35,12 @@ import org.springframework.web.bind.annotation.RestController
  * **ADR-005 Hexagonal Architecture**
  * - CharacterViewQueryPort: PostgreSQL 조회
  * - CalculationQueuePort: 큐 작업 추가
+ * - EquipmentFanOutPort: FanOut Micro-Batch 프리페치 (fanout.enabled=true)
+ *
+ * **FanOut Integration (fanout.enabled=true)**
+ * - PostgreSQL MISS 시 장비 데이터를 Micro-Batch Coalescing으로 프리페치
+ * - 프리페치 후 Calculation Worker가 캐시된 데이터를 활용 (빠른 계산)
+ * - Best-effort: 실패해도 큐잉은 정상 수행
  */
 @RestController
 @RequestMapping("/api/v5/characters")
@@ -40,6 +49,9 @@ class GameCharacterControllerV5(
     private val queryPort: CharacterViewQueryPort,
     private val queuePort: CalculationQueuePort,
     private val executorPort: ExecutorPort,
+    private val ocidPort: CharacterOcidPort,
+    @Value("\${fanout.enabled:false}") private val fanOutEnabled: Boolean,
+    private val fanOutPort: EquipmentFanOutPort,
 ) {
 
     /**
@@ -77,8 +89,36 @@ class GameCharacterControllerV5(
             return ResponseEntity.ok(cachedResult.get())
         }
 
-        // 3. MISS: Queue to Command Side via Port
+        // 3. MISS: Pre-warm equipment cache via FanOut (best-effort)
+        if (fanOutEnabled) {
+            preWarmEquipmentCache(userIgn, context)
+        }
+
+        // 4. Queue to Command Side via Port
         return queueCalculationTask(userIgn, false, context)
+    }
+
+    /**
+     * FanOut Micro-Batch로 장비 데이터 프리페치 (Best-Effort)
+     *
+     * <p>OCID 해석 → EquipmentFanOutPort.preFetchByOcid():
+     * <ul>
+     *   <li>L1 Cache HIT → 즉시 반환 (0ms)</li>
+     *   <li>In-Flight Coalescing → 기존 요청 대기</li>
+     *   <li>Fast Lane → EquipmentFetchProvider.fetchWithCache()</li>
+     *   <li>Batch Lane → NexonFanOutBatchLoader.load()</li>
+     * </ul>
+     *
+     * <p>실패해도 큐잉은 정상 수행 (Best-Effort)
+     */
+    private fun preWarmEquipmentCache(userIgn: String, context: TaskContext) {
+        executorPort.executeVoidJava({
+            val ocid = ocidPort.resolveOcid(userIgn)
+            if (ocid != null) {
+                fanOutPort.preFetchByOcid(ocid)
+                log.debug("[V5] FanOut pre-warm: ign={}, ocid={}", maskIgn(userIgn), ocid.take(8))
+            }
+        }, context)
     }
 
     /**


### PR DESCRIPTION
## 🔗 관련 이슈

See also : Fan-Out Explosion and Admission Control 설계 문서

## 🗣 개요

Nexon API 429 Rate Limit 대응을 위한 Fan-Out Batch Worker 아키텍처 구현.
기존 `AdaptiveMicroBatchUserService`를 재사용하여 Request Coalescing + Adaptive Routing + Batch Lane 병렬 실행 + PGMQ 기반 429 재시도를 통합.

## 🛠 작업 내용

### New Files (9)
- **`FanOutQueuePort`** (module-core): PGMQ enqueue 포트 인터페이스 (DIP 준수)
- **`EquipmentFanOutPort`** (module-core): Controller 연동 포트 인터페이스
- **`FanOutQueueProducer`** (module-infra): `FanOutQueuePort` 구현체, `@Transactional` + PGMQ send
- **`NexonFanOutBatchLoader`** (module-infra): CompletableFuture 기반 병렬 실행, Semaphore(30) + 429 시 PGMQ enqueue
- **`NexonEquipmentMicroBatchAdapter`** (module-infra): `AdaptiveMicroBatchUserService<EquipmentResponse>` 래핑 어댑터
- **`NexonFanOutWorker`** (module-infra): PGMQ 워커, 429 재시도 시 1.0~1.3s jitter VT 설정
- **`FanOutRequest`** (PgmqMessage): 429 재시도 메시지 페이로드
- **`V105__nexon_fanout_queue.sql`**: PGMQ 큐 생성 마이그레이션

### Modified Files (5)
- **`PgmqClient`**: `setVisibilityTimeout()` 추가 (429 jitter retry용)
- **`PgmqWorker`**: `onProcessingFailed()` hook 추가 (subclass 오버라이드)
- **`PgmqWorkerConfig`**: `nexonFanout` 워커 설정 필드 추가
- **`GameCharacterControllerV5`**: 캐시 미스 시 fan-out pre-warm → 202 flow
- **`application.yml` / `application-pglocal.yml` / `application-pgprod.yml`**: `fanout.*` 설정 추가

### Plan
- `docs/09_Plans/2026-04-01-fanout-batch-worker-with-coalescing.md`

## 💬 리뷰 포인트

1. **`startBatchWorker()` 호출**: `AdaptiveMicroBatchUserService`는 Spring Bean이 아니므로 어댑터의 `@PostConstruct`에서 명시 호출 (기존 `GameCharacterMicroBatchAdapter`, `L2CacheMicroBatchAdapter`에도 동일 이슈 존재)
2. **429 탐지**: `WebClientResponseException.statusCode == 429` 타입 체크만 사용 (문자열 매칭 제거)
3. **`ExecutorService` lifecycle**: `@PreDestroy`로 graceful shutdown
4. **Feature flag**: `fanout.enabled: false` 기본값, Phase 1에서는 비활성화

## 💱 트레이드 오프 결정 근거

| 결정 | 선택 | 대안 | 이유 |
|------|------|------|------|
| 비동기 패턴 | CompletableFuture | Kotlin Coroutine | 기존 `NexonApiClient`가 CF 반환, `.join()` ADR 유지 |
| 재시도 큐 | PGMQ (단일 큐 + VT) | RabbitMQ / Kafka | 인프라 추가 없이 PostgreSQL 통합 |
| 동시성 제어 | Semaphore(30) < Bulkhead(50) | Semaphore = Bulkhead | Semaphore가 의도적 병목, layered defense |
| 설정 외부화 | 일부 상수 hardcoded | `@ConfigurationProperties` | Phase 1에서는 상수로 충분, 튜닝 필요시 외부화 |

## ✅ 체크리스트

- [x] 컴파일 통과 (`./gradlew compileKotlin compileJava --continue`)
- [x] 모듈별 테스트 통과 (`module-core`, `module-infra`, `module-web`)
- [x] CLAUDE.md 원칙 준수 (Zero Try-Catch, LogicExecutor, Hexagonal Architecture)
- [x] Consensus Review (Architect + Critic + Code-Reviewer) 통과
- [x] 브랜치 생성 (`feature/fanout-batch-worker`)
- [x] `fanout.enabled: false` 기본값으로 안전한 배포