### PR TITLE
FIX : Issues #715 #716 cache_storage 마이그레이션 누락 + 버전 카운터 충돌

### DIFF
--- a/docs/01_ADR/ADR-715-716-cache-storage-migration-version-counter-fix.md
+++ b/docs/01_ADR/ADR-715-716-cache-storage-migration-version-counter-fix.md
@@ -1,0 +1,35 @@
+# ADR: cache_storage 마이그레이션 누락 수정 + 버전 카운터 충돌 해결
+
+## Status: Accepted
+
+## Issues
+
+- #715 (P0): cache_storage 테이블 CREATE 마이그레이션 누락
+- #716 (P1): TieredCache 버전 카운터 충돌로 cross-instance evict 무시
+
+## Decision
+
+### #715: V110 마이그레이션으로 cache_storage 테이블 생성
+
+`CREATE UNLOGGED TABLE IF NOT EXISTS` 사용. 기존 환경에서는 no-op, 신규 환경에서는 테이블 생성.
+
+### #716: evict() 버전 카운터 증가 + strict `<` 비교
+
+**근본 원인**: `TieredCache.evict()`가 `versionCounter.get()`을 사용하여 `put()`과 동일 버전 발행.
+
+**수정**:
+1. `evict()`에서 `versionCounter.incrementAndGet()` 사용
+2. PostgresNotifySubscriber에서 `<=` → `<` (strict less-than)
+3. EVICT 후 `clearKeyVersion()`으로 로컬 keyVersions 정리
+
+## Rejected Alternatives
+
+| 대안 | 기각 이유 |
+|------|----------|
+| EVICT version check 완전 제거 | out-of-order notification에 대한 방어막 상실 |
+| L2 기반 버전 관리 (version column 추가) | DB 왕복 오버헤드, 스키마 변경 범위 과대 |
+| 공유 PostgreSQL SEQUENCE | DB 왕복 오버헤드 |
+| Instance별 version prefix | 복잡도 증가, 디버깅 어려움 |
+
+## Confidence: high
+## Scope-risk: narrow

