### PR TITLE
fix: widen equipment_persistence_tracker.ocid to VARCHAR(64)

### DIFF
--- a/module-infra/src/main/resources/db/migration/V119__widen_equipment_persistence_tracker_ocid.sql
+++ b/module-infra/src/main/resources/db/migration/V119__widen_equipment_persistence_tracker_ocid.sql
@@ -1,0 +1,4 @@
+-- Widen equipment_persistence_tracker.ocid from VARCHAR(20) to VARCHAR(64)
+-- Real Nexon OCID values exceed 20 characters, causing DataIntegrityViolationException
+-- Aligns with calculation_jobs.ocid (VARCHAR(64)) and other tables
+ALTER TABLE equipment_persistence_tracker ALTER COLUMN ocid TYPE VARCHAR(64);


### PR DESCRIPTION
## Summary
- `equipment_persistence_tracker.ocid` 컬럼이 `VARCHAR(20)`이어서 실제 Nexon OCID 값 삽입 시 `DataIntegrityViolationException` 발생
- `VARCHAR(64)`로 확장하여 `calculation_jobs` 등 다른 테이블과 일치

## Test plan
- [x] 서버 런타임 검증: 아델 recalculate → 파이프라인 정상 완료
- [x] varchar(20) 오류 재현 불가 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)