### PR TITLE
Validate Nexon API account & OCIDs, fix rate limiter permit leak, improve builders and tests

### DIFF
--- a/docs/09_Plans/open-issues-remediation-plan-2026-04-17.md
+++ b/docs/09_Plans/open-issues-remediation-plan-2026-04-17.md
@@ -1,0 +1,41 @@
+# Open Issues Remediation Plan (2026-04-17)
+
+## 목표
+- 오픈 이슈 #651 ~ #695를 우선순위(P0→P2) 기준으로 단계적으로 해결한다.
+- 보안/신뢰성 리스크(P0/P1)를 먼저 차단하고, 이후 아키텍처/품질 개선(P2)을 병렬 처리한다.
+
+## 우선순위별 실행 전략
+
+### Phase 1 — Critical Stabilization (P0/P1)
+1. **#667 [P0][Auth] Login 시 Nexon API 계정 검증 강제**
+   - 로그인 플로우에서 API Key 유효성 + 소유 계정 검증을 hard-fail로 보장.
+   - 회귀 테스트: 유효/무효 API Key, 동일 계정 다중 키 시나리오.
+2. **#693 [P1][Infra] Rate Limiter permit leak 차단**
+   - acquire/release 짝 불일치, 예외 경로 release 누락 여부 점검.
+   - 실패/타임아웃 경로 포함 단위 테스트 추가.
+3. **#672 [P1][Infra] PostgresSingleFlightStrategy xact lock 전환 검증**
+   - `pg_try_advisory_xact_lock` 사용 고정 및 세션락 회귀 방지 테스트 추가.
+
+### Phase 2 — Security/Observability Hardening (P2, high impact)
+4. **#652 [P2][Security] 인증 엔드포인트 Rate Limiting 적용**
+5. **#651 [P2][Reliability] Leader Election 구조화 메트릭 추가**
+6. **#653 [P2][Concurrency] PostgresNotifySubscriber @Volatile → AtomicReference 정리**
+
+### Phase 3 — Architecture & Quality (P2)
+7. **#694 [P2][Architecture] ExecutorPort 확장으로 DIP 준수**
+8. **#655 [P2][Architecture] ADR-022 Redis 제거 잔여물 정리**
+9. **#660 [P2][Architecture] API v1 Deprecation 계획/마이그레이션 가이드 확정**
+10. **#659 [P2][Performance] JPA Batch Fetch 검증 리포트 + N+1 회귀 테스트**
+11. **#658 [P2][Code-Quality] BulkLoaderService 순환복잡도 리팩터링**
+12. **#657 [P2][Null-Safety] Builder `!!` 제거 (`require`/명시적 검증)**
+13. **#656 [P2][Test] `Thread.sleep` → Awaitility 전환**
+14. **#654 [P2][Configuration] 매직 넘버 설정 외부화**
+15. **#695 [P2][Test] NexonFanOutBatchLoader 단위 테스트 보강**
+
+## 이번 커밋에서 처리한 범위
+- #695를 먼저 착수해 핵심 단위 테스트(성공/429/non-429/헬퍼 함수)를 추가.
+- 나머지 이슈는 상기 Phase 순서대로 후속 브랜치에서 분할 처리 권장.
+
+## 브랜치/PR 운영 원칙
+- 각 Phase 또는 1~2개 이슈 단위로 작은 PR 생성.
+- 머지 전 체크: `compileKotlin compileJava --continue`, 관련 모듈 단위 테스트, 영향도 문서 업데이트.