--- a/docs/09_Plans/issues-715-716-cache-storage-migration-version-counter-fix.md
+++ b/docs/09_Plans/issues-715-716-cache-storage-migration-version-counter-fix.md
@@ -1,0 +1,91 @@
+# Issues #715 & #716: cache_storage 마이그레이션 누락 + 버전 카운터 충돌 수정 계획
+
+## 배경
+
+Issue #704 Multi-Instance Cache Invalidation Test 구현 중 두 가지 버그 발견.
+
+## Issue #715 (P0): cache_storage 테이블 CREATE 마이그레이션 누락
+
+**문제**: `cache_storage` 테이블이 코드베이스 어디에도 CREATE되지 않음. V102, V107은 인덱스만 생성. `PostgresL2CacheStrategy`는 해당 테이블에 SELECT/INSERT/DELETE를 실행.
+
+**영향**: 신규 환경 배포 시 L2 캐시(PostgreSQL) 전체 기능 동작 안 함.
+
+**해결**: V110 마이그레이션으로 `CREATE UNLOGGED TABLE IF NOT EXISTS` 추가.
+
+## Issue #716 (P1): TieredCache 버전 카운터 충돌
+
+**문제**: `TieredCache.evict()`가 `versionCounter.get()`을 사용하여 `put()`과 동일 버전 발행. 각 인스턴스의 counter가 `AtomicLong(0)`에서 독립 시작하므로 cross-instance 버전 충돌 발생.
+
+**근본 원인** (Critic 발견):
+- `TieredCache.kt:112` — `put()`: `versionCounter.incrementAndGet()` (증가)
+- `TieredCache.kt:138` — `evict()`: `versionCounter.get()` (증가 없음)
+- 결과: put(v=1) → evict(v=1) 동일 버전 발행
+
+**재현 경로**:
+1. Instance A: put("key") → v=1, publish evict(v=1)
+2. Instance B: get("key") → L2 backfill → keyVersions["key"]=1
+3. Instance A: evict("key") → publish evict(v=1) (동일 버전!)
+4. Instance B: `event.version(1) <= currentVersion(1)` → stale 판단, evict 스킵
+
+## Consensus Review 결과 (Architect + Critic + Code-Reviewer)
+
+### Cross-Agent Convergence
+- 3/3 동의: V110 마이그레이션 필요
+- Critic이 근본 원인 발견: evict()의 `.get()` vs put()의 `.incrementAndGet()`
+
+### Key Divergence → 합의
+- Architect: version check 제거
+- Critic: check 유지 + strict `<` + evict increment (근본 원인 해결)
+- Code-Reviewer: L2 기반 버전 관리
+- **합의**: Critic 접근 채택 (근본 원인 해결 + 방어막 유지)
+
+## 수정 계획
+
+### 1. V110 cache_storage CREATE 마이그레이션 (Issue #715)
+**파일**: `module-infra/src/main/resources/db/migration/V110__cache_storage_create_table.sql` (신규)
+```sql
+CREATE UNLOGGED TABLE IF NOT EXISTS cache_storage (
+    cache_key VARCHAR(500) PRIMARY KEY,
+    cache_value BYTEA NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL
+);
+COMMENT ON TABLE cache_storage IS 'PostgreSQL L2 cache tier (UNLOGGED). Key format: {cacheName}:v1:{actualKey}';
+```
+
+### 2. evict() 버전 카운터 수정 (Issue #716 근본 원원인, P0)
+**파일**: `module-infra/src/main/kotlin/maple/expectation/infrastructure/cache/TieredCache.kt:138`
+- `versionCounter.get()` → `versionCounter.incrementAndGet()`
+
+### 3. version check strict `<` 변경 (Issue #716, P1)
+**파일**: `module-infra/src/main/kotlin/maple/expectation/infrastructure/cache/invalidation/impl/PostgresNotifySubscriber.kt:235`
+- `event.version <= currentVersion` → `event.version < currentVersion`
+- 동일 버전은 통과시키고, 명확히 구버전만 스킵
+
+### 4. clearKeyVersion() 단일 키 삭제 메서드 추가 (P1)
+**파일**: `TieredCache.kt` — `fun clearKeyVersion(key: Any)` 추가
+**파일**: `TieredCacheManager.kt` — `fun clearKeyVersion(cacheName: String, key: Any)` 위임 메서드 추가
+
+### 5. clear()에서 keyVersions.clear() 추가 (P1)
+**파일**: `TieredCache.kt:157`
+- `l1.clear()` 후 `keyVersions.clear()` 호출 (메모리 누수 방지)
+
+### 6. EVICT 후 clearKeyVersion 호출 (P1)
+**파일**: `PostgresNotifySubscriber.kt:246`
+- L1 evict 후 `tieredCacheManager.clearKeyVersion()` 호출
+
+### 7. EVICT 로그에 version 정보 추가 (P2)
+**파일**: `PostgresNotifySubscriber.kt:248-254`
+- eventVersion, currentVersion 포함
+
+### 8. ADR 문서 작성
+**파일**: `docs/01_ADR/ADR-XXX-cache-storage-migration-version-fix.md`
+
+## 검증
+```bash
+./gradlew compileKotlin compileJava --continue
+./gradlew test
+```
+
+## 이미 검증 완료
+- 컴파일: PASS
+- 테스트: PASS (37 tasks)

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/cache/TieredCache.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/cache/TieredCache.kt
@@ -135,7 +135,7 @@ class TieredCache(
         }
         executor.executeVoid({ l1.evict(key) }, context)
         keyVersions.remove(key)
