### PR TITLE
FEAT : Worker 배치 Fan-out + Coalescing pre-warm (ADR-387)

### DIFF
--- a/docs/01_ADR/ADR-387-worker-batch-fanout-coalescing.md
+++ b/docs/01_ADR/ADR-387-worker-batch-fanout-coalescing.md
@@ -1,0 +1,76 @@
+# ADR-387: Worker Batch Fan-out + Coalescing Pre-warm
+
+**Status**: Accepted
+**Date**: 2026-04-05
+**Context**: ExpectationCalcWorker, ExpectationCalcLowWorker, PgmqWorker
+
+## Context
+
+PR #699에서 Worker RPS를 2.75→98.5까지 개선했으나, 배치 내 **동일 OCID에 대한 중복 API 호출**이 병목으로 확인됨.
+
+### 문제
+
+배치 91개 메시지가 각각 독립적으로 OCID 해석 + 장비 fetch → 동일 OCID가 N번 fetch됨.
+Nexon API 호출 수: 91 messages × 3 API calls = 273 calls (unique OCID는 ~50개).
+
+### 기존 인프라
+
+V4에 이미 구축된 micro-batch coalescing 인프라:
+- `AdaptiveMicroBatchUserService`: semaphore(10) 기반 Fast/Batch Lane 분기
+- `NexonEquipmentMicroBatchAdapter`: `preFetchByOcid()` → coalescing 트리거
+- `NexonFanOutBatchLoader`: Batch Lane에서 병렬 batch fetch
+- `CharacterOcidPort.resolveOcids()`: IN clause batch OCID resolve
+
+## Decision
+
+`PgmqWorker`에 `preWarmBatch()` 훅을 추가하고, `ExpectationCalcWorker`/`ExpectationCalcLowWorker`에서 override하여 배치 처리 전 OCID dedup + 장비 캐시 pre-warm 수행.
+
+### 설계
+
+```
+processMessages() {
+    messages = pgmq.read(batch)
+    preWarmBatch(messages)     // ← 신규 훅
+    messages.forEach { process(it) }  // 기존 로직 (캐시 warm 상태)
+}
+```
+
+#### preWarmBatch() 흐름
+
+1. 배치 내 unique IGN 추출 (`messages.map { it.payload.userIgn }.toSet()`)
+2. Batch OCID resolve (`CharacterOcidPort.resolveOcids(igns)` → 1 DB query)
+3. **Concurrent** `EquipmentFanOutPort.preFetchByOcid(ocid)` submission
+   - 동시 submit 필수: 순차 호출 시 semaphore 항상 available → 전부 Fast Lane → coalescing 미발생
+   - Virtual Thread에서 동시 submit → semaphore(10) 초과 → Batch Lane routing → `NexonFanOutBatchLoader.load()` batch fetch
+4. `orTimeout(15s)` + `.handle { _, _ -> }` → best-effort
+
+### Best-effort 정책
+
+- pre-warm 실패해도 메시지 처리에 영향 없음
+- `resolveOcids` 누락 IGN (신규 캐릭터) → `process()`에서 정상 경로로 처리
+- pre-warm 타임아웃 → `process()`에서 캐시 miss → API 호출 fallback
+
+## Consequences
+
+### 긍정
+- Nexon API 호출 수: 273 → ~50 (82% 감소 예상)
+- 기존 V4 micro-batch 인프라 100% 재사용 (중복 구현 없음)
+- `PgmqWorker` 훅은 open → 다른 Worker도 필요시 override 가능
+
+### 부정
+- pre-warm으로 인한 배치 처리 시작 지연 (~1-3초, 타임아웃 15s)
+- 캐시 TTL 만료 시 pre-warm 무효 가능 (TTL 설정에 따라)
+
+### 변경 파일
+
+| 파일 | 변경 |
+|------|------|
+| `PgmqWorker.kt` | `preWarmBatch()` open 훅 추가 + `processMessages()`에서 호출 |
+| `ExpectationCalcWorker.kt` | `preWarmBatch()` override + `CharacterOcidPort`, `EquipmentFanOutPort` 주입 |
+| `ExpectationCalcLowWorker.kt` | 동일 패턴 적용 |
+
+### 재사용 컴포넌트 (변경 없음)
+
+- `CharacterOcidPort.resolveOcids(Set<String>): Map<String, String>`
+- `EquipmentFanOutPort.preFetchByOcid(ocid: String): Boolean`
+- `NexonEquipmentMicroBatchAdapter` → `AdaptiveMicroBatchUserService` → `NexonFanOutBatchLoader`

