### PR TITLE
refactor: bulk JDBC upsert for view batch writes (#734)

### DIFF
--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/repository/CharacterViewBatchRepository.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/repository/CharacterViewBatchRepository.kt
@@ -1,0 +1,153 @@
+package maple.expectation.infrastructure.persistence.repository
+
+import java.time.Instant
+import maple.expectation.infrastructure.executor.LogicExecutor
+import maple.expectation.infrastructure.executor.TaskContext
+import org.slf4j.LoggerFactory
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.stereotype.Component
+
+@Component
+class CharacterViewBatchRepository(
+    private val jdbcTemplate: JdbcTemplate,
+    private val executor: LogicExecutor,
+) {
+    companion object {
+        private val log = LoggerFactory.getLogger(CharacterViewBatchRepository::class.java)
+
+        private val SELECT_EXISTING_SQL = """
+            SELECT DISTINCT ON (user_ign)
+                id, user_ign, version, last_applied_version
+            FROM character_valuation_views
+            WHERE user_ign = ANY(?)
+            ORDER BY user_ign, calculated_at DESC, id DESC
+        """.trimIndent()
+
+        private val UPDATE_SQL = """
+            UPDATE character_valuation_views SET
+                message_id = ?, character_ocid = ?, character_class = ?,
+                calculated_at = ?, jpa_version = COALESCE(jpa_version, 0) + 1,
+                version = version + 1, last_applied_version = ?,
+                total_expected_cost = ?, max_preset_no = ?,
+                presets = ?::jsonb, from_cache = ?
+            WHERE id = ? AND COALESCE(last_applied_version, version, 0) < ?
+        """.trimIndent()
+
+        private val INSERT_SQL = """
+            INSERT INTO character_valuation_views (
+                user_ign, message_id, character_ocid, character_class,
+                calculated_at, version, last_applied_version,
+                total_expected_cost, max_preset_no, presets, from_cache, jpa_version
+            ) VALUES (?, ?, ?, ?, ?, 1, ?, ?, ?, ?::jsonb, ?, 0)
+        """.trimIndent()
+    }
+
+    data class ParsedViewResult(
+        val userIgn: String,
+        val messageId: String,
+        val characterOcid: String,
+        val characterClass: String,
+        val totalExpectedCost: Long,
+        val maxPresetNo: Int,
+        val presetsJson: String,
+        val version: Long,
+    )
+
+    private data class ExistingRow(
+        val id: Long,
+        val version: Long?,
+        val lastAppliedVersion: Long?,
+    )
+
+    private data class UpdateEntry(
+        val result: ParsedViewResult,
+        val existingId: Long,
+    )
+
+    fun bulkUpsert(results: List<ParsedViewResult>) {
+        if (results.isEmpty()) return
+
+        val context = TaskContext.of("ViewBatch", "BulkUpsert", "${results.size}")
+        executor.executeVoid({
+            val existing = findExistingByUserIgns(results.map { it.userIgn }.toSet())
+            val (toUpdate, toInsert) = splitUpdateInsert(results, existing)
+
+            val updated = if (toUpdate.isNotEmpty()) batchUpdate(toUpdate) else 0
+            val inserted = if (toInsert.isNotEmpty()) batchInsert(toInsert) else 0
+
+            log.info("[ViewBatch] Bulk upsert: {} results -> {} updated, {} inserted", results.size, updated, inserted)
+        }, context)
+    }
+
+    private fun findExistingByUserIgns(userIgns: Set<String>): Map<String, ExistingRow> {
+        val existing = mutableMapOf<String, ExistingRow>()
+        jdbcTemplate.query(SELECT_EXISTING_SQL, { rs ->
+            existing[rs.getString("user_ign")] = ExistingRow(
+                id = rs.getLong("id"),
+                version = rs.getLong("version").takeIf { !rs.wasNull() },
+                lastAppliedVersion = rs.getLong("last_applied_version").takeIf { !rs.wasNull() },
+            )
+        }, userIgns.toTypedArray())
+        return existing
+    }
+
+    private fun splitUpdateInsert(
+        results: List<ParsedViewResult>,
+        existing: Map<String, ExistingRow>,
+    ): Pair<List<UpdateEntry>, List<ParsedViewResult>> {
+        val toUpdate = mutableListOf<UpdateEntry>()
+        val toInsert = mutableListOf<ParsedViewResult>()
+
+        for (result in results) {
+            val row = existing[result.userIgn]
+            if (row == null) {
+                toInsert.add(result)
+            } else {
+                val currentVersion = row.lastAppliedVersion ?: row.version ?: 0L
+                if (result.version > currentVersion) {
+                    toUpdate.add(UpdateEntry(result, row.id))
+                }
+            }
+        }
+        return toUpdate to toInsert
+    }
+
+    private fun batchUpdate(entries: List<UpdateEntry>): Int {
+        val now = Instant.now()
+        val args = entries.map { e ->
+            arrayOf<Any?>(
+                e.result.messageId,
+                e.result.characterOcid,
+                e.result.characterClass,
+                now,
+                e.result.version,
+                e.result.totalExpectedCost,
+                e.result.maxPresetNo,
+                e.result.presetsJson,
+                false,
+                e.existingId,
+                e.result.version,
+            )
+        }
+        return jdbcTemplate.batchUpdate(UPDATE_SQL, args).sumOf { it }
+    }
+
+    private fun batchInsert(rows: List<ParsedViewResult>): Int {
+        val now = Instant.now()
+        val args = rows.map { r ->
+            arrayOf<Any?>(
+                r.userIgn,
+                r.messageId,
+                r.characterOcid,
+                r.characterClass,
+                now,
+                r.version,
+                r.totalExpectedCost,
+                r.maxPresetNo,
+                r.presetsJson,
+                false,
+            )
+        }
+        return jdbcTemplate.batchUpdate(INSERT_SQL, args).sumOf { it }
+    }
+}

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/repository/CharacterViewBatchRepository.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/repository/CharacterViewBatchRepository.kt
@@ -1,5 +1,6 @@
 package maple.expectation.infrastructure.persistence.repository
 
+import java.sql.Timestamp
 import java.time.Instant
 import maple.expectation.infrastructure.executor.LogicExecutor
 import maple.expectation.infrastructure.executor.TaskContext
@@ -113,7 +114,7 @@ class CharacterViewBatchRepository(
     }
 
     private fun batchUpdate(entries: List<UpdateEntry>): Int {
-        val now = Instant.now()
+        val now = Timestamp.from(Instant.now())
         val args = entries.map { e ->
             arrayOf<Any?>(
                 e.result.messageId,
@@ -133,7 +134,7 @@ class CharacterViewBatchRepository(
     }
 
     private fun batchInsert(rows: List<ParsedViewResult>): Int {
-        val now = Instant.now()
+        val now = Timestamp.from(Instant.now())
         val args = rows.map { r ->
             arrayOf<Any?>(
                 r.userIgn,

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/AbstractExpectationCalcWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/AbstractExpectationCalcWorker.kt
@@ -1,5 +1,6 @@
 package maple.expectation.infrastructure.worker
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.micrometer.core.instrument.MeterRegistry
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executor
@@ -21,6 +22,8 @@ import maple.expectation.infrastructure.pgmq.PgmqMessage
 import maple.expectation.infrastructure.pgmq.PgmqWorker
 import maple.expectation.infrastructure.pgmq.PgmqWorkerConfig
 import maple.expectation.infrastructure.pgmq.WorkerQueueMetrics
+import maple.expectation.infrastructure.persistence.repository.CharacterViewBatchRepository
+import maple.expectation.infrastructure.persistence.repository.CharacterViewBatchRepository.ParsedViewResult
 import org.slf4j.Logger
 import org.springframework.transaction.support.TransactionTemplate
 
@@ -41,6 +44,8 @@ abstract class AbstractExpectationCalcWorker(
     private val cacheProperties: CacheProperties,
     private val transactionTemplate: TransactionTemplate,
     private val viewQueryPort: CharacterViewQueryPort,
+    private val batchRepo: CharacterViewBatchRepository,
+    private val objectMapper: ObjectMapper,
 ) : PgmqWorker<ExpectationCalcMessage>(pgmqClient, executor, config, meterRegistry, queueMetrics, lifecycleWrapper) {
 
     override val payloadClass: Class<ExpectationCalcMessage> = ExpectationCalcMessage::class.java
@@ -142,31 +147,41 @@ abstract class AbstractExpectationCalcWorker(
     }
 
     private fun batchViewUpsert(results: List<CalculationResult>) {
-        val objectMapper = com.fasterxml.jackson.databind.ObjectMapper()
-            .registerModule(com.fasterxml.jackson.datatype.jsr310.JavaTimeModule())
-        for (result in results) {
-            executor.executeOrCatch({
+        // 1. Dedup by userIgn — keep latest result per character
+        val grouped = results.groupBy { it.character.userIgn.value }
+        if (grouped.any { it.value.size > 1 }) {
+            workerLog.warn("[{}] Duplicate userIgn in batch: {}", workerName,
+                grouped.filter { it.value.size > 1 }.keys)
+        }
+        val deduped = grouped.mapValues { it.value.last() }.values.toList()
+
+        // 2. Parse all results in one pass
+        val parsed = deduped.mapNotNull { result ->
+            try {
                 val tree = objectMapper.valueToTree<com.fasterxml.jackson.databind.JsonNode>(result.response)
-                val totalExpectedCost = tree.get("totalExpectedCost")?.asLong() ?: return@executeOrCatch null
-                val maxPresetNo = tree.get("maxPresetNo")?.asInt() ?: return@executeOrCatch null
-                val presetsNode = tree.get("presets") ?: return@executeOrCatch null
+                val totalExpectedCost = tree.get("totalExpectedCost")?.asLong() ?: return@mapNotNull null
+                val maxPresetNo = tree.get("maxPresetNo")?.asInt() ?: return@mapNotNull null
+                val presetsNode = tree.get("presets") ?: return@mapNotNull null
                 val char = result.character
-                viewQueryPort.upsertFromCalculation(
+                ParsedViewResult(
                     userIgn = char.userIgn.value,
                     messageId = result.message.messageId.toString(),
                     characterOcid = char.characterId.value,
-                    characterClass = char.characterClass,
-                    characterLevel = null,
+                    characterClass = char.characterClass ?: "",
                     totalExpectedCost = totalExpectedCost,
                     maxPresetNo = maxPresetNo,
                     presetsJson = objectMapper.writeValueAsString(presetsNode),
+                    version = System.currentTimeMillis(),
                 )
+            } catch (e: Exception) {
+                workerLog.warn("[{}] Parse failed for {}: {}", workerName, result.character.userIgn.value, e.message)
                 null
-            }, { e ->
-                workerLog.warn("[{}] View upsert failed for {}: {}", workerName, result.message.payload.userIgn, e.message)
-                null
-            }, TaskContext.of(workerName, "ViewUpsert", result.message.payload.userIgn))
+            }
         }
+        if (parsed.isEmpty()) return
+
+        // 3. Bulk upsert — 3 queries total (SELECT + batch UPDATE/INSERT)
+        batchRepo.bulkUpsert(parsed)
     }
 
     private fun batchL2CachePut(results: List<CalculationResult>) {

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/ExpectationCalcLowWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/ExpectationCalcLowWorker.kt
@@ -1,5 +1,6 @@
 package maple.expectation.infrastructure.worker
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.micrometer.core.instrument.MeterRegistry
 import java.util.concurrent.Executor
 import maple.expectation.core.port.inbound.CharacterViewQueryPort
@@ -11,6 +12,7 @@ import maple.expectation.infrastructure.cache.tiered.L2CacheStrategy
 import maple.expectation.infrastructure.config.CacheProperties
 import maple.expectation.infrastructure.executor.LogicExecutor
 import maple.expectation.infrastructure.lifecycle.ScheduledTaskLifecycleWrapper
+import maple.expectation.infrastructure.persistence.repository.CharacterViewBatchRepository
 import maple.expectation.infrastructure.pgmq.PgmqClient
 import maple.expectation.infrastructure.pgmq.PgmqWorkerConfig
 import maple.expectation.infrastructure.pgmq.WorkerQueueMetrics
@@ -39,6 +41,8 @@ class ExpectationCalcLowWorker(
     cacheProperties: CacheProperties,
     transactionTemplate: TransactionTemplate,
     viewQueryPort: CharacterViewQueryPort,
+    batchRepo: CharacterViewBatchRepository,
+    objectMapper: ObjectMapper,
 ) : AbstractExpectationCalcWorker(
     pgmqClient,
     executor,
@@ -55,6 +59,8 @@ class ExpectationCalcLowWorker(
     cacheProperties,
     transactionTemplate,
     viewQueryPort,
+    batchRepo,
+    objectMapper,
 ) {
 
     override val queueName: String = QUEUE_NAME

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/ExpectationCalcWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/ExpectationCalcWorker.kt
@@ -1,5 +1,6 @@
 package maple.expectation.infrastructure.worker
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.micrometer.core.instrument.MeterRegistry
 import java.util.concurrent.Executor
 import maple.expectation.core.port.inbound.CharacterViewQueryPort
@@ -11,6 +12,7 @@ import maple.expectation.infrastructure.cache.tiered.L2CacheStrategy
 import maple.expectation.infrastructure.config.CacheProperties
 import maple.expectation.infrastructure.executor.LogicExecutor
 import maple.expectation.infrastructure.lifecycle.ScheduledTaskLifecycleWrapper
+import maple.expectation.infrastructure.persistence.repository.CharacterViewBatchRepository
 import maple.expectation.infrastructure.pgmq.PgmqClient
 import maple.expectation.infrastructure.pgmq.PgmqWorkerConfig
 import maple.expectation.infrastructure.pgmq.WorkerQueueMetrics
@@ -39,6 +41,8 @@ class ExpectationCalcWorker(
     cacheProperties: CacheProperties,
     transactionTemplate: TransactionTemplate,
     viewQueryPort: CharacterViewQueryPort,
+    batchRepo: CharacterViewBatchRepository,
+    objectMapper: ObjectMapper,
 ) : AbstractExpectationCalcWorker(
     pgmqClient,
     executor,
@@ -55,6 +59,8 @@ class ExpectationCalcWorker(
     cacheProperties,
     transactionTemplate,
     viewQueryPort,
+    batchRepo,
+    objectMapper,
 ) {
 
     override val queueName: String = QUEUE_NAME


### PR DESCRIPTION
## Summary
- Replace per-row JPA (30-120 DB round trips per batch) with bulk JDBC using `CharacterViewBatchRepository`
- 1 bulk SELECT + batch UPDATE/INSERT = **3 queries total** per batch
- Rewrites `batchViewUpsert()` in `AbstractExpectationCalcWorker` to dedup + parse JSON in one pass, then delegate to batch repo

## Changes
| File | Action |
|------|--------|
| `CharacterViewBatchRepository.kt` | NEW — bulk JDBC upsert (SELECT + batch UPDATE/INSERT) |
| `AbstractExpectationCalcWorker.kt` | MODIFY — rewrite `batchViewUpsert()` to use batch repo |
| `ExpectationCalcWorker.kt` | MODIFY — pass new deps to super |
| `ExpectationCalcLowWorker.kt` | MODIFY — pass new deps to super |

## Test plan
- [x] `./gradlew compileKotlin compileJava --continue` — BUILD SUCCESSFUL
- [x] `./gradlew test` — all tests pass
- [ ] Load test to verify `batchWrite` probe time reduction

Closes #734