### PR TITLE
fix: apply Codex review feedback PR 729-774 (17 items)

### DIFF
--- a/module-app/src/main/java/maple/expectation/application/service/expectation/cache/ExpectationCacheCoordinator.java
+++ b/module-app/src/main/java/maple/expectation/application/service/expectation/cache/ExpectationCacheCoordinator.java
@@ -343,19 +343,22 @@ public class ExpectationCacheCoordinator {
   private EquipmentExpectationResponseV4 handleAdmissionException(
       String cacheKey, Throwable exception) {
     Throwable cause = exception.getCause();
-    if (cause instanceof AdmissionTimeoutException) {
+    // AdmissionRejectedException/AdmissionTimeoutException may be set directly
+    // (not wrapped) when the CF completes exceptionally with them
+    Throwable target = (cause != null) ? cause : exception;
+    if (target instanceof AdmissionTimeoutException) {
       log.error("[V4] Admission control timeout for: {}", cacheKey);
       throw new EquipmentDataProcessingException(
-          String.format("Calculation rejected due to system overload: %s", cacheKey), cause);
+          String.format("Calculation rejected due to system overload: %s", cacheKey), target);
     }
-    if (cause instanceof AdmissionRejectedException) {
+    if (target instanceof AdmissionRejectedException) {
       log.warn("[V4] Admission control queue full - rejecting: {}", cacheKey);
       throw new EquipmentDataProcessingException(
-          String.format("System at capacity - queue full: %s", cacheKey), cause);
+          String.format("System at capacity - queue full: %s", cacheKey), target);
     }
-    log.error("[V4] Unexpected exception during admission control for: {}", cacheKey, cause);
+    log.error("[V4] Unexpected exception during admission control for: {}", cacheKey, target);
     throw new EquipmentDataProcessingException(
-        String.format("Calculation failed with admission control: %s", cacheKey), cause);
+        String.format("Calculation failed with admission control: %s", cacheKey), target);
   }
 
   /** Base64 → GZIP byte[] → JSON → Response 압축 해제 (#262 Fix) */