--- a/docs/09_Plans/2026-04-05-worker-batch-fanout-coalescing.md
+++ b/docs/09_Plans/2026-04-05-worker-batch-fanout-coalescing.md
@@ -1,0 +1,158 @@
+# Plan: Worker Batch Fan-out + Coalescing (ADR-700)
+
+## Context
+
+PR #699에서 Worker RPS 2.75→98.5 달성. 이후 병목: **배치 내 동일 OCID에 대한 중복 API 호출**.
+
+현재 배치 91개 메시지가 각각 독립적으로 OCID 해석 + 장비 fetch → 동일 OCID가 N번 fetch됨.
+V4에 이미 구축된 `AdaptiveMicroBatchUserService` + `NexonEquipmentMicroBatchAdapter` + `CharacterOcidPort.resolveOcids()` 재활용.
+
+**목표:** 배치 내 OCID 중복 제거 → 장비 캐시 pre-warm → 기존 `process()`는 캐시 hit → API 호출 감소
+**RPS 타겟:** 검증 필요. 현재 98.5 RPS에서 API 호출 감소로 유의미한 개선 예상.
+
+---
+
+## 수정 파일
+
+### 1. `PgmqWorker.kt` — pre-warm hook 추가
+**경로:** `module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/PgmqWorker.kt`
+
+`processMessages()`에서 병렬 처리 **직전**에 `preWarmBatch(messages)` 훅 호출. 기본 구현은 no-op.
+
+```kotlin
+// 추가: pre-warm hook (하위 클래스에서 override)
+protected open fun preWarmBatch(messages: List<PgmqMessage<T>>) {
+    // no-op by default
+}
+
+// processMessages() 수정 위치 (line ~102):
+// val messages = pgmqClient.read(...)
+// if (messages.isEmpty()) return
+//
+// preWarmBatch(messages)  // ← 추가: OCID dedup + equipment cache pre-warm
+//
+// // 이후 기존 병렬 처리 로직 그대로 (수정 없음)
+// val futures = messages.map { ... }
+```
+
+**장점:** `workerPool` 노출 불필요, 병렬 처리 로직은 한 곳에 집중, 하위 클래스는 pre-warm만 담당.
+
+### 2. `ExpectationCalcWorker.kt` — preWarmBatch override
+**경로:** `module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/ExpectationCalcWorker.kt`
+
+추가 주입: `CharacterOcidPort`, `EquipmentFanOutPort`
+
+```kotlin
+override fun preWarmBatch(messages: List<PgmqMessage<ExpectationCalcMessage>>) {
+    val context = TaskContext.of("ExpectationCalcWorker", "PreWarm", queueName)
+
+    executor.executeVoid({
+        // 1. 배치 내 unique IGN 추출
+        val igns = messages.map { it.payload.userIgn }.toSet()
+
+        // 2. Batch OCID resolve (재사용: CharacterOcidPort.resolveOcids)
+        val ignToOcid = characterOcidPort.resolveOcids(igns)
+
+        if (ignToOcid.isEmpty()) return@executeVoid
+
+        // 3. Equipment cache pre-warm — CONCURRENT submission 필수
+        //    순차 호출 시 AdaptiveMicroBatchUserService가 Fast Lane으로 처리 → coalescing 미발생
+        //    Virtual Thread에서 동시 submit → semaphore(10) 초과 시 Batch Lane으로 routing
+        //    → NexonFanOutBatchLoader.load()가 병렬 batch fetch → L1/L2 캐시 적재
+        val warmupFutures = ignToOcid.values.map { ocid ->
+            CompletableFuture.supplyAsync {
+                equipmentFanOutPort.preFetchByOcid(ocid)
+            }
+        }
+        CompletableFuture.allOf(*warmupFutures.toTypedArray())
+            .orTimeout(15, TimeUnit.SECONDS)
+            .handle { _, _ -> }  // best-effort: 실패해도 진행
+
+        log.info("[ExpectationCalcWorker] Pre-warm: {} igns → {} ocids", igns.size, ignToOcid.size)
+    }, context)
+}
+```
+
+**Critical: 왜 동시 submit인가?**
+- `AdaptiveMicroBatchUserService.getByKey()`는 `semaphore.tryAcquire()`로 Fast/Batch Lane 분기
+- `semaphorePermits=10` → 10개까지 Fast Lane (개별 fetch)
+- 초과분은 Channel → 10ms 대기 → `batchLoader(batch)` → `NexonFanOutBatchLoader.load()` batch fetch
+- **순차 호출 시**: 매 호출이 blocking → semaphore 항상 available → 전부 Fast Lane → coalescing 없음
+- **동시 submit 시**: 50개가 동시에 들어오면 10개 Fast + 40개 Batch → coalescing 발생 → API 호출 최소화
+
+**Best-effort 정책:**
+- `resolveOcids`에서 누락된 IGN (신규 캐릭터) → `process()`에서 정상 처리 (기존 경로)
+- pre-warm 타임아웃/실패 → `process()`에서 캐시 miss → API 호출 fallback
+- pre-warm은 최적화일 뿐, 실패해도 Worker 동작에 영향 없음
+
+이후 기존 `process()` → `calculateExpectationAsync()` 호출 시 장비 fetch가 **캐시 hit** → API 호출 생략.
+
+### 3. `ExpectationCalcLowWorker.kt` — 동일 패턴 적용
+**경로:** `module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/ExpectationCalcLowWorker.kt`
+
+`ExpectationCalcWorker`와 동일한 `preWarmBatch()` override. `CharacterOcidPort`, `EquipmentFanOutPort` 주입 추가.
+
+### 4. `application-vultr.yml` — 설정 변경 없음
+기존 `AdaptiveMicroBatchProperties` 기본값 사용:
+- `semaphorePermits=10`, `batchMaxWaitMs=10`, `batchMaxSize=50`
+
+---
+
+## 재사용 인프라 (변경 없음)
+
+| 컴포넌트 | 역할 | 경로 |
+|----------|------|------|
+| `CharacterOcidPort.resolveOcids(Set)` | Batch IGN→OCID (IN clause) | `module-core/.../port/out/CharacterOcidPort.kt` |
+| `EquipmentFanOutPort.preFetchByOcid(ocid)` | Cache pre-fetch + coalescing 트리거 | `module-core/.../port/out/EquipmentFanOutPort.kt` |
+| `NexonEquipmentMicroBatchAdapter` | preFetchByOcid 구현체 | `module-infra/.../batch/NexonEquipmentMicroBatchAdapter.kt` |
+| `AdaptiveMicroBatchUserService` | Core coalescing engine (semaphore routing) | `module-infra/.../batch/AdaptiveMicroBatchUserService.kt` |
+| `NexonFanOutBatchLoader.load(ocids)` | Batch Lane 병렬 fetch | `module-infra/.../fanout/NexonFanOutBatchLoader.kt` |
+
+---
+
+## 처리 흐름 (Before → After)
+
+**Before:**
+```
+91 messages → 91x OCID resolve → 91x equipment API fetch → 91x calculate → 91x save
+= 273 API calls (Nexon API bottleneck)
+```
+
+**After:**
+```
+91 messages
+→ preWarmBatch:
+    1) batch OCID resolve: 91 IGNs → ~50 unique OCIDs (1 DB query)
+    2) concurrent preFetchByOcid(50 OCIDs):
+       - 10 Fast Lane (semaphore=10, 개별 fetch+cache)
+       - 40 Batch Lane (coalescing → NexonFanOutBatchLoader.load() → 병렬 batch fetch)
+    = ~50 API calls (unique OCIDs only)
+→ 91x process() → calculateExpectationAsync():
+    - equipment fetch = 캐시 hit (0 API calls)
+    - calculate + save (CPU + DB)
+= ~50 API calls (기존 273에서 82% 감소)
+```
+
+---
+
+## Verification
+
+1. `./gradlew compileKotlin compileJava --continue` — 컴파일 확인
+2. `./gradlew test` — 기존 테스트 통과
+3. 서버 기동 후 PGMQ에 테스트 메시지 enqueue → Worker 로그에서:
+   - `Pre-warm: X igns → Y ocids` 로그 확인
+   - 기존 `process()` 로그 정상 출력
+4. Micrometer: `pgmq.worker.processed{status=success}` 카운터 증가 확인
+5. Nexon API 호출 수 감소 확인 (`nexon_api_calls_total` 비교)
+
+---
+
+## DoD
+
+- [ ] ADR-700 문서 작성 (`docs/01_ADR/`)
+- [ ] 컴파일 통과
+- [ ] 단위 테스트 통과
+- [ ] CLAUDE.md 원칙 준수 (Zero try-catch, LogicExecutor 위임)
+- [ ] 중복 구현 없음 (V4 micro-batch 100% 재활용)
+- [ ] Best-effort pre-warm (실패해도 Worker 동작 보장)
+- [ ] `develop` 브랜치 PR

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/PgmqWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/PgmqWorker.kt
@@ -74,11 +74,25 @@ abstract class PgmqWorker<T : Any>(
     }
 
     /**
+     * 배치 pre-warm 훅 (ADR-700)
+     *
+     * <p>병렬 메시지 처리 전 호출. 하위 클래스에서 override하여
+     * 배치 내 OCID 중복 제거, 장비 캐시 pre-warm 등 수행.
+     * 기본 구현은 no-op. Best-effort: 실패해도 메시지 처리에 영향 없음.
+     *
+     * @param messages 배치로 읽은 메시지 목록
+     */
+    protected open fun preWarmBatch(messages: List<PgmqMessage<T>>) {
+        // no-op by default
+    }
+
+    /**
      * 메시지 배치 처리
      *
      * <p>1. 큐에서 메시지 읽기
-     * <p>2. 각 메시지 처리
-     * <p>3. 성공 시 archive, 실패 시 delete
+     * <p>2. 배치 pre-warm (ADR-700: OCID dedup + equipment cache pre-warm)
+     * <p>3. 각 메시지 병렬 처리
+     * <p>4. 성공 시 archive, 실패 시 delete
      */
     @Scheduled(fixedDelayString = "\${pgmq.worker.common.polling-interval-ms:300}")
     fun processMessages() {
@@ -100,6 +114,9 @@ abstract class PgmqWorker<T : Any>(
             }
 
             log.debug("📥 [{}] Processing {} messages", queueName, messages.size)
+
+            // ADR-700: 배치 pre-warm (OCID dedup + equipment cache pre-warm)
+            preWarmBatch(messages)
 
             // ADR-355: Batch-level aggregate metrics
             val batchStart = System.nanoTime()

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/ExpectationCalcLowWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/ExpectationCalcLowWorker.kt
@@ -1,6 +1,8 @@
 package maple.expectation.infrastructure.worker
 
 import maple.expectation.core.port.inbound.ExpectationV4Port
+import maple.expectation.core.port.out.CharacterOcidPort
+import maple.expectation.core.port.out.EquipmentFanOutPort
 import maple.expectation.infrastructure.executor.LogicExecutor
 import maple.expectation.infrastructure.executor.TaskContext
 import maple.expectation.infrastructure.pgmq.ExpectationCalcMessage
@@ -9,6 +11,8 @@ import maple.expectation.infrastructure.pgmq.PgmqMessage
 import maple.expectation.infrastructure.pgmq.PgmqWorker
 import maple.expectation.infrastructure.pgmq.PgmqWorkerConfig
 import io.micrometer.core.instrument.MeterRegistry
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Component
@@ -40,11 +44,49 @@ class ExpectationCalcLowWorker(
     config: PgmqWorkerConfig,
     meterRegistry: MeterRegistry,
     private val expectationPort: ExpectationV4Port,
+    private val characterOcidPort: CharacterOcidPort,
+    private val equipmentFanOutPort: EquipmentFanOutPort,
 ) : PgmqWorker<ExpectationCalcMessage>(pgmqClient, executor, config, meterRegistry) {
 
     override val queueName: String = QUEUE_NAME
     override val payloadClass: Class<ExpectationCalcMessage> = ExpectationCalcMessage::class.java
     override val workerSettings: PgmqWorkerConfig.WorkerSettings = config.expectationCalcLow
+
+    /**
+     * 배치 pre-warm (ADR-700)
+     *
+     * <p>병렬 메시지 처리 전 배치 내 OCID 중복 제거 + 장비 캐시 pre-warm.
+     * Best-effort: 실패해도 메시지 처리에 영향 없음.
+     *
+     * @see ExpectationCalcWorker.preWarmBatch 동일 로직 (HIGH priority)
+     */
+    override fun preWarmBatch(messages: List<PgmqMessage<ExpectationCalcMessage>>) {
+        val context = TaskContext.of("ExpectationCalcLowWorker", "PreWarm", queueName)
+
+        executor.executeVoid({
+            // 1. 배치 내 unique IGN 추출
+            val igns = messages.map { it.payload.userIgn }.toSet()
+
+            // 2. Batch OCID resolve (재사용: CharacterOcidPort.resolveOcids)
+            val ignToOcid = characterOcidPort.resolveOcids(igns)
+
+            if (ignToOcid.isEmpty()) return@executeVoid
+
+            // 3. Equipment cache pre-warm — CONCURRENT submission 필수
+            //    Virtual Thread에서 동시 submit → semaphore(10) 초과 시 Batch Lane으로 routing
+            //    → NexonFanOutBatchLoader.load()가 병렬 batch fetch → L1/L2 캐시 적재
+            val warmupFutures = ignToOcid.values.map { ocid ->
+                CompletableFuture.supplyAsync {
+                    equipmentFanOutPort.preFetchByOcid(ocid)
+                }
+            }
+            CompletableFuture.allOf(*warmupFutures.toTypedArray())
+                .orTimeout(15, TimeUnit.SECONDS)
+                .handle { _, _ -> }  // best-effort: 실패해도 진행
+
+            log.info("[ExpectationCalcLowWorker] Pre-warm: {} igns → {} ocids", igns.size, ignToOcid.size)
+        }, context)
+    }
 
     override fun process(message: PgmqMessage<ExpectationCalcMessage>): Boolean {
         val request = message.payload

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/ExpectationCalcWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/ExpectationCalcWorker.kt
@@ -1,6 +1,8 @@
 package maple.expectation.infrastructure.worker
 
 import maple.expectation.core.port.inbound.ExpectationV4Port
+import maple.expectation.core.port.out.CharacterOcidPort
+import maple.expectation.core.port.out.EquipmentFanOutPort
 import maple.expectation.infrastructure.executor.LogicExecutor
 import maple.expectation.infrastructure.executor.TaskContext
 import maple.expectation.infrastructure.pgmq.ExpectationCalcMessage
@@ -9,6 +11,8 @@ import maple.expectation.infrastructure.pgmq.PgmqMessage
 import maple.expectation.infrastructure.pgmq.PgmqWorker
 import maple.expectation.infrastructure.pgmq.PgmqWorkerConfig
 import io.micrometer.core.instrument.MeterRegistry
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Component
@@ -40,11 +44,50 @@ class ExpectationCalcWorker(
     config: PgmqWorkerConfig,
     meterRegistry: MeterRegistry,
     private val expectationPort: ExpectationV4Port,
+    private val characterOcidPort: CharacterOcidPort,
+    private val equipmentFanOutPort: EquipmentFanOutPort,
 ) : PgmqWorker<ExpectationCalcMessage>(pgmqClient, executor, config, meterRegistry) {
 
     override val queueName: String = QUEUE_NAME
     override val payloadClass: Class<ExpectationCalcMessage> = ExpectationCalcMessage::class.java
     override val workerSettings: PgmqWorkerConfig.WorkerSettings = config.expectationCalcHigh
+
+    /**
+     * 배치 pre-warm (ADR-700)
+     *
+     * <p>병렬 메시지 처리 전 배치 내 OCID 중복 제거 + 장비 캐시 pre-warm.
+     * Best-effort: 실패해도 메시지 처리에 영향 없음.
+     *
+     * <h3>동시 submit 이유</h3>
+     * <p>AdaptiveMicroBatchUserService는 semaphore(10)로 Fast/Batch Lane 분기.
+     * 순차 호출 시 전부 Fast Lane → coalescing 미발생.
+     * 동시 submit 시 초과분이 Batch Lane → NexonFanOutBatchLoader.load() batch fetch.
+     */
+    override fun preWarmBatch(messages: List<PgmqMessage<ExpectationCalcMessage>>) {
+        val context = TaskContext.of("ExpectationCalcWorker", "PreWarm", queueName)
+
+        executor.executeVoid({
+            // 1. 배치 내 unique IGN 추출
+            val igns = messages.map { it.payload.userIgn }.toSet()
+
+            // 2. Batch OCID resolve (재사용: CharacterOcidPort.resolveOcids)
+            val ignToOcid = characterOcidPort.resolveOcids(igns)
+
+            if (ignToOcid.isEmpty()) return@executeVoid
+
+            // 3. Equipment cache pre-warm — CONCURRENT submission 필수
+            val warmupFutures = ignToOcid.values.map { ocid ->
+                CompletableFuture.supplyAsync {
+                    equipmentFanOutPort.preFetchByOcid(ocid)
+                }
+            }
+            CompletableFuture.allOf(*warmupFutures.toTypedArray())
+                .orTimeout(15, TimeUnit.SECONDS)
+                .handle { _, _ -> }  // best-effort: 실패해도 진행
+
+            log.info("[ExpectationCalcWorker] Pre-warm: {} igns → {} ocids", igns.size, ignToOcid.size)
+        }, context)
+    }
 
     override fun process(message: PgmqMessage<ExpectationCalcMessage>): Boolean {
         val request = message.payload


### PR DESCRIPTION
## Summary
- `PgmqWorker`에 `preWarmBatch()` open 훅 추가 — 배치 메시지 병렬 처리 전 호출
- `ExpectationCalcWorker` / `ExpectationCalcLowWorker`에서 override:
  - 배치 내 unique IGN 추출 → `CharacterOcidPort.resolveOcids()` batch OCID resolve (1 DB query)
  - **Concurrent** `EquipmentFanOutPort.preFetchByOcid()` submit → AdaptiveMicroBatchUserService coalescing 트리거 → Batch Lane에서 `NexonFanOutBatchLoader.load()` 병렬 fetch → L1/L2 캐시 적재
  - 이후 `process()`에서 장비 fetch 시 캐시 hit → 중복 API 호출 생략
- V4 micro-batch 인프라 100% 재사용, **중복 구현 없음**

### 처리량 개선 (예상)
- Before: 91 msgs × 3 API calls = 273 Nexon API calls
- After: ~50 unique OCIDs → ~50 API calls (82% 감소)

### 설계 포인트
- **동시 submit 필수**: 순차 호출 시 semaphore 항상 available → 전부 Fast Lane → coalescing 미발생
- **Best-effort**: pre-warm 실패/타임아웃(15s)해도 `process()` 정상 동작 (캐시 miss → API fallback)

## Test plan
- [x] `./gradlew compileKotlin compileJava --continue` — BUILD SUCCESSFUL
- [x] `./gradlew test` — BUILD SUCCESSFUL (all tests pass)
- [ ] 서버 기동 후 Worker 로그에서 pre-warm 동작 확인
- [ ] Nexon API 호출 수 감소 확인 (`nexon_api_calls_total` 비교)

🤖 Generated with [Claude Code](https://claude.com/claude-code)