### PR TITLE
refactor: align PipelineBuffer capacity with maxInflight (#739)

### DIFF
--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/PgmqWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/PgmqWorker.kt
@@ -59,7 +59,7 @@ abstract class PgmqWorker<T : Any>(
     /** Pipeline buffer for two-phase workers — Phase 1 results queue here before drain */
     private val pipelineBuffer = PipelineBuffer<CalculationResult>(
         microBatchSize = config.common.pipelineMicroBatchSize,
-        maxBufferSize = config.common.pipelineMaxBufferSize,
+        maxBufferSize = maxInflight * 2,
     )
 
     /** 큐별 종합 메트릭 (lazy init — 하위 클래스의 queueName 초기화 이후 접근 시 생성) */
@@ -192,12 +192,10 @@ abstract class PgmqWorker<T : Any>(
                 // P1-9 FIX: Use explicit property instead of runtime probe
                 if (supportsTwoPhase) {
                     if (pipelineBuffer.isFull()) {
-                        log.warn("[{}] Pipeline buffer full ({}), skipping poll", queueName, pipelineBuffer.size())
-                        messages.forEach { metrics.inflightDecrement() }
-                        inflightPermits.release(messages.size)
-                    } else {
-                        processBatchPipelined(messages)
+                        log.warn("[{}] Pipeline buffer full ({}), draining before poll", queueName, pipelineBuffer.size())
+                        drainMicroBatch()
                     }
+                    processBatchPipelined(messages)
                 } else {
                     processBatchSinglePhase(messages)
                 }

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/PgmqWorkerConfig.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/PgmqWorkerConfig.kt
@@ -59,8 +59,6 @@ class PgmqWorkerConfig {
         var pipelineMicroBatchSize: Int = 10,
         /** Pipeline drain interval (ms) */
         var pipelineDrainIntervalMs: Long = 100,
-        /** Pipeline max buffer size (backpressure threshold) */
-        var pipelineMaxBufferSize: Int = 500,
 
         /** Worker pool size (replaces Virtual Thread). Default: availableProcessors * 2 */
         var workerPoolSize: Int = Runtime.getRuntime().availableProcessors() * 2,


### PR DESCRIPTION
## Summary
- Buffer capacity = `maxInflight * 2` (auto-calculated from semaphore, removes independent `pipelineMaxBufferSize` config)
- Buffer full → drain first instead of skipping poll entirely (prevents result drops)
- Removes `pipelineMaxBufferSize` from `CommonSettings`

## Changes
| File | Action |
|------|--------|
| `PgmqWorker.kt` | Buffer capacity = maxInflight*2, drain-before-skip |
| `PgmqWorkerConfig.kt` | Remove `pipelineMaxBufferSize` |

## Test plan
- [x] `./gradlew compileKotlin compileJava --continue` — BUILD SUCCESSFUL
- [x] `./gradlew test` — all tests pass

Closes #739