### PR TITLE
FIX : Codex review P0-P2 이슈 픽스 (DLQ, 계정 인증, SingleFlight, lifecycle, 백프레셔)

### DIFF
--- a/module-app/src/main/kotlin/maple/expectation/application/service/auth/ApiKeyValidator.kt
+++ b/module-app/src/main/kotlin/maple/expectation/application/service/auth/ApiKeyValidator.kt
@@ -89,11 +89,17 @@ class ApiKeyValidator(
             throw InvalidApiKeyException("No valid character OCIDs found for API key")
         }
 
-        // 5. #667: Nexon account_id 추출 (동일 계정 = 동일 ID, API Key 무관)
-        val accountId = characterList.accountList
-            ?.asSequence()
-            ?.mapNotNull { it.accountId?.trim()?.takeIf(String::isNotBlank) }
-            ?.firstOrNull()
+        // 5. #667: 소유권을 인증한 계정에서 account_id 추출
+        val normalizedUserIgn = userIgn.trim()
+        val owningAccount = characterList.accountList
+            ?.firstOrNull { account ->
+                account.characterList.orEmpty().any { char ->
+                    char.characterName?.trim()?.equals(normalizedUserIgn, ignoreCase = true) == true
+                }
+            }
+            ?: throw InvalidApiKeyException("No matching account found for character: $userIgn")
+
+        val accountId = owningAccount.accountId?.trim()?.takeIf(String::isNotBlank)
             ?: throw InvalidApiKeyException("Nexon account_id is missing in character/list response")
 
         log.info("API key validation successful: userIgn={}, ocids={}, accountId={}", userIgn, myOcids.size, accountId)

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/batch/AdaptiveMicroBatchUserService.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/batch/AdaptiveMicroBatchUserService.kt
@@ -181,20 +181,21 @@ class AdaptiveMicroBatchUserService<T : Any>(
             return cached
         }
 
-        // Step 1.5: Backpressure — in-flight 초과 시 fail-fast
-        if (inFlightRequests.size >= MAX_IN_FLIGHT) {
-            rejectedCounter.increment()
-            log.warn { "[AdaptiveMicroBatch] Rejected: inFlight=${inFlightRequests.size}, key=$key" }
-            throw IllegalStateException("In-flight requests limit reached (${inFlightRequests.size})")
-        }
-
         // Step 2: Request Coalescing
         val newFuture = CompletableFuture<T?>()
         val existingFuture = inFlightRequests.putIfAbsent(key, newFuture)
 
-        // 이미 진행 중인 요청이 있으면 대기
+        // 이미 진행 중인 요청이 있으면 대기 (coalesced)
         if (existingFuture != null) {
             return awaitWithTimeout(existingFuture, key)
+        }
+
+        // Step 2.5: Backpressure — 새 요청만 검사 (coalesced 요청은 통과)
+        if (inFlightRequests.size > MAX_IN_FLIGHT) {
+            inFlightRequests.remove(key, newFuture)
+            rejectedCounter.increment()
+            log.warn { "[AdaptiveMicroBatch] Rejected: inFlight=${inFlightRequests.size}, key=$key" }
+            throw IllegalStateException("In-flight requests limit reached (${inFlightRequests.size})")
         }
 
         // Step 3: Adaptive Routing
@@ -212,20 +213,21 @@ class AdaptiveMicroBatchUserService<T : Any>(
             return cached
         }
 
-        // Step 1.5: Backpressure — in-flight 초과 시 fail-fast
-        if (inFlightRequests.size >= MAX_IN_FLIGHT) {
-            rejectedCounter.increment()
-            log.warn { "[AdaptiveMicroBatch] Rejected: inFlight=${inFlightRequests.size}, key=$key" }
-            throw IllegalStateException("In-flight requests limit reached (${inFlightRequests.size})")
-        }
-
         // Step 2: Request Coalescing
         val newFuture = CompletableFuture<T?>()
         val existingFuture = inFlightRequests.putIfAbsent(key, newFuture)
 
