### PR TITLE
fix: harden v5 expectation task flow

### DIFF
--- a/module-app/src/main/java/maple/expectation/application/service/expectation/EquipmentExpectationServiceV4.java
+++ b/module-app/src/main/java/maple/expectation/application/service/expectation/EquipmentExpectationServiceV4.java
@@ -121,8 +121,15 @@ public class EquipmentExpectationServiceV4 implements CacheWarmupPort {
   @TraceLog
   public CompletableFuture<EquipmentExpectationResponseV4> calculateExpectationAsync(
       String userIgn, boolean force) {
+    return calculateExpectationAsync(userIgn, force, null);
+  }
+
+  @TraceLog
+  public CompletableFuture<EquipmentExpectationResponseV4> calculateExpectationAsync(
+      String userIgn, boolean force, @Nullable String taskId) {
     return CompletableFuture.supplyAsync(
-            () -> selfProvider.getObject().calculateExpectation(userIgn, force), equipmentExecutor)
+            () -> selfProvider.getObject().calculateExpectation(userIgn, force, taskId),
+            equipmentExecutor)
         .orTimeout(ASYNC_TIMEOUT_SECONDS, TimeUnit.SECONDS);
   }
 
@@ -137,8 +144,21 @@ public class EquipmentExpectationServiceV4 implements CacheWarmupPort {
   /** 캐릭터 기대값 계산 (동기, force 옵션) */
   @Transactional("transactionManager")
   public EquipmentExpectationResponseV4 calculateExpectation(String userIgn, boolean force) {
+    return calculateExpectation(userIgn, force, null);
+  }
+
+  @Transactional("transactionManager")
+  public EquipmentExpectationResponseV4 calculateExpectation(
+      String userIgn, boolean force, @Nullable String taskId) {
     validateInitialized();
-    return cacheCoordinator.getOrCalculate(userIgn, force, () -> doCalculateExpectation(userIgn));
+    EquipmentExpectationResponseV4 response =
+        cacheCoordinator.getOrCalculate(userIgn, force, () -> doCalculateExpectation(userIgn, taskId));
+
+    if (taskId != null && response.isFromCache()) {
+      syncCachedResponseToViewTable(userIgn, response, taskId);
+    }
+
+    return response;
   }
 
   /** 캐시 웜업 (CacheWarmupPort 구현) */
@@ -151,7 +171,7 @@ public class EquipmentExpectationServiceV4 implements CacheWarmupPort {
   public byte[] getGzipExpectation(String userIgn, boolean force) {
     validateInitialized();
     return cacheCoordinator.getGzipOrCalculate(
-        userIgn, force, () -> doCalculateExpectation(userIgn));
+        userIgn, force, () -> doCalculateExpectation(userIgn, null));
   }
 
   /** L1 캐시 직접 조회 - Fast Path (#264 성능 최적화) */
@@ -176,7 +196,8 @@ public class EquipmentExpectationServiceV4 implements CacheWarmupPort {
    * <p>loadEquipmentDataAsync로 API 대기 시간 분리. TieredCache Callable 내에서는 .join() 사용 (분산 락 내부이므로 스레드
    * 점유 제한적)
    */
-  private EquipmentExpectationResponseV4 doCalculateExpectation(String userIgn) {
+  private EquipmentExpectationResponseV4 doCalculateExpectation(
+      String userIgn, @Nullable String taskId) {
     TaskContext context = TaskContext.of("ExpectationV4", "Calculate", userIgn);
 
     return executor.execute(
@@ -193,7 +214,7 @@ public class EquipmentExpectationServiceV4 implements CacheWarmupPort {
 
           // V5: Inline View Write — same TX, no queue (Async Materialized View pattern)
           // TODO: Replace with async projection (event-driven) when scaling out
-          syncToViewTable(userIgn, character, response);
+          syncToViewTable(userIgn, character, response, taskId);
 
           return response;
         },
@@ -209,13 +230,16 @@ public class EquipmentExpectationServiceV4 implements CacheWarmupPort {
    * <p>Async Materialized View pattern: Worker → DB write → API read.
    */
   private void syncToViewTable(
-      String userIgn, GameCharacter character, EquipmentExpectationResponseV4 response) {
+      String userIgn,
+      GameCharacter character,
+      EquipmentExpectationResponseV4 response,
+      @Nullable String taskId) {
     CharacterViewQueryServicePostgres viewService = viewQueryServiceProvider.getIfAvailable();
     if (viewService == null) return; // V5 미활성화 시 skip
 
     executor.executeVoidJava(
         () -> {
-          var entity = viewTransformer.toEntityFromResponse(userIgn, character, response);
+          var entity = viewTransformer.toEntityFromResponse(userIgn, character, response, taskId);
           viewService.upsert(entity);
           log.debug("[ExpectationV4] Synced to view table: userIgn={}", userIgn);
         },
@@ -227,6 +251,12 @@ public class EquipmentExpectationServiceV4 implements CacheWarmupPort {
    *
    * <p>V5 워커가 V2 워커 풀에 의존하지 않도록 V2 Service를 직접 호출
    */
+  private void syncCachedResponseToViewTable(
+      String userIgn, EquipmentExpectationResponseV4 response, String taskId) {
+    GameCharacter character = findCharacterBypassingWorker(userIgn);
+    syncToViewTable(userIgn, character, response, taskId);
+  }
+
   private GameCharacter findCharacterBypassingWorker(String userIgn) {
     return executor.execute(
         () -> {

--- a/module-app/src/main/java/maple/expectation/application/service/expectation/event/ViewTransformer.java
+++ b/module-app/src/main/java/maple/expectation/application/service/expectation/event/ViewTransformer.java
@@ -19,6 +19,7 @@ import maple.expectation.web.dto.v4.EquipmentExpectationResponseV4;
 import maple.expectation.web.dto.v4.EquipmentExpectationResponseV4.CostBreakdownDto;
 import maple.expectation.web.dto.v4.EquipmentExpectationResponseV4.ItemExpectationV4;
 import maple.expectation.web.dto.v4.EquipmentExpectationResponseV4.PresetExpectation;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 
 /**
@@ -84,14 +85,25 @@ public class ViewTransformer {
    */
   public CharacterValuationViewEntity toEntityFromResponse(
       String userIgn, GameCharacter character, EquipmentExpectationResponseV4 response) {
+    return toEntityFromResponse(userIgn, character, response, null);
+  }
+
+  public CharacterValuationViewEntity toEntityFromResponse(
+      String userIgn,
+      GameCharacter character,
+      EquipmentExpectationResponseV4 response,
+      @Nullable String messageId) {
     return executor.executeOrDefault(
-        () -> toEntityFromResponseInternal(userIgn, character, response),
-        createEmptyViewFromResponse(userIgn, character),
+        () -> toEntityFromResponseInternal(userIgn, character, response, messageId),
+        createEmptyViewFromResponse(userIgn, character, messageId),
         TaskContext.of("ViewTransformer", "ToEntityFromResponse", userIgn));
   }
 
   private CharacterValuationViewEntity toEntityFromResponseInternal(
-      String userIgn, GameCharacter character, EquipmentExpectationResponseV4 response) {
+      String userIgn,
+      GameCharacter character,
+      EquipmentExpectationResponseV4 response,
+      @Nullable String messageId) {
     long version = System.currentTimeMillis();
     List<PresetView> presetViews =
         response.getPresets() != null
@@ -104,7 +116,7 @@ public class ViewTransformer {
         null, // id (auto-generated)
         null, // jpaVersion (auto-managed by JPA @Version)
         userIgn,
-        null, // messageId (not applicable for inline write)
+        messageId,
         character.getCharacterId() != null ? character.getCharacterId().value() : null,
         character.getCharacterClass(),
         null, // characterLevel (not stored in GameCharacter)
@@ -123,12 +135,12 @@ public class ViewTransformer {
   }
 
   private CharacterValuationViewEntity createEmptyViewFromResponse(
-      String userIgn, GameCharacter character) {
+      String userIgn, GameCharacter character, @Nullable String messageId) {
     return new CharacterValuationViewEntity(
         null,
         null, // jpaVersion
         userIgn,
-        null,
+        messageId,
         character.getCharacterId() != null ? character.getCharacterId().value() : null,
         character.getCharacterClass(),
         null,

--- a/module-app/src/main/java/maple/expectation/application/service/expectation/queue/ExpectationCalculationQueue.java
+++ b/module-app/src/main/java/maple/expectation/application/service/expectation/queue/ExpectationCalculationQueue.java
@@ -66,23 +66,7 @@ public class ExpectationCalculationQueue {
     TaskContext context = TaskContext.of("Queue", "Offer", task.getUserIgn());
 
     return executor.executeOrDefault(
-        () -> {
-          if (isQueueFull(task.getPriority(), task.getUserIgn())) {
-            return false;
-          }
-
-          String queueName = resolveQueueName(task.getPriority());
-          ExpectationCalcMessage message =
-              new ExpectationCalcMessage(
-                  task.getUserIgn(), task.isForceRecalculation());
-          pgmqClient.send(queueName, message);
-
-          log.debug(
-              "[Queue] Task queued: priority={}, userIgn={}",
-              task.getPriority(),
-              task.getUserIgn());
-          return true;
-        },
+        () -> enqueue(task).getQueued(),
         false,
         context);
   }
@@ -103,24 +87,7 @@ public class ExpectationCalculationQueue {
     TaskContext context = TaskContext.of("Queue", "OfferWithReceipt", task.getUserIgn());
 
     return executor.executeOrDefault(
-        () -> {
-          if (isQueueFull(task.getPriority(), task.getUserIgn())) {
-            return TaskReceipt.rejected(task.getUserIgn());
-          }
-
-          String queueName = resolveQueueName(task.getPriority());
-          ExpectationCalcMessage message =
-              new ExpectationCalcMessage(
-                  task.getUserIgn(), task.isForceRecalculation());
-          long messageId = pgmqClient.send(queueName, message);
-
-          log.debug(
-              "[Queue] Task queued with receipt: priority={}, userIgn={}, taskId={}",
-              task.getPriority(),
-              task.getUserIgn(),
-              messageId);
-          return new TaskReceipt(String.valueOf(messageId), task.getUserIgn(), true);
-        },
+        () -> enqueue(task),
         TaskReceipt.rejected(task.getUserIgn()),
         context);
   }
@@ -224,5 +191,35 @@ public class ExpectationCalculationQueue {
       return true;
     }
     return false;
+  }
+
+  private TaskReceipt enqueue(ExpectationCalculationTask task) {
+    if (isQueueFull(task.getPriority(), task.getUserIgn())) {
+      return TaskReceipt.rejected(task.getUserIgn());
+    }
+
+    String queueName = resolveQueueName(task.getPriority());
+    if (!task.isForceRecalculation()) {
+      Long existingMessageId = pgmqClient.findActiveMessageIdByUserIgn(queueName, task.getUserIgn());
+      if (existingMessageId != null) {
+        log.debug(
+            "[Queue] Reusing active task: priority={}, userIgn={}, taskId={}",
+            task.getPriority(),
+            task.getUserIgn(),
+            existingMessageId);
+        return new TaskReceipt(String.valueOf(existingMessageId), task.getUserIgn(), true);
+      }
+    }
+
+    ExpectationCalcMessage message =
+        new ExpectationCalcMessage(task.getUserIgn(), task.isForceRecalculation());
+    long messageId = pgmqClient.send(queueName, message);
+
+    log.debug(
+        "[Queue] Task queued: priority={}, userIgn={}, taskId={}",
+        task.getPriority(),
+        task.getUserIgn(),
+        messageId);
+    return new TaskReceipt(String.valueOf(messageId), task.getUserIgn(), true);
   }
 }

--- a/module-app/src/main/java/maple/expectation/application/service/task/TaskStatusService.java
+++ b/module-app/src/main/java/maple/expectation/application/service/task/TaskStatusService.java
@@ -52,24 +52,26 @@ public class TaskStatusService implements TaskStatusPort {
     }
 
     private TaskStatus resolveStatus(String userIgn, String taskId) {
+        long messageId = parseMessageId(taskId);
+        if (messageId <= 0) {
+            return TaskStatus.NOT_FOUND;
+        }
+
         // 1. PostgreSQL (source of truth)
         Optional<CharacterView> cached = queryPort.findByUserIgn(userIgn);
-        if (cached.isPresent()) {
+        if (cached.filter(view -> taskId.equals(view.getMessageId())).isPresent()) {
             return TaskStatus.COMPLETED;
         }
 
         // 2. PGMQ archive check (보조)
-        long messageId = parseMessageId(taskId);
-        if (messageId > 0) {
-            if (isArchivedInAnyQueue(messageId)) {
-                return TaskStatus.COMPLETED;
-            }
+        if (isArchivedInAnyQueue(messageId)) {
+            return TaskStatus.COMPLETED;
+        }
 
             // 3. 활성 큐에서 read_ct 확인 → PROCESSING 판별
-            int readCount = getMaxReadCount(messageId);
-            if (readCount > 0) {
-                return TaskStatus.PROCESSING;
-            }
+        int readCount = getMaxReadCount(messageId);
+        if (readCount > 0) {
+            return TaskStatus.PROCESSING;
         }
 
         // 4. 기본값: PENDING

--- a/module-app/src/main/java/maple/expectation/application/usecase/ExpectationV4PortAdapter.java
+++ b/module-app/src/main/java/maple/expectation/application/usecase/ExpectationV4PortAdapter.java
@@ -21,9 +21,13 @@ public class ExpectationV4PortAdapter implements ExpectationV4Port {
 
   @Override
   public CompletableFuture<Object> calculateExpectationAsync(String userIgn, boolean force) {
-    return expectationService
-        .calculateExpectationAsync(userIgn, force)
-        .thenApply(response -> response);
+    return calculateExpectationAsync(userIgn, force, null);
+  }
+
+  @Override
+  public CompletableFuture<Object> calculateExpectationAsync(
+      String userIgn, boolean force, String taskId) {
+    return expectationService.calculateExpectationAsync(userIgn, force, taskId).thenApply(response -> response);
   }
 
   @Override
@@ -46,7 +50,12 @@ public class ExpectationV4PortAdapter implements ExpectationV4Port {
    */
   @Override
   public Object calculateExpectation(String userIgn, boolean force) {
-    return expectationService.calculateExpectation(userIgn, force);
+    return calculateExpectation(userIgn, force, null);
+  }
+
+  @Override
+  public Object calculateExpectation(String userIgn, boolean force, String taskId) {
+    return expectationService.calculateExpectation(userIgn, force, taskId);
   }
 
   @Override

--- a/module-app/src/test/java/maple/expectation/service/v5/PriorityCalculationQueueTest.java
+++ b/module-app/src/test/java/maple/expectation/service/v5/PriorityCalculationQueueTest.java
@@ -4,7 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.Instant;
@@ -12,6 +15,7 @@ import maple.expectation.application.service.expectation.queue.ExpectationCalcul
 import maple.expectation.application.service.expectation.queue.ExpectationCalculationTask;
 import maple.expectation.application.service.expectation.queue.QueuePriority;
 import maple.expectation.common.function.ThrowingSupplier;
+import maple.expectation.core.port.inbound.TaskReceipt;
 import maple.expectation.infrastructure.executor.CheckedLogicExecutor;
 import maple.expectation.infrastructure.executor.LogicExecutor;
 import maple.expectation.infrastructure.executor.TaskContext;
@@ -63,6 +67,33 @@ class ExpectationCalculationQueueTest {
 
     assertThat(queue.offer(highTask)).isTrue();
     assertThat(queue.offer(lowTask)).isTrue();
+  }
+
+  @Test
+  @DisplayName("이미 활성 task가 있으면 non-force 요청은 기존 taskId를 재사용")
+  void offerWithReceiptReusesExistingTaskForNonForceRequests() {
+    when(pgmqClient.queueLength(anyString())).thenReturn(0L);
+    when(pgmqClient.findActiveMessageIdByUserIgn("expectation_calc_high", "user1")).thenReturn(99L);
+
+    TaskReceipt receipt = queue.offerWithReceipt(ExpectationCalculationTask.highPriority("user1", false));
+
+    assertThat(receipt.getQueued()).isTrue();
+    assertThat(receipt.getTaskId()).isEqualTo("99");
+    verify(pgmqClient, never()).send(anyString(), any());
+  }
+
+  @Test
+  @DisplayName("force 요청은 기존 task가 있어도 새 메시지를 enqueue")
+  void offerWithReceiptEnqueuesFreshTaskForForceRequests() {
+    when(pgmqClient.queueLength(anyString())).thenReturn(0L);
+    when(pgmqClient.findActiveMessageIdByUserIgn("expectation_calc_high", "user1")).thenReturn(99L);
+    when(pgmqClient.send(anyString(), any())).thenReturn(100L);
+
+    TaskReceipt receipt = queue.offerWithReceipt(ExpectationCalculationTask.highPriority("user1", true));
+
+    assertThat(receipt.getQueued()).isTrue();
+    assertThat(receipt.getTaskId()).isEqualTo("100");
+    verify(pgmqClient).send(eq("expectation_calc_high"), any());
   }
 
   @Test

--- a/module-app/src/test/java/maple/expectation/service/v5/TaskStatusServiceTest.java
+++ b/module-app/src/test/java/maple/expectation/service/v5/TaskStatusServiceTest.java
@@ -1,0 +1,217 @@
+package maple.expectation.service.v5;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import maple.expectation.application.service.task.TaskStatusService;
+import maple.expectation.common.function.ThrowingSupplier;
+import maple.expectation.core.domain.model.character.CharacterView;
+import maple.expectation.core.port.inbound.CharacterViewQueryPort;
+import maple.expectation.core.port.inbound.TaskStatus;
+import maple.expectation.infrastructure.executor.LogicExecutor;
+import maple.expectation.infrastructure.executor.TaskContext;
+import maple.expectation.infrastructure.executor.function.ThrowingRunnable;
+import maple.expectation.infrastructure.executor.strategy.ExceptionTranslator;
+import maple.expectation.infrastructure.pgmq.PgmqClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("unit")
+@DisplayName("TaskStatusService")
+class TaskStatusServiceTest {
+
+  private CharacterViewQueryPort queryPort;
+  private PgmqClient pgmqClient;
+  private TaskStatusService service;
+
+  @BeforeEach
+  void setUp() {
+    queryPort = mock(CharacterViewQueryPort.class);
+    pgmqClient = mock(PgmqClient.class);
+    service = new TaskStatusService(queryPort, pgmqClient, new TestLogicExecutor());
+  }
+
+  @Test
+  @DisplayName("matching messageId view is COMPLETED")
+  void matchingViewMessageIdReturnsCompleted() {
+    CharacterView view = mock(CharacterView.class);
+    when(view.getMessageId()).thenReturn("123");
+    when(queryPort.findByUserIgn("user1")).thenReturn(Optional.of(view));
+
+    TaskStatus status = service.getStatus("user1", "123");
+
+    assertThat(status).isEqualTo(TaskStatus.COMPLETED);
+  }
+
+  @Test
+  @DisplayName("mismatched view messageId does not complete unrelated task")
+  void mismatchedViewMessageIdDoesNotCompleteTask() {
+    CharacterView view = mock(CharacterView.class);
+    when(view.getMessageId()).thenReturn("999");
+    when(queryPort.findByUserIgn("user1")).thenReturn(Optional.of(view));
+    when(pgmqClient.isArchived("expectation_calc_high", 123L)).thenReturn(false);
+    when(pgmqClient.isArchived("expectation_calc_low", 123L)).thenReturn(false);
+    when(pgmqClient.getMessageReadCount("expectation_calc_high", 123L)).thenReturn(0);
+    when(pgmqClient.getMessageReadCount("expectation_calc_low", 123L)).thenReturn(0);
+
+    TaskStatus status = service.getStatus("user1", "123");
+
+    assertThat(status).isEqualTo(TaskStatus.PENDING);
+  }
+
+  @Test
+  @DisplayName("archived task is COMPLETED even without current view row")
+  void archivedTaskReturnsCompleted() {
+    when(queryPort.findByUserIgn("user1")).thenReturn(Optional.empty());
+    when(pgmqClient.isArchived("expectation_calc_high", 123L)).thenReturn(true);
+
+    TaskStatus status = service.getStatus("user1", "123");
+
+    assertThat(status).isEqualTo(TaskStatus.COMPLETED);
+  }
+
+  @Test
+  @DisplayName("read count marks task as PROCESSING")
+  void readCountReturnsProcessing() {
+    when(queryPort.findByUserIgn("user1")).thenReturn(Optional.empty());
+    when(pgmqClient.isArchived("expectation_calc_high", 123L)).thenReturn(false);
+    when(pgmqClient.isArchived("expectation_calc_low", 123L)).thenReturn(false);
+    when(pgmqClient.getMessageReadCount("expectation_calc_high", 123L)).thenReturn(1);
+    when(pgmqClient.getMessageReadCount("expectation_calc_low", 123L)).thenReturn(0);
+
+    TaskStatus status = service.getStatus("user1", "123");
+
+    assertThat(status).isEqualTo(TaskStatus.PROCESSING);
+  }
+
+  @Test
+  @DisplayName("invalid taskId is NOT_FOUND")
+  void invalidTaskIdReturnsNotFound() {
+    TaskStatus status = service.getStatus("user1", "not-a-number");
+
+    assertThat(status).isEqualTo(TaskStatus.NOT_FOUND);
+  }
+
+  private static class TestLogicExecutor implements LogicExecutor {
+    @Override
+    public <T> T execute(ThrowingSupplier<T> task, TaskContext context) {
+      try {
+        return task.get();
+      } catch (Throwable e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    @Override
+    public <T> T execute(ThrowingSupplier<T> task, String taskName) {
+      return execute(task, TaskContext.of("Legacy", taskName));
+    }
+
+    @Override
+    public <T> T executeOrDefault(ThrowingSupplier<T> task, T defaultValue, TaskContext context) {
+      try {
+        return task.get();
+      } catch (Throwable e) {
+        return defaultValue;
+      }
+    }
+
+    @Override
+    public void executeVoid(ThrowingRunnable task, TaskContext context) {
+      try {
+        task.run();
+      } catch (Throwable e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    @Override
+    public void executeVoid(ThrowingRunnable task, String taskName) {
+      executeVoid(task, TaskContext.of("Legacy", taskName));
+    }
+
+    @Override
+    public <T> T executeWithFinally(
+        ThrowingSupplier<T> task, Runnable finallyBlock, TaskContext context) {
+      try {
+        return task.get();
+      } catch (Throwable e) {
+        throw new RuntimeException(e);
+      } finally {
+        finallyBlock.run();
+      }
+    }
+
+    @Override
+    public <T> T executeWithTranslation(
+        ThrowingSupplier<T> task, ExceptionTranslator translator, TaskContext context) {
+      try {
+        return task.get();
+      } catch (Throwable e) {
+        throw translator.translate(e, context);
+      }
+    }
+
+    @Override
+    public <T> T executeWithFallback(
+        ThrowingSupplier<T> task,
+        kotlin.jvm.functions.Function1<? super Throwable, ? extends T> fallback,
+        TaskContext context) {
+      try {
+        return task.get();
+      } catch (Throwable e) {
+        return fallback.invoke(e);
+      }
+    }
+
+    @Override
+    public <T> T executeWithFallback(
+        ThrowingSupplier<T> task, ExceptionTranslator translator, TaskContext context) {
+      try {
+        return task.get();
+      } catch (Throwable e) {
+        @SuppressWarnings("unchecked")
+        T result = (T) translator.translate(e, context);
+        return result;
+      }
+    }
+
+    @Override
+    public <T> T executeOrCatch(
+        ThrowingSupplier<T> task,
+        kotlin.jvm.functions.Function1<? super Throwable, ? extends T> recovery,
+        TaskContext context) {
+      try {
+        return task.get();
+      } catch (Throwable e) {
+        return recovery.invoke(e);
+      }
+    }
+
+    @Override
+    public <T> T executeOrCatch(
+        ThrowingSupplier<T> task, ExceptionTranslator translator, TaskContext context) {
+      try {
+        return task.get();
+      } catch (Throwable e) {
+        @SuppressWarnings("unchecked")
+        T result = (T) translator.translate(e, context);
+        return result;
+      }
+    }
+
+    @Override
+    public void executeVoidJava(Runnable task, TaskContext context) {
+      task.run();
+    }
+
+    @Override
+    public void executeVoidJava(Runnable task, String taskName) {
+      executeVoidJava(task, TaskContext.of("Legacy", taskName));
+    }
+  }
+}

--- a/module-core/src/main/kotlin/maple/expectation/core/domain/model/character/CharacterView.kt
+++ b/module-core/src/main/kotlin/maple/expectation/core/domain/model/character/CharacterView.kt
@@ -15,6 +15,9 @@ interface CharacterView {
     /** 캐릭터 IGN */
     val userIgn: String
 
+    /** V5 queue message ID */
+    val messageId: String?
+
     /** 계산 시간 */
     val calculatedAt: Instant?
 

--- a/module-core/src/main/kotlin/maple/expectation/core/port/inbound/ExpectationV4Port.kt
+++ b/module-core/src/main/kotlin/maple/expectation/core/port/inbound/ExpectationV4Port.kt
@@ -24,6 +24,11 @@ interface ExpectationV4Port {
     fun calculateExpectationAsync(userIgn: String, force: Boolean): CompletableFuture<Any>
 
     /**
+     * V5 queue/worker aware async calculation.
+     */
+    fun calculateExpectationAsync(userIgn: String, force: Boolean, taskId: String?): CompletableFuture<Any>
+
+    /**
      * 🔥 기대값 동기 계산 (Admission Control용)
      *
      * <p>NOTE: Admission control은 sync 작업만 관리합니다.
@@ -34,6 +39,11 @@ interface ExpectationV4Port {
      * @return 기대값 응답 (Any = EquipmentExpectationResponseV4)
      */
     fun calculateExpectation(userIgn: String, force: Boolean): Any
+
+    /**
+     * V5 queue/worker aware sync calculation.
+     */
+    fun calculateExpectation(userIgn: String, force: Boolean, taskId: String?): Any
 
     /**
      * GZIP 기대값 비동기 조회

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/CharacterViewQueryPortAdapter.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/CharacterViewQueryPortAdapter.kt
@@ -20,7 +20,7 @@ import java.util.Optional
  * </ul>
  */
 @Service
-@ConditionalOnProperty(name = ["app.v5.enabled"], havingValue = "true", matchIfMissing = false)
+@ConditionalOnProperty(name = ["v5.enabled"], havingValue = "true", matchIfMissing = false)
 class CharacterViewQueryPortAdapter(
     private val queryService: CharacterViewQueryServicePostgres,
 ) : CharacterViewQueryPort {
@@ -47,6 +47,8 @@ class CharacterViewQueryPortAdapter(
     ) : CharacterView {
         override val userIgn: String
             get() = entity.userIgn
+        override val messageId: String?
+            get() = entity.messageId
         override val calculatedAt: java.time.Instant?
             get() = entity.calculatedAt
         override val fromCache: Boolean?

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/CharacterViewQueryServicePostgres.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/CharacterViewQueryServicePostgres.kt
@@ -1,7 +1,7 @@
 package maple.expectation.infrastructure.persistence
 
 import io.micrometer.core.instrument.MeterRegistry
-import java.time.Duration
+import java.util.concurrent.TimeUnit
 import maple.expectation.infrastructure.executor.LogicExecutor
 import maple.expectation.infrastructure.executor.TaskContext
 import maple.expectation.infrastructure.persistence.entity.CharacterValuationViewEntity
@@ -24,7 +24,7 @@ import org.springframework.transaction.annotation.Transactional
  * </ul>
  */
 @Service
-@ConditionalOnProperty(name = ["app.v5.enabled"], havingValue = "true", matchIfMissing = false)
+@ConditionalOnProperty(name = ["v5.enabled"], havingValue = "true", matchIfMissing = false)
 class CharacterViewQueryServicePostgres(
     private val repository: CharacterValuationViewJpaRepository,
     private val executor: LogicExecutor,
@@ -38,18 +38,12 @@ class CharacterViewQueryServicePostgres(
 
         return executor.executeOrDefault(
             {
-                val result = repository.findByUserIgn(userIgn)
-                if (result != null) {
-                    meterRegistry
-                        .timer("postgres.query.latency", "operation", "hit")
-                        .record(Duration.ofMillis(1))
-                    result
-                } else {
-                    meterRegistry
-                        .timer("postgres.query.latency", "operation", "miss")
-                        .record(Duration.ofMillis(1))
-                    null
-                }
+                val startNanos = System.nanoTime()
+                val result = repository.findTopByUserIgnOrderByCalculatedAtDescIdDesc(userIgn)
+                meterRegistry
+                    .timer("postgres.query.latency", "operation", if (result != null) "hit" else "miss")
+                    .record(System.nanoTime() - startNanos, TimeUnit.NANOSECONDS)
+                result
             },
             null,
             context,
@@ -67,42 +61,22 @@ class CharacterViewQueryServicePostgres(
 
         executor.executeVoid(
             {
-                val existing = repository.findByUserIgn(entity.userIgn)
+                val existing = findExistingEntity(entity)
 
                 if (existing != null) {
-                    // Update existing
                     val incomingVersion = entity.version ?: 0L
-                    val currentVersion = existing.version ?: 0L
+                    val currentVersion = existing.lastAppliedVersion ?: existing.version ?: 0L
 
                     if (incomingVersion > currentVersion) {
-                        // Incoming update is newer - apply update
-                        val updated = CharacterValuationViewEntity(
-                            id = existing.id,
-                            jpaVersion = existing.jpaVersion,
-                            userIgn = entity.userIgn,
-                            messageId = entity.messageId,
-                            characterOcid = entity.characterOcid,
-                            characterClass = entity.characterClass,
-                            characterLevel = entity.characterLevel,
-                            calculatedAt = entity.calculatedAt,
-                            lastApiSyncAt = entity.lastApiSyncAt,
-                            version = incomingVersion + 1,
-                            lastAppliedVersion = incomingVersion,
-                            totalExpectedCost = entity.totalExpectedCost,
-                            maxPresetNo = entity.maxPresetNo,
-                            presets = entity.presets,
-                            fromCache = entity.fromCache,
-                        )
-                        repository.save(updated)
+                        repository.save(buildUpdatedEntity(existing, entity, incomingVersion))
                         meterRegistry.counter("postgres.optimistic_lock.updated").increment()
                         log.debug(
                             "[OptimisticLock] Updated: userIgn={}, version={}->{}",
                             entity.userIgn,
                             currentVersion,
-                            incomingVersion + 1,
+                            incomingVersion,
                         )
                     } else {
-                        // Incoming update is older or same - skip
                         meterRegistry.counter("postgres.optimistic_lock.skipped").increment()
                         log.debug(
                             "[OptimisticLock] Skipped: userIgn={}, incoming={}, current={}",
@@ -112,25 +86,7 @@ class CharacterViewQueryServicePostgres(
                         )
                     }
                 } else {
-                    // Insert new
-                    val newEntity = CharacterValuationViewEntity(
-                        id = null,
-                        jpaVersion = null,
-                        userIgn = entity.userIgn,
-                        messageId = entity.messageId,
-                        characterOcid = entity.characterOcid,
-                        characterClass = entity.characterClass,
-                        characterLevel = entity.characterLevel,
-                        calculatedAt = entity.calculatedAt,
-                        lastApiSyncAt = entity.lastApiSyncAt,
-                        version = 1L,
-                        lastAppliedVersion = entity.version ?: 1L,
-                        totalExpectedCost = entity.totalExpectedCost,
-                        maxPresetNo = entity.maxPresetNo,
-                        presets = entity.presets,
-                        fromCache = entity.fromCache,
-                    )
-                    repository.save(newEntity)
+                    repository.save(buildNewEntity(entity))
                     meterRegistry.counter("postgres.optimistic_lock.inserted").increment()
                     log.debug("[OptimisticLock] Inserted: userIgn={}, version=1", entity.userIgn)
                 }
@@ -138,6 +94,50 @@ class CharacterViewQueryServicePostgres(
             context,
         )
     }
+
+    private fun findExistingEntity(entity: CharacterValuationViewEntity): CharacterValuationViewEntity? =
+        entity.messageId?.let(repository::findByMessageId)
+            ?: repository.findTopByUserIgnOrderByCalculatedAtDescIdDesc(entity.userIgn)
+
+    private fun buildUpdatedEntity(
+        existing: CharacterValuationViewEntity,
+        incoming: CharacterValuationViewEntity,
+        incomingVersion: Long,
+    ): CharacterValuationViewEntity = CharacterValuationViewEntity(
+        id = existing.id,
+        jpaVersion = existing.jpaVersion,
+        userIgn = incoming.userIgn,
+        messageId = incoming.messageId ?: existing.messageId,
+        characterOcid = incoming.characterOcid ?: existing.characterOcid,
+        characterClass = incoming.characterClass ?: existing.characterClass,
+        characterLevel = incoming.characterLevel ?: existing.characterLevel,
+        calculatedAt = incoming.calculatedAt ?: existing.calculatedAt,
+        lastApiSyncAt = incoming.lastApiSyncAt ?: existing.lastApiSyncAt,
+        version = maxOf(existing.version ?: 0L, incomingVersion) + 1,
+        lastAppliedVersion = incomingVersion,
+        totalExpectedCost = incoming.totalExpectedCost,
+        maxPresetNo = incoming.maxPresetNo,
+        presets = incoming.presets,
+        fromCache = incoming.fromCache,
+    )
+
+    private fun buildNewEntity(entity: CharacterValuationViewEntity): CharacterValuationViewEntity = CharacterValuationViewEntity(
+        id = null,
+        jpaVersion = null,
+        userIgn = entity.userIgn,
+        messageId = entity.messageId,
+        characterOcid = entity.characterOcid,
+        characterClass = entity.characterClass,
+        characterLevel = entity.characterLevel,
+        calculatedAt = entity.calculatedAt,
+        lastApiSyncAt = entity.lastApiSyncAt,
+        version = 1L,
+        lastAppliedVersion = entity.version ?: 1L,
+        totalExpectedCost = entity.totalExpectedCost,
+        maxPresetNo = entity.maxPresetNo,
+        presets = entity.presets,
+        fromCache = entity.fromCache,
+    )
 
     /** Delete by user IGN (for invalidation) */
     @Transactional("transactionManager")
@@ -166,7 +166,7 @@ class CharacterViewQueryServicePostgres(
         val context = TaskContext.of("PostgresQuery", "Count", userIgn)
 
         return executor.executeOrDefault(
-            { if (repository.findByUserIgn(userIgn) != null) 1L else 0L },
+            { if (repository.findTopByUserIgnOrderByCalculatedAtDescIdDesc(userIgn) != null) 1L else 0L },
             0L,
             context,
         )
@@ -183,7 +183,7 @@ class CharacterViewQueryServicePostgres(
 
         return executor.executeOrDefault(
             {
-                val entity = repository.findByUserIgn(userIgn)
+                val entity = repository.findTopByUserIgnOrderByCalculatedAtDescIdDesc(userIgn)
                 entity?.lastAppliedVersion ?: 0L
             },
             0L,

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/repository/CharacterValuationViewJpaRepository.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/repository/CharacterValuationViewJpaRepository.kt
@@ -21,6 +21,8 @@ interface CharacterValuationViewJpaRepository : JpaRepository<CharacterValuation
      */
     fun findByUserIgn(userIgn: String): CharacterValuationViewEntity?
 
+    fun findTopByUserIgnOrderByCalculatedAtDescIdDesc(userIgn: String): CharacterValuationViewEntity?
+
     /**
      * messageId으로 조회
      */

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/PgmqClient.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/PgmqClient.kt
@@ -204,6 +204,21 @@ class PgmqClient(
         return executor.executeOrDefault({ performGetReadCount(queueName, messageId) }, 0, context)
     }
 
+    /**
+     * Find the latest active message for a user in the target queue.
+     *
+     * <p>Used to deduplicate repeated V5 MISS requests so the API can return the
+     * currently active task instead of enqueueing duplicate work.
+     */
+    fun findActiveMessageIdByUserIgn(queueName: String, userIgn: String): Long? {
+        val context = TaskContext.of("PgmqClient", "FindActiveMessage", "$queueName:$userIgn")
+        return executor.executeOrDefault(
+            { performFindActiveMessageIdByUserIgn(queueName, userIgn) },
+            null,
+            context,
+        )
+    }
+
     // ==================== Internal Implementation ====================
 
     private fun <T : Any> performSend(queueName: String, message: T): Long {
@@ -316,6 +331,22 @@ class PgmqClient(
             Int::class.java,
             messageId,
         ) ?: 0
+    }
+
+    private fun performFindActiveMessageIdByUserIgn(queueName: String, userIgn: String): Long? {
+        validateQueueName(queueName)
+        val queueTable = "pgmq.q_$queueName"
+        return jdbcTemplate.queryForObject(
+            """
+            SELECT msg_id
+            FROM $queueTable
+            WHERE message ->> 'userIgn' = ?
+            ORDER BY msg_id DESC
+            LIMIT 1
+            """.trimIndent(),
+            Long::class.java,
+            userIgn,
+        )
     }
 
     private fun validateQueueName(queueName: String) {

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/AbstractExpectationCalcWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/AbstractExpectationCalcWorker.kt
@@ -1,0 +1,80 @@
+package maple.expectation.infrastructure.worker
+
+import io.micrometer.core.instrument.MeterRegistry
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executor
+import java.util.concurrent.TimeUnit
+import maple.expectation.core.port.inbound.ExpectationV4Port
+import maple.expectation.core.port.out.CharacterOcidPort
+import maple.expectation.core.port.out.EquipmentFanOutPort
+import maple.expectation.infrastructure.executor.LogicExecutor
+import maple.expectation.infrastructure.executor.TaskContext
+import maple.expectation.infrastructure.lifecycle.ScheduledTaskLifecycleWrapper
+import maple.expectation.infrastructure.pgmq.ExpectationCalcMessage
+import maple.expectation.infrastructure.pgmq.PgmqClient
+import maple.expectation.infrastructure.pgmq.PgmqMessage
+import maple.expectation.infrastructure.pgmq.PgmqWorker
+import maple.expectation.infrastructure.pgmq.PgmqWorkerConfig
+import org.slf4j.Logger
+
+abstract class AbstractExpectationCalcWorker(
+    pgmqClient: PgmqClient,
+    executor: LogicExecutor,
+    config: PgmqWorkerConfig,
+    meterRegistry: MeterRegistry,
+    lifecycleWrapper: ScheduledTaskLifecycleWrapper,
+    private val expectationPort: ExpectationV4Port,
+    private val characterOcidPort: CharacterOcidPort,
+    private val equipmentFanOutPort: EquipmentFanOutPort,
+    private val preWarmExecutor: Executor,
+) : PgmqWorker<ExpectationCalcMessage>(pgmqClient, executor, config, meterRegistry, lifecycleWrapper) {
+
+    override val payloadClass: Class<ExpectationCalcMessage> = ExpectationCalcMessage::class.java
+
+    protected abstract val workerName: String
+    protected abstract val workerLog: Logger
+
+    override fun preWarmBatch(messages: List<PgmqMessage<ExpectationCalcMessage>>) {
+        val context = TaskContext.of(workerName, "PreWarm", queueName)
+
+        executor.executeVoid({
+            val igns = messages.asSequence().map { it.payload.userIgn }.toSet()
+            if (igns.isEmpty()) return@executeVoid
+
+            val ignToOcid = characterOcidPort.resolveOcids(igns)
+            if (ignToOcid.isEmpty()) return@executeVoid
+
+            val warmupFutures = ignToOcid.values.map { ocid ->
+                CompletableFuture.supplyAsync(
+                    { equipmentFanOutPort.preFetchByOcid(ocid) },
+                    preWarmExecutor,
+                )
+            }
+
+            CompletableFuture.allOf(*warmupFutures.toTypedArray())
+                .orTimeout(15, TimeUnit.SECONDS)
+                .handle { _, _ -> null }
+                .join()
+
+            workerLog.info("[{}] Pre-warm: {} igns -> {} ocids", workerName, igns.size, ignToOcid.size)
+        }, context)
+    }
+
+    override fun process(message: PgmqMessage<ExpectationCalcMessage>): Boolean {
+        val request = message.payload
+        val context = TaskContext.of(workerName, "Process", request.userIgn)
+
+        return executor.executeOrDefault({
+            workerLog.info("[{}] Processing: userIgn={}, taskId={}", workerName, request.userIgn, message.messageId)
+
+            expectationPort.calculateExpectationAsync(
+                request.userIgn,
+                request.forceRecalculation,
+                message.messageId.toString(),
+            ).join()
+
+            workerLog.info("[{}] Completed: userIgn={}, taskId={}", workerName, request.userIgn, message.messageId)
+            true
+        }, false, context)
+    }
+}

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/CalculationWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/CalculationWorker.kt
@@ -60,6 +60,7 @@ class CalculationWorker(
             val future = expectationPort.calculateExpectationAsync(
                 request.userIgn,
                 request.forceRecalculation,
+                message.messageId.toString(),
             )
             future.join()
 

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/ExpectationCalcLowWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/ExpectationCalcLowWorker.kt
@@ -1,42 +1,20 @@
 package maple.expectation.infrastructure.worker
 
+import io.micrometer.core.instrument.MeterRegistry
+import java.util.concurrent.Executor
 import maple.expectation.core.port.inbound.ExpectationV4Port
 import maple.expectation.core.port.out.CharacterOcidPort
 import maple.expectation.core.port.out.EquipmentFanOutPort
 import maple.expectation.infrastructure.executor.LogicExecutor
-import maple.expectation.infrastructure.executor.TaskContext
-import maple.expectation.infrastructure.pgmq.ExpectationCalcMessage
-import maple.expectation.infrastructure.pgmq.PgmqClient
-import maple.expectation.infrastructure.pgmq.PgmqMessage
-import maple.expectation.infrastructure.pgmq.PgmqWorker
-import maple.expectation.infrastructure.pgmq.PgmqWorkerConfig
 import maple.expectation.infrastructure.lifecycle.ScheduledTaskLifecycleWrapper
-import io.micrometer.core.instrument.MeterRegistry
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.TimeUnit
+import maple.expectation.infrastructure.pgmq.PgmqClient
+import maple.expectation.infrastructure.pgmq.PgmqWorkerConfig
+import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Component
 
-/**
- * 기대값 계산 Worker - LOW Priority (Issue #634)
- *
- * <h3>역할</h3>
- * <p>expectation_calc_low 큐에서 메시지를 소비하고 장비 기대값 계산 수행
- *
- * <h3>처리 흐름</h3>
- * <ol>
- *   <li>expectation_calc_low 큐에서 메시지 읽기</li>
- *   <li>ExpectationV4Port를 통해 비동기 계산 수행</li>
- *   <li>성공 시 아카이브, 실패 시 재시도 또는 삭제</li>
- * </ol>
- *
- * <h3>Feature Flag</h3>
- * <p>pgmq.worker.expectation-calc-low.enabled=true로 활성화
- *
- * @see ExpectationCalcMessage 메시지 페이로드
- * @see ExpectationV4Port 계산 포트
- */
 @Component
 @Profile("!test")
 class ExpectationCalcLowWorker(
@@ -45,73 +23,29 @@ class ExpectationCalcLowWorker(
     config: PgmqWorkerConfig,
     meterRegistry: MeterRegistry,
     lifecycleWrapper: ScheduledTaskLifecycleWrapper,
-    private val expectationPort: ExpectationV4Port,
-    private val characterOcidPort: CharacterOcidPort,
-    private val equipmentFanOutPort: EquipmentFanOutPort,
-) : PgmqWorker<ExpectationCalcMessage>(pgmqClient, executor, config, meterRegistry, lifecycleWrapper) {
+    expectationPort: ExpectationV4Port,
+    characterOcidPort: CharacterOcidPort,
+    equipmentFanOutPort: EquipmentFanOutPort,
+    @Qualifier("asyncExecutor") preWarmExecutor: Executor,
+) : AbstractExpectationCalcWorker(
+    pgmqClient,
+    executor,
+    config,
+    meterRegistry,
+    lifecycleWrapper,
+    expectationPort,
+    characterOcidPort,
+    equipmentFanOutPort,
+    preWarmExecutor,
+) {
 
     override val queueName: String = QUEUE_NAME
-    override val payloadClass: Class<ExpectationCalcMessage> = ExpectationCalcMessage::class.java
     override val workerSettings: PgmqWorkerConfig.WorkerSettings = config.expectationCalcLow
-
-    /**
-     * 배치 pre-warm (ADR-700)
-     *
-     * <p>병렬 메시지 처리 전 배치 내 OCID 중복 제거 + 장비 캐시 pre-warm.
-     * Best-effort: 실패해도 메시지 처리에 영향 없음.
-     *
-     * @see ExpectationCalcWorker.preWarmBatch 동일 로직 (HIGH priority)
-     */
-    override fun preWarmBatch(messages: List<PgmqMessage<ExpectationCalcMessage>>) {
-        val context = TaskContext.of("ExpectationCalcLowWorker", "PreWarm", queueName)
-
-        executor.executeVoid({
-            // 1. 배치 내 unique IGN 추출
-            val igns = messages.map { it.payload.userIgn }.toSet()
-
-            // 2. Batch OCID resolve (재사용: CharacterOcidPort.resolveOcids)
-            val ignToOcid = characterOcidPort.resolveOcids(igns)
-
-            if (ignToOcid.isEmpty()) return@executeVoid
-
-            // 3. Equipment cache pre-warm — CONCURRENT submission 필수
-            //    Virtual Thread에서 동시 submit → semaphore(10) 초과 시 Batch Lane으로 routing
-            //    → NexonFanOutBatchLoader.load()가 병렬 batch fetch → L1/L2 캐시 적재
-            val warmupFutures = ignToOcid.values.map { ocid ->
-                CompletableFuture.supplyAsync {
-                    equipmentFanOutPort.preFetchByOcid(ocid)
-                }
-            }
-            CompletableFuture.allOf(*warmupFutures.toTypedArray())
-                .orTimeout(15, TimeUnit.SECONDS)
-                .handle { _, _ -> }  // best-effort: 실패해도 진행
-
-            log.info("[ExpectationCalcLowWorker] Pre-warm: {} igns → {} ocids", igns.size, ignToOcid.size)
-        }, context)
-    }
-
-    override fun process(message: PgmqMessage<ExpectationCalcMessage>): Boolean {
-        val request = message.payload
-        val context = TaskContext.of("ExpectationCalcLowWorker", "Process", request.userIgn)
-
-        return executor.executeOrDefault({
-            log.info("[ExpectationCalcLowWorker] Processing: userIgn={}", request.userIgn)
-
-            val future = expectationPort.calculateExpectationAsync(
-                request.userIgn,
-                request.forceRecalculation,
-            )
-            future.join()
-
-            log.info("[ExpectationCalcLowWorker] Completed: userIgn={}", request.userIgn)
-            true
-        }, false, context)
-    }
+    override val workerName: String = "ExpectationCalcLowWorker"
+    override val workerLog: Logger = log
 
     companion object {
         private val log = LoggerFactory.getLogger(ExpectationCalcLowWorker::class.java)
-
-        /** 큐 이름 */
         const val QUEUE_NAME = "expectation_calc_low"
     }
 }

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/ExpectationCalcWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/ExpectationCalcWorker.kt
@@ -1,42 +1,20 @@
 package maple.expectation.infrastructure.worker
 
+import io.micrometer.core.instrument.MeterRegistry
+import java.util.concurrent.Executor
 import maple.expectation.core.port.inbound.ExpectationV4Port
 import maple.expectation.core.port.out.CharacterOcidPort
 import maple.expectation.core.port.out.EquipmentFanOutPort
 import maple.expectation.infrastructure.executor.LogicExecutor
-import maple.expectation.infrastructure.executor.TaskContext
-import maple.expectation.infrastructure.pgmq.ExpectationCalcMessage
-import maple.expectation.infrastructure.pgmq.PgmqClient
-import maple.expectation.infrastructure.pgmq.PgmqMessage
-import maple.expectation.infrastructure.pgmq.PgmqWorker
-import maple.expectation.infrastructure.pgmq.PgmqWorkerConfig
 import maple.expectation.infrastructure.lifecycle.ScheduledTaskLifecycleWrapper
-import io.micrometer.core.instrument.MeterRegistry
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.TimeUnit
+import maple.expectation.infrastructure.pgmq.PgmqClient
+import maple.expectation.infrastructure.pgmq.PgmqWorkerConfig
+import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Component
 
-/**
- * 기대값 계산 Worker - HIGH Priority (Issue #634)
- *
- * <h3>역할</h3>
- * <p>expectation_calc_high 큐에서 메시지를 소비하고 장비 기대값 계산 수행
- *
- * <h3>처리 흐름</h3>
- * <ol>
- *   <li>expectation_calc_high 큐에서 메시지 읽기</li>
- *   <li>ExpectationV4Port를 통해 비동기 계산 수행</li>
- *   <li>성공 시 아카이브, 실패 시 재시도 또는 삭제</li>
- * </ol>
- *
- * <h3>Feature Flag</h3>
- * <p>pgmq.worker.expectation-calc-high.enabled=true로 활성화
- *
- * @see ExpectationCalcMessage 메시지 페이로드
- * @see ExpectationV4Port 계산 포트
- */
 @Component
 @Profile("!test")
 class ExpectationCalcWorker(
@@ -45,74 +23,29 @@ class ExpectationCalcWorker(
     config: PgmqWorkerConfig,
     meterRegistry: MeterRegistry,
     lifecycleWrapper: ScheduledTaskLifecycleWrapper,
-    private val expectationPort: ExpectationV4Port,
-    private val characterOcidPort: CharacterOcidPort,
-    private val equipmentFanOutPort: EquipmentFanOutPort,
-) : PgmqWorker<ExpectationCalcMessage>(pgmqClient, executor, config, meterRegistry, lifecycleWrapper) {
+    expectationPort: ExpectationV4Port,
+    characterOcidPort: CharacterOcidPort,
+    equipmentFanOutPort: EquipmentFanOutPort,
+    @Qualifier("asyncExecutor") preWarmExecutor: Executor,
+) : AbstractExpectationCalcWorker(
+    pgmqClient,
+    executor,
+    config,
+    meterRegistry,
+    lifecycleWrapper,
+    expectationPort,
+    characterOcidPort,
+    equipmentFanOutPort,
+    preWarmExecutor,
+) {
 
     override val queueName: String = QUEUE_NAME
-    override val payloadClass: Class<ExpectationCalcMessage> = ExpectationCalcMessage::class.java
     override val workerSettings: PgmqWorkerConfig.WorkerSettings = config.expectationCalcHigh
-
-    /**
-     * 배치 pre-warm (ADR-700)
-     *
-     * <p>병렬 메시지 처리 전 배치 내 OCID 중복 제거 + 장비 캐시 pre-warm.
-     * Best-effort: 실패해도 메시지 처리에 영향 없음.
-     *
-     * <h3>동시 submit 이유</h3>
-     * <p>AdaptiveMicroBatchUserService는 semaphore(10)로 Fast/Batch Lane 분기.
-     * 순차 호출 시 전부 Fast Lane → coalescing 미발생.
-     * 동시 submit 시 초과분이 Batch Lane → NexonFanOutBatchLoader.load() batch fetch.
-     */
-    override fun preWarmBatch(messages: List<PgmqMessage<ExpectationCalcMessage>>) {
-        val context = TaskContext.of("ExpectationCalcWorker", "PreWarm", queueName)
-
-        executor.executeVoid({
-            // 1. 배치 내 unique IGN 추출
-            val igns = messages.map { it.payload.userIgn }.toSet()
-
-            // 2. Batch OCID resolve (재사용: CharacterOcidPort.resolveOcids)
-            val ignToOcid = characterOcidPort.resolveOcids(igns)
-
-            if (ignToOcid.isEmpty()) return@executeVoid
-
-            // 3. Equipment cache pre-warm — CONCURRENT submission 필수
-            val warmupFutures = ignToOcid.values.map { ocid ->
-                CompletableFuture.supplyAsync {
-                    equipmentFanOutPort.preFetchByOcid(ocid)
-                }
-            }
-            CompletableFuture.allOf(*warmupFutures.toTypedArray())
-                .orTimeout(15, TimeUnit.SECONDS)
-                .handle { _, _ -> }  // best-effort: 실패해도 진행
-
-            log.info("[ExpectationCalcWorker] Pre-warm: {} igns → {} ocids", igns.size, ignToOcid.size)
-        }, context)
-    }
-
-    override fun process(message: PgmqMessage<ExpectationCalcMessage>): Boolean {
-        val request = message.payload
-        val context = TaskContext.of("ExpectationCalcWorker", "Process", request.userIgn)
-
-        return executor.executeOrDefault({
-            log.info("[ExpectationCalcWorker] Processing: userIgn={}", request.userIgn)
-
-            val future = expectationPort.calculateExpectationAsync(
-                request.userIgn,
-                request.forceRecalculation,
-            )
-            future.join()
-
-            log.info("[ExpectationCalcWorker] Completed: userIgn={}", request.userIgn)
-            true
-        }, false, context)
-    }
+    override val workerName: String = "ExpectationCalcWorker"
+    override val workerLog: Logger = log
 
     companion object {
         private val log = LoggerFactory.getLogger(ExpectationCalcWorker::class.java)
-
-        /** 큐 이름 */
         const val QUEUE_NAME = "expectation_calc_high"
     }
 }

--- a/module-web/src/main/kotlin/maple/expectation/web/controller/v5/GameCharacterControllerV5.kt
+++ b/module-web/src/main/kotlin/maple/expectation/web/controller/v5/GameCharacterControllerV5.kt
@@ -23,11 +23,13 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import maple.expectation.web.validation.ValidIgn
 
 /**
  * V5 CQRS 캐릭터 컨트롤러 (ADR-005 이관)
@@ -47,6 +49,7 @@ import org.springframework.web.bind.annotation.RestController
  * - 프리페치 후 Calculation Worker가 캐시된 데이터를 활용 (빠른 계산)
  * - Best-effort: 실패해도 큐잉은 정상 수행
  */
+@Validated
 @RestController
 @RequestMapping("/api/v5/characters")
 @ConditionalOnProperty(name = ["v5.enabled"], havingValue = "true", matchIfMissing = false)
@@ -58,6 +61,7 @@ class GameCharacterControllerV5(
     @Value("\${fanout.enabled:false}") private val fanOutEnabled: Boolean,
     private val fanOutPort: EquipmentFanOutPort,
     @Qualifier("expectationComputeExecutor") private val computeExecutor: Executor,
+    @Qualifier("asyncExecutor") private val preWarmExecutor: Executor,
     meterRegistry: MeterRegistry,
 ) {
     private val preWarmFailureCounter = meterRegistry.counter("v5.prewarm.failures", "type", "error")
@@ -72,10 +76,11 @@ class GameCharacterControllerV5(
     @GetMapping("/{userIgn}/expectation")
     @PreAuthorize("permitAll()")
     fun getExpectationV5(
-        @PathVariable @NotBlank userIgn: String,
+        @PathVariable @NotBlank @ValidIgn userIgn: String,
     ): CompletableFuture<ResponseEntity<*>> {
-        log.debug("[V5] Query expectation for: {}", maskIgn(userIgn))
-        return CompletableFuture.supplyAsync({ processPostgreSQLCacheFirstLookup(userIgn) }, computeExecutor)
+        val normalizedIgn = userIgn.trim()
+        log.debug("[V5] Query expectation for: {}", maskIgn(normalizedIgn))
+        return CompletableFuture.supplyAsync({ processPostgreSQLCacheFirstLookup(normalizedIgn) }, computeExecutor)
     }
 
     private fun processPostgreSQLCacheFirstLookup(userIgn: String): ResponseEntity<*> {
@@ -102,7 +107,7 @@ class GameCharacterControllerV5(
         if (fanOutEnabled) {
             CompletableFuture.runAsync(
                 { preWarmEquipmentCache(userIgn, context) },
-                computeExecutor,
+                preWarmExecutor,
             ).exceptionally { e ->
                 if (e is RejectedExecutionException) {
                     preWarmRejectedCounter.increment()
@@ -151,10 +156,11 @@ class GameCharacterControllerV5(
     @PostMapping("/{userIgn}/expectation/recalculate")
     @PreAuthorize("permitAll()")
     fun recalculateExpectationV5(
-        @PathVariable userIgn: String,
+        @PathVariable @NotBlank @ValidIgn userIgn: String,
     ): CompletableFuture<ResponseEntity<*>> {
-        log.info("[V5] Force recalculation requested: {}", maskIgn(userIgn))
-        return CompletableFuture.supplyAsync({ processCacheInvalidation(userIgn) }, computeExecutor)
+        val normalizedIgn = userIgn.trim()
+        log.info("[V5] Force recalculation requested: {}", maskIgn(normalizedIgn))
+        return CompletableFuture.supplyAsync({ processCacheInvalidation(normalizedIgn) }, computeExecutor)
     }
 
     private fun processCacheInvalidation(userIgn: String): ResponseEntity<*> {

--- a/module-web/src/main/kotlin/maple/expectation/web/controller/v5/TaskStatusController.kt
+++ b/module-web/src/main/kotlin/maple/expectation/web/controller/v5/TaskStatusController.kt
@@ -1,14 +1,19 @@
 package maple.expectation.web.controller.v5
 
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
 import maple.expectation.core.port.inbound.TaskStatus
 import maple.expectation.core.port.inbound.TaskStatusPort
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import maple.expectation.web.validation.ValidIgn
 
 /**
  * V5 Task 상태 조회 Controller (ADR-355)
@@ -16,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController
  * <p>클라이언트가 비동기 계산 완료 여부를 polling.
  * userIgn을 path에 포함하여 타 사용자 taskId 추측 공격 방어.
  */
+@Validated
 @RestController
 @RequestMapping("/api/v5/characters")
 @ConditionalOnProperty(name = ["v5.enabled"], havingValue = "true", matchIfMissing = false)
@@ -26,16 +32,19 @@ class TaskStatusController(
     @GetMapping("/{userIgn}/task/{taskId}")
     @PreAuthorize("permitAll()")
     fun getTaskStatus(
-        @PathVariable userIgn: String,
-        @PathVariable taskId: String,
+        @PathVariable @NotBlank @ValidIgn userIgn: String,
+        @PathVariable @NotBlank @Pattern(regexp = "\\d+") taskId: String,
     ): ResponseEntity<TaskStatusResponse> {
-        val status = taskStatusPort.getStatus(userIgn, taskId)
+        val normalizedIgn = userIgn.trim()
+        val status = taskStatusPort.getStatus(normalizedIgn, taskId)
         val response = TaskStatusResponse(taskId, status.name)
 
         return if (status == TaskStatus.PENDING || status == TaskStatus.PROCESSING) {
             ResponseEntity.ok()
                 .header("Retry-After", "5")
                 .body(response)
+        } else if (status == TaskStatus.NOT_FOUND) {
+            ResponseEntity.status(HttpStatus.NOT_FOUND).body(response)
         } else {
             ResponseEntity.ok(response)
         }


### PR DESCRIPTION
## 관련 이슈
#634
#639

## 개요
V5 expectation 요청 경로의 task 정합성, queue dedupe, query-side read consistency, worker 중복 로직을 함께 정리해 CQRS 플로우를 더 안전하게 만들었습니다.
기존에 `userIgn` 기준으로 잘못 완료 처리되거나 동일 IGN이 중복 enqueue 되던 문제를 줄이고, cache hit 시에도 V5 read model이 다시 동기화되도록 보강했습니다.

## 작업 내용
- [x] `taskId/messageId`를 expectation 계산, view transform, worker 경로 끝까지 전파
- [x] `TaskStatusService`를 `taskId == messageId` 기준 완료 판정으로 수정하고 invalid taskId는 `NOT_FOUND` 처리
- [x] `ExpectationCalculationQueue`에 active task 재사용 로직을 추가해 non-force 중복 enqueue 제거
- [x] V5 controller validation과 HTTP status handling 강화 (`@Validated`, `@ValidIgn`, 404)
- [x] query-side feature flag를 `v5.enabled`로 통일하고 최신 row 기준 조회/실측 latency metric 반영
- [x] HIGH/LOW expectation worker 중복 로직을 `AbstractExpectationCalcWorker`로 통합하고 pre-warm executor 분리
- [x] 회귀 테스트 추가 (`ExpectationCalculationQueueTest`, `TaskStatusServiceTest`)

## 변경 파일
| 파일 | 변경 유형 | 설명 |
|------|----------|------|
| `module-app/.../EquipmentExpectationServiceV4.java` | 수정 | cache hit 시 V5 view 재동기화 및 taskId 전파 |
| `module-app/.../ViewTransformer.java` | 수정 | response -> view 변환 시 messageId 유지 |
| `module-app/.../ExpectationCalculationQueue.java` | 수정 | queue dedupe 및 receipt 로직 통합 |
| `module-app/.../TaskStatusService.java` | 수정 | taskId 기반 완료/진행 상태 판정 수정 |
| `module-infra/.../PgmqClient.kt` | 수정 | active message lookup 추가 |
| `module-infra/.../CharacterViewQueryServicePostgres.kt` | 수정 | 최신 row 조회, 실측 latency metric, upsert 보강 |
| `module-infra/.../worker/AbstractExpectationCalcWorker.kt` | 추가 | HIGH/LOW 공통 worker 로직 추출 |
| `module-web/.../GameCharacterControllerV5.kt` | 수정 | IGN validation, pre-warm executor 분리 |
| `module-web/.../TaskStatusController.kt` | 수정 | task validation 및 404 응답 |
| `module-app/.../TaskStatusServiceTest.java` | 추가 | task 상태 회귀 테스트 |
| **총계** | **+618 -309 라인** | **19개 파일 변경** |

## 리뷰 포인트
- `taskId`가 worker -> calculation -> view -> status 조회까지 일관되게 이어지는지
- queue dedupe가 non-force 요청만 재사용하고 force 요청은 새 작업으로 남기는지
- query-side 최신 row 조회가 기존 단일 row 가정을 깨지 않으면서도 race 영향을 줄였는지
- worker 공통화 이후 pre-warm과 process 로직이 HIGH/LOW 간 동일하게 유지되는지

## 트레이드 오프 결정 근거
- `user_ign` DB unique 제약을 이번 PR에 바로 추가하지 않고, 애플리케이션 레벨에서 latest-row read + dedupe로 먼저 안정화했습니다. 운영 스키마 변경 없이 리스크를 낮추기 위한 선택입니다.
- pre-warm은 요청 처리용 `expectationComputeExecutor` 대신 `asyncExecutor`로 분리했습니다. 요청 starvation을 줄이는 대신 executor 경로가 하나 늘어납니다.
- queue dedupe는 active visible message 재사용만 적용했습니다. force 요청까지 합치면 재계산 의도를 훼손할 수 있어 제외했습니다.

## Breaking Changes (선택)
- [ ] 데이터베이스 스키마 변경
- [ ] API 인터페이스 변경
- [ ] 환경 변수 필수 추가

## 마이그레이션 가이드 (선택)
해당 없음.

## 테스트 결과
```bash
./gradlew.bat :module-core:compileKotlin :module-infra:compileKotlin :module-web:compileKotlin :module-app:compileJava
./gradlew.bat :module-app:test --tests "maple.expectation.service.v5.ExpectationCalculationQueueTest" --tests "maple.expectation.service.v5.TaskStatusServiceTest"
```

결과 요약:
- compile path: PASS
- `ExpectationCalculationQueueTest`: PASS
- `TaskStatusServiceTest`: PASS

## 성능 비교 (선택)
정식 부하 테스트는 이번 PR 범위에서 수행하지 않았습니다.
다만 중복 enqueue 제거, 요청 executor/pre-warm executor 분리, query latency 실측 기록으로 병목 관찰성과 낭비 작업을 줄였습니다.

## 체크리스트
- [x] 브랜치/커밋 규칙 준수 여부
- [x] 테스트 통과 여부
- [x] CLAUDE.md 가이드라인 준수
- [x] 코드 리뷰 포인트 정리
- [ ] 정적 분석 통과 (별도 미실행)
- [ ] Chaos Test 통과 (별도 미실행)
- [ ] 문서 업데이트
- [x] PR 템플릿 출처 확인 (`docs/98_Templates/PR_TEMPLATE.md`)
