### PR TITLE
refactor(write-path): CalculationJobService를 External API + Write Path로 분리

### DIFF
--- a/module-app/src/main/kotlin/maple/expectation/application/worker/ApiResponseWorker.kt
+++ b/module-app/src/main/kotlin/maple/expectation/application/worker/ApiResponseWorker.kt
@@ -8,7 +8,7 @@ import maple.expectation.core.port.out.mq.ConsumeResult
 import maple.expectation.core.domain.event.IntegrationEvent
 import maple.expectation.infrastructure.executor.LogicExecutor
 import maple.expectation.infrastructure.executor.TaskContext
-import maple.expectation.infrastructure.job.CalculationJobService
+import maple.expectation.infrastructure.job.CalculationExecutionService
 import maple.expectation.infrastructure.mq.pgmq.topic.NexonApiResponseTopic
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.slf4j.LoggerFactory
@@ -20,7 +20,7 @@ class ApiResponseWorker(
     private val nexonApiResponseTopic: NexonApiResponseTopic,
     private val pureCalculator: PureExpectationCalculator,
     private val jobPort: CalculationJobPort,
-    private val jobService: CalculationJobService,
+    private val executionService: CalculationExecutionService,
     private val calculationInputPort: CalculationInputPort,
     private val objectMapper: ObjectMapper,
     private val executor: LogicExecutor
@@ -45,7 +45,7 @@ class ApiResponseWorker(
             { e ->
                 log.error("[jobId={}] Calculation failed: {}", jobId, e.message)
                 val msg = (e.message ?: "Unknown error").take(200)
-                executor.executeVoid({ jobService.handleCalculationFailure(jobId, "CALCULATION_ERROR", msg) }, context)
+                executor.executeVoid({ executionService.handleCalculationFailure(jobId, "CALCULATION_ERROR", msg) }, context)
                 ConsumeResult.Ack
             },
             context
@@ -70,7 +70,7 @@ class ApiResponseWorker(
             return ConsumeResult.Ack
         }
 
-        val started = jobService.startCalculation(jobId, "ApiResponseWorker")
+        val started = executionService.startCalculation(jobId, "ApiResponseWorker")
         if (!started) {
             log.warn("[jobId={}] Could not start calculation, archiving", jobId)
             return ConsumeResult.Ack
@@ -90,7 +90,7 @@ class ApiResponseWorker(
 
         val resultJson = objectMapper.writeValueAsString(result)
 
-        jobService.completeCalculationWithResult(
+        executionService.completeCalculationWithResult(
             jobId = jobId,
             resultJson = resultJson,
             characterClass = input.characterClass,

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/job/CalculationExecutionService.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/job/CalculationExecutionService.kt
@@ -1,0 +1,126 @@
+package maple.expectation.infrastructure.job
+
+import maple.expectation.core.model.job.CalculationJobStatus
+import maple.expectation.core.port.out.CalculationJobPort
+import maple.expectation.core.port.out.CalculationResultData
+import maple.expectation.core.port.out.CalculationResultPort
+import maple.expectation.core.port.out.OutboxEventPort
+import maple.expectation.core.port.out.mq.DomainEventAppender
+import maple.expectation.infrastructure.mq.event.NexonApiResponseEventFactory
+import maple.expectation.infrastructure.mq.pgmq.topic.NexonApiResponseTopic
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+import java.util.UUID
+
+@Service
+class CalculationExecutionService(
+    private val jobPort: CalculationJobPort,
+    private val eventAppender: DomainEventAppender,
+    private val nexonApiResponseTopic: NexonApiResponseTopic,
+    private val resultPort: CalculationResultPort,
+    private val outboxPort: OutboxEventPort,
+    private val objectMapper: ObjectMapper
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Transactional
+    fun startCalculation(jobId: UUID, workerId: String): Boolean {
+        val locked = jobPort.lockForProcessing(jobId, workerId, CalculationJobStatus.SNAPSHOT_READY)
+        if (locked) {
+            jobPort.transitionStatus(jobId, CalculationJobStatus.SNAPSHOT_READY, CalculationJobStatus.CALCULATING)
+            log.info("[jobId={}] Calculation started by {}", jobId, workerId)
+        }
+        return locked
+    }
+
+    @Transactional
+    fun handleCalculationFailure(jobId: UUID, errorCode: String, errorMessage: String) {
+        val job = jobPort.findJobById(jobId) ?: return
+
+        if (job.retryCount >= job.maxRetries) {
+            jobPort.markFailed(jobId, errorCode, errorMessage)
+            log.warn("[jobId={}] Calculation failed after {} retries: {}", jobId, job.retryCount, errorMessage)
+            return
+        }
+
+        val backoffSeconds = calculateBackoff(job.retryCount)
+        val nextRetry = Instant.now().plusSeconds(backoffSeconds)
+        val retried = jobPort.retryCalculation(jobId, errorCode, nextRetry)
+        if (retried) {
+            val event = NexonApiResponseEventFactory.create(
+                jobId.toString(),
+                job.snapshotId?.toString() ?: return,
+                "",
+                job.ocid ?: return,
+                job.userIgn,
+                job.presetNo
+            )
+            eventAppender.append(nexonApiResponseTopic, event)
+            log.info("[jobId={}] Calculation retry scheduled (attempt {}, backoff={}s)", jobId, job.retryCount + 1, backoffSeconds)
+        } else {
+            jobPort.markFailed(jobId, errorCode, errorMessage)
+        }
+    }
+
+    @Transactional
+    fun completeCalculationWithResult(
+        jobId: UUID,
+        resultJson: String,
+        characterClass: String,
+        presetNo: Int,
+        characterId: String
+    ): Boolean {
+        val completed = jobPort.transitionStatus(jobId, CalculationJobStatus.CALCULATING, CalculationJobStatus.COMPLETED)
+        if (!completed) return false
+
+        val gzipData = gzipCompress(resultJson.toByteArray())
+        val hash = sha256Hex(resultJson.toByteArray())
+
+        resultPort.save(CalculationResultData(
+            resultId = UUID.randomUUID(),
+            jobId = jobId,
+            characterClass = characterClass,
+            presetNo = presetNo,
+            schemaVersion = 1,
+            contentType = "application/json",
+            contentEncoding = "gzip",
+            responseBody = gzipData,
+            originalSize = resultJson.toByteArray().size,
+            compressedSize = gzipData.size,
+            hash = hash,
+            status = "SUCCESS"
+        ))
+
+        val eventPayload = objectMapper.writeValueAsString(mapOf(
+            "jobId" to jobId.toString(),
+            "characterId" to characterId,
+            "presetNo" to presetNo,
+            "contentEncoding" to "gzip",
+            "schemaVersion" to 1
+        ))
+        outboxPort.insertIfAbsent("CALCULATION_COMPLETED", jobId, eventPayload)
+
+        jobPort.unlock(jobId)
+        log.info("[jobId={}] Calculation completed with result saved", jobId)
+        return true
+    }
+
+    private fun calculateBackoff(retryCount: Int): Long {
+        val baseSeconds = 30L
+        return minOf(baseSeconds * (1L shl retryCount), 600L)
+    }
+
+    private fun gzipCompress(data: ByteArray): ByteArray {
+        val bos = java.io.ByteArrayOutputStream()
+        java.util.zip.GZIPOutputStream(bos).use { it.write(data) }
+        return bos.toByteArray()
+    }
+
+    private fun sha256Hex(data: ByteArray): String {
+        val digest = java.security.MessageDigest.getInstance("SHA-256")
+        return digest.digest(data).joinToString("") { "%02x".format(it) }
+    }
+}

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/job/CalculationJobService.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/job/CalculationJobService.kt
@@ -3,9 +3,6 @@ package maple.expectation.infrastructure.job
 import maple.expectation.core.model.job.CalculationJob
 import maple.expectation.core.model.job.CalculationJobStatus
 import maple.expectation.core.port.out.CalculationJobPort
-import maple.expectation.core.port.out.CalculationResultData
-import maple.expectation.core.port.out.CalculationResultPort
-import maple.expectation.core.port.out.OutboxEventPort
 import maple.expectation.core.port.out.mq.DomainEventAppender
 import maple.expectation.infrastructure.mq.event.NexonApiRequestEventFactory
 import maple.expectation.infrastructure.mq.event.NexonApiResponseEventFactory
@@ -15,11 +12,9 @@ import maple.expectation.infrastructure.mq.pgmq.topic.NexonApiResponseTopic
 import maple.expectation.infrastructure.mq.pgmq.topic.OcidResolveTopic
 import maple.expectation.infrastructure.persistence.entity.CalculationSnapshotEntity
 import maple.expectation.infrastructure.persistence.repository.CalculationSnapshotRepository
-import com.fasterxml.jackson.databind.ObjectMapper
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.Instant
 import java.util.UUID
 
 @Service
@@ -29,10 +24,7 @@ class CalculationJobService(
     private val ocidResolveTopic: OcidResolveTopic,
     private val nexonApiRequestTopic: NexonApiRequestTopic,
     private val nexonApiResponseTopic: NexonApiResponseTopic,
-    private val snapshotRepository: CalculationSnapshotRepository,
-    private val resultPort: CalculationResultPort,
-    private val outboxPort: OutboxEventPort,
-    private val objectMapper: ObjectMapper
+    private val snapshotRepository: CalculationSnapshotRepository
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -75,24 +67,6 @@ class CalculationJobService(
     }
 
     @Transactional
-    fun requestApiData(jobId: UUID) {
-        val transitioned = jobPort.transitionStatus(
-            jobId,
-            CalculationJobStatus.REQUESTED,
-            CalculationJobStatus.API_REQUESTED
-        )
-        if (!transitioned) {
-            log.warn("[jobId={}] Cannot transition to API_REQUESTED", jobId)
-            return
-        }
-
-        val job = jobPort.findJobById(jobId) ?: return
-
-        eventAppender.append(nexonApiRequestTopic, NexonApiRequestEventFactory.create(job.jobId.toString(), job.ocid ?: return, job.userIgn, job.presetNo))
-        log.info("[jobId={}] Transitioned to API_REQUESTED, request enqueued", jobId)
-    }
-
-    @Transactional
     fun saveSnapshotAndMarkReady(
         snapshotEntity: CalculationSnapshotEntity,
         jobId: UUID,
@@ -117,26 +91,6 @@ class CalculationJobService(
             }
         }
         return ready
-    }
-
-    @Transactional
-    fun startCalculation(jobId: UUID, workerId: String): Boolean {
-        val locked = jobPort.lockForProcessing(jobId, workerId, CalculationJobStatus.SNAPSHOT_READY)
-        if (locked) {
-            jobPort.transitionStatus(jobId, CalculationJobStatus.SNAPSHOT_READY, CalculationJobStatus.CALCULATING)
-            log.info("[jobId={}] Calculation started by {}", jobId, workerId)
-        }
-        return locked
-    }
-
-    @Transactional
-    fun completeCalculation(jobId: UUID): Boolean {
-        val completed = jobPort.transitionStatus(jobId, CalculationJobStatus.CALCULATING, CalculationJobStatus.COMPLETED)
-        if (completed) {
-            jobPort.unlock(jobId)
-            log.info("[jobId={}] Calculation completed", jobId)
-        }
-        return completed
     }
 
     @Transactional
@@ -169,93 +123,5 @@ class CalculationJobService(
                 log.info("[jobId={}] OCID resolve retry (attempt {}): {}", jobId, job.retryCount + 1, errorCode)
             }
         }
-    }
-
-    @Transactional
-    fun handleCalculationFailure(jobId: UUID, errorCode: String, errorMessage: String) {
-        val job = jobPort.findJobById(jobId) ?: return
-
-        if (job.retryCount >= job.maxRetries) {
-            jobPort.markFailed(jobId, errorCode, errorMessage)
-            log.warn("[jobId={}] Calculation failed after {} retries: {}", jobId, job.retryCount, errorMessage)
-            return
-        }
-
-        val backoffSeconds = calculateBackoff(job.retryCount)
-        val nextRetry = Instant.now().plusSeconds(backoffSeconds)
-        val retried = jobPort.retryCalculation(jobId, errorCode, nextRetry)
-        if (retried) {
-            val event = NexonApiResponseEventFactory.create(
-                jobId.toString(),
-                job.snapshotId?.toString() ?: return,
-                "",
-                job.ocid ?: return,
-                job.userIgn,
-                job.presetNo
-            )
-            eventAppender.append(nexonApiResponseTopic, event)
-            log.info("[jobId={}] Calculation retry scheduled (attempt {}, backoff={}s)", jobId, job.retryCount + 1, backoffSeconds)
-        } else {
-            jobPort.markFailed(jobId, errorCode, errorMessage)
-        }
-    }
-
-    private fun calculateBackoff(retryCount: Int): Long {
-        val baseSeconds = 30L
-        return minOf(baseSeconds * (1L shl retryCount), 600L)
-    }
-
-    @Transactional
-    fun completeCalculationWithResult(
-        jobId: UUID,
-        resultJson: String,
-        characterClass: String,
-        presetNo: Int,
-        characterId: String
-    ): Boolean {
-        val completed = jobPort.transitionStatus(jobId, CalculationJobStatus.CALCULATING, CalculationJobStatus.COMPLETED)
-        if (!completed) return false
-
-        val gzipData = gzipCompress(resultJson.toByteArray())
-        val hash = sha256Hex(resultJson.toByteArray())
-
-        resultPort.save(CalculationResultData(
-            resultId = UUID.randomUUID(),
-            jobId = jobId,
-            characterClass = characterClass,
-            presetNo = presetNo,
-            schemaVersion = 1,
-            contentType = "application/json",
-            contentEncoding = "gzip",
-            responseBody = gzipData,
-            originalSize = resultJson.toByteArray().size,
-            compressedSize = gzipData.size,
-            hash = hash,
-            status = "SUCCESS"
-        ))
-
-        val eventPayload = objectMapper.writeValueAsString(mapOf(
-            "jobId" to jobId.toString(),
-            "characterId" to characterId,
-            "presetNo" to presetNo,
-            "contentEncoding" to "gzip",
-            "schemaVersion" to 1
-        ))
-        outboxPort.insertIfAbsent("CALCULATION_COMPLETED", jobId, eventPayload)
-
-        jobPort.unlock(jobId)
-        log.info("[jobId={}] Calculation completed with result saved", jobId)
-        return true
-    }
-
-    private fun gzipCompress(data: ByteArray): ByteArray {
-        val bos = java.io.ByteArrayOutputStream()
-        java.util.zip.GZIPOutputStream(bos).use { it.write(data) }
-        return bos.toByteArray()
-    }
-
-    private fun sha256Hex(data: ByteArray): String {
-        val digest = java.security.MessageDigest.getInstance("SHA-256")
-        return digest.digest(data).joinToString("") { "%02x".format(it) }
     }
 }

--- a/module-infra/src/test/kotlin/maple/expectation/infrastructure/job/CalculationJobServiceTest.kt
+++ b/module-infra/src/test/kotlin/maple/expectation/infrastructure/job/CalculationJobServiceTest.kt
@@ -5,10 +5,7 @@ import maple.expectation.core.port.out.CalculationJobPort
 import maple.expectation.core.port.out.CalculationResultPort
 import maple.expectation.core.port.out.OutboxEventPort
 import maple.expectation.core.port.out.mq.DomainEventAppender
-import maple.expectation.infrastructure.mq.pgmq.topic.OcidResolveTopic
-import maple.expectation.infrastructure.mq.pgmq.topic.NexonApiRequestTopic
 import maple.expectation.infrastructure.mq.pgmq.topic.NexonApiResponseTopic
-import maple.expectation.infrastructure.persistence.repository.CalculationSnapshotRepository
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -24,29 +21,23 @@ import org.mockito.Mock
 import java.util.UUID
 
 @ExtendWith(MockitoExtension::class)
-class CalculationJobServiceTest {
+class CalculationExecutionServiceTest {
 
     @Mock lateinit var jobPort: CalculationJobPort
     @Mock lateinit var eventAppender: DomainEventAppender
+    @Mock lateinit var nexonApiResponseTopic: NexonApiResponseTopic
     @Mock lateinit var resultPort: CalculationResultPort
     @Mock lateinit var outboxPort: OutboxEventPort
-    @Mock lateinit var snapshotRepository: CalculationSnapshotRepository
-    @Mock lateinit var ocidResolveTopic: OcidResolveTopic
-    @Mock lateinit var nexonApiRequestTopic: NexonApiRequestTopic
-    @Mock lateinit var nexonApiResponseTopic: NexonApiResponseTopic
     private val objectMapper = ObjectMapper()
 
-    private lateinit var service: CalculationJobService
+    private lateinit var service: CalculationExecutionService
 
     @BeforeEach
     fun setUp() {
-        service = CalculationJobService(
+        service = CalculationExecutionService(
             jobPort = jobPort,
             eventAppender = eventAppender,
-            ocidResolveTopic = ocidResolveTopic,
-            nexonApiRequestTopic = nexonApiRequestTopic,
             nexonApiResponseTopic = nexonApiResponseTopic,
-            snapshotRepository = snapshotRepository,
             resultPort = resultPort,
             outboxPort = outboxPort,
             objectMapper = objectMapper


### PR DESCRIPTION
## Summary

- `CalculationJobService`를 경로별로 분리하여 External API Path와 Write Path의 결합도 제거
- Write Path 메서드를 새로운 `CalculationExecutionService`로 이동
- 미사용 메서드(`requestApiData`, `completeCalculation`) 삭제

## Changes

| 파일 | 변경 |
|------|------|
| `CalculationExecutionService.kt` | **신규** — startCalculation, handleCalculationFailure, completeCalculationWithResult |
| `CalculationJobService.kt` | External API Path 메서드만 남김 (createJob, OCID resolve, snapshot ready, API/OCID failure) |
| `ApiResponseWorker.kt` | `jobService` → `executionService` 참조 변경 |
| `CalculationJobServiceTest.kt` | → `CalculationExecutionServiceTest` 재작성 |

## Before / After

```
Before: CalculationJobService (16개 메서드, 9개 의존성, 모든 경로 혼재)
After:
  CalculationJobService      — External API Path (8개 메서드, 6개 의존성)
  CalculationExecutionService — Write Path (3개 메서드, 6개 의존성)
```

## Test plan

- [x] `./gradlew compileKotlin compileJava --continue` BUILD SUCCESSFUL
- [x] `./gradlew test` BUILD SUCCESSFUL
- [x] `CalculationExecutionServiceTest` 2개 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)