### PR TITLE
FIX : Micro-batch Future lifecycle — batch 실패 즉시 종료 + in-flight backpressure

### DIFF
--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/batch/AdaptiveMicroBatchUserService.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/batch/AdaptiveMicroBatchUserService.kt
@@ -91,6 +91,9 @@ class AdaptiveMicroBatchUserService<T : Any>(
     /** Request Coalescing: 진행 중인 요청 맵 (CompletableFuture 기반) */
     private val inFlightRequests = ConcurrentHashMap<String, CompletableFuture<T?>>()
 
+    /** Backpressure: in-flight 최대 개수 (초과 시 fail-fast) */
+    private val MAX_IN_FLIGHT = 1000
+
     /** Coroutine Scope: 백그라운드 워커 실행용 */
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
@@ -101,6 +104,7 @@ class AdaptiveMicroBatchUserService<T : Any>(
     private val batchSizeTimer: Timer
     private val timeoutCounter: Counter
     private val errorCounter: Counter
+    private val rejectedCounter: Counter
 
     init {
         val cacheName = cache.name
@@ -127,6 +131,10 @@ class AdaptiveMicroBatchUserService<T : Any>(
             .register(meterRegistry)
 
         errorCounter = Counter.builder("adaptive_batch_error")
+            .tag("cache", cacheName)
+            .register(meterRegistry)
+
+        rejectedCounter = Counter.builder("adaptive_batch_rejected")
             .tag("cache", cacheName)
             .register(meterRegistry)
     }
@@ -173,6 +181,13 @@ class AdaptiveMicroBatchUserService<T : Any>(
             return cached
         }
 
+        // Step 1.5: Backpressure — in-flight 초과 시 fail-fast
+        if (inFlightRequests.size >= MAX_IN_FLIGHT) {
+            rejectedCounter.increment()
+            log.warn { "[AdaptiveMicroBatch] Rejected: inFlight=${inFlightRequests.size}, key=$key" }
+            throw IllegalStateException("In-flight requests limit reached (${inFlightRequests.size})")
+        }
+
         // Step 2: Request Coalescing
         val newFuture = CompletableFuture<T?>()
         val existingFuture = inFlightRequests.putIfAbsent(key, newFuture)
@@ -195,6 +210,13 @@ class AdaptiveMicroBatchUserService<T : Any>(
         if (cached != null) {
             cacheHitCounter.increment()
             return cached
+        }
+
+        // Step 1.5: Backpressure — in-flight 초과 시 fail-fast
+        if (inFlightRequests.size >= MAX_IN_FLIGHT) {
+            rejectedCounter.increment()
+            log.warn { "[AdaptiveMicroBatch] Rejected: inFlight=${inFlightRequests.size}, key=$key" }
+            throw IllegalStateException("In-flight requests limit reached (${inFlightRequests.size})")
         }
 
         // Step 2: Request Coalescing
@@ -395,21 +417,33 @@ class AdaptiveMicroBatchUserService<T : Any>(
     private fun processChunk(keys: List<String>, batch: List<BatchRequest<T>>) {
         val context = TaskContext.of("AdaptiveBatch", "ProcessChunk", "${keys.size}")
 
-        logicExecutor.executeVoid({
-            val results = batchLoader(keys)
-            val keyToFuture = batch.associateBy { it.key }
+        logicExecutor.executeOrCatch(
+            {
+                val results = batchLoader(keys)
+                val keyToFuture = batch.associateBy { it.key }
 
-            keys.forEach { key ->
-                val result = results[key]
-                val future = keyToFuture[key]?.future
+                keys.forEach { key ->
+                    val result = results[key]
+                    val future = keyToFuture[key]?.future
 
-                if (result != null) {
-                    cache.put(key, result)
+                    if (result != null) {
+                        cache.put(key, result)
+                    }
+                    future?.complete(result)
+                    cleanupInFlight(key)
                 }
-                future?.complete(result)
-                cleanupInFlight(key)
-            }
-        }, context)
+                null
+            },
+            { e ->
+                log.error(e) { "[AdaptiveMicroBatch] Batch failed: keys=${keys.size}, completing futures exceptionally" }
+                batch.forEach { request ->
+                    request.future.completeExceptionally(e)
+                    cleanupInFlight(request.key)
+                }
+                null
+            },
+            context,
+        )
     }
 
     /**


### PR DESCRIPTION
## 🔗 관련 이슈


## 🗣 개요

AdaptiveMicroBatchUserService의 Future lifecycle 관리 개선.
Batch 실패 시 Future가 무기한 대기하는 문제와 in-flight 무제한 증가를 방지.

## 🛠 작업 내용

- `processChunk`: `executeVoid` → `executeOrCatch` 전환
  - batchLoader 예외 시 즉시 `completeExceptionally` + `cleanupInFlight`
  - 기존: 500ms 타임아웃까지 방치 → 실제 예외 원인 전달 불가
  - 개선: 즉시 예외 전파, 불필요한 대기 제거
- In-flight backpressure 추가
  - `MAX_IN_FLIGHT = 1000` 한계 설정
  - `getByKey` / `getByKeySuspend` 진입 전 체크
  - 초과 시 `rejectedCounter` 메트릭 기록 + `IllegalStateException` fail-fast
- `adaptive_batch_rejected` 메트릭 추가

## 💬 리뷰 포인트

- `executeOrCatch` 복구 경로에서 모든 Future를 `completeExceptionally`로 종료하는 것이 적절한지
- `MAX_IN_FLIGHT = 1000` 기본값이 합리적인지 (설정으로 추출 가능)

## 💱 트레이드 오프 결정 근거

- try-catch 없이 LogicExecutor 패턴 4번(`executeOrCatch`) 사용 → CLAUDE.md Zero Try-Catch 정책 준수
- backpressure를 설정 가능한 property가 아닌 상수로 추가 → 추후 필요시 `AdaptiveMicroBatchProperties`로 추출 가능

## ✅ 체크리스트

- [x] 컴파일 통과 (`./gradlew compileKotlin compileJava --continue`)
- [x] 전체 테스트 통과 (`./gradlew test --no-build-cache`)
- [x] CLAUDE.md 원칙 준수 (Zero Try-Catch, LogicExecutor 위임)

🤖 Generated with [Claude Code](https://claude.com/claude-code)