-        publishEvictEvent(key, versionCounter.get())
+        publishEvictEvent(key, versionCounter.incrementAndGet())
     }
 
     override fun clear() {
@@ -154,6 +154,7 @@ class TieredCache(
             l2FailureCounter.increment()
         }
         executor.executeVoid({ l1.clear() }, context)
+        keyVersions.clear()
         publishClearAllEvent()
     }
 
@@ -167,6 +168,10 @@ class TieredCache(
 
     fun clearKeyVersions() {
         keyVersions.clear()
+    }
+
+    fun clearKeyVersion(key: Any) {
+        keyVersions.remove(key)
     }
 
     fun getKeyVersion(key: Any): Long? = keyVersions[key]

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/cache/TieredCacheManager.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/cache/TieredCacheManager.kt
@@ -177,4 +177,8 @@ class TieredCacheManager(
     fun clearKeyVersions(cacheName: String) {
         (getCache(cacheName) as? TieredCache)?.clearKeyVersions()
     }
+
+    fun clearKeyVersion(cacheName: String, key: Any) {
+        (getCache(cacheName) as? TieredCache)?.clearKeyVersion(key)
+    }
 }

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/cache/invalidation/impl/PostgresNotifySubscriber.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/cache/invalidation/impl/PostgresNotifySubscriber.kt
@@ -232,7 +232,7 @@ class PostgresNotifySubscriber(
         when (event.type) {
             InvalidationType.EVICT -> {
                 val currentVersion = tieredCacheManager.getKeyVersion(event.cacheName, event.key ?: "")
-                if (currentVersion != null && event.version <= currentVersion) {
+                if (currentVersion != null && event.version < currentVersion) {
                     log.debug(
                         "[PostgresNotify] Stale evict skipped: cache={}, key={}, eventVersion={}, currentVersion={}",
                         event.cacheName,
@@ -243,11 +243,14 @@ class PostgresNotifySubscriber(
                     return
                 }
                 event.key?.let { l1Cache.evict(it) }
+                tieredCacheManager.clearKeyVersion(event.cacheName, event.key ?: "")
                 log.debug(
-                    "[PostgresNotify] L1 evicted: cache={}, key={}, source={}",
+                    "[PostgresNotify] L1 evicted: cache={}, key={}, source={}, eventVersion={}, currentVersion={}",
                     event.cacheName,
                     event.key,
                     event.sourceInstanceId,
+                    event.version,
+                    currentVersion,
                 )
             }
             InvalidationType.CLEAR_ALL -> {

--- a/module-infra/src/main/resources/db/migration/V110__cache_storage_create_table.sql
+++ b/module-infra/src/main/resources/db/migration/V110__cache_storage_create_table.sql
@@ -1,0 +1,11 @@
+-- V110__cache_storage_create_table.sql
+-- Issue #715: Create cache_storage table (missing from V102, V107)
+-- PostgreSQL L2 cache tier for TieredCache (ADR-022)
+
+CREATE UNLOGGED TABLE IF NOT EXISTS cache_storage (
+    cache_key VARCHAR(500) PRIMARY KEY,
+    cache_value BYTEA NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL
+);
+
+COMMENT ON TABLE cache_storage IS 'PostgreSQL L2 cache tier (UNLOGGED). Key format: {cacheName}:v1:{actualKey}';


### PR DESCRIPTION
## Summary
- **#715 (P0)**: V110 마이그레이션으로 `cache_storage` UNLOGGED 테이블 CREATE 추가 (기존 V102, V107은 인덱스만 생성)
- **#716 (P1)**: `TieredCache.evict()`가 `versionCounter.get()`을 사용해 `put()`과 동일 버전 발행하는 근본 원인 수정
- evict → incrementAndGet, version check strict `<`, clearKeyVersion 추가

## Test plan
- [x] `./gradlew compileKotlin compileJava --continue` PASS
- [x] `./gradlew test` PASS (37 tasks)
- [ ] 신규 환경에서 Flyway migrate 후 cache_storage 테이블 존재 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)