### PR TITLE
fix: resolve Codex review issues from PRs #697-727

### DIFF
--- a/module-app/src/main/java/maple/expectation/application/service/task/TaskStatusService.java
+++ b/module-app/src/main/java/maple/expectation/application/service/task/TaskStatusService.java
@@ -70,8 +70,10 @@ public class TaskStatusService implements TaskStatusPort {
       return TaskStatus.PROCESSING;
     }
 
-    // 4. 기본값: PENDING
-    return TaskStatus.PENDING;
+    // 4. Task record deleted and no signal in any queue or archive.
+    // Return NOT_FOUND (terminal) instead of PENDING to prevent infinite polling
+    // when the task record has been cleaned up.
+    return TaskStatus.NOT_FOUND;
   }
 
   private boolean isArchivedInAnyQueue(long messageId) {
@@ -86,11 +88,9 @@ public class TaskStatusService implements TaskStatusPort {
   }
 
   private long parseMessageId(String taskId) {
-    try {
-      return Long.parseLong(taskId);
-    } catch (NumberFormatException e) {
-      log.warn("[TaskStatus] Invalid taskId format: {}", taskId);
-      return -1;
-    }
+    return executor.executeOrDefault(
+        () -> Long.parseLong(taskId),
+        -1L,
+        TaskContext.of("TaskStatus", "ParseId", taskId));
   }
 }

--- a/module-app/src/test/java/maple/expectation/service/v5/TaskStatusServiceTest.java
+++ b/module-app/src/test/java/maple/expectation/service/v5/TaskStatusServiceTest.java
@@ -48,7 +48,7 @@ class TaskStatusServiceTest {
   }
 
   @Test
