### PR TITLE
refactor: remove Semaphore(64) + pipeline ADR + V5 flow diagrams

### DIFF
--- a/module-app/src/main/java/maple/expectation/application/service/expectation/PresetCalculationHelper.java
+++ b/module-app/src/main/java/maple/expectation/application/service/expectation/PresetCalculationHelper.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Semaphore;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import maple.expectation.application.service.calculator.v4.EquipmentExpectationCalculator;
@@ -65,22 +64,18 @@ public class PresetCalculationHelper {
   private final FlameTrialsPort flameTrialsProvider;
   private final FlameInputResolver flameInputResolver;
   private final Executor itemExecutor;
-  private final Semaphore globalItemPermits;
 
   public PresetCalculationHelper(
       EquipmentExpectationCalculatorFactory calculatorFactory,
       StarforceLookupPort starforceLookupPort,
       FlameTrialsPort flameTrialsProvider,
       FlameInputResolver flameInputResolver,
-      @Qualifier("itemCalculationExecutor") Executor itemExecutor,
-      @Value("${executor.item.max-pool-size:32}") int maxItemThreads,
-      @Value("${executor.item.semaphore-permits:64}") int semaphorePermits) {
+      @Qualifier("itemCalculationExecutor") Executor itemExecutor) {
     this.calculatorFactory = calculatorFactory;
     this.starforceLookupPort = starforceLookupPort;
     this.flameTrialsProvider = flameTrialsProvider;
     this.flameInputResolver = flameInputResolver;
     this.itemExecutor = itemExecutor;
-    this.globalItemPermits = new Semaphore(semaphorePermits);  // Gate concurrency; executor threads are the hard limit
   }
 
   /**
@@ -115,14 +110,7 @@ public class PresetCalculationHelper {
 
       itemFutures.add(
           CompletableFuture.supplyAsync(
-                  () -> {
-                    globalItemPermits.acquireUninterruptibly();
-                    try {
-                      return calculateSingleItem(input, cubeInput, characterClass);
-                    } finally {
-                      globalItemPermits.release();
-                    }
-                  },
+                  () -> calculateSingleItem(input, cubeInput, characterClass),
                   itemExecutor));
     }
 

--- a/module-app/src/main/resources/application.yml
+++ b/module-app/src/main/resources/application.yml
@@ -572,7 +572,7 @@ executor:
     queue-capacity: 500
   item:
     core-pool-size: 16    # 1:2 ratio enforced
-    max-pool-size: 32     # Semaphore(32) matches thread count for 1:1 fair gating
+    max-pool-size: 32     # Thread count is the hard concurrency limit (no Semaphore needed)
     queue-capacity: 5000  # 2× burst headroom: inflight(40) × items(60) = 2400
 
 # Global Admission Control (Issue #617) - PRODUCTION READY


### PR DESCRIPTION
## Summary

- **#733 Semaphore(64) 제거**: `PresetCalculationHelper`에서 불필요한 Semaphore 제거. ThreadPool max=32에서 Semaphore(64)는 항상 즉시 acquire되어 zero gating, 순수 오버헤드였음
- **Pipeline ADR**: fan-out 구조 리팩토링 ADR 문서 추가 (probe 이력, 튜닝 결과 포함)
- **PGMQ atomic dedup**: dedup index + monotonic upsert migration
- **V5 캐시 미스 다이어그램**: 데이터플로우 + 시퀀스 다이어그램 (순차/병렬, 스레드 수, IO/CPU 표시)
- **P0 단위 테스트**: query service, port adapter, V5 controller 테스트

## Test plan

- [x] `./gradlew compileKotlin compileJava --continue` 통과
- [x] `./gradlew test` 전체 통과
- [ ] 부하테스트 10K에서 throughput/regression 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)