### PR TITLE
chore: unify all profiles to use only DB_URL

### DIFF
--- a/module-app/src/main/resources/application-ci.yml
+++ b/module-app/src/main/resources/application-ci.yml
@@ -4,10 +4,7 @@ spring:
       on-profile: ci
 
   datasource:
-    # PostgreSQL Configuration (Issue #591: MySQL migration complete)
-    url: jdbc:postgresql://localhost:5432/${DB_SCHEMA_NAME:maple_test}
-    username: maple
-    password: ${DB_ROOT_PASSWORD:testpassword}
+    url: ${DB_URL}
     driver-class-name: org.postgresql.Driver
 
     hikari:

--- a/module-app/src/main/resources/application-local.yml
+++ b/module-app/src/main/resources/application-local.yml
@@ -10,10 +10,7 @@ spring:
       on-profile: local
 
   datasource:
-    # PostgreSQL Configuration (Issue #591: MySQL migration complete)
-    url: jdbc:postgresql://${DB_SERVER_IP:localhost}:5432/maple_expectation
-    username: maple
-    password: ${DB_ROOT_PASSWORD}
+    url: ${DB_URL}
     driver-class-name: org.postgresql.Driver
 
     hikari:

--- a/module-app/src/main/resources/application-pglocal.yml
+++ b/module-app/src/main/resources/application-pglocal.yml
@@ -15,9 +15,7 @@ spring:
       on-profile: pglocal
 
   datasource:
-    url: jdbc:postgresql://localhost:5432/maple_expectation?currentSchema=public
-    username: ${DB_USERNAME:-maple}
-    password: ${DB_PASSWORD:-maple123}
+    url: ${DB_URL}
     driver-class-name: org.postgresql.Driver
 
     hikari:

--- a/module-app/src/main/resources/application-prod.yml
+++ b/module-app/src/main/resources/application-prod.yml
@@ -13,8 +13,6 @@ spring:
 
   datasource:
     url: ${DB_URL}
-    username: ${DB_USER}
-    password: ${DB_PASSWORD}
 
     hikari:
       maximum-pool-size: 25  # Match Tomcat threads (prevent connection starvation)

--- a/module-app/src/main/resources/application-vultr.yml
+++ b/module-app/src/main/resources/application-vultr.yml
@@ -13,10 +13,7 @@ spring:
       on-profile: vultr
 
   datasource:
-    # PostgreSQL Configuration for Vultr Seoul
-    url: jdbc:postgresql://${DB_SERVER_IP:158.247.218.6}:5432/maple_expectation
-    username: ${DB_USER:maple}
-    password: ${DB_ROOT_PASSWORD}
+    url: ${DB_URL}
     driver-class-name: org.postgresql.Driver
 
     hikari:


### PR DESCRIPTION
## Summary
- 모든 Spring 프로필(prod, vultr, local, pglocal, ci)의 datasource 설정을 `DB_URL` 단일 환경변수로 통일
- 프로필별 하드코딩된 URL, username, password 제거

## Test plan
- [ ] 각 프로필로 bootRun 시 DB 연결 정상 동작 확인
- [ ] CI 프로필로 테스트 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)