-  @DisplayName("mismatched view messageId does not complete unrelated task")
+  @DisplayName("mismatched view messageId does not complete unrelated task — returns NOT_FOUND when no queue/archive signal exists")
   void mismatchedViewMessageIdDoesNotCompleteTask() {
     CharacterView view = mock(CharacterView.class);
     when(view.getMessageId()).thenReturn("999");
@@ -60,7 +60,9 @@ class TaskStatusServiceTest {
 
     TaskStatus status = service.getStatus("user1", "123");
 
-    assertThat(status).isEqualTo(TaskStatus.PENDING);
+    // Returns NOT_FOUND (terminal) instead of PENDING to prevent infinite polling
+    // when task record has disappeared from all queues and archives
+    assertThat(status).isEqualTo(TaskStatus.NOT_FOUND);
   }
 
   @Test

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/batch/AdaptiveMicroBatchUserService.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/batch/AdaptiveMicroBatchUserService.kt
@@ -180,23 +180,16 @@ class AdaptiveMicroBatchUserService<T : Any>(
             return cached
         }
 
-        // Step 1.5: Backpressure — in-flight 초과 시 fail-fast
-        if (inFlightRequests.size >= MAX_IN_FLIGHT) {
-            rejectedCounter.increment()
-            log.warn { "[AdaptiveMicroBatch] Rejected: inFlight=${inFlightRequests.size}, key=$key" }
-            throw IllegalStateException("In-flight requests limit reached (${inFlightRequests.size})")
-        }
-
-        // Step 2: Request Coalescing
+        // Step 2: Request Coalescing — putIfAbsent first to allow coalesced requests through
         val newFuture = CompletableFuture<T?>()
         val existingFuture = inFlightRequests.putIfAbsent(key, newFuture)
 
-        // 이미 진행 중인 요청이 있으면 대기 (coalesced)
+        // 이미 진행 중인 요청이 있으면 대기 (coalesced) — backpressure does NOT reject coalesced requests
         if (existingFuture != null) {
             return awaitWithTimeout(existingFuture, key)
         }
 
-        // Step 2.5: Backpressure — 새 요청만 검사 (coalesced 요청은 통과)
+        // Step 2.5: Backpressure — only reject NEW keys after coalescing check
         if (inFlightRequests.size > MAX_IN_FLIGHT) {
             inFlightRequests.remove(key, newFuture)
             rejectedCounter.increment()
@@ -219,23 +212,16 @@ class AdaptiveMicroBatchUserService<T : Any>(
             return cached
         }
 
-        // Step 1.5: Backpressure — in-flight 초과 시 fail-fast
-        if (inFlightRequests.size >= MAX_IN_FLIGHT) {
-            rejectedCounter.increment()
-            log.warn { "[AdaptiveMicroBatch] Rejected: inFlight=${inFlightRequests.size}, key=$key" }
-            throw IllegalStateException("In-flight requests limit reached (${inFlightRequests.size})")
-        }
-
-        // Step 2: Request Coalescing
+        // Step 2: Request Coalescing — putIfAbsent first to allow coalesced requests through
         val newFuture = CompletableFuture<T?>()
         val existingFuture = inFlightRequests.putIfAbsent(key, newFuture)
 
-        // 이미 진행 중인 요청이 있으면 대기 (coalesced)
+        // 이미 진행 중인 요청이 있으면 대기 (coalesced) — backpressure does NOT reject coalesced requests
         if (existingFuture != null) {
             return awaitWithTimeoutSuspend(existingFuture, key)
         }
 
-        // Step 2.5: Backpressure — 새 요청만 검사 (coalesced 요청은 통과)
+        // Step 2.5: Backpressure — only reject NEW keys after coalescing check
         if (inFlightRequests.size > MAX_IN_FLIGHT) {
             inFlightRequests.remove(key, newFuture)
             rejectedCounter.increment()

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/cache/tiered/PostgresL2CacheFactory.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/cache/tiered/PostgresL2CacheFactory.kt
@@ -49,7 +49,7 @@ class PostgresL2CacheFactory(
 
     companion object {
         private val log = LoggerFactory.getLogger(PostgresL2CacheFactory::class.java)
-        private const val DEFAULT_L2_TTL_SECONDS = 15L
+        private const val DEFAULT_L2_TTL_MINUTES = 15L
     }
 
     private val cacheMap = ConcurrentHashMap<String, Cache>()
@@ -62,18 +62,25 @@ class PostgresL2CacheFactory(
      * Create a new PostgresL2CacheAdapter instance with cache-specific TTL from YAML config.
      */
     private fun createPostgresL2CacheAdapter(name: String): Cache {
-        val ttlSeconds = resolveTtlSeconds(name)
-        log.debug("[PostgresL2Factory] Creating cache: {} with TTL: {}s", name, ttlSeconds)
-        return PostgresL2CacheAdapter(name, l2Strategy, executor, meterRegistry, ttlSeconds)
+        val ttlMinutes = resolveTtlMinutes(name)
+        log.debug("[PostgresL2Factory] Creating cache: {} with TTL: {}min", name, ttlMinutes)
+        return PostgresL2CacheAdapter(name, l2Strategy, executor, meterRegistry, ttlMinutes)
     }
 
-    private fun resolveTtlSeconds(cacheName: String): Long {
+    /**
+     * Resolve TTL as minutes for the L2 strategy.
+     *
+     * The L2CacheStrategy.put() parameter is named ttlMinutes and internally
+     * converts to seconds via `plusSeconds(ttlMinutes * 60)`. We must pass
+     * raw minutes here, not pre-converted seconds.
+     */
+    private fun resolveTtlMinutes(cacheName: String): Long {
         val spec = cacheProperties.specs[cacheName]
         if (spec == null) {
-            log.warn("[PostgresL2Factory] Cache '{}' not found in specs, using default TTL={}s. Define it in cache.specs.", cacheName, DEFAULT_L2_TTL_SECONDS)
-            return DEFAULT_L2_TTL_SECONDS
+            log.warn("[PostgresL2Factory] Cache '{}' not found in specs, using default TTL={}min. Define it in cache.specs.", cacheName, DEFAULT_L2_TTL_MINUTES)
+            return DEFAULT_L2_TTL_MINUTES
         }
-        return spec.l2TtlMinutes.toLong() * 60
+        return spec.l2TtlMinutes.toLong()
     }
 }
 
@@ -92,7 +99,7 @@ class PostgresL2CacheAdapter(
     private val l2Strategy: L2CacheStrategy,
     private val executor: LogicExecutor,
     private val meterRegistry: MeterRegistry,
-    private val ttlSeconds: Long,
+    private val ttlMinutes: Long,
 ) : org.springframework.cache.support.AbstractValueAdaptingCache(true) {
 
     companion object {
@@ -138,7 +145,7 @@ class PostgresL2CacheAdapter(
                 putCounter.increment()
                 // Fix: Ensure String values are properly serialized through TypedValue wrapper
                 // The L2Strategy will wrap the value in TypedValue for type-safe deserialization
-                l2Strategy.put(key.toString(), value, ttlSeconds)
+                l2Strategy.put(key.toString(), value, ttlMinutes)
             },
             context,
         )

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/CharacterViewQueryServicePostgres.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/CharacterViewQueryServicePostgres.kt
@@ -220,5 +220,16 @@ class CharacterViewQueryServicePostgres(
         )
     }
 
+    /**
+     * Serialize entity to JSON for read model storage.
+     *
+     * TODO(#727): Currently serializes the JPA entity which diverges from the V4/V5 API DTO
+     * contract (e.g., totalExpectedCost is Long in entity vs Double in DTO, presets use
+     * PresetView vs PresetExpectation shape). The entity uses @JsonIgnore on internal fields
+     * (id, jpaVersion, version) so those are excluded, but the remaining field types and
+     * structures may not match the API response shape that the Next.js query server expects.
+     * Proper fix requires introducing a port/interface in module-core for DTO-accurate
+     * serialization, allowing module-web to provide the correct mapping implementation.
+     */
     private fun serializeEntityToJson(entity: CharacterValuationViewEntity): String = objectMapper.writeValueAsString(entity)
 }

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/DlqReplayWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/DlqReplayWorker.kt
@@ -61,11 +61,11 @@ class DlqReplayWorker(
         if (!lifecycleWrapper.beforeTask()) return
         val context = TaskContext.of("DlqReplayWorker", "Replay")
 
-        try {
-            executor.executeVoid({ doReplay() }, context)
-        } finally {
-            lifecycleWrapper.afterTask()
-        }
+        executor.executeWithFinally(
+            task = { doReplay() },
+            finallyBlock = { lifecycleWrapper.afterTask() },
+            context = context,
+        )
     }
 
     private fun doReplay() {

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/PgmqClient.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/PgmqClient.kt
@@ -340,14 +340,18 @@ class PgmqClient(
     private fun performArchiveBatch(queueName: String, messageIds: List<Long>): Int {
         val queueTable = "pgmq.q_$queueName"
         val archiveTable = "pgmq.a_$queueName"
+        validateQueueName(queueName)
         val placeholders = messageIds.map { "?" }.joinToString(",")
+        // Move rows from queue to archive table (INSERT + DELETE), not just DELETE.
+        // This preserves message history for audit and status lookups.
         return jdbcTemplate.queryForObject(
             """
             WITH deleted AS (
                 DELETE FROM $queueTable WHERE msg_id IN ($placeholders)
-                RETURNING *
+                RETURNING msg_id, read_ct, enqueued_at, vt, message
             )
-            SELECT COUNT(*) FROM $archiveTable
+            INSERT INTO $archiveTable (msg_id, read_ct, enqueued_at, vt, message)
+                SELECT msg_id, read_ct, enqueued_at, vt, message FROM deleted
             """.trimIndent(),
             Int::class.java,
             *messageIds.toTypedArray(),

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/PgmqWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/PgmqWorker.kt
@@ -133,35 +133,38 @@ abstract class PgmqWorker<T : Any>(
 
         val context = TaskContext.of("PgmqWorker", "ProcessBatch", queueName)
 
-        executor.executeVoid({
-            val batchSize = workerSettings.batchSize ?: config.common.batchSize
-            val visibilityTimeout = config.common.visibilityTimeoutSec
+        // P1-10 FIX: executeWithFinally guarantees afterTask() runs even when
+        // pgmqClient.read() or setup throws, preventing counter leak.
+        executor.executeWithFinally(
+            task = {
+                val batchSize = workerSettings.batchSize ?: config.common.batchSize
+                val visibilityTimeout = config.common.visibilityTimeoutSec
 
-            val messages = pgmqClient.read(queueName, payloadClass, batchSize, visibilityTimeout)
+                val messages = pgmqClient.read(queueName, payloadClass, batchSize, visibilityTimeout)
 
-            metrics.updateQueueDepth(pgmqClient.queueLength(queueName))
+                metrics.updateQueueDepth(pgmqClient.queueLength(queueName))
 
-            if (messages.isEmpty()) {
-                lifecycleWrapper.afterTask()
-                return@executeVoid
-            }
+                if (messages.isEmpty()) return@executeWithFinally
 
-            log.debug("[{}] Processing {} messages", queueName, messages.size)
+                log.debug("[{}] Processing {} messages", queueName, messages.size)
 
-            messages.forEach { message ->
-                metrics.inflightIncrement()
-                metrics.recordWaitDuration(message.enqueuedAt)
-            }
+                messages.forEach { message ->
+                    metrics.inflightIncrement()
+                    metrics.recordWaitDuration(message.enqueuedAt)
+                }
 
-            preWarmBatch(messages)
+                preWarmBatch(messages)
 
-            // P1-9 FIX: Use explicit property instead of runtime probe
-            if (supportsTwoPhase) {
-                processBatchTwoPhase(messages)
-            } else {
-                processBatchSinglePhase(messages)
-            }
-        }, context)
+                // P1-9 FIX: Use explicit property instead of runtime probe
+                if (supportsTwoPhase) {
+                    processBatchTwoPhase(messages)
+                } else {
+                    processBatchSinglePhase(messages)
+                }
+            },
+            finallyBlock = { lifecycleWrapper.afterTask() },
+            context = context,
+        )
     }
 
     /**
@@ -177,13 +180,10 @@ abstract class PgmqWorker<T : Any>(
             )
         }
 
-        CompletableFuture.allOf(*futures.toTypedArray())
-            .thenRun { handlePhaseTwoCompletion(futures) }
-            .exceptionally { ex ->
-                log.warn("[{}] Batch completion error: {}", queueName, ex.message)
-                lifecycleWrapper.afterTask()
-                null
-            }
+        // Join all phase-1 futures first
+        CompletableFuture.allOf(*futures.toTypedArray()).join()
+
+        handlePhaseTwoCompletion(futures)
     }
 
     private fun handlePhaseTwoCompletion(
@@ -205,8 +205,6 @@ abstract class PgmqWorker<T : Any>(
         }
 
         failedMessages.forEach { message -> processSingleMessage(message) }
-
-        lifecycleWrapper.afterTask()
     }
 
     /**
@@ -242,7 +240,7 @@ abstract class PgmqWorker<T : Any>(
                 log.warn("[{}] Batch completion error: {}", queueName, ex.message)
                 null
             }
-            .thenRun { lifecycleWrapper.afterTask() }
+            .join()
     }
 
     /**
@@ -264,38 +262,42 @@ abstract class PgmqWorker<T : Any>(
             metrics.retry.increment()
         }
 
-        metrics.concurrentIncrement()
-        try {
-            val success = executor.executeOrDefault(
-                { process(message) },
-                false,
-                context,
-            )
+        return executor.executeWithFinally(
+            task = {
+                metrics.concurrentIncrement()
+                val success = executor.executeOrDefault(
+                    { process(message) },
+                    false,
+                    context,
+                )
 
-            when {
-                success -> {
-                    pgmqClient.archive(queueName, message.messageId)
-                    metrics.success.increment()
-                    log.debug("✅ [{}] Archived message: msgId={}", queueName, message.messageId)
+                when {
+                    success -> {
+                        pgmqClient.archive(queueName, message.messageId)
+                        metrics.success.increment()
+                        log.debug("[{}] Archived message: msgId={}", queueName, message.messageId)
+                    }
+                    message.isRetryable(maxRetries) -> {
+                        onProcessingFailed(message)
+                        metrics.failure.increment()
+                        log.warn("[{}] Message will be retried: msgId={}, readCount={}", queueName, message.messageId, message.readCount)
+                    }
+                    else -> {
+                        pgmqClient.archive(queueName, message.messageId)
+                        metrics.failure.increment()
+                        metrics.dlq.increment()
+                        log.error("[{}] Archived message after max retries: msgId={}, readCount={}", queueName, message.messageId, message.readCount)
+                    }
                 }
-                message.isRetryable(maxRetries) -> {
-                    onProcessingFailed(message)
-                    metrics.failure.increment()
-                    log.warn("⚠️ [{}] Message will be retried: msgId={}, readCount={}", queueName, message.messageId, message.readCount)
-                }
-                else -> {
-                    pgmqClient.archive(queueName, message.messageId)
-                    metrics.failure.increment()
-                    metrics.dlq.increment()
-                    log.error("❌ [{}] Archived message after max retries: msgId={}, readCount={}", queueName, message.messageId, message.readCount)
-                }
-            }
 
-            return success
-        } finally {
-            metrics.concurrentDecrement()
-            metrics.inflightDecrement()
-        }
+                success
+            },
+            finallyBlock = {
+                metrics.concurrentDecrement()
+                metrics.inflightDecrement()
+            },
+            context = context,
+        )
     }
 
     companion object {

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/AbstractExpectationCalcWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/AbstractExpectationCalcWorker.kt
@@ -132,6 +132,13 @@ abstract class AbstractExpectationCalcWorker(
         }, context)
     }
 
+    // TODO(#727): Two-phase batch path writes L2 cache + archives messages but does not
+    // upsert the view table (character_valuation_views) or the read model. This means V5
+    // reads served from the read model will remain stale until the next single-phase
+    // calculation cycle. Full view upsert requires a module-core port for clean DIP —
+    // tracked as architectural debt. The single-phase path (process()) correctly writes
+    // the view table via ExpectationV4Port.calculateExpectationAsync -> event handler.
+
     private fun batchL2CachePut(results: List<CalculationResult>) {
         val entries = results.map { result ->
             val cacheKey = "expectationV4:${cacheProperties.keyVersion}:${result.message.payload.userIgn}"


### PR DESCRIPTION
## Summary

Resolve all actionable Codex (AI code review) findings from PRs #697-727. 6 of 13 issues were already fixed in later PRs. This addresses the remaining 7.

## Fixes

**P0:**
- `AbstractExpectationCalcWorker.kt`: Add TODO documenting deferred view upsert in two-phase path (architectural debt)

**P1:**
- `TaskStatusService.java`: Return `NOT_FOUND` (terminal) instead of `PENDING` when task record disappears — prevents infinite client polling
- `PostgresL2CacheFactory.kt`: Fix TTL 60x too long — factory was converting minutes→seconds then strategy also did `* 60`
- `PgmqWorker.kt`: Use `executeWithFinally` in `processMessages()` to guarantee `afterTask()` runs even on exceptions. Make batch paths synchronous with `.join()` so finally block runs after actual completion. Convert `processSingleMessage` try-finally to `executeWithFinally`
- `PgmqClient.kt`: Fix `archiveBatch` to INSERT INTO archive before DELETE from queue — was losing message history
- `CharacterViewQueryServicePostgres.kt`: Add TODO documenting entity-vs-DTO serialization gap

**P2:**
- `AdaptiveMicroBatchUserService.kt`: Move backpressure check after `putIfAbsent` — coalesced requests no longer rejected

**Zero Try-Catch compliance:**
- `DlqReplayWorker.kt`: Convert try-finally to `executeWithFinally`
- `TaskStatusService.java`: Convert try-catch to `executeOrDefault`

## Skipped (already fixed in later PRs)

- P0 #1: DlqReplayWorker discoverAndTrack — already filters `read_ct > 1`
- P1 #4: DlqReplayWorker replay transaction — already uses `transactionTemplate`
- P1 #5: DlqReplayWorker JSON double-serialization — already uses `sendRawJson`
- P1 #6: DlqReplayWorker mark resolved — already calls `deleteTracking`
- P1 #7: ApiKeyValidator account_id — already extracts from matching entry
- P1 #8: PostgresSingleFlightStrategy leader future — already completes via `whenComplete`

## Test plan

- [x] `./gradlew compileKotlin compileJava --continue` — PASS
- [x] `./gradlew test` — ALL PASS (37 tasks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)