### PR TITLE
refactor: Virtual Thread → FixedThreadPool in PgmqWorker (#735)

### DIFF
--- a/module-app/src/main/resources/application-local.yml
+++ b/module-app/src/main/resources/application-local.yml
@@ -182,6 +182,8 @@ admission-control:
 # PGMQ Worker Configuration
 pgmq:
   worker:
+    common:
+      worker-pool-size: 8  # t3.small: 2 vCPU × 4 = 8 platform threads (replaces virtual threads)
     expectation-calc-high:
       enabled: true
     expectation-calc-low:

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/PgmqWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/PgmqWorker.kt
@@ -1,9 +1,13 @@
 package maple.expectation.infrastructure.pgmq
 
 import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executors
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.Semaphore
+import java.util.concurrent.TimeUnit
+import jakarta.annotation.PreDestroy
 import maple.expectation.infrastructure.executor.LogicExecutor
 import maple.expectation.infrastructure.executor.TaskContext
 import maple.expectation.infrastructure.lifecycle.ScheduledTaskLifecycleWrapper
@@ -39,8 +43,14 @@ abstract class PgmqWorker<T : Any>(
     private val lifecycleWrapper: ScheduledTaskLifecycleWrapper,
 ) {
 
-    /** 메시지 병렬 처리용 Virtual Thread Executor */
-    private val workerPool = Executors.newVirtualThreadPerTaskExecutor()
+    /** 메시지 병렬 처리용 Fixed Thread Pool (replaces Virtual Thread for CPU-bound stability) */
+    private val workerPool: ExecutorService by lazy {
+        val pool = Executors.newFixedThreadPool(config.common.workerPoolSize) { runnable ->
+            Thread(runnable, "$queueName-worker").apply { isDaemon = true }
+        }
+        ExecutorServiceMetrics.monitor(meterRegistry, pool, "$queueName-worker-pool", "pgmq.worker")
+        pool
+    }
 
     protected open val maxInflight: Int = 100
 
@@ -352,6 +362,16 @@ abstract class PgmqWorker<T : Any>(
             },
             context = context,
         )
+    }
+
+    @PreDestroy
+    fun shutdownWorkerPool() {
+        log.info("[{}] Shutting down worker pool", queueName)
+        workerPool.shutdown()
+        if (!workerPool.awaitTermination(5, TimeUnit.SECONDS)) {
+            log.warn("[{}] Worker pool did not terminate in 5s, forcing", queueName)
+            workerPool.shutdownNow()
+        }
     }
 
     companion object {

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/PgmqWorkerConfig.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/PgmqWorkerConfig.kt
@@ -61,6 +61,9 @@ class PgmqWorkerConfig {
         var pipelineDrainIntervalMs: Long = 100,
         /** Pipeline max buffer size (backpressure threshold) */
         var pipelineMaxBufferSize: Int = 500,
+
+        /** Worker pool size (replaces Virtual Thread). Default: availableProcessors * 2 */
+        var workerPoolSize: Int = Runtime.getRuntime().availableProcessors() * 2,
     )
 
     data class WorkerSettings(


### PR DESCRIPTION
## Summary
- Replace `newVirtualThreadPerTaskExecutor()` with `newFixedThreadPool(workerPoolSize)` in `PgmqWorker`
- Virtual Thread causes carrier thread pinning on 2 vCPU (t3.small) when running CPU-bound expectation calculations
- Pool size configurable via `pgmq.worker.common.worker-pool-size` (default: `availableProcessors * 2`)
- Micrometer `ExecutorServiceMetrics` for pool observability
- `@PreDestroy` graceful shutdown with 5s timeout

## Changes
| File | Action |
|------|--------|
| `PgmqWorker.kt` | FixedThreadPool + Micrometer + shutdown |
| `PgmqWorkerConfig.kt` | `workerPoolSize` in CommonSettings |
| `application-local.yml` | `worker-pool-size: 8` |

## Load Test Results (10K requests, concurrency 50)

| Metric | Before (VT) | After (FixedThreadPool) |
|--------|-------------|------------------------|
| Status 202 | 0 | **10,000** |
| Status 503 | 10,000 | **0** |
| Admission throughput | 99.7 req/s | **511.9 req/s** (5.1x) |
| Avg response time | 429ms | **97ms** (4.4x faster) |
| p99 | 1,425ms | **191ms** |
| Error rate | 100% | **0%** |

## Test plan
- [x] `./gradlew compileKotlin compileJava --continue` — BUILD SUCCESSFUL
- [x] `./gradlew test` — all tests pass
- [x] Load test 10K — 0 errors, 5x admission throughput improvement

Closes #735