### PR TITLE
FIX: Vultr 프로필 서버 기동 에러 4건 수정

### DIFF
--- a/module-app/src/main/java/maple/expectation/config/V5Config.java
+++ b/module-app/src/main/java/maple/expectation/config/V5Config.java
@@ -39,10 +39,10 @@ public class V5Config {
 
     checkedLogicExecutor.executeUncheckedVoid(
         () -> {
-          log.info("[V5-Config] Initializing V5 CQRS worker pool...");
-          executor.start();
-          // ADR-080 Fix 4: Workers log their own startup - removed misleading message
-          log.info("[V5-Config] Worker pool initialization submitted");
+          log.info("[V5-Config] V5 CQRS initialized (PGMQ workers handle consumption, polling workers disabled)");
+          // Legacy polling workers disabled — PGMQ workers (ExpectationCalcWorker, ExpectationCalcLowWorker)
+          // now handle message consumption via @Scheduled pgmqClient.read()
+          // executor.start();
         },
         context,
         e -> new IllegalStateException("V5 CQRS worker pool startup failed", e));

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/config/TransactionConfig.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/config/TransactionConfig.kt
@@ -1,8 +1,10 @@
 package maple.expectation.infrastructure.config
 
+import jakarta.persistence.EntityManagerFactory
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
+import org.springframework.orm.jpa.JpaTransactionManager
 import org.springframework.transaction.PlatformTransactionManager
 import org.springframework.transaction.support.TransactionTemplate
 
@@ -36,6 +38,18 @@ import org.springframework.transaction.support.TransactionTemplate
  */
 @Configuration
 class TransactionConfig {
+
+    /**
+     * Explicit JPA TransactionManager bean.
+     *
+     * Required because LockHikariConfig creates lockTransactionManager (PlatformTransactionManager),
+     * which triggers Spring Boot's @ConditionalOnMissingBean and prevents auto-configuration
+     * of the JPA transactionManager bean.
+     */
+    @Bean("transactionManager")
+    @Primary
+    fun transactionManager(entityManagerFactory: EntityManagerFactory): PlatformTransactionManager =
+        JpaTransactionManager(entityManagerFactory)
 
     /**
      * 기본 TransactionTemplate (읽기/쓰기 가능)

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/hotkey/HotKeyDetector.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/hotkey/HotKeyDetector.kt
@@ -1,5 +1,6 @@
 package maple.expectation.infrastructure.hotkey
 
+import java.sql.Timestamp
 import java.time.Instant
 import maple.expectation.infrastructure.executor.LogicExecutor
 import maple.expectation.infrastructure.executor.TaskContext
@@ -51,7 +52,7 @@ class HotKeyDetector(
                     """,
                 Long::class.java,
                 key,
-                Instant.now().minusSeconds(windowSizeSeconds.toLong()),
+                Timestamp.from(Instant.now().minusSeconds(windowSizeSeconds.toLong())),
             ) ?: 0L
 
             count > threshold
@@ -76,7 +77,7 @@ class HotKeyDetector(
                     DO UPDATE SET count = hot_key_counter.count + 1
                     """,
                     key,
-                    Instant.now(),
+                    Timestamp.from(Instant.now()),
                 )
             },
             TaskContext.of("HotKey", "Record", key),
@@ -98,7 +99,7 @@ class HotKeyDetector(
                     """,
                 Long::class.java,
                 key,
-                Instant.now().minusSeconds(windowSizeSeconds.toLong()),
+                Timestamp.from(Instant.now().minusSeconds(windowSizeSeconds.toLong())),
             ) ?: 0L
         },
         0L,
@@ -117,7 +118,7 @@ class HotKeyDetector(
                     DELETE FROM hot_key_counter
                     WHERE window_start < ?
                     """,
-                    Instant.now().minusSeconds(windowSizeSeconds.toLong() * 2),
+                    Timestamp.from(Instant.now().minusSeconds(windowSizeSeconds.toLong() * 2)),
                 )
                 if (deleted > 0) {
                     log.debug("[HotKey] Cleaned up {} old entries", deleted)
@@ -145,7 +146,7 @@ class HotKeyDetector(
                 { rs, _ ->
                     rs.getString("key") to rs.getLong("total_count")
                 },
-                Instant.now().minusSeconds(windowSizeSeconds.toLong()),
+                Timestamp.from(Instant.now().minusSeconds(windowSizeSeconds.toLong())),
                 threshold,
             ).toMap()
         },

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/PgmqClient.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/PgmqClient.kt
@@ -292,7 +292,7 @@ class PgmqClient(
 
     private fun performQueueLength(queueName: String): Long {
         return jdbcTemplate.queryForObject(
-            "SELECT pgmq.queue_length(?)",
+            "SELECT queue_length FROM pgmq.metrics(?)",
             Long::class.java,
             queueName,
         ) ?: 0L


### PR DESCRIPTION
## Summary
- V5Config: Legacy polling workers 비활성화 (PGMQ workers가 소비 담당, `executor.start()` 주석 처리)
- TransactionConfig: 명시적 JPA `transactionManager` bean 추가 (LockHikariConfig 충돌 해결)
- HotKeyDetector: `Instant` → `Timestamp.from()` 변환 (PostgreSQL JDBC 타입 추론 에러 5곳 수정)
- PgmqClient: `pgmq.queue_length()` → `pgmq.metrics()` 교체 (PGMQ v1.5.1 호환)

## Test plan
- [x] `./gradlew compileKotlin compileJava --continue` 성공
- [x] `./gradlew test` 전체 통과
- [x] Vultr 프로필 서버 기동 후 에러 0건 확인
- [x] 원격 DB에 누락 테이블/큐 생성 (equipment_persistence_tracker, hot_key_counter, nexon_retry_queue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)