### PR TITLE
fix: External API Boundary — PR review fixes and dead code cleanup

### DIFF
--- a/module-core/src/main/kotlin/maple/expectation/core/model/job/CalculationJobStatus.kt
+++ b/module-core/src/main/kotlin/maple/expectation/core/model/job/CalculationJobStatus.kt
@@ -3,13 +3,10 @@ package maple.expectation.core.model.job
 enum class CalculationJobStatus {
     REQUESTED,
     OCID_RESOLVING,
-    OCID_RESOLVED,
     API_REQUESTED,
     SNAPSHOT_READY,
     CALCULATING,
     COMPLETED,
     FAILED,
-    OCID_RETRY_WAIT,
-    API_RETRY_WAIT,
     RETRYING
 }

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/repository/CalculationJobRepository.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/repository/CalculationJobRepository.kt
@@ -13,7 +13,7 @@ interface CalculationJobRepository : JpaRepository<CalculationJobEntity, UUID> {
     @Query("""
         SELECT j FROM CalculationJobEntity j
         WHERE j.userIgn = :userIgn AND j.presetNo = :presetNo
-          AND j.status IN ('REQUESTED', 'OCID_RESOLVING', 'OCID_RESOLVED', 'API_REQUESTED', 'SNAPSHOT_READY', 'CALCULATING', 'RETRYING')
+          AND j.status IN ('REQUESTED', 'OCID_RESOLVING', 'API_REQUESTED', 'SNAPSHOT_READY', 'CALCULATING', 'RETRYING')
     """)
     fun findActiveByUserIgnAndPreset(@Param("userIgn") userIgn: String, @Param("presetNo") presetNo: Int): CalculationJobEntity?
 

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/NexonApiWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/NexonApiWorker.kt
@@ -5,7 +5,6 @@ import maple.expectation.core.port.out.QueueNames
 import maple.expectation.core.port.out.SnapshotObjectStore
 import maple.expectation.infrastructure.executor.LogicExecutor
 import maple.expectation.infrastructure.executor.TaskContext
-import maple.expectation.infrastructure.external.NexonApiClient
 import maple.expectation.infrastructure.job.CalculationJobService
 import maple.expectation.infrastructure.persistence.entity.CalculationSnapshotEntity
 import maple.expectation.infrastructure.pgmq.PgmqClient


### PR DESCRIPTION
## Summary
- Fix 4 P1 PR review issues from chatgpt-codex-connector
- Add V116 migration for NULL OCID dedup index
- Remove dead code (unused enum values, import)

### P1 Fixes
1. **PostgresLockHikariConfig**: Add `spring.datasource.username/password` fallback when credentials not in JDBC URL params
2. **ApiResponseWorker snapshot boundary**: Remove try-catch from `populateEquipmentCacheFromSnapshot` — failures propagate instead of falling back to live API calls
3. **ApiResponseWorker CALCULATING redelivery**: Fail stuck jobs instead of archiving and leaving them orphaned
4. **TimeoutScanner threshold**: Raise API_REQUESTED stale threshold from 30s to 180s (120s visibility window + 60s buffer)

### V116 Migration
- Fix active-job dedup index to include rows where `ocid IS NULL` — the previous index excluded these rows, removing the DB-level guard for concurrent duplicate active jobs

### Dead Code Cleanup
- Remove unused `NexonApiClient` import from `NexonApiWorker`
- Remove `OCID_RESOLVED`, `OCID_RETRY_WAIT`, `API_RETRY_WAIT` from `CalculationJobStatus` enum — never reached in the async flow
- Remove `OCID_RESOLVED` from `findActiveByUserIgnAndPreset` query

## Test plan
- [x] `./gradlew compileKotlin compileJava --continue` passes
- [x] V116 migration applied to production DB
- [ ] Server startup verified
- [ ] End-to-end test with character name

🤖 Generated with [Claude Code](https://claude.com/claude-code)