### PR TITLE
FIX : 확률 > 1 감지 false positive 수정 (tolerance 불일치)

### DIFF
--- a/module-app/src/main/java/maple/expectation/application/service/cube/component/SlotDistributionBuilder.java
+++ b/module-app/src/main/java/maple/expectation/application/service/cube/component/SlotDistributionBuilder.java
@@ -163,7 +163,7 @@ public class SlotDistributionBuilder {
 
     double deviation = Math.abs(allTotal - 1.0);
     if (deviation <= MASS_TOLERANCE) {
-      return 1.0; // 정상 범위
+      return allTotal; // 정규화 보정 → 개별 확률 ≤ 1.0 보장
     }
 
     // 정책에 따라 분기 (내부 enum 참조)


### PR DESCRIPTION
## Summary
- CSV 데이터 총 질량이 1.000001~1.000009로 미세 초과 시 `MASS_TOLERANCE(1e-5)` 내라 정규화 생략 → contribution=0 버킷이 allTotal 보유 → `hasValueExceedingOne(1e-10)` 초과
- `validateAndGetNormalizationFactor`에서 `deviation <= MASS_TOLERANCE` 시에도 `allTotal` 반환하여 항상 정규화 보장

## Root Cause
`MASS_TOLERANCE(1e-5)`는 allTotal > 1.0을 허용하지만, `hasValueExceedingOne()`의 tolerance(1e-10)는 이를 허용하지 않음. 두 tolerance 불일치로 인해 CRITICAL_DAMAGE/IGNORE_DEFENSE 옵션이 없는 장비 부위(무기 등)에서 9,375개 key에 대해 false positive 발생.

## Test plan
- [x] `./gradlew compileKotlin compileJava --continue` 통과
- [x] `./gradlew test` 통과
- [ ] 서버 기동 후 끈적끈적/양파농부 expectation 계산 → `ProbabilityInvariantException` 미발생 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)