### PR TITLE
FEAT : PgmqWorker 배치 병렬 처리로 처리량 3배 향상

### DIFF
--- a/module-app/src/main/resources/application-vultr.yml
+++ b/module-app/src/main/resources/application-vultr.yml
@@ -85,6 +85,15 @@ resilience:
   retry-budget:
     enabled: false
 
+# Bulkhead — 기본 50 concurrent calls가 Worker 병렬 처리 병목
+# 91 msg/batch × 3 API calls = 273 동시 호출 필요
+resilience4j:
+  bulkhead:
+    instances:
+      nexonApi:
+        maxConcurrentCalls: 200
+        maxWaitDuration: 2s
+
 # Rate Limiting
 ratelimit:
   enabled: false  # Disable for initial testing

--- a/module-app/src/main/resources/application-vultr.yml
+++ b/module-app/src/main/resources/application-vultr.yml
@@ -79,6 +79,12 @@ pgmq:
     expectation-calc-low:
       enabled: true
 
+# Retry Budget — tryAcquire가 모든 API 호출마다 카운트되어
+# 100/min 예산으로는 8 RPS × 3 calls = 1440/min 감당 불가 → death spiral
+resilience:
+  retry-budget:
+    enabled: false
+
 # Rate Limiting
 ratelimit:
   enabled: false  # Disable for initial testing

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/PgmqWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/PgmqWorker.kt
@@ -3,6 +3,8 @@ package maple.expectation.infrastructure.pgmq
 import maple.expectation.infrastructure.executor.LogicExecutor
 import maple.expectation.infrastructure.executor.TaskContext
 import io.micrometer.core.instrument.MeterRegistry
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled
@@ -31,6 +33,9 @@ abstract class PgmqWorker<T : Any>(
     private val config: PgmqWorkerConfig,
     private val meterRegistry: MeterRegistry,
 ) {
+
+    /** 메시지 병렬 처리용 Virtual Thread Executor */
+    private val workerPool = Executors.newVirtualThreadPerTaskExecutor()
 
     /**
      * 큐 이름
@@ -101,9 +106,14 @@ abstract class PgmqWorker<T : Any>(
             var successCount = 0
             var failCount = 0
 
-            messages.forEach { message ->
-                val success = processSingleMessage(message)
-                if (success) successCount++ else failCount++
+            val futures = messages.map { message ->
+                CompletableFuture.supplyAsync({
+                    processSingleMessage(message)
+                }, workerPool)
+            }
+            CompletableFuture.allOf(*futures.toTypedArray()).join()
+            futures.forEach { future ->
+                if (future.get()) successCount++ else failCount++
             }
 
             val batchDuration = System.nanoTime() - batchStart


### PR DESCRIPTION
## Summary
- PgmqWorker의 sequential `messages.forEach`를 `CompletableFuture.supplyAsync` + Virtual Thread Executor로 변경
- `.join()`이 개별 virtual thread만 블로킹하므로 배치 내 메시지가 동시 처리됨
- 처리량: ~2.75 RPS → ~8 RPS (약 3배 향상)

## Test plan
- [x] `./gradlew :module-infra:compileKotlin --continue` 컴파일 통과
- [x] Vultr 프로필 서버 기동 정상
- [x] 1000 IGN 부하 테스트: HTTP 573.6 RPS, 0% 에러
- [x] Worker 드레인: ~8 RPS (기존 ~2.75 RPS 대비 3배 향상)
- [x] Prometheus 메트릭 정상 수집 (`pgmq_worker_processed_total`, `pgmq_worker_batch_latency_seconds`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)