--- a/module-core/src/main/kotlin/maple/expectation/core/dto/v4/EquipmentItemConverter.kt
+++ b/module-core/src/main/kotlin/maple/expectation/core/dto/v4/EquipmentItemConverter.kt
@@ -8,7 +8,7 @@ object EquipmentItemConverter {
         level = item.level,
         part = item.part.koreanName,
         grade = item.potential?.grade?.koreanName,
-        options = item.potential?.asList()?.toMutableList() ?: mutableListOf(),
+        options = item.potential?.asList()?.filterNotNull()?.toMutableList() ?: mutableListOf(),
         itemName = item.itemName,
         itemIcon = "",
         itemEquipmentPart = item.equipmentPart.koreanName,

--- a/module-infra/src/main/kotlin/maple/expectation/adapter/outgoing/OutboxEventPortAdapter.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/adapter/outgoing/OutboxEventPortAdapter.kt
@@ -4,6 +4,7 @@ import java.util.UUID
 import maple.expectation.core.port.out.OutboxEvent
 import maple.expectation.core.port.out.OutboxEventPort
 import maple.expectation.infrastructure.persistence.repository.OutboxEventRepository
+import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Component
 
 @Component
@@ -13,7 +14,7 @@ class OutboxEventPortAdapter(
 
     override fun insertIfAbsent(eventType: String, jobId: UUID, payload: String?): Boolean = repo.insertIfAbsent(UUID.randomUUID(), eventType, jobId, payload) > 0
 
-    override fun findUnpublished(limit: Int): List<OutboxEvent> = repo.findUnpublished(limit).map {
+    override fun findUnpublished(limit: Int): List<OutboxEvent> = repo.findUnpublished(limit, PageRequest.of(0, limit)).map {
         OutboxEvent(it.eventId, it.eventType, it.jobId, it.payload, it.published, it.publishAttempts)
     }
 

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/config/JacksonConfig.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/config/JacksonConfig.kt
@@ -9,6 +9,7 @@ import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilde
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder
 
 /**
  * Jackson JSON 파싱 설정
@@ -43,7 +44,9 @@ class JacksonConfig {
      */
     @Bean
     @Primary
-    fun objectMapper(): ObjectMapper = ObjectMapper()
+    fun objectMapper(builder: Jackson2ObjectMapperBuilder): ObjectMapper = builder
+        .createXmlMapper(false)
+        .build<ObjectMapper>()
         .registerModule(KotlinModule.Builder().build())
         .registerModule(JavaTimeModule())
         .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/config/PostgresL2CacheConfig.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/config/PostgresL2CacheConfig.kt
@@ -48,6 +48,7 @@ import org.springframework.context.annotation.Primary
 @ConditionalOnProperty(
     name = ["cache.l2.enabled"],
     havingValue = "true",
+    matchIfMissing = true,
 )
 @ConditionalOnProperty(
     name = ["cache.l2.impl"],
@@ -174,7 +175,9 @@ class PostgresL2CacheConfig {
      * <p>Required by TotalExpectationCacheService for JSON serialization.
      */
     @Bean(name = ["expectationObjectMapper"])
-    fun expectationObjectMapper(): com.fasterxml.jackson.databind.ObjectMapper = com.fasterxml.jackson.databind.ObjectMapper()
+    fun expectationObjectMapper(builder: org.springframework.http.converter.json.Jackson2ObjectMapperBuilder): com.fasterxml.jackson.databind.ObjectMapper = builder
+        .createXmlMapper(false)
+        .build<com.fasterxml.jackson.databind.ObjectMapper>()
         .registerModule(com.fasterxml.jackson.datatype.jsr310.JavaTimeModule())
         .registerModule(com.fasterxml.jackson.module.kotlin.KotlinModule.Builder().build())
         .disable(com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/repository/OutboxEventRepository.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/repository/OutboxEventRepository.kt
@@ -11,7 +11,7 @@ import org.springframework.data.repository.query.Param
 interface OutboxEventRepository : JpaRepository<OutboxEventEntity, UUID> {
 
     @Query("SELECT e FROM OutboxEventEntity e WHERE e.published = false ORDER BY e.createdAt")
-    fun findUnpublished(limit: Int): List<OutboxEventEntity>
+    fun findUnpublished(limit: Int, pageable: org.springframework.data.domain.Pageable): List<OutboxEventEntity>
 
     @Modifying
     @Query("UPDATE OutboxEventEntity e SET e.published = true, e.publishedAt = :now WHERE e.eventId = :eventId")

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/PgmqWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/PgmqWorker.kt
@@ -52,7 +52,7 @@ abstract class PgmqWorker<T : Any>(
         val pool = Executors.newFixedThreadPool(config.common.workerPoolSize) { runnable ->
             Thread.ofVirtual().name("$queueName-worker").unstarted(runnable)
         }
-        ExecutorServiceMetrics.monitor(meterRegistry, pool, "$queueName-worker-pool", "pgmq.worker")
+        ExecutorServiceMetrics.monitor(meterRegistry, pool, "$queueName-worker-pool", io.micrometer.core.instrument.Tags.of("type", "pgmq.worker"))
         pool
     }
 
@@ -267,8 +267,6 @@ abstract class PgmqWorker<T : Any>(
                 workerPool,
             ).exceptionally { error ->
                 log.warn("[{}] Phase 1 failed for msgId={}: {}", queueName, message.messageId, error.message)
-                metrics.inflightDecrement()
-                inflightPermits.release()
                 null to message
             }.thenAccept { result ->
                 val calcResult = result.first as? CalculationResult
@@ -279,7 +277,7 @@ abstract class PgmqWorker<T : Any>(
                         inflightPermits.release()
                     }
                 } else {
-                    log.warn("[{}] Phase 1 returned non-CalculationResult for msgId={}, dropping", queueName, result.second.messageId)
+                    log.warn("[{}] Phase 1 returned null for msgId={}, releasing permit", queueName, result.second.messageId)
                     metrics.inflightDecrement()
                     inflightPermits.release()
                 }
@@ -309,13 +307,16 @@ abstract class PgmqWorker<T : Any>(
         )
     }
 
+    @Volatile
+    private var pendingBatchFuture: CompletableFuture<*>? = null
+
     private fun processBatchSinglePhase(messages: List<PgmqMessage<T>>) {
         val futures = messages.map { message ->
             CompletableFuture.supplyAsync({
                 processSingleMessage(message)
             }, workerPool)
         }
-        CompletableFuture.allOf(*futures.toTypedArray())
+        pendingBatchFuture = CompletableFuture.allOf(*futures.toTypedArray())
             .exceptionally { ex ->
                 log.warn("[{}] Batch completion error: {}", queueName, ex.message)
                 null
@@ -459,6 +460,7 @@ abstract class PgmqWorker<T : Any>(
             flushSequentialBatch()
         }
         log.info("[{}] Shutting down worker pool", queueName)
+        pendingBatchFuture?.join()
         workerPool.shutdown()
         if (!workerPool.awaitTermination(5, TimeUnit.SECONDS)) {
             log.warn("[{}] Worker pool did not terminate in 5s, forcing", queueName)

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/AbstractExpectationCalcWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/AbstractExpectationCalcWorker.kt
@@ -85,6 +85,7 @@ abstract class AbstractExpectationCalcWorker(
                 request.userIgn,
                 request.forceRecalculation,
                 message.messageId.toString(),
+                request.presetNo,
             )
 
             val character = gameCharacterPort.getCharacterOrThrow(request.userIgn)
@@ -162,6 +163,21 @@ abstract class AbstractExpectationCalcWorker(
 
         // 3. Bulk upsert — 3 queries total (SELECT + batch UPDATE/INSERT)
         batchRepo.bulkUpsert(parsed)
+
+        // 4. Sync read model for query-server
+        parsed.forEach { view ->
+            viewQueryPort.upsertFromCalculation(
+                userIgn = view.userIgn,
+                messageId = view.messageId,
+                characterOcid = view.characterOcid,
+                characterClass = view.characterClass,
+                characterLevel = null,
+                totalExpectedCost = view.totalExpectedCost,
+                maxPresetNo = view.maxPresetNo,
+                presetNo = view.presetNo,
+                presetsJson = view.presetsJson,
+            )
+        }
     }
 
     private fun batchL2CachePut(results: List<CalculationResult>) {

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/NexonApiWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/NexonApiWorker.kt
@@ -41,9 +41,18 @@ class NexonApiWorker(
         val payload = envelope.payload as Map<*, *>
         val jobId = UUID.fromString(payload["jobId"].toString())
         val context = TaskContext.of("NexonApiWorker", "Process", jobId.toString())
-        return executor.executeOrDefault({
-            processApiRequest(payload, jobId)
-        }, ConsumeResult.Ack, context)
+        return executor.executeOrCatch(
+            { processApiRequest(payload, jobId) },
+            { e ->
+                log.error("[jobId={}] API request failed: {}", jobId, e.message)
+                executor.executeVoid(
+                    { jobService.handleApiFailure(jobId, "API_ERROR", e.message?.take(200) ?: "Unknown") },
+                    context,
+                )
+                ConsumeResult.Ack
+            },
+            context,
+        )
     }
 
     private fun processApiRequest(payload: Map<*, *>, jobId: UUID): ConsumeResult {

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/OutboxRelayWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/OutboxRelayWorker.kt
@@ -1,5 +1,6 @@
 package maple.expectation.infrastructure.worker
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import maple.expectation.core.port.out.OutboxEventPort
 import maple.expectation.infrastructure.executor.LogicExecutor
 import maple.expectation.infrastructure.executor.TaskContext
@@ -15,6 +16,7 @@ class OutboxRelayWorker(
     private val outboxPort: OutboxEventPort,
     private val resultReadyTopic: ResultReadyTopic,
     private val executor: LogicExecutor,
+    private val objectMapper: ObjectMapper,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -32,11 +34,14 @@ class OutboxRelayWorker(
             val context = TaskContext.of("OutboxRelayWorker", "Relay", event.eventId.toString())
             executor.executeOrCatch(
                 {
+                    val payload = event.payload?.let {
+                        runCatching { objectMapper.readValue(it, Map::class.java) as Map<*, *> }.getOrNull()
+                    }
                     val integrationEvent = ResultReadyEventFactory.create(
                         jobId = event.jobId.toString(),
                         resultId = event.eventId.toString(),
-                        characterId = "",
-                        presetNo = 1,
+                        characterId = payload?.get("characterId")?.toString() ?: "",
+                        presetNo = (payload?.get("presetNo") as? Number)?.toInt() ?: 1,
                     )
                     resultReadyTopic.publish(integrationEvent)
                     outboxPort.markPublished(event.eventId)

--- a/module-infra/src/main/resources/db/migration/V118__codex_review_fixes.sql
+++ b/module-infra/src/main/resources/db/migration/V118__codex_review_fixes.sql
@@ -1,0 +1,8 @@
+-- Create result_ready_queue for outbox relay (PR #771 Codex review)
+SELECT pgmq.create('result_ready_queue');
+
+-- Migrate legacy status values to current enum (PR #769 Codex review)
+-- OCID_RESOLVED, OCID_RETRY_WAIT, API_RETRY_WAIT were removed from CalculationJobStatus
+UPDATE calculation_jobs
+SET status = 'RETRYING'
+WHERE status IN ('OCID_RESOLVED', 'OCID_RETRY_WAIT', 'API_RETRY_WAIT');

--- a/module-web/src/main/kotlin/maple/expectation/web/controller/v5/GameCharacterControllerV5.kt
+++ b/module-web/src/main/kotlin/maple/expectation/web/controller/v5/GameCharacterControllerV5.kt
@@ -96,6 +96,7 @@ class GameCharacterControllerV5(
         val cachedResult: Optional<EquipmentExpectationResponseV5> = executorPort.executeOrDefault(
             {
                 queryPort.findByUserIgn(userIgn)
+                    .filter { view -> view.presets?.any { it.presetNo == presetNo } ?: false }
                     .map { CharacterViewMapper.toResponseDto(it) }
                     .orElse(Optional.empty())
             },
@@ -105,7 +106,7 @@ class GameCharacterControllerV5(
 
         // 2. HIT: Return immediately (1-10ms)
         if (cachedResult.isPresent) {
-            log.debug("[V5] PostgreSQL HIT: {}", maskIgn(userIgn))
+            log.debug("[V5] PostgreSQL HIT: {} (presetNo={})", maskIgn(userIgn), presetNo)
             return ResponseEntity.ok(cachedResult.get())
         }
 

--- a/module-web/src/test/kotlin/maple/expectation/web/controller/v5/GameCharacterControllerV5Test.kt
+++ b/module-web/src/test/kotlin/maple/expectation/web/controller/v5/GameCharacterControllerV5Test.kt
@@ -236,7 +236,7 @@ class GameCharacterControllerV5Test {
         override val fromCache = true
         override val totalExpectedCost = 1000000L
         override val maxPresetNo = 3
-        override val presets = emptyList<CharacterView.PresetView>()
+        override val presets = listOf(CharacterView.PresetView(presetNo = 1, totalExpectedCost = 1000000L, totalCostText = "100만", costBreakdown = null, items = null))
     }
 
     /**


### PR DESCRIPTION
## Summary
- PR 729~774에서 수집한 Codex 리뷰 피드백 35건 중 실제 수정이 필요한 17건 반영
- P1: 13건 (Micrometer tags, batch lifecycle, ObjectMapper, presetNo, read-model sync, outbox payload 등)
- P2: 4건 (cache config gap, legacy enum migration)

## Changes

| # | PR | File | Fix |
|---|-----|------|-----|
| 1 | 746 | PgmqWorker | Micrometer tags key/value pair |
| 2 | 774 | PgmqWorker | Single-phase batch lifecycle tracking + shutdown join |
| 3 | 729 | PgmqWorker | Phase-1 failure double-release prevention |
| 4 | 754 | JacksonConfig | Spring Boot builder instead of raw ObjectMapper |
| 5 | 754 | PostgresL2CacheConfig | Same ObjectMapper fix + matchIfMissing |
| 6 | 772 | EquipmentItemConverter | filterNotNull() on potential options |
| 7 | 756 | GameCharacterControllerV5 | Filter cache hits by presetNo |
| 8 | 756 | AbstractExpectationCalcWorker | Pass presetNo to calculateExpectationWriteOnly |
| 9 | 745 | AbstractExpectationCalcWorker | Sync read-model in batchViewUpsert |
| 10 | 770 | NexonApiWorker | Route failures to handleApiFailure |
| 11 | 774 | ExpectationCacheCoordinator | Handle null cause in admission exceptions |
| 12 | 771 | OutboxEventRepository | Bind limit via Pageable |
| 13 | 771 | OutboxRelayWorker | Parse actual payload from outbox events |
| 14 | 771 | V118 migration | Create result_ready_queue + migrate legacy statuses |

## Test plan
- [x] `./gradlew compileKotlin compileJava --continue` passes
- [x] `./gradlew test` passes (all 36 tasks)
- [x] V5 controller unit tests updated for presetNo filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)