-        // 이미 진행 중인 요청이 있으면 대기
+        // 이미 진행 중인 요청이 있으면 대기 (coalesced)
         if (existingFuture != null) {
             return awaitWithTimeoutSuspend(existingFuture, key)
+        }
+
+        // Step 2.5: Backpressure — 새 요청만 검사 (coalesced 요청은 통과)
+        if (inFlightRequests.size > MAX_IN_FLIGHT) {
+            inFlightRequests.remove(key, newFuture)
+            rejectedCounter.increment()
+            log.warn { "[AdaptiveMicroBatch] Rejected: inFlight=${inFlightRequests.size}, key=$key" }
+            throw IllegalStateException("In-flight requests limit reached (${inFlightRequests.size})")
         }
 
         // Step 3: Adaptive Routing

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/concurrency/PostgresSingleFlightStrategy.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/concurrency/PostgresSingleFlightStrategy.kt
@@ -130,11 +130,19 @@ class PostgresSingleFlightStrategy(
 
         log.debug("👑 [SingleFlight Leader] Claimed for key: {}", maskKey(key))
 
-        return asyncSupplier.get().whenComplete { result, error ->
+        asyncSupplier.get().whenComplete { result, error ->
             if (error == null && result != null) {
                 @Suppress("UNCHECKED_CAST")
                 resultCache[key] = CompletableFuture.completedFuture(result as Any)
                 log.debug("💾 [SingleFlight Leader] Cached result: {}", maskKey(key))
+            }
+
+            // Propagate to leaderFuture so followers waiting on it get unblocked
+            if (error != null) {
+                leaderFuture.completeExceptionally(error)
+            } else {
+                @Suppress("UNCHECKED_CAST")
+                (leaderFuture as CompletableFuture<Any?>).complete(result)
             }
 
             CompletableFuture.delayedExecutor(CACHE_TTL_SECONDS, TimeUnit.SECONDS)
@@ -146,6 +154,8 @@ class PostgresSingleFlightStrategy(
             lockMetrics.recordLockReleased("postgres")
             log.debug("🔓 [SingleFlight Leader] Completed: {}", maskKey(key))
         }
+
+        return leaderFuture
     }
 
     /**

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/DlqReplayWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/DlqReplayWorker.kt
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
+import org.springframework.transaction.support.TransactionTemplate
 import java.time.Instant
 
 /**
@@ -21,9 +22,10 @@ import java.time.Instant
  *
  * <h3>Flow</h3>
  * <ol>
- *   <li>Discover archived messages from pgmq.a_{queue_name} not yet tracked</li>
+ *   <li>Discover archived messages with read_ct > 1 (DLQ only, excludes single-attempt successes)</li>
  *   <li>Insert tracking records into dlq_replay_meta</li>
- *   <li>Replay eligible messages (backoff elapsed, replay_count < MAX)</li>
+ *   <li>Replay eligible messages (backoff elapsed, replay_count < MAX) inside a transaction</li>
+ *   <li>Delete tracking row on successful replay (prevents duplicate re-sends)</li>
  *   <li>Alert on permanent failures (replay_count >= MAX)</li>
  * </ol>
  *
@@ -35,6 +37,7 @@ class DlqReplayWorker(
     private val pgmqClient: PgmqClient,
     private val executor: LogicExecutor,
     private val jdbcTemplate: JdbcTemplate,
+    private val transactionTemplate: TransactionTemplate,
     private val meterRegistry: MeterRegistry,
     private val alertService: StatelessAlertService,
     private val lifecycleWrapper: ScheduledTaskLifecycleWrapper,
@@ -58,8 +61,11 @@ class DlqReplayWorker(
         if (!lifecycleWrapper.beforeTask()) return
         val context = TaskContext.of("DlqReplayWorker", "Replay")
 
-        executor.executeVoid({ doReplay() }, context)
-        lifecycleWrapper.afterTask()
+        try {
+            executor.executeVoid({ doReplay() }, context)
+        } finally {
+            lifecycleWrapper.afterTask()
+        }
     }
 
     private fun doReplay() {
@@ -78,16 +84,19 @@ class DlqReplayWorker(
     }
 
     /**
-     * PGMQ archive 테이블에서 추적되지 않은 메시지를 발견하여 dlq_replay_meta에 등록
+     * PGMQ archive 테이블에서 DLQ 메시지(read_ct > 1) 중 추적되지 않은 것을 발견하여 등록
+     *
+     * <p>read_ct > 1 필터로 성공적으로 처리된 메시지(read_ct = 1)를 제외.
+     * 오직 재시도 끝에 실패한 메시지만 추적 대상.
      */
     private fun discoverAndTrack(queueName: String) {
         val archiveTable = "pgmq.a_$queueName"
 
         val untracked = jdbcTemplate.queryForList(
-            // archive 테이블에서 msg_id 목록 조회 + 이미 추적 중인 것 제외
             """
             SELECT a.msg_id FROM $archiveTable a
-            WHERE NOT EXISTS (
+            WHERE a.read_ct > 1
+            AND NOT EXISTS (
                 SELECT 1 FROM dlq_replay_meta m
                 WHERE m.queue_name = ? AND m.message_id = a.msg_id
             )
@@ -102,7 +111,7 @@ class DlqReplayWorker(
             insertTracking(queueName, msgId)
         }
 
-        log.info("[DlqReplayWorker] Discovered {} new archived messages in {}", untracked.size, queueName)
+        log.info("[DlqReplayWorker] Discovered {} new DLQ messages in {}", untracked.size, queueName)
     }
 
     private fun insertTracking(queueName: String, messageId: Long) {
@@ -156,6 +165,13 @@ class DlqReplayWorker(
         return Instant.now().isAfter(nextAttempt)
     }
 
+    /**
+     * 메시지를 트랜잭션 내에서 재발행
+     *
+     * <p>- TransactionTemplate으로 감싸 PgmqClient TX 검증 충족
+     * <p>- sendRawJson으로 JSON 재직렬화(double-encoding) 방지
+     * <p>- 성공 시 tracking row 삭제 (중복 재발행 방지)
+     */
     private fun replaySingleMessage(candidate: ReplayCandidate) {
         val archiveTable = "pgmq.a_${candidate.queueName}"
 
@@ -170,8 +186,10 @@ class DlqReplayWorker(
             return
         }
 
-        pgmqClient.send(candidate.queueName, payload)
-        incrementReplayCount(candidate)
+        transactionTemplate.executeWithoutResult {
+            pgmqClient.sendRawJson(candidate.queueName, payload)
+            deleteTracking(candidate)
+        }
 
         meterRegistry.counter("pgmq.worker.replay", "queue", candidate.queueName).increment()
         log.info(
@@ -180,9 +198,15 @@ class DlqReplayWorker(
         )
     }
 
-    private fun incrementReplayCount(candidate: ReplayCandidate) {
+    /**
+     * 성공적으로 재발행된 tracking row 삭제
+     *
+     * <p>삭제하지 않으면 다음 스케줄에서 동일 메시지가 중복 발행됨.
+     * 메시지가 다시 실패하면 PgmqWorker가 archive하고 discoverAndTrack이 재등록함.
+     */
+    private fun deleteTracking(candidate: ReplayCandidate) {
         jdbcTemplate.update(
-            "UPDATE dlq_replay_meta SET replay_count = replay_count + 1, last_replayed_at = NOW() WHERE queue_name = ? AND message_id = ?",
+            "DELETE FROM dlq_replay_meta WHERE queue_name = ? AND message_id = ?",
             candidate.queueName,
             candidate.messageId,
         )

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/PgmqClient.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/PgmqClient.kt
@@ -73,6 +73,30 @@ class PgmqClient(
     }
 
     /**
+     * Raw JSON 메시지 발행 (DLQ Replay 전용)
+     *
+     * <p>이미 직렬화된 JSON 문자열을 그대로 JSONB로 전송.
+     * Jackson 재직렬화로 인한 double-encoding 방지.
+     *
+     * @param queueName 큐 이름
+     * @param json 직렬화된 JSON 문자열
+     * @return 메시지 ID
+     */
+    @CircuitBreaker(name = "pgmq", fallbackMethod = "sendRawJsonFallback")
+    fun sendRawJson(queueName: String, json: String): Long {
+        if (config.transactionCheckEnabled && !TransactionSynchronizationManager.isActualTransactionActive()) {
+            throw PgmqPublishException(
+                "pgmqClient.sendRawJson('$queueName') must be called within @Transactional.",
+            )
+        }
+        val context = TaskContext.of("PgmqClient", "SendRaw", queueName)
+        val translator = ExceptionTranslator { e, _ ->
+            PgmqPublishException("Failed to send raw JSON to queue: $queueName", e)
+        }
+        return executor.executeWithTranslation({ performSendRawJson(queueName, json) }, translator, context)
+    }
+
+    /**
      * 메시지 소비
      *
      * <p>SKIP LOCKED 기반으로 여러 Worker가 동시에 안전하게 소비.
@@ -237,6 +261,20 @@ class PgmqClient(
         return messageId
     }
 
+    private fun performSendRawJson(queueName: String, json: String): Long {
+        val result = jdbcTemplate.queryForMap(
+            "SELECT pgmq.send(?, ?::jsonb) as msg_id",
+            queueName,
+            json,
+        )
+
+        val messageId = (result["msg_id"] as Number?)?.toLong()
+            ?: throw PgmqPublishException("Failed to get message ID from send result")
+
+        log.debug("📤 [PGMQ] Sent raw JSON: queue={}, msgId={}", queueName, messageId)
+        return messageId
+    }
+
     private fun <T : Any> performRead(
         queueName: String,
         clazz: Class<T>,
@@ -371,6 +409,11 @@ class PgmqClient(
     private fun <T : Any> sendFallback(queueName: String, message: T, e: Throwable): Long {
         log.error("⚡ [PGMQ] Circuit Breaker OPEN - send fallback: queue={}", queueName, e)
         throw PgmqPublishException("Circuit Breaker is OPEN for send operation", e)
+    }
+
+    private fun sendRawJsonFallback(queueName: String, json: String, e: Throwable): Long {
+        log.error("⚡ [PGMQ] Circuit Breaker OPEN - sendRawJson fallback: queue={}", queueName, e)
+        throw PgmqPublishException("Circuit Breaker is OPEN for sendRawJson operation", e)
     }
 
     private fun <T : Any> readFallback(

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/PgmqWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/PgmqWorker.kt
@@ -107,46 +107,48 @@ abstract class PgmqWorker<T : Any>(
 
         val context = TaskContext.of("PgmqWorker", "ProcessBatch", queueName)
 
-        executor.executeVoid({
-            val batchSize = workerSettings.batchSize ?: config.common.batchSize
-            val visibilityTimeout = config.common.visibilityTimeoutSec
+        try {
+            executor.executeVoid({
+                val batchSize = workerSettings.batchSize ?: config.common.batchSize
+                val visibilityTimeout = config.common.visibilityTimeoutSec
 
-            val messages = pgmqClient.read(queueName, payloadClass, batchSize, visibilityTimeout)
+                val messages = pgmqClient.read(queueName, payloadClass, batchSize, visibilityTimeout)
 
-            if (messages.isEmpty()) {
-                return@executeVoid
-            }
+                if (messages.isEmpty()) {
+                    return@executeVoid
+                }
 
-            log.debug("📥 [{}] Processing {} messages", queueName, messages.size)
+                log.debug("📥 [{}] Processing {} messages", queueName, messages.size)
 
-            // ADR-700: 배치 pre-warm (OCID dedup + equipment cache pre-warm)
-            preWarmBatch(messages)
+                // ADR-700: 배치 pre-warm (OCID dedup + equipment cache pre-warm)
+                preWarmBatch(messages)
 
-            // ADR-355: Batch-level aggregate metrics
-            val batchStart = System.nanoTime()
-            var successCount = 0
-            var failCount = 0
+                // ADR-355: Batch-level aggregate metrics
+                val batchStart = System.nanoTime()
+                var successCount = 0
+                var failCount = 0
 
-            val futures = messages.map { message ->
-                CompletableFuture.supplyAsync({
-                    processSingleMessage(message)
-                }, workerPool)
-            }
-            CompletableFuture.allOf(*futures.toTypedArray()).join()
-            futures.forEach { future ->
-                if (future.get()) successCount++ else failCount++
-            }
+                val futures = messages.map { message ->
+                    CompletableFuture.supplyAsync({
+                        processSingleMessage(message)
+                    }, workerPool)
+                }
+                CompletableFuture.allOf(*futures.toTypedArray()).join()
+                futures.forEach { future ->
+                    if (future.get()) successCount++ else failCount++
+                }
 
-            val batchDuration = System.nanoTime() - batchStart
-            meterRegistry.counter("pgmq.worker.processed", "queue", queueName, "status", "success")
-                .increment(successCount.toDouble())
-            meterRegistry.counter("pgmq.worker.processed", "queue", queueName, "status", "failed")
-                .increment(failCount.toDouble())
-            meterRegistry.timer("pgmq.worker.batch.latency", "queue", queueName)
-                .record(batchDuration, TimeUnit.NANOSECONDS)
-        }, context)
-
-        lifecycleWrapper.afterTask()
+                val batchDuration = System.nanoTime() - batchStart
+                meterRegistry.counter("pgmq.worker.processed", "queue", queueName, "status", "success")
+                    .increment(successCount.toDouble())
+                meterRegistry.counter("pgmq.worker.processed", "queue", queueName, "status", "failed")
+                    .increment(failCount.toDouble())
+                meterRegistry.timer("pgmq.worker.batch.latency", "queue", queueName)
+                    .record(batchDuration, TimeUnit.NANOSECONDS)
+            }, context)
+        } finally {
+            lifecycleWrapper.afterTask()
+        }
     }
 
     /**

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/ratelimit/filter/RateLimitingFilter.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/ratelimit/filter/RateLimitingFilter.kt
@@ -12,12 +12,19 @@ import maple.expectation.infrastructure.ratelimit.RateLimitContext
 import maple.expectation.infrastructure.ratelimit.RateLimitingFacade
 import maple.expectation.infrastructure.ratelimit.config.RateLimitProperties
 import maple.expectation.infrastructure.security.AuthenticatedUser
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.security.core.Authentication
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
 
 @Component
+@ConditionalOnProperty(
+    prefix = "ratelimit",
+    name = ["enabled"],
+    havingValue = "true",
+    matchIfMissing = true,
+)
 open class RateLimitingFilter(
     private val rateLimitingFacade: RateLimitingFacade,
     private val properties: RateLimitProperties,

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/security/config/SecurityConfig.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/security/config/SecurityConfig.kt
@@ -27,7 +27,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @EnableMethodSecurity(prePostEnabled = true)
 class SecurityConfig(
     private val jwtAuthenticationFilter: JwtAuthenticationFilter,
-    private val rateLimitingFilter: RateLimitingFilter,
+    private val rateLimitingFilter: RateLimitingFilter?,
 ) {
 
     @Bean
@@ -38,7 +38,7 @@ class SecurityConfig(
             .register(meterRegistry)
 
         return http
-            // CSRF 비활성화: stateless JWT API, 세션 쿠키 미사용
+            // CSRF 비활성화: stateless JWT API, 세션 쿠기 미사용
             .csrf { it.disable() }
             .cors { it.disable() }
             .formLogin { it.disable() }
@@ -67,7 +67,11 @@ class SecurityConfig(
                 entrypointCounter.increment()
                 response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized")
             } }
-            .addFilterBefore(rateLimitingFilter, JwtAuthenticationFilter::class.java)
+            .also {
+                if (rateLimitingFilter != null) {
+                    it.addFilterBefore(rateLimitingFilter, JwtAuthenticationFilter::class.java)
+                }
+            }
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
             .build()
     }


### PR DESCRIPTION
## Summary
PR #712 이후 Codex 리뷰어가 발견한 P0~P2 이슈 전체 픽스:

**P0**
- DlqReplayWorker: `read_ct > 1` 필터로 성공 메시지 제외 (DLQ만 추적)

**P1**
- DlqReplayWorker: TransactionTemplate + `sendRawJson`으로 재전송 (TX 누락 + 이중 직렬화 해결)
- DlqReplayWorker: 성공 재전송 후 tracking row 삭제 (중복 재전송 방지)
- ApiKeyValidator: 소유 계정에서 account_id 추출 (auth-integrity regression 수정)
- PostgresSingleFlightStrategy: leaderFuture 팬아웃 수정 (follower hang 해결)

**P2**
- PgmqWorker: afterTask try/finally 래핑 (lifecycle counter 누수 방지)
- AdaptiveMicroBatch: 백프레셔를 coalescing 이후로 이동 (coalesced 요청 거부 해결)

**추가**
- RateLimitingFilter `@ConditionalOnProperty` + SecurityConfig nullable 대응 (서버 기동 이슈)

## Test plan
- [x] `./gradlew test` 전체 통과 (BUILD SUCCESSFUL)
- [x] 컴파일 검증 (`--continue`) 통과
- [x] 서버 기동 확인 (HTTP 200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)