--- a/module-app/src/main/kotlin/maple/expectation/application/service/auth/ApiKeyValidator.kt
+++ b/module-app/src/main/kotlin/maple/expectation/application/service/auth/ApiKeyValidator.kt
@@ -43,7 +43,8 @@ class ApiKeyValidator(
         userIgn: String,
         characters: List<CharacterListResponse.CharacterInfo>,
     ): Boolean {
-        val ownsCharacter = characters.any { it.characterName.equals(userIgn, ignoreCase = true) }
+        val normalizedUserIgn = userIgn.trim()
+        val ownsCharacter = characters.any { it.characterName?.trim()?.equals(normalizedUserIgn, ignoreCase = true) == true }
 
         if (!ownsCharacter) {
             log.warn("Character ownership verification failed: userIgn={}", userIgn)
@@ -79,13 +80,21 @@ class ApiKeyValidator(
         }
 
         // 4. 모든 캐릭터 OCID 수집
-        val myOcids = characters.mapNotNull { it.ocid }.toSet()
+        val myOcids = characters
+            .mapNotNull { it.ocid?.trim()?.takeIf(String::isNotBlank) }
+            .toSet()
+
+        if (myOcids.isEmpty()) {
+            log.warn("API key validation failed: no valid OCIDs found for userIgn={}", userIgn)
+            throw InvalidApiKeyException("No valid character OCIDs found for API key")
+        }
 
         // 5. #667: Nexon account_id 추출 (동일 계정 = 동일 ID, API Key 무관)
         val accountId = characterList.accountList
+            ?.asSequence()
+            ?.mapNotNull { it.accountId?.trim()?.takeIf(String::isNotBlank) }
             ?.firstOrNull()
-            ?.accountId
-            ?: throw InvalidApiKeyException()
+            ?: throw InvalidApiKeyException("Nexon account_id is missing in character/list response")
 
         log.info("API key validation successful: userIgn={}, ocids={}, accountId={}", userIgn, myOcids.size, accountId)
 

--- a/module-app/src/test/kotlin/maple/expectation/application/service/auth/ApiKeyValidatorTest.kt
+++ b/module-app/src/test/kotlin/maple/expectation/application/service/auth/ApiKeyValidatorTest.kt
@@ -1,0 +1,117 @@
+package maple.expectation.application.service.auth
+
+import java.util.Optional
+import maple.expectation.error.exception.CharacterNotOwnedException
+import maple.expectation.error.exception.InvalidApiKeyException
+import maple.expectation.infrastructure.external.NexonAuthClient
+import maple.expectation.infrastructure.external.dto.v2.CharacterListResponse
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+
+@ExtendWith(MockitoExtension::class)
+@DisplayName("ApiKeyValidator ownership verification tests")
+class ApiKeyValidatorTest {
+
+    @Mock
+    private lateinit var nexonAuthClient: NexonAuthClient
+
+    @InjectMocks
+    private lateinit var validator: ApiKeyValidator
+
+    @Test
+    @DisplayName("account_id가 blank면 InvalidApiKeyException을 던진다")
+    fun `validateAndVerifyOwnership should fail when account id is blank`() {
+        whenever(nexonAuthClient.getCharacterList("api-key")).thenReturn(
+            Optional.of(
+                CharacterListResponse(
+                    accountList = listOf(
+                        CharacterListResponse.AccountInfo(
+                            accountId = "  ",
+                            characterList = listOf(character(name = "Hero", ocid = "ocid-1")),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        assertThatThrownBy { validator.validateAndVerifyOwnership("api-key", "Hero") }
+            .isInstanceOf(InvalidApiKeyException::class.java)
+            .hasMessageContaining("account_id")
+    }
+
+    @Test
+    @DisplayName("유효한 OCID가 하나도 없으면 InvalidApiKeyException을 던진다")
+    fun `validateAndVerifyOwnership should fail when no valid ocids exist`() {
+        whenever(nexonAuthClient.getCharacterList("api-key")).thenReturn(
+            Optional.of(
+                CharacterListResponse(
+                    accountList = listOf(
+                        CharacterListResponse.AccountInfo(
+                            accountId = "account-1",
+                            characterList = listOf(character(name = "Hero", ocid = " ")),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        assertThatThrownBy { validator.validateAndVerifyOwnership("api-key", "Hero") }
+            .isInstanceOf(InvalidApiKeyException::class.java)
+            .hasMessageContaining("OCIDs")
+    }
+
+    @Test
+    @DisplayName("userIgn 비교 시 공백/대소문자를 무시하고 소유권을 인정한다")
+    fun `validateAndVerifyOwnership should match ownership with trimmed case-insensitive ign`() {
+        whenever(nexonAuthClient.getCharacterList("api-key")).thenReturn(
+            Optional.of(
+                CharacterListResponse(
+                    accountList = listOf(
+                        CharacterListResponse.AccountInfo(
+                            accountId = "account-1",
+                            characterList = listOf(character(name = "  hero  ", ocid = "ocid-1")),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val result = validator.validateAndVerifyOwnership("api-key", " HERO ")
+
+        assertThat(result.accountId).isEqualTo("account-1")
+        assertThat(result.myOcids).containsExactly("ocid-1")
+    }
+
+    @Test
+    @DisplayName("소유하지 않은 캐릭터면 CharacterNotOwnedException을 던진다")
+    fun `validateAndVerifyOwnership should fail when character is not owned`() {
+        whenever(nexonAuthClient.getCharacterList("api-key")).thenReturn(
+            Optional.of(
+                CharacterListResponse(
+                    accountList = listOf(
+                        CharacterListResponse.AccountInfo(
+                            accountId = "account-1",
+                            characterList = listOf(character(name = "Other", ocid = "ocid-1")),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        assertThatThrownBy { validator.validateAndVerifyOwnership("api-key", "Hero") }
+            .isInstanceOf(CharacterNotOwnedException::class.java)
+    }
+
+    private fun character(name: String, ocid: String): CharacterListResponse.CharacterInfo =
+        CharacterListResponse.CharacterInfo(
+            characterName = name,
+            ocid = ocid,
+        )
+}

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/external/impl/MetricsNexonApiClientWrapper.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/external/impl/MetricsNexonApiClientWrapper.kt
@@ -142,7 +142,15 @@ class MetricsNexonApiClientWrapper(
             logger.debug("[NexonRateLimiter] {} blocked for {}ms waiting for permit", endpoint, acquireTime / 1_000_000)
         }
 
-        return block()
+        val future = runCatching { block() }
+            .getOrElse { throwable ->
+                rateLimiter.releasePermit()
+                recordError(endpoint, throwable)
+                sample.stop(getTimer(endpoint, "error"))
+                return CompletableFuture.failedFuture(throwable)
+            }
+
+        return future
             .whenComplete { result, ex ->
                 try {
                     // Always release permit after call completes

--- a/module-infra/src/test/kotlin/maple/expectation/infrastructure/batch/DedupeMicroBatchWriterTest.kt
+++ b/module-infra/src/test/kotlin/maple/expectation/infrastructure/batch/DedupeMicroBatchWriterTest.kt
@@ -10,6 +10,7 @@ import maple.expectation.infrastructure.executor.TaskContext
 import maple.expectation.infrastructure.executor.function.ThrowingRunnable
 import maple.expectation.infrastructure.executor.strategy.ExceptionTranslator
 import maple.expectation.infrastructure.persistence.repository.ExpectationBatchRepository
+import org.awaitility.Awaitility.await
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -19,6 +20,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import java.time.LocalDateTime
+import java.time.Duration
 import java.util.concurrent.TimeUnit
 
 /**
@@ -123,8 +125,9 @@ class DedupeMicroBatchWriterTest {
         val dedupeCount = meterRegistry.counter("micro_batch_dedupe").count()
         assertThat(dedupeCount).isGreaterThan(0.0)
 
-        // Wait a bit for any async operations
-        Thread.sleep(200)
+        await().atMost(Duration.ofSeconds(2)).untilAsserted {
+            assertThat(meterRegistry.counter("micro_batch_dedupe").count()).isGreaterThan(0.0)
+        }
     }
 
     @Test
@@ -139,10 +142,9 @@ class DedupeMicroBatchWriterTest {
         tasks.forEach { writer.offer(it) }
 
         // Then: Flush should be triggered (size-trigger)
-        Thread.sleep(200)
-
-        val flushCount = meterRegistry.counter("micro_batch_flush").count()
-        assertThat(flushCount).isGreaterThan(0.0)
+        await().atMost(Duration.ofSeconds(2)).untilAsserted {
+            assertThat(meterRegistry.counter("micro_batch_flush").count()).isGreaterThan(0.0)
+        }
 
         val sizeTriggerCount = meterRegistry
             .counter("micro_batch_flush_trigger", "trigger", "size")
@@ -160,10 +162,9 @@ class DedupeMicroBatchWriterTest {
         writer.offer(task)
 
         // Then: Wait for time-triggered flush (flushIntervalMs = 100ms)
-        Thread.sleep(300)  // Wait longer than flushIntervalMs
-
-        val flushCount = meterRegistry.counter("micro_batch_flush").count()
-        assertThat(flushCount).isGreaterThan(0.0)
+        await().atMost(Duration.ofSeconds(2)).untilAsserted {
+            assertThat(meterRegistry.counter("micro_batch_flush").count()).isGreaterThan(0.0)
+        }
 
         val timeTriggerCount = meterRegistry
             .counter("micro_batch_flush_trigger", "trigger", "time")
@@ -183,10 +184,9 @@ class DedupeMicroBatchWriterTest {
         tasks.forEach { writer.offer(it) }
 
         // Then: Buffer size gauge should reflect current size
-        Thread.sleep(50)  // Small delay to ensure metrics are updated
-
-        val bufferSize = meterRegistry.get("micro_batch_buffer_size").gauge()
-        assertThat(bufferSize).isNotNull
+        await().atMost(Duration.ofSeconds(2)).untilAsserted {
+            assertThat(meterRegistry.get("micro_batch_buffer_size").gauge()).isNotNull
+        }
     }
 
     @Test
@@ -199,7 +199,9 @@ class DedupeMicroBatchWriterTest {
 
         // When: Trigger flush
         tasks.forEach { writer.offer(it) }
-        Thread.sleep(200)
+        await().atMost(Duration.ofSeconds(2)).untilAsserted {
+            assertThat(meterRegistry.counter("micro_batch_flush").count()).isGreaterThan(0.0)
+        }
 
         // Then: Flush duration timer should exist
         val timer = meterRegistry.get("micro_batch_flush_duration").timer()
@@ -220,7 +222,9 @@ class DedupeMicroBatchWriterTest {
         writer.flushNow()
 
         // Then: Wait for flush to complete
-        Thread.sleep(200)
+        await().atMost(Duration.ofSeconds(2)).untilAsserted {
+            assertThat(meterRegistry.counter("micro_batch_flush").count()).isGreaterThan(0.0)
+        }
 
         val flushCount = meterRegistry.counter("micro_batch_flush").count()
         assertThat(flushCount).isGreaterThan(0.0)

--- a/module-infra/src/test/kotlin/maple/expectation/infrastructure/external/impl/MetricsNexonApiClientWrapperTest.kt
+++ b/module-infra/src/test/kotlin/maple/expectation/infrastructure/external/impl/MetricsNexonApiClientWrapperTest.kt
@@ -1,0 +1,76 @@
+package maple.expectation.infrastructure.external.impl
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import java.util.concurrent.CompletableFuture
+import maple.expectation.infrastructure.external.NexonApiClient
+import maple.expectation.infrastructure.external.dto.v2.EquipmentResponse
+import maple.expectation.infrastructure.ratelimit.NexonRateLimiter
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+
+@ExtendWith(MockitoExtension::class)
+@DisplayName("MetricsNexonApiClientWrapper permit lifecycle tests")
+class MetricsNexonApiClientWrapperTest {
+
+    @Mock
+    private lateinit var delegate: NexonApiClient
+
+    private lateinit var meterRegistry: SimpleMeterRegistry
+    private lateinit var rateLimiter: NexonRateLimiter
+    private lateinit var wrapper: MetricsNexonApiClientWrapper
+
+    @BeforeEach
+    fun setUp() {
+        meterRegistry = SimpleMeterRegistry()
+        rateLimiter = NexonRateLimiter(2, meterRegistry)
+        wrapper = MetricsNexonApiClientWrapper(delegate, meterRegistry, rateLimiter)
+    }
+
+    @Test
+    @DisplayName("delegate가 Future를 반환하기 전에 예외를 던져도 permit이 누수되지 않는다")
+    fun `should release permit when delegate throws synchronously`() {
+        whenever(delegate.getItemDataByOcid("ocid-sync-fail"))
+            .thenThrow(IllegalStateException("sync failure"))
+
+        val future = wrapper.getItemDataByOcid("ocid-sync-fail")
+
+        assertThatThrownBy { future.join() }
+            .hasCauseInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("sync failure")
+        assertThat(rateLimiter.availablePermits()).isEqualTo(2)
+    }
+
+    @Test
+    @DisplayName("비동기 실패 경로에서도 permit이 정상 반환된다")
+    fun `should release permit on async failure`() {
+        whenever(delegate.getItemDataByOcid("ocid-async-fail"))
+            .thenReturn(CompletableFuture.failedFuture(RuntimeException("async failure")))
+
+        val future = wrapper.getItemDataByOcid("ocid-async-fail")
+
+        assertThatThrownBy { future.join() }
+            .hasCauseInstanceOf(RuntimeException::class.java)
+            .hasMessageContaining("async failure")
+        assertThat(rateLimiter.availablePermits()).isEqualTo(2)
+    }
+
+    @Test
+    @DisplayName("성공 경로에서도 permit이 정상 반환된다")
+    fun `should release permit on success`() {
+        val response = EquipmentResponse(characterClass = "Warrior")
+        whenever(delegate.getItemDataByOcid("ocid-ok"))
+            .thenReturn(CompletableFuture.completedFuture(response))
+
+        val result = wrapper.getItemDataByOcid("ocid-ok").join()
+
+        assertThat(result).isEqualTo(response)
+        assertThat(rateLimiter.availablePermits()).isEqualTo(2)
+    }
+}

--- a/module-infra/src/test/kotlin/maple/expectation/infrastructure/fanout/NexonFanOutBatchLoaderTest.kt
+++ b/module-infra/src/test/kotlin/maple/expectation/infrastructure/fanout/NexonFanOutBatchLoaderTest.kt
@@ -1,0 +1,176 @@
+package maple.expectation.infrastructure.fanout
+
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.CompletableFuture
+import maple.expectation.common.function.ThrowingSupplier
+import maple.expectation.core.port.out.FanOutQueuePort
+import maple.expectation.infrastructure.executor.LogicExecutor
+import maple.expectation.infrastructure.executor.TaskContext
+import maple.expectation.infrastructure.executor.function.ThrowingRunnable
+import maple.expectation.infrastructure.executor.strategy.ExceptionTranslator
+import maple.expectation.infrastructure.external.NexonApiClient
+import maple.expectation.infrastructure.external.dto.v2.EquipmentResponse
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.http.HttpHeaders
+import org.springframework.web.reactive.function.client.WebClientResponseException
+
+@ExtendWith(MockitoExtension::class)
+@DisplayName("NexonFanOutBatchLoader Tests")
+class NexonFanOutBatchLoaderTest {
+
+    @Mock
+    private lateinit var nexonApiClient: NexonApiClient
+
+    @Mock
+    private lateinit var fanOutQueuePort: FanOutQueuePort
+
+    private val executor: LogicExecutor = ImmediateLogicExecutor()
+
+    private lateinit var sut: NexonFanOutBatchLoader
+
+    private val sampleResponse = EquipmentResponse(characterClass = "Archer")
+
+    @AfterEach
+    fun tearDown() {
+        if (::sut.isInitialized) {
+            sut.shutdown()
+        }
+    }
+
+    @Test
+    @DisplayName("빈 OCID 목록이면 빈 결과를 반환한다")
+    fun `load returns empty map when ocids is empty`() {
+        sut = NexonFanOutBatchLoader(nexonApiClient, fanOutQueuePort, executor)
+
+        val result = sut.load(emptyList())
+
+        assertThat(result).isEmpty()
+        verify(nexonApiClient, never()).getItemDataByOcid(any())
+        verify(fanOutQueuePort, never()).enqueue(any(), any())
+    }
+
+    @Test
+    @DisplayName("정상 응답은 OCID-장비 매핑으로 반환한다")
+    fun `load returns successful responses`() {
+        sut = NexonFanOutBatchLoader(nexonApiClient, fanOutQueuePort, executor)
+        whenever(nexonApiClient.getItemDataByOcid("ocid-1")).thenReturn(CompletableFuture.completedFuture(sampleResponse))
+
+        val result = sut.load(listOf("ocid-1"))
+
+        assertThat(result).containsEntry("ocid-1", sampleResponse)
+        verify(fanOutQueuePort, never()).enqueue(any(), any())
+    }
+
+    @Test
+    @DisplayName("429 에러면 재시도 큐에 enqueue 하고 결과에서 제외한다")
+    fun `load enqueues retry when 429 occurs`() {
+        sut = NexonFanOutBatchLoader(nexonApiClient, fanOutQueuePort, executor)
+        val tooManyRequests = WebClientResponseException.create(
+            429,
+            "Too Many Requests",
+            HttpHeaders.EMPTY,
+            "rate limited".toByteArray(StandardCharsets.UTF_8),
+            StandardCharsets.UTF_8,
+        )
+        whenever(nexonApiClient.getItemDataByOcid("ocid-429")).thenReturn(CompletableFuture.failedFuture(tooManyRequests))
+
+        val result = sut.load(listOf("ocid-429"))
+
+        assertThat(result).isEmpty()
+        verify(fanOutQueuePort, times(1)).enqueue(eq("ocid-429"), eq("batch"))
+    }
+
+    @Test
+    @DisplayName("429가 아닌 에러면 enqueue 하지 않고 결과에서 제외한다")
+    fun `load does not enqueue retry when non-429 error occurs`() {
+        sut = NexonFanOutBatchLoader(nexonApiClient, fanOutQueuePort, executor)
+        whenever(nexonApiClient.getItemDataByOcid("ocid-500"))
+            .thenReturn(CompletableFuture.failedFuture(IllegalStateException("boom")))
+
+        val result = sut.load(listOf("ocid-500"))
+
+        assertThat(result).isEmpty()
+        verify(fanOutQueuePort, never()).enqueue(any(), any())
+    }
+
+    @Test
+    @DisplayName("is429는 CompletionException 래핑 체인에서도 429를 감지한다")
+    fun `is429 detects wrapped WebClientResponseException`() {
+        val tooManyRequests = WebClientResponseException.create(
+            429,
+            "Too Many Requests",
+            HttpHeaders.EMPTY,
+            null,
+            null,
+        )
+        val wrapped = RuntimeException("outer", RuntimeException("middle", tooManyRequests))
+
+        val result = NexonFanOutBatchLoader.is429(wrapped)
+
+        assertThat(result).isTrue()
+    }
+
+    private class ImmediateLogicExecutor : LogicExecutor {
+        override fun <T> execute(task: ThrowingSupplier<T>, context: TaskContext): T = task.get()
+
+        override fun <T> executeOrDefault(task: ThrowingSupplier<T>, defaultValue: T, context: TaskContext): T =
+            runCatching { task.get() ?: defaultValue }.getOrElse { defaultValue }
+
+        override fun executeVoid(task: ThrowingRunnable, context: TaskContext) {
+            task.run()
+        }
+
+        override fun executeVoidJava(task: Runnable, context: TaskContext) {
+            task.run()
+        }
+
+        override fun <T> executeWithFinally(task: ThrowingSupplier<T>, finallyBlock: Runnable, context: TaskContext): T =
+            try {
+                task.get()
+            } finally {
+                finallyBlock.run()
+            }
+
+        override fun <T> executeWithTranslation(
+            task: ThrowingSupplier<T>,
+            customTranslator: ExceptionTranslator,
+            context: TaskContext,
+        ): T = try {
+            task.get()
+        } catch (e: Exception) {
+            throw customTranslator.translate(e, context)
+        }
+
+        override fun <T> executeWithFallback(task: ThrowingSupplier<T>, fallback: (Throwable) -> T, context: TaskContext): T =
+            runCatching { task.get() }.getOrElse { fallback(it) }
+
+        override fun <T> executeWithFallback(task: ThrowingSupplier<T>, fallback: ExceptionTranslator, context: TaskContext): T =
+            try {
+                task.get()
+            } catch (e: Exception) {
+                throw fallback.translate(e, context)
+            }
+
+        override fun <T> executeOrCatch(task: ThrowingSupplier<T>, recovery: (Throwable) -> T, context: TaskContext): T =
+            runCatching { task.get() }.getOrElse { recovery(it) }
+
+        override fun <T> executeOrCatch(task: ThrowingSupplier<T>, recovery: ExceptionTranslator, context: TaskContext): T =
+            try {
+                task.get()
+            } catch (e: Exception) {
+                throw recovery.translate(e, context)
+            }
+    }
+}

--- a/module-web/src/main/kotlin/maple/expectation/web/dto/v4/EquipmentExpectationResponseV4.kt
+++ b/module-web/src/main/kotlin/maple/expectation/web/dto/v4/EquipmentExpectationResponseV4.kt
@@ -23,6 +23,9 @@ data class EquipmentExpectationResponseV4(
     companion object {
         @JvmStatic
         fun builder() = Builder()
+
+        private fun <T : Any> required(value: T?, fieldName: String): T =
+            requireNotNull(value) { "Missing required field: $fieldName" }
     }
 
     class Builder {
@@ -44,14 +47,14 @@ data class EquipmentExpectationResponseV4(
         fun maxPresetNo(v: Int) = apply { maxPresetNo = v }
         fun presets(v: List<PresetExpectation>) = apply { presets = v }
         fun build() = EquipmentExpectationResponseV4(
-            userIgn = userIgn!!,
-            calculatedAt = calculatedAt!!,
+            userIgn = required(userIgn, "userIgn"),
+            calculatedAt = required(calculatedAt, "calculatedAt"),
             fromCache = fromCache,
-            totalExpectedCost = totalExpectedCost!!,
-            totalCostText = totalCostText!!,
-            totalCostBreakdown = totalCostBreakdown!!,
+            totalExpectedCost = required(totalExpectedCost, "totalExpectedCost"),
+            totalCostText = required(totalCostText, "totalCostText"),
+            totalCostBreakdown = required(totalCostBreakdown, "totalCostBreakdown"),
             maxPresetNo = maxPresetNo,
-            presets = presets!!,
+            presets = required(presets, "presets"),
         )
     }
 
@@ -127,24 +130,24 @@ data class EquipmentExpectationResponseV4(
             fun starforceExpectation(v: StarforceExpectationDto) = apply { starforceExpectation = v }
             fun flameExpectation(v: FlameExpectationDto) = apply { flameExpectation = v }
             fun build() = ItemExpectationV4(
-                itemName = itemName!!,
-                itemIcon = itemIcon!!,
-                itemPart = itemPart!!,
+                itemName = required(itemName, "itemName"),
+                itemIcon = required(itemIcon, "itemIcon"),
+                itemPart = required(itemPart, "itemPart"),
                 itemLevel = itemLevel,
-                expectedCost = expectedCost!!,
-                expectedCostText = expectedCostText!!,
-                costBreakdown = costBreakdown!!,
-                enhancePath = enhancePath!!,
+                expectedCost = required(expectedCost, "expectedCost"),
+                expectedCostText = required(expectedCostText, "expectedCostText"),
+                costBreakdown = required(costBreakdown, "costBreakdown"),
+                enhancePath = required(enhancePath, "enhancePath"),
                 potentialGrade = potentialGrade,
                 additionalPotentialGrade = additionalPotentialGrade,
                 currentStar = currentStar,
                 targetStar = targetStar,
                 isNoljang = isNoljang,
                 specialRingLevel = specialRingLevel,
-                blackCubeExpectation = blackCubeExpectation!!,
-                additionalCubeExpectation = additionalCubeExpectation!!,
-                starforceExpectation = starforceExpectation!!,
-                flameExpectation = flameExpectation!!,
+                blackCubeExpectation = required(blackCubeExpectation, "blackCubeExpectation"),
+                additionalCubeExpectation = required(additionalCubeExpectation, "additionalCubeExpectation"),
+                starforceExpectation = required(starforceExpectation, "starforceExpectation"),
+                flameExpectation = required(flameExpectation, "flameExpectation"),
             )
         }
     }
@@ -187,12 +190,12 @@ data class EquipmentExpectationResponseV4(
             fun targetGrade(v: String) = apply { targetGrade = v }
             fun potential(v: String) = apply { potential = v }
             fun build() = CubeExpectationDto(
-                expectedCost = expectedCost!!,
-                expectedCostText = expectedCostText!!,
-                expectedTrials = expectedTrials!!,
-                currentGrade = currentGrade!!,
-                targetGrade = targetGrade!!,
-                potential = potential!!,
+                expectedCost = required(expectedCost, "expectedCost"),
+                expectedCostText = required(expectedCostText, "expectedCostText"),
+                expectedTrials = required(expectedTrials, "expectedTrials"),
+                currentGrade = required(currentGrade, "currentGrade"),
+                targetGrade = required(targetGrade, "targetGrade"),
+                potential = required(potential, "potential"),
             )
         }
     }
@@ -250,12 +253,12 @@ data class EquipmentExpectationResponseV4(
                 currentStar = currentStar,
                 targetStar = targetStar,
                 isNoljang = isNoljang,
-                costWithoutDestroyPrevention = costWithoutDestroyPrevention!!,
-                costWithoutDestroyPreventionText = costWithoutDestroyPreventionText!!,
-                expectedDestroyCountWithout = expectedDestroyCountWithout!!,
-                costWithDestroyPrevention = costWithDestroyPrevention!!,
-                costWithDestroyPreventionText = costWithDestroyPreventionText!!,
-                expectedDestroyCountWith = expectedDestroyCountWith!!,
+                costWithoutDestroyPrevention = required(costWithoutDestroyPrevention, "costWithoutDestroyPrevention"),
+                costWithoutDestroyPreventionText = required(costWithoutDestroyPreventionText, "costWithoutDestroyPreventionText"),
+                expectedDestroyCountWithout = required(expectedDestroyCountWithout, "expectedDestroyCountWithout"),
+                costWithDestroyPrevention = required(costWithDestroyPrevention, "costWithDestroyPrevention"),
+                costWithDestroyPreventionText = required(costWithDestroyPreventionText, "costWithDestroyPreventionText"),
+                expectedDestroyCountWith = required(expectedDestroyCountWith, "expectedDestroyCountWith"),
             )
         }
     }
@@ -286,9 +289,9 @@ data class EquipmentExpectationResponseV4(
             fun eternalFlameTrials(v: Double) = apply { eternalFlameTrials = v }
             fun abyssFlameTrials(v: Double) = apply { abyssFlameTrials = v }
             fun build() = FlameExpectationDto(
-                powerfulFlameTrials = powerfulFlameTrials!!,
-                eternalFlameTrials = eternalFlameTrials!!,
-                abyssFlameTrials = abyssFlameTrials!!,
+                powerfulFlameTrials = required(powerfulFlameTrials, "powerfulFlameTrials"),
+                eternalFlameTrials = required(eternalFlameTrials, "eternalFlameTrials"),
+                abyssFlameTrials = required(abyssFlameTrials, "abyssFlameTrials"),
             )
         }
     }

--- a/module-web/src/test/kotlin/maple/expectation/web/dto/v4/EquipmentExpectationResponseV4BuilderTest.kt
+++ b/module-web/src/test/kotlin/maple/expectation/web/dto/v4/EquipmentExpectationResponseV4BuilderTest.kt
@@ -1,0 +1,94 @@
+package maple.expectation.web.dto.v4
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("EquipmentExpectationResponseV4 Builder null-safety tests")
+class EquipmentExpectationResponseV4BuilderTest {
+
+    @Test
+    @DisplayName("필수 필드 누락 시 명시적인 IllegalArgumentException을 던진다")
+    fun `builder should fail fast with required field message`() {
+        assertThatThrownBy {
+            EquipmentExpectationResponseV4.builder().build()
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Missing required field: userIgn")
+    }
+
+    @Test
+    @DisplayName("모든 필수 필드가 있으면 DTO를 생성한다")
+    fun `builder should build response when all required fields are present`() {
+        val cube = EquipmentExpectationResponseV4.CubeExpectationDto.builder()
+            .expectedCost(1.0)
+            .expectedCostText("1")
+            .expectedTrials(2.0)
+            .currentGrade("UNIQUE")
+            .targetGrade("LEGENDARY")
+            .potential("STR%")
+            .build()
+
+        val starforce = EquipmentExpectationResponseV4.StarforceExpectationDto.builder()
+            .currentStar(17)
+            .targetStar(22)
+            .isNoljang(false)
+            .costWithoutDestroyPrevention(100.0)
+            .costWithoutDestroyPreventionText("100")
+            .expectedDestroyCountWithout(0.1)
+            .costWithDestroyPrevention(120.0)
+            .costWithDestroyPreventionText("120")
+            .expectedDestroyCountWith(0.05)
+            .build()
+
+        val flame = EquipmentExpectationResponseV4.FlameExpectationDto.builder()
+            .powerfulFlameTrials(10.0)
+            .eternalFlameTrials(5.0)
+            .abyssFlameTrials(3.0)
+            .build()
+
+        val item = EquipmentExpectationResponseV4.ItemExpectationV4.builder()
+            .itemName("앱솔랩스 모자")
+            .itemIcon("icon")
+            .itemPart("모자")
+            .itemLevel(160)
+            .expectedCost(1000.0)
+            .expectedCostText("1,000")
+            .costBreakdown(EquipmentExpectationResponseV4.CostBreakdownDto(1.0, 2.0, 3.0, 4.0))
+            .enhancePath("black_cube")
+            .currentStar(17)
+            .targetStar(22)
+            .isNoljang(false)
+            .specialRingLevel(0)
+            .blackCubeExpectation(cube)
+            .additionalCubeExpectation(cube)
+            .starforceExpectation(starforce)
+            .flameExpectation(flame)
+            .build()
+
+        val response = EquipmentExpectationResponseV4.builder()
+            .userIgn("테스터")
+            .calculatedAt(java.time.LocalDateTime.now())
+            .fromCache(false)
+            .totalExpectedCost(1000.0)
+            .totalCostText("1,000")
+            .totalCostBreakdown(EquipmentExpectationResponseV4.CostBreakdownDto(1.0, 2.0, 3.0, 4.0))
+            .maxPresetNo(1)
+            .presets(
+                listOf(
+                    EquipmentExpectationResponseV4.PresetExpectation(
+                        presetNo = 1,
+                        totalExpectedCost = 1000.0,
+                        totalCostText = "1,000",
+                        costBreakdown = EquipmentExpectationResponseV4.CostBreakdownDto(1.0, 2.0, 3.0, 4.0),
+                        items = listOf(item),
+                    ),
+                ),
+            )
+            .build()
+
+        assertThat(response.userIgn).isEqualTo("테스터")
+        assertThat(response.presets).hasSize(1)
+    }
+}


### PR DESCRIPTION
### Motivation

- Enforce stronger Nexon API key/account validation to prevent accepting malformed or unrelated API keys and to address issue #667 requiring account_id-based identification. 
- Prevent permit leaks in the Nexon rate limiter when the delegated client throws synchronously or when futures fail. 
- Improve null-safety and developer-friendly errors in DTO builders and reduce flaky tests caused by `Thread.sleep` usage. 

### Description

- Added an overall remediation plan document at `docs/09_Plans/open-issues-remediation-plan-2026-04-17.md` outlining phased issue fixes and PR practices. 
- Hardened `ApiKeyValidator` by trimming and null-checking `characterName` and `ocid`, collecting non-blank OCIDs, extracting and validating `account_id` from `CharacterListResponse.accountList`, and throwing clearer `InvalidApiKeyException` when necessary. 
- Replaced unsafe `!!` usages in `EquipmentExpectationResponseV4` builder with a `required` helper that calls `requireNotNull` to provide explicit missing-field messages and added null-safety across nested builders. 
- Fixed permit leak in `MetricsNexonApiClientWrapper.recordApiCall` by catching synchronous exceptions thrown before a `CompletableFuture` is returned so the rate limiter permit is released and errors are recorded. 
- Replaced `Thread.sleep` waits in `DedupeMicroBatchWriterTest` with Awaitility (`await().atMost(...)`) to make timing-sensitive assertions reliable. 
- Added unit tests: `ApiKeyValidatorTest`, `MetricsNexonApiClientWrapperTest`, `NexonFanOutBatchLoaderTest`, and `EquipmentExpectationResponseV4BuilderTest` to validate the above behaviors and added permit/async lifecycle tests for the wrapper. 

### Testing

- Ran `ApiKeyValidatorTest` which asserts account_id/OCID validation and ownership behavior and it passed. 
- Ran `MetricsNexonApiClientWrapperTest` which verifies permit release on synchronous, async failure, and success paths and it passed. 
- Ran `NexonFanOutBatchLoaderTest` which covers empty input, success, 429 retry enqueueing, and non-429 failures and it passed. 
- Ran `DedupeMicroBatchWriterTest` with `Awaitility` updates and `EquipmentExpectationResponseV4BuilderTest` for builder null-safety and both tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1ae942af0832db7cbfaf243f07192)