### PR TITLE
fix(v5): stabilize db throughput load test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# Repository Instructions for Codex
+
+This repository also has Claude Code instructions in:
+
+- `CLAUDE.md`
+- `.claude/rules/`
+
+When working in this repository, read and follow those files as project-specific guidance.
+
+Important:
+- Prefer small, focused changes.
+- Do not run destructive database commands unless explicitly asked.
+- For performance work, preserve before/after metrics.
+- For backend changes, pay attention to transactions, idempotency, PGMQ/Kafka boundaries, and connection-pool pressure.
+- Run relevant tests before committing when feasible.

--- a/docs/superpowers/plans/2026-04-28-write-path-pure-calculate.md
+++ b/docs/superpowers/plans/2026-04-28-write-path-pure-calculate.md
@@ -1,0 +1,826 @@
+# Write Path Pure Calculate Refactoring
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract pure calculation from `EquipmentExpectationServiceV4`'s fetch+calculate+persist pipeline into a standalone `PureExpectationCalculator`, then wire `ApiResponseWorker` to load `CalculationInput` from DB and call the pure calculator — removing all `.join()` blocking and `@Transactional` overlap from the Write Path.
+
+**Architecture:** The current `calculateExpectationAsync` is an orchestration function (fetch + calculate + persist) masquerading as a calculation function. We split it at line 214-216 of `EquipmentExpectationServiceV4.java` — everything above is fetch (stays in Read Path / External API Path), everything below is pure calculate (moves to `PureExpectationCalculator`). The `ApiResponseWorker` loads pre-built `CalculationInput` from DB, calls the pure calculator synchronously (no `CompletableFuture`, no `.join()`), then persists the result in a separate `@Transactional` boundary.
+
+**Tech Stack:** Kotlin 2.x, Spring Boot 3.x, JUnit 5, MockK
+
+---
+
+## File Structure
+
+### Created
+| File | Responsibility |
+|------|---------------|
+| `module-core/.../dto/v4/EquipmentItemConverter.kt` | `EquipmentItem` → `CubeCalculationInput` pure data mapping |
+| `module-app/.../service/expectation/PureExpectationCalculator.kt` | `CalculationInput` → `EquipmentExpectationResponseV4` (pure, no I/O) |
+| `module-core/src/test/.../dto/v4/EquipmentItemConverterTest.kt` | Converter unit test |
+| `module-app/src/test/.../service/expectation/PureExpectationCalculatorTest.kt` | Calculator unit test |
+
+### Modified
+| File | Change |
+|------|--------|
+| `module-app/.../worker/ApiResponseWorker.kt` | Replace `expectationPort.calculateExpectationAsync().join()` with `pureCalculator.calculate(input)` |
+| `module-core/.../port/out/CalculationJobPort.kt` | Add `retryCalculation()` method |
+| `module-infra/.../repository/CalculationJobRepository.kt` | Add `retryCalculation()` JPQL |
+| `module-infra/.../adapter/outgoing/CalculationJobPortAdapter.kt` | Implement `retryCalculation()` |
+| `module-infra/.../job/CalculationJobService.kt` | Add `handleCalculationFailure()` with exponential backoff |
+
+---
+
+### Task 1: EquipmentItemConverter — EquipmentItem → CubeCalculationInput
+
+**Files:**
+- Create: `module-core/src/main/kotlin/maple/expectation/core/dto/v4/EquipmentItemConverter.kt`
+- Create: `module-core/src/test/kotlin/maple/expectation/core/dto/v4/EquipmentItemConverterTest.kt`
+
+This is the missing bridge between the typed `CalculationInput` contract and the existing calculator pipeline (`PresetCalculationHelper`). It maps each `EquipmentItem` field to the corresponding `CubeCalculationInput` field — a pure data transformation with no I/O or external dependencies.
+
+- [ ] **Step 1: Write the converter test**
+
+```kotlin
+package maple.expectation.core.dto.v4
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.*
+
+class EquipmentItemConverterTest {
+
+    @Test
+    fun `maps all EquipmentItem fields to CubeCalculationInput`() {
+        val item = EquipmentItem(
+            part = EquipmentSlot.WEAPON,
+            equipmentPart = EquipmentPart.WEAPON,
+            itemName = "아케인셰이드 스태프",
+            level = 200,
+            potential = PotentialLines(
+                grade = PotentialGrade.LEGENDARY,
+                line1 = "INT +12%",
+                line2 = "마력 +9%",
+                line3 = "올스탯 +3%"
+            ),
+            additionalPotential = PotentialLines(
+                grade = PotentialGrade.UNIQUE,
+                line1 = "INT +9%",
+                line2 = "마력 +6%",
+                line3 = null
+            ),
+            starforce = 17,
+            starforceScrollFlag = StarforceScrollFlag.USED,
+            addOption = AddOption(
+                str = 0, dex = 0, int = 3, luk = 0,
+                maxHp = 0, allStat = 0,
+                attackPower = 0, magicPower = 5,
+                bossDamage = 0, damage = 0
+            ),
+            baseAttackPower = 10,
+            baseMagicPower = 200
+        )
+
+        val result = EquipmentItemConverter.toCubeInput(item)
+
+        assertEquals(200, result.level)
+        assertEquals("무기", result.part)
+        assertEquals("아케인셰이드 스태프", result.itemName)
+        assertEquals("무기", result.itemEquipmentPart)
+        assertEquals("레전드리", result.grade)
+        assertEquals(listOf("INT +12%", "마력 +9%", "올스탯 +3%"), result.options)
+        assertEquals("유니크", result.additionalGrade)
+        assertEquals(listOf("INT +9%", "마력 +6%"), result.additionalOptions)
+        assertEquals(17, result.starforce)
+        assertEquals("사용", result.starforceScrollFlag)
+        assertEquals(3, result.addOptionInt)
+        assertEquals(5, result.addOptionMag)
+        assertEquals(10, result.baseAttackPower)
+        assertEquals(200, result.baseMagicPower)
+    }
+
+    @Test
+    fun `handles null potentials gracefully`() {
+        val item = EquipmentItem(
+            part = EquipmentSlot.MEDAL,
+            equipmentPart = EquipmentPart.ETC,
+            itemName = "훈장",
+            level = 100,
+            potential = null,
+            additionalPotential = null,
+            starforce = 0,
+            starforceScrollFlag = StarforceScrollFlag.NOT_USED,
+            addOption = AddOption(0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+            baseAttackPower = 0,
+            baseMagicPower = 0
+        )
+
+        val result = EquipmentItemConverter.toCubeInput(item)
+
+        assertNull(result.grade)
+        assertTrue(result.options.isEmpty())
+        assertNull(result.additionalGrade)
+        assertTrue(result.additionalOptions.isEmpty())
+        assertEquals(0, result.starforce)
+        assertEquals("미사용", result.starforceScrollFlag)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :module-core:test --tests "maple.expectation.core.dto.v4.EquipmentItemConverterTest" 2>&1 | tail -5`
+Expected: FAIL — `EquipmentItemConverter` does not exist yet
+
+- [ ] **Step 3: Write the converter**
+
+```kotlin
+package maple.expectation.core.dto.v4
+
+import maple.expectation.core.dto.cube.CubeCalculationInput
+
+object EquipmentItemConverter {
+
+    fun toCubeInput(item: EquipmentItem): CubeCalculationInput = CubeCalculationInput(
+        level = item.level,
+        part = item.part.koreanName,
+        grade = item.potential?.grade?.koreanName,
+        options = item.potential?.asList()?.toMutableList() ?: mutableListOf(),
+        itemName = item.itemName,
+        itemEquipmentPart = item.equipmentPart.koreanName,
+        additionalGrade = item.additionalPotential?.grade?.koreanName,
+        additionalOptions = item.additionalPotential?.asList()?.filterNotNull()?.toMutableList() ?: mutableListOf(),
+        starforce = item.starforce,
+        starforceScrollFlag = item.starforceScrollFlag.koreanValue,
+        addOptionStr = item.addOption.str,
+        addOptionDex = item.addOption.dex,
+        addOptionInt = item.addOption.int,
+        addOptionLuk = item.addOption.luk,
+        addOptionMaxHp = item.addOption.maxHp,
+        addOptionAllStat = item.addOption.allStat,
+        addOptionAtt = item.addOption.attackPower,
+        addOptionMag = item.addOption.magicPower,
+        addOptionBossDmg = item.addOption.bossDamage,
+        addOptionDmg = item.addOption.damage,
+        baseAttackPower = item.baseAttackPower,
+        baseMagicPower = item.baseMagicPower,
+    )
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :module-core:test --tests "maple.expectation.core.dto.v4.EquipmentItemConverterTest" 2>&1 | tail -5`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add module-core/src/main/kotlin/maple/expectation/core/dto/v4/EquipmentItemConverter.kt module-core/src/test/kotlin/maple/expectation/core/dto/v4/EquipmentItemConverterTest.kt
+git commit -m "feat(write-path): add EquipmentItemConverter for pure calculation input"
+```
+
+---
+
+### Task 2: PureExpectationCalculator — CalculationInput → EquipmentExpectationResponseV4
+
+**Files:**
+- Create: `module-app/src/main/kotlin/maple/expectation/application/service/expectation/PureExpectationCalculator.kt`
+- Create: `module-app/src/test/kotlin/maple/expectation/application/service/expectation/PureExpectationCalculatorTest.kt`
+
+This is the core refactoring — a `@Component` that takes `CalculationInput` (already loaded from DB, no I/O) and returns `EquipmentExpectationResponseV4`. It converts items via `EquipmentItemConverter` then delegates to the existing `PresetCalculationHelper`.
+
+The `future.get(30, TimeUnit.SECONDS)` on the internal CompletableFuture is temporary (per user's direction: "30s timeout은 임시로만 유지하거나 단계적으로 제거"). This blocks only the item-calculation thread pool — no DB connections, no external calls.
+
+- [ ] **Step 1: Write the calculator test**
+
+```kotlin
+package maple.expectation.application.service.expectation
+
+import maple.expectation.core.dto.v4.*
+import maple.expectation.core.dto.v4.EquipmentExpectationResponseV4.PresetExpectation
+import maple.expectation.core.dto.v4.EquipmentExpectationResponseV4.CostBreakdownDto
+import maple.expectation.core.dto.v4.EquipmentExpectationResponseV4.ItemExpectationV4
+import maple.expectation.core.dto.v4.EquipmentExpectationResponseV4.CubeExpectationDto
+import maple.expectation.core.dto.v4.EquipmentExpectationResponseV4.StarforceExpectationDto
+import maple.expectation.core.dto.v4.EquipmentExpectationResponseV4.FlameExpectationDto
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.*
+import java.util.concurrent.CompletableFuture
+
+class PureExpectationCalculatorTest {
+
+    private val presetHelper: PresetCalculationHelper = mockk()
+    private val calculator = PureExpectationCalculator(presetHelper)
+
+    private fun stubPreset() = PresetExpectation(
+        presetNo = 1,
+        totalExpectedCost = 1_000_000.0,
+        totalCostText = "1,000,000",
+        costBreakdown = CostBreakdownDto(
+            blackCubeCost = 500_000.0,
+            redCubeCost = 300_000.0,
+            additionalCubeCost = 100_000.0,
+            starforceCost = 100_000.0
+        ),
+        items = listOf(
+            ItemExpectationV4(
+                itemName = "테스트 무기",
+                itemIcon = "",
+                itemPart = "무기",
+                itemLevel = 200,
+                expectedCost = 1_000_000.0,
+                expectedCostText = "1,000,000",
+                costBreakdown = CostBreakdownDto.empty(),
+                enhancePath = "에픽→유니크→레전드리",
+                potentialGrade = "레전드리",
+                additionalPotentialGrade = null,
+                currentStar = 0,
+                targetStar = 17,
+                isNoljang = true,
+                specialRingLevel = 0,
+                blackCubeExpectation = CubeExpectationDto.empty(),
+                additionalCubeExpectation = CubeExpectationDto.empty(),
+                starforceExpectation = StarforceExpectationDto.empty(),
+                flameExpectation = FlameExpectationDto.empty()
+            )
+        )
+    )
+
+    @Test
+    fun `calculate returns response with correct user IGN and preset data`() {
+        val input = CalculationInput(
+            jobId = "test-job",
+            userIgn = "테스트유저",
+            characterClass = "아크메이지",
+            presetNo = 1,
+            items = listOf(
+                EquipmentItem(
+                    part = EquipmentSlot.WEAPON,
+                    equipmentPart = EquipmentPart.WEAPON,
+                    itemName = "테스트 무기",
+                    level = 200,
+                    potential = PotentialLines(PotentialGrade.LEGENDARY, "INT +12%", "마력 +9%", "올스탯 +3%"),
+                    additionalPotential = null,
+                    starforce = 17,
+                    starforceScrollFlag = StarforceScrollFlag.USED,
+                    addOption = AddOption(0, 0, 3, 0, 0, 0, 0, 5, 0, 0),
+                    baseAttackPower = 10,
+                    baseMagicPower = 200
+                )
+            )
+        )
+
+        val preset = stubPreset()
+        every { presetHelper.calculatePresetAsync(any(), eq(1), eq("아크메이지")) } returns CompletableFuture.completedFuture(preset)
+
+        val result = calculator.calculate(input)
+
+        assertEquals("테스트유저", result.userIgn)
+        assertFalse(result.fromCache)
+        assertEquals(1_000_000.0, result.totalExpectedCost)
+        assertEquals(1, result.maxPresetNo)
+        assertEquals(1, result.presets.size)
+        assertEquals(1_000_000.0, result.presets[0].totalExpectedCost)
+    }
+
+    @Test
+    fun `calculate propagates exceptions from preset helper`() {
+        val input = CalculationInput(
+            jobId = "test-job",
+            userIgn = "테스트유저",
+            characterClass = "아크메이지",
+            presetNo = 1,
+            items = emptyList()
+        )
+
+        every { presetHelper.calculatePresetAsync(any(), any(), any()) } returns
+            CompletableFuture.failedFuture(RuntimeException("Calculation failed"))
+
+        assertThrows(Exception::class.java) {
+            calculator.calculate(input)
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :module-app:test --tests "maple.expectation.application.service.expectation.PureExpectationCalculatorTest" 2>&1 | tail -5`
+Expected: FAIL — `PureExpectationCalculator` does not exist yet
+
+- [ ] **Step 3: Write the calculator**
+
+```kotlin
+package maple.expectation.application.service.expectation
+
+import maple.expectation.core.dto.v4.CalculationInput
+import maple.expectation.core.dto.v4.EquipmentExpectationResponseV4
+import maple.expectation.core.dto.v4.EquipmentItemConverter
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+import java.util.concurrent.TimeUnit
+
+@Component
+class PureExpectationCalculator(
+    private val presetHelper: PresetCalculationHelper
+) {
+    fun calculate(input: CalculationInput): EquipmentExpectationResponseV4 {
+        val cubeInputs = input.items.map { EquipmentItemConverter.toCubeInput(it) }
+
+        val future = presetHelper.calculatePresetAsync(
+            cubeInputs, input.presetNo, input.characterClass
+        )
+        val preset = future.get(30, TimeUnit.SECONDS)
+
+        return EquipmentExpectationResponseV4(
+            userIgn = input.userIgn,
+            calculatedAt = LocalDateTime.now(),
+            fromCache = false,
+            totalExpectedCost = preset.totalExpectedCost,
+            totalCostText = preset.totalCostText,
+            totalCostBreakdown = preset.costBreakdown,
+            maxPresetNo = input.presetNo,
+            presets = listOf(preset)
+        )
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :module-app:test --tests "maple.expectation.application.service.expectation.PureExpectationCalculatorTest" 2>&1 | tail -5`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add module-app/src/main/kotlin/maple/expectation/application/service/expectation/PureExpectationCalculator.kt module-app/src/test/kotlin/maple/expectation/application/service/expectation/PureExpectationCalculatorTest.kt
+git commit -m "feat(write-path): add PureExpectationCalculator — pure CalculationInput to response"
+```
+
+---
+
+### Task 3: Calculation Retry — handleCalculationFailure + retryCalculation
+
+**Depends on:** Task 1, Task 2 (must be implemented before Task 4)
+
+**Files:**
+- Modify: `module-core/src/main/kotlin/maple/expectation/core/port/out/CalculationJobPort.kt`
+- Modify: `module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/repository/CalculationJobRepository.kt`
+- Modify: `module-infra/src/main/kotlin/maple/expectation/adapter/outgoing/CalculationJobPortAdapter.kt`
+- Modify: `module-infra/src/main/kotlin/maple/expectation/infrastructure/job/CalculationJobService.kt`
+
+Follow the existing retry pattern from `handleApiFailure()` / `handleOcidFailure()`: check retry count, if under max then transition to a retryable state and re-publish the MQ event, otherwise mark failed.
+
+For calculation retry, the transition is `CALCULATING → SNAPSHOT_READY` (so the existing `snapshot_ready` flow picks it up again). This avoids creating new job statuses.
+
+- [ ] **Step 1: Add retryCalculation to the port interface**
+
+In `module-core/src/main/kotlin/maple/expectation/core/port/out/CalculationJobPort.kt`, add:
+
+```kotlin
+fun retryCalculation(jobId: UUID, errorCode: String, nextRetryAt: Instant): Boolean
+```
+
+Full file after edit:
+
+```kotlin
+package maple.expectation.core.port.out
+
+import maple.expectation.core.model.job.CalculationJob
+import maple.expectation.core.model.job.CalculationJobStatus
+import java.time.Instant
+import java.util.UUID
+
+interface CalculationJobPort {
+    fun createJob(ocid: String?, userIgn: String, presetNo: Int): CalculationJob
+    fun findJobById(jobId: UUID): CalculationJob?
+    fun transitionStatus(jobId: UUID, from: CalculationJobStatus, to: CalculationJobStatus): Boolean
+    fun markSnapshotReady(jobId: UUID, snapshotId: UUID, from: CalculationJobStatus): Boolean
+    fun markFailed(jobId: UUID, errorCode: String, errorMessage: String): Boolean
+    fun incrementRetry(jobId: UUID, errorCode: String): Boolean
+    fun incrementRetryForOcid(jobId: UUID, errorCode: String): Boolean
+    fun retryCalculation(jobId: UUID, errorCode: String, nextRetryAt: Instant): Boolean
+    fun lockForProcessing(jobId: UUID, workerId: String, from: CalculationJobStatus): Boolean
+    fun unlock(jobId: UUID): Boolean
+    fun findStaleJobs(status: CalculationJobStatus, olderThanSeconds: Long): List<CalculationJob>
+    fun findActiveJobByUserIgn(userIgn: String, presetNo: Int): CalculationJob?
+    fun resolveOcidAndTransition(jobId: UUID, ocid: String): Boolean
+    fun findCompletedJobsMissingOutboxEvents(limit: Int): List<UUID>
+}
+```
+
+- [ ] **Step 2: Add retryCalculation JPQL to repository**
+
+In `module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/repository/CalculationJobRepository.kt`, add before the closing `}`:
+
+```kotlin
+@Modifying
+@Query("""
+    UPDATE CalculationJobEntity j
+    SET j.retryCount = j.retryCount + 1,
+        j.status = 'SNAPSHOT_READY',
+        j.nextRetryAt = :nextRetryAt,
+        j.lastErrorCode = :errorCode,
+        j.lockedBy = NULL, j.lockedUntil = NULL,
+        j.updatedAt = CURRENT_TIMESTAMP
+    WHERE j.jobId = :jobId
+      AND j.status = 'CALCULATING'
+      AND j.retryCount < j.maxRetries
+""")
+fun retryCalculation(
+    @Param("jobId") jobId: UUID,
+    @Param("errorCode") errorCode: String,
+    @Param("nextRetryAt") nextRetryAt: Instant
+): Int
+```
+
+- [ ] **Step 3: Implement retryCalculation in adapter**
+
+In `module-infra/src/main/kotlin/maple/expectation/adapter/outgoing/CalculationJobPortAdapter.kt`, add:
+
+```kotlin
+override fun retryCalculation(jobId: UUID, errorCode: String, nextRetryAt: Instant): Boolean {
+    return jobRepository.retryCalculation(jobId, errorCode, nextRetryAt) > 0
+}
+```
+
+- [ ] **Step 4: Add handleCalculationFailure to CalculationJobService**
+
+In `module-infra/src/main/kotlin/maple/expectation/infrastructure/job/CalculationJobService.kt`, add after `handleOcidFailure()` (line ~171):
+
+```kotlin
+@Transactional
+fun handleCalculationFailure(jobId: UUID, errorCode: String, errorMessage: String) {
+    val job = jobPort.findJobById(jobId) ?: return
+
+    if (job.retryCount >= job.maxRetries) {
+        jobPort.markFailed(jobId, errorCode, errorMessage)
+        log.warn("[jobId={}] Calculation failed after {} retries: {}", jobId, job.retryCount, errorMessage)
+        return
+    }
+
+    val backoffSeconds = calculateBackoff(job.retryCount)
+    val nextRetry = java.time.Instant.now().plusSeconds(backoffSeconds)
+    val retried = jobPort.retryCalculation(jobId, errorCode, nextRetry)
+    if (retried) {
+        val event = NexonApiResponseEventFactory.create(
+            jobId.toString(),
+            job.snapshotId?.toString() ?: return,
+            "",
+            job.ocid ?: return,
+            job.userIgn,
+            job.presetNo
+        )
+        eventAppender.append(nexonApiResponseTopic, event)
+        log.info("[jobId={}] Calculation retry scheduled (attempt {}, backoff={}s)", jobId, job.retryCount + 1, backoffSeconds)
+    } else {
+        jobPort.markFailed(jobId, errorCode, errorMessage)
+    }
+}
+
+private fun calculateBackoff(retryCount: Int): Long {
+    val baseSeconds = 30L
+    return minOf(baseSeconds * (1L shl retryCount), 600L)
+}
+```
+
+The exponential backoff formula: `30s → 60s → 120s → 240s → 480s` capped at 600s (10 min).
+
+- [ ] **Step 5: Compile and commit**
+
+Run: `./gradlew compileKotlin compileJava --continue 2>&1 | grep -E "(ERROR|FAIL|BUILD)" | head -10`
+Expected: BUILD SUCCESSFUL
+
+```bash
+git add module-core/src/main/kotlin/maple/expectation/core/port/out/CalculationJobPort.kt module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/repository/CalculationJobRepository.kt module-infra/src/main/kotlin/maple/expectation/adapter/outgoing/CalculationJobPortAdapter.kt module-infra/src/main/kotlin/maple/expectation/infrastructure/job/CalculationJobService.kt
+git commit -m "feat(write-path): add calculation retry with exponential backoff"
+```
+
+---
+
+### Task 4: ApiResponseWorker — Remove .join(), Use Pure Calculator
+
+**Depends on:** Task 1, Task 2, Task 3
+
+**Files:**
+- Modify: `module-app/src/main/kotlin/maple/expectation/application/worker/ApiResponseWorker.kt`
+
+This is the critical change. Replace `expectationPort.calculateExpectationAsync(userIgn, false, jobId.toString(), presetNo).join()` with:
+1. Load `CalculationInput` from DB (already done at line 83)
+2. Call `pureCalculator.calculate(input)` — synchronous, pure, no I/O
+3. Serialize and persist result (existing code)
+
+The `@Transactional` boundary is now ONLY in `jobService.completeCalculationWithResult()` — no transaction wraps the calculation itself.
+
+- [ ] **Step 1: Modify ApiResponseWorker**
+
+Replace the `expectationPort` dependency with `pureCalculator` and restructure `processApiResponse`:
+
+```kotlin
+package maple.expectation.application.worker
+
+import maple.expectation.application.service.expectation.PureExpectationCalculator
+import maple.expectation.core.model.job.CalculationJobStatus
+import maple.expectation.core.port.out.CalculationInputPort
+import maple.expectation.core.port.out.CalculationJobPort
+import maple.expectation.core.port.out.mq.ConsumeResult
+import maple.expectation.core.domain.event.IntegrationEvent
+import maple.expectation.infrastructure.executor.LogicExecutor
+import maple.expectation.infrastructure.executor.TaskContext
+import maple.expectation.infrastructure.job.CalculationJobService
+import maple.expectation.infrastructure.mq.pgmq.topic.NexonApiResponseTopic
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+class ApiResponseWorker(
+    private val nexonApiResponseTopic: NexonApiResponseTopic,
+    private val pureCalculator: PureExpectationCalculator,
+    private val jobPort: CalculationJobPort,
+    private val jobService: CalculationJobService,
+    private val calculationInputPort: CalculationInputPort,
+    private val objectMapper: ObjectMapper,
+    private val executor: LogicExecutor
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+    private val terminalStatuses = setOf(
+        CalculationJobStatus.COMPLETED,
+        CalculationJobStatus.FAILED
+    )
+
+    init {
+        nexonApiResponseTopic.subscribe { envelope, _ -> handleApiResponse(envelope) }
+    }
+
+    private fun handleApiResponse(envelope: IntegrationEvent<*>): ConsumeResult {
+        val payload = envelope.payload as Map<*, *>
+        val jobId = UUID.fromString(payload["jobId"].toString())
+        val userIgn = payload["userIgn"].toString()
+        val context = TaskContext.of("ApiResponseWorker", "Process", userIgn)
+        return executor.executeOrCatch(
+            { processApiResponse(payload, jobId, userIgn) },
+            { e ->
+                log.error("[jobId={}] Calculation failed: {}", jobId, e.message)
+                val msg = (e.message ?: "Unknown error").take(200)
+                executor.executeVoid({ jobService.handleCalculationFailure(jobId, "CALCULATION_ERROR", msg) }, context)
+                ConsumeResult.Ack
+            },
+            context
+        )
+    }
+
+    private fun processApiResponse(payload: Map<*, *>, jobId: UUID, userIgn: String): ConsumeResult {
+        val job = jobPort.findJobById(jobId)
+        if (job == null) {
+            log.warn("[jobId={}] Job not found, archiving", jobId)
+            return ConsumeResult.Ack
+        }
+
+        if (job.status in terminalStatuses) {
+            log.info("[jobId={}] Already in terminal state: {}, skipping", jobId, job.status)
+            return ConsumeResult.Ack
+        }
+
+        if (job.status == CalculationJobStatus.CALCULATING) {
+            log.warn("[jobId={}] Stuck in CALCULATING on redelivery, marking as failed", jobId)
+            jobPort.markFailed(jobId, "CALCULATION_STUCK", "Calculation stuck after redelivery")
+            return ConsumeResult.Ack
+        }
+
+        val started = jobService.startCalculation(jobId, "ApiResponseWorker")
+        if (!started) {
+            log.warn("[jobId={}] Could not start calculation, archiving", jobId)
+            return ConsumeResult.Ack
+        }
+
+        val presetNo = (payload["presetNo"] as Number).toInt()
+        val characterId = payload["characterId"]?.toString() ?: ""
+
+        val input = calculationInputPort.findByJobId(jobId)
+        if (input == null) {
+            log.error("[jobId={}] CalculationInput not found, cannot proceed", jobId)
+            jobPort.markFailed(jobId, "INPUT_NOT_FOUND", "CalculationInput not found for job")
+            return ConsumeResult.Ack
+        }
+
+        val result = pureCalculator.calculate(input)
+
+        val resultJson = objectMapper.writeValueAsString(result)
+
+        jobService.completeCalculationWithResult(
+            jobId = jobId,
+            resultJson = resultJson,
+            characterClass = input.characterClass,
+            presetNo = presetNo,
+            characterId = characterId
+        )
+
+        log.info("[jobId={}] Calculation completed from CalculationInput (pure)", jobId)
+        return ConsumeResult.Ack
+    }
+}
+```
+
+Key changes vs current code:
+- `expectationPort: ExpectationV4Port` → `pureCalculator: PureExpectationCalculator`
+- `expectationPort.calculateExpectationAsync(...).join()` → `pureCalculator.calculate(input)` (no CompletableFuture, no .join())
+- Error handler: `jobPort.markFailed(...)` → `jobService.handleCalculationFailure(...)` (delegated to service with retry logic)
+
+- [ ] **Step 2: Compile to verify**
+
+Run: `./gradlew compileKotlin compileJava --continue 2>&1 | grep -E "(ERROR|FAIL|BUILD)" | head -10`
+Expected: BUILD SUCCESSFUL (no errors)
+
+Note: This step will fail until Task 4 is done because `handleCalculationFailure` doesn't exist yet. If needed, implement Task 4 first or add a stub.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add module-app/src/main/kotlin/maple/expectation/application/worker/ApiResponseWorker.kt
+git commit -m "refactor(write-path): replace .join() blocking with pure calculator in ApiResponseWorker"
+```
+
+---
+
+### Task 4: Calculation Retry — handleCalculationFailure + retryCalculation
+
+**Files:**
+- Modify: `module-core/src/main/kotlin/maple/expectation/core/port/out/CalculationJobPort.kt`
+- Modify: `module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/repository/CalculationJobRepository.kt`
+- Modify: `module-infra/src/main/kotlin/maple/expectation/adapter/outgoing/CalculationJobPortAdapter.kt`
+- Modify: `module-infra/src/main/kotlin/maple/expectation/infrastructure/job/CalculationJobService.kt`
+
+Follow the existing retry pattern from `handleApiFailure()` / `handleOcidFailure()`: check retry count, if under max then transition to a retryable state and re-publish the MQ event, otherwise mark failed.
+
+For calculation retry, the transition is `CALCULATING → SNAPSHOT_READY` (so the existing `snapshot_ready` flow picks it up again). This avoids creating new job statuses.
+
+- [ ] **Step 1: Add retryCalculation to the port interface**
+
+In `module-core/src/main/kotlin/maple/expectation/core/port/out/CalculationJobPort.kt`, add:
+
+```kotlin
+fun retryCalculation(jobId: UUID, errorCode: String, nextRetryAt: Instant): Boolean
+```
+
+Full file after edit:
+
+```kotlin
+package maple.expectation.core.port.out
+
+import maple.expectation.core.model.job.CalculationJob
+import maple.expectation.core.model.job.CalculationJobStatus
+import java.time.Instant
+import java.util.UUID
+
+interface CalculationJobPort {
+    fun createJob(ocid: String?, userIgn: String, presetNo: Int): CalculationJob
+    fun findJobById(jobId: UUID): CalculationJob?
+    fun transitionStatus(jobId: UUID, from: CalculationJobStatus, to: CalculationJobStatus): Boolean
+    fun markSnapshotReady(jobId: UUID, snapshotId: UUID, from: CalculationJobStatus): Boolean
+    fun markFailed(jobId: UUID, errorCode: String, errorMessage: String): Boolean
+    fun incrementRetry(jobId: UUID, errorCode: String): Boolean
+    fun incrementRetryForOcid(jobId: UUID, errorCode: String): Boolean
+    fun retryCalculation(jobId: UUID, errorCode: String, nextRetryAt: Instant): Boolean
+    fun lockForProcessing(jobId: UUID, workerId: String, from: CalculationJobStatus): Boolean
+    fun unlock(jobId: UUID): Boolean
+    fun findStaleJobs(status: CalculationJobStatus, olderThanSeconds: Long): List<CalculationJob>
+    fun findActiveJobByUserIgn(userIgn: String, presetNo: Int): CalculationJob?
+    fun resolveOcidAndTransition(jobId: UUID, ocid: String): Boolean
+    fun findCompletedJobsMissingOutboxEvents(limit: Int): List<UUID>
+}
+```
+
+- [ ] **Step 2: Add retryCalculation JPQL to repository**
+
+In `module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/repository/CalculationJobRepository.kt`, add before the closing `}`:
+
+```kotlin
+@Modifying
+@Query("""
+    UPDATE CalculationJobEntity j
+    SET j.retryCount = j.retryCount + 1,
+        j.status = 'SNAPSHOT_READY',
+        j.nextRetryAt = :nextRetryAt,
+        j.lastErrorCode = :errorCode,
+        j.lockedBy = NULL, j.lockedUntil = NULL,
+        j.updatedAt = CURRENT_TIMESTAMP
+    WHERE j.jobId = :jobId
+      AND j.status = 'CALCULATING'
+      AND j.retryCount < j.maxRetries
+""")
+fun retryCalculation(
+    @Param("jobId") jobId: UUID,
+    @Param("errorCode") errorCode: String,
+    @Param("nextRetryAt") nextRetryAt: Instant
+): Int
+```
+
+- [ ] **Step 3: Implement retryCalculation in adapter**
+
+In `module-infra/src/main/kotlin/maple/expectation/adapter/outgoing/CalculationJobPortAdapter.kt`, add:
+
+```kotlin
+override fun retryCalculation(jobId: UUID, errorCode: String, nextRetryAt: Instant): Boolean {
+    return jobRepository.retryCalculation(jobId, errorCode, nextRetryAt) > 0
+}
+```
+
+- [ ] **Step 4: Add handleCalculationFailure to CalculationJobService**
+
+In `module-infra/src/main/kotlin/maple/expectation/infrastructure/job/CalculationJobService.kt`, add after `handleOcidFailure()` (line ~171):
+
+```kotlin
+@Transactional
+fun handleCalculationFailure(jobId: UUID, errorCode: String, errorMessage: String) {
+    val job = jobPort.findJobById(jobId) ?: return
+
+    if (job.retryCount >= job.maxRetries) {
+        jobPort.markFailed(jobId, errorCode, errorMessage)
+        log.warn("[jobId={}] Calculation failed after {} retries: {}", jobId, job.retryCount, errorMessage)
+        return
+    }
+
+    val backoffSeconds = calculateBackoff(job.retryCount)
+    val nextRetry = java.time.Instant.now().plusSeconds(backoffSeconds)
+    val retried = jobPort.retryCalculation(jobId, errorCode, nextRetry)
+    if (retried) {
+        val event = NexonApiResponseEventFactory.create(
+            jobId.toString(),
+            job.snapshotId?.toString() ?: return,
+            "",
+            job.ocid ?: return,
+            job.userIgn,
+            job.presetNo
+        )
+        eventAppender.append(nexonApiResponseTopic, event)
+        log.info("[jobId={}] Calculation retry scheduled (attempt {}, backoff={}s)", jobId, job.retryCount + 1, backoffSeconds)
+    } else {
+        jobPort.markFailed(jobId, errorCode, errorMessage)
+    }
+}
+
+private fun calculateBackoff(retryCount: Int): Long {
+    val baseSeconds = 30L
+    return minOf(baseSeconds * (1L shl retryCount), 600L)
+}
+```
+
+The exponential backoff formula: `30s → 60s → 120s → 240s → 480s` capped at 600s (10 min).
+
+- [ ] **Step 5: Compile and commit**
+
+Run: `./gradlew compileKotlin compileJava --continue 2>&1 | grep -E "(ERROR|FAIL|BUILD)" | head -10`
+Expected: BUILD SUCCESSFUL
+
+```bash
+git add module-core/src/main/kotlin/maple/expectation/core/port/out/CalculationJobPort.kt module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/repository/CalculationJobRepository.kt module-infra/src/main/kotlin/maple/expectation/adapter/outgoing/CalculationJobPortAdapter.kt module-infra/src/main/kotlin/maple/expectation/infrastructure/job/CalculationJobService.kt
+git commit -m "feat(write-path): add calculation retry with exponential backoff"
+```
+
+---
+
+### Task 5: Compile Verification + Full Test Run
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Full compile check**
+
+Run: `./gradlew compileKotlin compileJava --continue 2>&1 | grep -E "(ERROR|FAIL|BUILD)" | head -10`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 2: Run all tests**
+
+Run: `./gradlew test 2>&1 | tail -10`
+Expected: BUILD SUCCESSFUL — all tests pass
+
+- [ ] **Step 3: Verify no .join() remains in ApiResponseWorker**
+
+Run: `grep -n "\.join()" module-app/src/main/kotlin/maple/expectation/application/worker/ApiResponseWorker.kt`
+Expected: no output (no .join() calls)
+
+---
+
+## Verification (Post-Implementation E2E)
+
+After all tasks are done, verify the Write Path end-to-end:
+
+1. Start the server: `set -a && source .env && set +a && ./gradlew :module-app:bootRun`
+2. Trigger a calculation via the v5 recalculate endpoint
+3. Watch the logs for: `Calculation completed from CalculationInput (pure)`
+4. Verify no `.join()` or `CompletableFuture` in the `ApiResponseWorker` path
+5. Verify result is persisted and outbox event is inserted
+6. Test retry: artificially cause a calculation failure and verify the job transitions to `SNAPSHOT_READY` with incremented retry count
+
+---
+
+## Out of Scope (Future Work)
+
+- Remove `@Transactional` from `EquipmentExpectationServiceV4.calculateExpectation()` (Read Path cleanup)
+- Remove the `orTimeout(30s)` from `calculateExpectationAsync` once Read Path is also refactored
+- Remove `CalculationWorker` (module-infra) if it's superseded by `ApiResponseWorker` + `PureExpectationCalculator`
+- Make `PresetCalculationHelper.calculatePresetAsync()` fully synchronous (remove internal CompletableFuture dispatch)

--- a/docs/superpowers/plans/2026-04-29-read-path-boundary-cleanup.md
+++ b/docs/superpowers/plans/2026-04-29-read-path-boundary-cleanup.md
@@ -1,0 +1,127 @@
+# Plan: Read Path V5 Boundary Cleanup
+
+**Date**: 2026-04-29
+**Scope**: V5 Controller + dead FanOut/remove deleteByUserIgn vertical slice
+**ADR Reference**: `docs/01_ADR/ADR-three-path-independence-mq-boundary.md` Phase 2
+**Issue**: #758
+
+## Goal
+
+V5 Read Path에서 ADR 경계 위반 2건을 제거하여 Read Path가 "HTTP + 조회 + enqueue only" 원칙을 완전히 준수하도록 한다. 동시에 미사용 코드(FanOut port/adapter, deleteByUserIgn vertical slice)를 완전히 제거한다.
+
+## Current Violations
+
+| # | Violation | Location | Severity |
+|---|-----------|----------|----------|
+| 1 | Pre-warm: `EquipmentFanOutPort.preFetchByOcid()` triggers Nexon API call chain | V5 Controller 113-163 | Medium |
+| 2 | Recalculate: `queryPort.deleteByUserIgn()` performs DELETE on view table | V5 Controller 186 | Low |
+
+## Dead Code to Remove
+
+| # | Dead Code | Why Dead |
+|---|-----------|----------|
+| 3 | `EquipmentFanOutPort` in Write Path Workers (`AbstractExpectationCalcWorker` 등) | `preWarmBatch()` is no-op, field unused |
+| 4 | `deleteByUserIgn()` entire vertical slice | V5 is the only caller; removing V5 usage makes it dead |
+| 5 | `EquipmentFanOutPort` interface + `NexonEquipmentMicroBatchAdapter` | After removing from V5 + Workers, no consumers remain |
+
+## Tasks
+
+### Task 1: Remove Pre-Warm from V5 Controller
+
+**What**: Remove all pre-warm related code from `GameCharacterControllerV5`.
+
+**How**:
+1. Remove `fanOutPort: EquipmentFanOutPort` constructor parameter
+2. Remove `@Value("\${fanout.enabled:false}") fanOutEnabled: Boolean`
+3. Remove `@Qualifier("asyncExecutor") preWarmExecutor: Executor`
+4. Remove `preWarmSemaphore`, `preWarmFailureCounter`, `preWarmRejectedCounter` fields
+5. Remove `preWarmEquipmentCache()` private method
+6. Remove pre-warm block (lines 113-128) from `processPostgreSQLCacheFirstLookup()`
+7. Remove `MeterRegistry` constructor parameter (only used for pre-warm counters)
+8. Clean up unused imports
+
+**Files**: `module-web/.../controller/v5/GameCharacterControllerV5.kt`
+
+### Task 2: Remove Recalculate DELETE from V5 Controller
+
+**What**: Remove `queryPort.deleteByUserIgn()` call. Keep `force=true` queue submission only.
+
+**How**:
+1. Remove `executorPort.executeVoidJava({ queryPort.deleteByUserIgn(userIgn) }, context)` from `processCacheInvalidation()`
+2. Keep `queueCalculationTask(userIgn, true, presetNo, context)` — `force=true` ensures Write Path overwrites
+3. Simplify `processCacheInvalidation()` — may inline to `queueCalculationTask` call
+
+**Files**: `module-web/.../controller/v5/GameCharacterControllerV5.kt`
+
+### Task 3: Remove Dead `EquipmentFanOutPort` from Write Path Workers
+
+**What**: Remove unused `EquipmentFanOutPort` injection from worker hierarchy.
+
+**How**:
+1. Remove `equipmentFanOutPort: EquipmentFanOutPort` from `AbstractExpectationCalcWorker` constructor
+2. Remove `@Qualifier("asyncExecutor") preWarmExecutor: Executor` from `AbstractExpectationCalcWorker` constructor
+3. Remove `preWarmBatch()` no-op method
+4. Update `ExpectationCalcWorker` and `ExpectationCalcLowWorker` constructors to match
+
+**Files**: `module-infra/.../worker/AbstractExpectationCalcWorker.kt`, `ExpectationCalcWorker.kt`, `ExpectationCalcLowWorker.kt`
+
+### Task 4: Delete `EquipmentFanOutPort` Interface + Adapter
+
+**What**: After Tasks 1+3 remove all consumers, delete the port and its sole implementation.
+
+**How**:
+1. Delete `module-core/.../port/out/EquipmentFanOutPort.kt`
+2. Delete `module-infra/.../adapter/outgoing/NexonEquipmentMicroBatchAdapter.kt`
+3. Search for any remaining references — should be zero
+
+**Files**: 2 files deleted
+
+### Task 5: Remove `deleteByUserIgn()` Vertical Slice
+
+**What**: Remove the entire `deleteByUserIgn()` method chain since V5 is the only caller.
+
+**How**:
+1. Remove `deleteByUserIgn()` from `CharacterViewQueryPort` interface
+2. Remove `deleteByUserIgn()` from `CharacterViewQueryPortAdapter`
+3. Remove `deleteByUserIgn()` from `CharacterViewQueryServicePostgres`
+4. Remove `deleteByUserIgn()` from `CharacterValuationJpaRepository`
+5. Remove `deleteByUserIgn()` from `CharacterValuationRepositoryImpl`
+6. Remove from `CharacterValuationViewJpaRepository` if present
+
+**Files**: port interface, adapter, service, JPA repos in module-core + module-infra
+
+### Task 6: Update Tests
+
+**What**: Remove/update tests for deleted functionality.
+
+**module-web test** (`GameCharacterControllerV5Test.kt`):
+1. Remove `FakeEquipmentFanOutPort` inner class
+2. Remove `getExpectationV5_fanOutEnabled_triggersPrewarm` test
+3. Remove `getExpectationV5_fanOutDisabled_noPrewarm` test
+4. Remove `recalculateExpectationV5_deletesCacheAndEnqueuesForce` test
+5. Update `setUp()` — remove `fanOutPort`, `preWarmExecutor`, `meterRegistry` setup
+
+**module-app test** (`GameCharacterControllerV5Test.java`):
+1. Remove `testForceRecalculation_DeletesCacheAndQueues` test
+2. Remove `testForceRecalculationQueueFull_Returns503` test
+3. Remove `TestableGameCharacterControllerV5.recalculateExpectationV5Internal()` helper
+
+**module-infra tests** (if `deleteByUserIgn` tests exist):
+1. Remove `deleteByUserIgn` test cases from `CharacterViewQueryServicePostgresTest`
+2. Remove `deleteByUserIgn` test cases from `CharacterViewQueryPortAdapterTest`
+
+**Files**: 2-4 test files
+
+### Task 7: Verification
+
+1. Compile: `./gradlew compileKotlin compileJava --continue`
+2. Test: `./gradlew test`
+3. Server runtime: `set -a && source .env && set +a && ./gradlew :module-app:bootRun` → curl V5 expectation endpoint
+4. Verify: no `EquipmentFanOutPort`, `NexonApiClient`, `deleteByUserIgn` references in module-web
+
+## Out of Scope
+
+- V4 Controller migration (legacy, separate effort)
+- EquipmentExpectationServiceV4 decomposition
+- module-read physical separation (Phase 3)
+- PopularCharacterWarmupScheduler cleanup (separate concern, uses CacheWarmupPort)

--- a/load-test/run-v5-db-throughput.sh
+++ b/load-test/run-v5-db-throughput.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$ROOT_DIR"
+
+load_env_file() {
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
+    [[ "$line" != *=* ]] && continue
+
+    local key="${line%%=*}"
+    local value="${line#*=}"
+    key="$(echo "$key" | xargs)"
+    value="${value%$'\r'}"
+    value="${value%\"}"
+    value="${value#\"}"
+    value="${value%\'}"
+    value="${value#\'}"
+    export "$key=$value"
+  done < .env
+}
+
+load_env_file
+
+PSQL_DB_HOST=$(echo "${DB_URL:?DB_URL is required}" | sed -n 's|.*://\([^:/]*\).*|\1|p')
+PSQL_DB_PORT=${DB_PORT:-6543}
+PSQL_DB_NAME=$(echo "$DB_URL" | sed -n 's|.*/\([^?]*\).*|\1|p')
+PSQL_DB_USER=$(echo "$DB_URL" | sed -n 's|.*user=\([^&]*\).*|\1|p')
+PSQL_DB_PASS=$(echo "$DB_URL" | sed -n 's|.*password=\(.*\)|\1|p')
+
+COUNT=${COUNT:-10000}
+CONCURRENCY=${CONCURRENCY:-50}
+SAMPLE_INTERVAL=${SAMPLE_INTERVAL:-30}
+POST_SAMPLE_COUNT=${POST_SAMPLE_COUNT:-2}
+RESET_VIEWS=${RESET_VIEWS:-0}
+MAX_DRAIN_WAIT=${MAX_DRAIN_WAIT:-200}
+
+SERVER_PID=""
+SERVER_STARTED=0
+MONITOR_PID=""
+BOOT_LOG="module-app/logs/load-test-bootrun-$(date +%Y%m%d_%H%M%S).log"
+
+psql_db() {
+  PGPASSWORD="$PSQL_DB_PASS" psql "host=$PSQL_DB_HOST port=$PSQL_DB_PORT user=$PSQL_DB_USER dbname=$PSQL_DB_NAME sslmode=require" "$@"
+}
+
+cleanup() {
+  if [[ -n "$MONITOR_PID" ]]; then
+    kill "$MONITOR_PID" 2>/dev/null || true
+  fi
+  if [[ "$SERVER_STARTED" == "1" && -n "$SERVER_PID" ]]; then
+    kill "$SERVER_PID" 2>/dev/null || true
+    wait "$SERVER_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+wait_for_server() {
+  for _ in $(seq 1 90); do
+    if curl -fsS http://localhost:8080/actuator/health >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 2
+  done
+  echo "Server did not become healthy. See $BOOT_LOG" >&2
+  return 1
+}
+
+db_counts() {
+  psql_db -At -c "
+    SELECT
+      (SELECT count(*) FROM character_valuation_views),
+      (SELECT count(*) FROM pgmq.q_expectation_calc_high);
+  "
+}
+
+monitor_db() {
+  local prev_views=""
+  local prev_ts=""
+
+  printf '%s\n' "timestamp,elapsed_s,views,queue_high,delta_views,views_per_sec"
+  while true; do
+    local ts
+    local counts
+    local views
+    local queue_high
+    local delta=0
+    local rate=0
+
+    ts=$(date +%s)
+    counts=$(db_counts)
+    views=$(echo "$counts" | awk -F'|' '{print $1}')
+    queue_high=$(echo "$counts" | awk -F'|' '{print $2}')
+
+    if [[ -n "$prev_ts" ]]; then
+      local dt=$((ts - prev_ts))
+      delta=$((views - prev_views))
+      if [[ "$dt" -gt 0 ]]; then
+        rate=$(awk -v d="$delta" -v t="$dt" 'BEGIN { printf "%.2f", d / t }')
+      fi
+    fi
+
+    printf '%s,%s,%s,%s,%s,%s\n' "$(date -Is)" "$((ts - START_TS))" "$views" "$queue_high" "$delta" "$rate"
+
+    prev_views=$views
+    prev_ts=$ts
+    sleep "$SAMPLE_INTERVAL"
+  done
+}
+
+if curl -fsS http://localhost:8080/actuator/health >/dev/null 2>&1; then
+  echo "Using existing server on localhost:8080"
+else
+  echo "Starting server in background. Log: $BOOT_LOG"
+  load_env_file
+  ./gradlew :module-app:bootRun >"$BOOT_LOG" 2>&1 &
+  SERVER_PID=$!
+  SERVER_STARTED=1
+  wait_for_server
+fi
+
+if [[ "$RESET_VIEWS" == "1" ]]; then
+  echo "Resetting character_valuation_views"
+  psql_db -c "DELETE FROM character_valuation_views;"
+else
+  echo "Skipping view reset. Set RESET_VIEWS=1 to delete character_valuation_views before the run."
+fi
+
+echo "Initial DB state"
+psql_db -c "SELECT count(*) AS character_valuation_views FROM character_valuation_views;"
+psql_db -c "SELECT count(*) AS expectation_calc_high_queue FROM pgmq.q_expectation_calc_high;"
+
+START_TS=$(date +%s)
+monitor_db &
+MONITOR_PID=$!
+
+COUNT="$COUNT" CONCURRENCY="$CONCURRENCY" MAX_DRAIN_WAIT="$MAX_DRAIN_WAIT" python3 load_test_v5.py
+
+for _ in $(seq 1 "$POST_SAMPLE_COUNT"); do
+  sleep "$SAMPLE_INTERVAL"
+done
+
+echo "Final DB state"
+psql_db -c "SELECT count(*) AS character_valuation_views FROM character_valuation_views;"
+psql_db -c "SELECT count(*) AS expectation_calc_high_queue FROM pgmq.q_expectation_calc_high;"

--- a/load_test_v5.py
+++ b/load_test_v5.py
@@ -7,6 +7,7 @@ V5 Expectation Endpoint Load Test
 """
 
 import csv
+import os
 import time
 import urllib.request
 import urllib.parse
@@ -19,10 +20,10 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 CSV_FILE = "module-app/src/main/resources/data/userIgn_List.csv"
 BASE_URL = "http://localhost:8080/api/v5/characters"
 PROMETHEUS_URL = "http://localhost:8080/actuator/prometheus"
-COUNT = 10000
-CONCURRENCY = 50
-METRICS_INTERVAL = 3  # seconds
-MAX_DRAIN_WAIT = 200  # 200s max wait for queue drain
+COUNT = int(os.getenv("COUNT", "10000"))
+CONCURRENCY = int(os.getenv("CONCURRENCY", "50"))
+METRICS_INTERVAL = int(os.getenv("METRICS_INTERVAL", "3"))  # seconds
+MAX_DRAIN_WAIT = int(os.getenv("MAX_DRAIN_WAIT", "200"))  # seconds
 
 # Shared state
 results_lock = threading.Lock()

--- a/module-app/src/main/resources/application-local.yml
+++ b/module-app/src/main/resources/application-local.yml
@@ -81,7 +81,7 @@ cache:
 # Supabase pooler 호환: Lock pool 축소
 lock:
   datasource:
-    pool-size: 5
+    pool-size: 20
 
 # Rate Limiting 비활성화 (부하 테스트용)
 ratelimit:

--- a/module-infra/src/main/kotlin/maple/expectation/adapter/outgoing/CalculationInputPortAdapter.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/adapter/outgoing/CalculationInputPortAdapter.kt
@@ -7,6 +7,7 @@ import maple.expectation.core.port.out.CalculationInputPort
 import maple.expectation.infrastructure.persistence.entity.CalculationSnapshotInputEntity
 import maple.expectation.infrastructure.persistence.repository.CalculationSnapshotInputRepository
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 
 @Component
 class CalculationInputPortAdapter(
@@ -14,6 +15,7 @@ class CalculationInputPortAdapter(
     private val objectMapper: ObjectMapper,
 ) : CalculationInputPort {
 
+    @Transactional(value = "transactionManager", readOnly = false)
     override fun save(input: CalculationInput): CalculationInput {
         val payload = objectMapper.writeValueAsString(input)
         repo.save(
@@ -26,11 +28,13 @@ class CalculationInputPortAdapter(
         return input
     }
 
+    @Transactional(value = "transactionManager", readOnly = true)
     override fun findByJobId(jobId: UUID): CalculationInput? {
         val entity = repo.findByJobId(jobId) ?: return null
         return objectMapper.readValue(entity.payload, CalculationInput::class.java)
     }
 
+    @Transactional(value = "transactionManager", readOnly = false)
     override fun saveIfAbsent(input: CalculationInput): Boolean {
         val payload = objectMapper.writeValueAsString(input)
         return repo.insertIfAbsent(

--- a/module-infra/src/main/kotlin/maple/expectation/adapter/outgoing/CalculationResultPortAdapter.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/adapter/outgoing/CalculationResultPortAdapter.kt
@@ -6,12 +6,14 @@ import maple.expectation.core.port.out.CalculationResultPort
 import maple.expectation.infrastructure.persistence.entity.CalculationResultEntity
 import maple.expectation.infrastructure.persistence.repository.CalculationResultRepository
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 
 @Component
 class CalculationResultPortAdapter(
     private val repo: CalculationResultRepository,
 ) : CalculationResultPort {
 
+    @Transactional(value = "transactionManager", readOnly = false)
     override fun save(result: CalculationResultData): CalculationResultData {
         val existing = repo.findByJobId(result.jobId)
         val entity = if (existing != null && existing.hash == result.hash) {
@@ -50,10 +52,13 @@ class CalculationResultPortAdapter(
         )
     }
 
+    @Transactional(value = "transactionManager", readOnly = true)
     override fun findByJobId(jobId: UUID): CalculationResultData? = repo.findByJobId(jobId)?.toData()
 
+    @Transactional(value = "transactionManager", readOnly = true)
     override fun existsByJobId(jobId: UUID): Boolean = repo.existsByJobId(jobId)
 
+    @Transactional(value = "transactionManager", readOnly = false)
     override fun saveIfAbsent(result: CalculationResultData): Boolean = repo.insertIfAbsent(
         result.resultId,
         result.jobId,

--- a/module-infra/src/main/kotlin/maple/expectation/adapter/outgoing/OutboxEventPortAdapter.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/adapter/outgoing/OutboxEventPortAdapter.kt
@@ -6,22 +6,27 @@ import maple.expectation.core.port.out.OutboxEventPort
 import maple.expectation.infrastructure.persistence.repository.OutboxEventRepository
 import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 
 @Component
 class OutboxEventPortAdapter(
     private val repo: OutboxEventRepository,
 ) : OutboxEventPort {
 
+    @Transactional(value = "transactionManager", readOnly = false)
     override fun insertIfAbsent(eventType: String, jobId: UUID, payload: String?): Boolean = repo.insertIfAbsent(UUID.randomUUID(), eventType, jobId, payload) > 0
 
+    @Transactional(value = "transactionManager", readOnly = true)
     override fun findUnpublished(limit: Int): List<OutboxEvent> = repo.findUnpublished(limit, PageRequest.of(0, limit)).map {
         OutboxEvent(it.eventId, it.eventType, it.jobId, it.payload, it.published, it.publishAttempts)
     }
 
+    @Transactional(value = "transactionManager", readOnly = false)
     override fun markPublished(eventId: UUID) {
         repo.markPublished(eventId)
     }
 
+    @Transactional(value = "transactionManager", readOnly = false)
     override fun incrementPublishAttempts(eventId: UUID) {
         repo.incrementPublishAttempts(eventId)
     }

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/CharacterViewQueryServicePostgres.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/CharacterViewQueryServicePostgres.kt
@@ -2,6 +2,7 @@ package maple.expectation.infrastructure.persistence
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.micrometer.core.instrument.MeterRegistry
+import java.sql.Timestamp
 import java.util.concurrent.TimeUnit
 import maple.expectation.infrastructure.executor.LogicExecutor
 import maple.expectation.infrastructure.executor.TaskContext
@@ -42,6 +43,7 @@ class CharacterViewQueryServicePostgres(
     @Transactional(value = "transactionManager", readOnly = true)
     fun findByUserIgn(userIgn: String): CharacterValuationViewEntity? = findByUserIgnEntity(userIgn)
 
+    @Transactional(value = "transactionManager", readOnly = false)
     fun upsertFromCalculation(
         userIgn: String,
         messageId: String?,
@@ -116,7 +118,7 @@ class CharacterViewQueryServicePostgres(
      *
      * @param entity The entity to upsert
      */
-    @Transactional("transactionManager")
+    @Transactional(value = "transactionManager", readOnly = false)
     fun upsert(entity: CharacterValuationViewEntity) {
         val context = TaskContext.of("PostgresQuery", "Upsert", entity.userIgn)
         executor.executeVoid({ performUpsert(entity) }, context)
@@ -148,8 +150,8 @@ class CharacterViewQueryServicePostgres(
             "characterOcid" to entity.characterOcid,
             "characterClass" to entity.characterClass,
             "characterLevel" to entity.characterLevel,
-            "calculatedAt" to entity.calculatedAt,
-            "lastApiSyncAt" to entity.lastApiSyncAt,
+            "calculatedAt" to entity.calculatedAt?.let(Timestamp::from),
+            "lastApiSyncAt" to entity.lastApiSyncAt?.let(Timestamp::from),
             "version" to (entity.version ?: 1L),
             "lastAppliedVersion" to (entity.lastAppliedVersion ?: entity.version ?: 1L),
             "totalExpectedCost" to entity.totalExpectedCost,
@@ -161,19 +163,22 @@ class CharacterViewQueryServicePostgres(
         jdbc.update(
             """
             INSERT INTO character_valuation_views (
-                user_ign, message_id, character_ocid, character_class, character_level,
+                user_ign, message_id, jpa_version, character_ocid, character_class, character_level,
                 calculated_at, last_api_sync_at, version, last_applied_version,
                 total_expected_cost, max_preset_no, preset_no, presets, from_cache
             ) VALUES (
-                :userIgn, :messageId, :characterOcid, :characterClass, :characterLevel,
+                :userIgn, :messageId, 0, :characterOcid, :characterClass, :characterLevel,
                 :calculatedAt, :lastApiSyncAt, :version + 1, :lastAppliedVersion,
                 :totalExpectedCost, :maxPresetNo, :presetNo, CAST(:presets AS jsonb), :fromCache
             )
             ON CONFLICT (message_id) DO UPDATE SET
                 user_ign = EXCLUDED.user_ign,
+                jpa_version = character_valuation_views.jpa_version + 1,
                 character_ocid = COALESCE(EXCLUDED.character_ocid, character_valuation_views.character_ocid),
                 character_class = COALESCE(EXCLUDED.character_class, character_valuation_views.character_class),
+                character_level = COALESCE(EXCLUDED.character_level, character_valuation_views.character_level),
                 calculated_at = EXCLUDED.calculated_at,
+                last_api_sync_at = COALESCE(EXCLUDED.last_api_sync_at, character_valuation_views.last_api_sync_at),
                 version = character_valuation_views.version + 1,
                 last_applied_version = EXCLUDED.last_applied_version,
                 total_expected_cost = EXCLUDED.total_expected_cost,
@@ -257,7 +262,7 @@ class CharacterViewQueryServicePostgres(
     )
 
     /** Delete all documents (for testing) */
-    @Transactional("transactionManager")
+    @Transactional(value = "transactionManager", readOnly = false)
     fun deleteAll() {
         val context = TaskContext.of("PostgresQuery", "DeleteAll", "all")
 

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/ExpectationReadModelWriteService.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/ExpectationReadModelWriteService.kt
@@ -8,6 +8,7 @@ import maple.expectation.util.GzipUtils
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 /**
  * V5 Query Server: Write service for Character Expectation Read Model
@@ -36,6 +37,7 @@ class ExpectationReadModelWriteService(
      * @param json JSON string to compress and store
      * @param calculatedAt Timestamp of expectation calculation
      */
+    @Transactional(value = "transactionManager", readOnly = false)
     fun writeToReadModel(userIgn: String, json: String, calculatedAt: Instant) {
         val context = TaskContext.of("ReadModel", "Write", userIgn)
         executor.executeVoid({ performWrite(userIgn, json, calculatedAt) }, context)
@@ -55,6 +57,7 @@ class ExpectationReadModelWriteService(
      * @param json JSON string to compress and store
      * @param calculatedAt Timestamp of expectation calculation
      */
+    @Transactional(value = "transactionManager", readOnly = false)
     fun writeToReadModelRaw(userIgn: String, json: String, calculatedAt: Instant) {
         val compressed = GzipUtils.compressUnchecked(json)
         repository.upsertNative(userIgn, compressed, calculatedAt)

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/ExternalApiWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/ExternalApiWorker.kt
@@ -19,6 +19,7 @@ import maple.expectation.core.port.out.CharacterOcidPort
 import maple.expectation.core.port.out.PureCalculationPort
 import maple.expectation.core.port.out.QueueNames
 import maple.expectation.core.port.out.SnapshotObjectStore
+import maple.expectation.error.exception.CharacterNotFoundException
 import maple.expectation.infrastructure.converter.EquipmentResponseToCalculationInputConverter
 import maple.expectation.infrastructure.executor.LogicExecutor
 import maple.expectation.infrastructure.executor.TaskContext
@@ -35,6 +36,7 @@ import maple.expectation.infrastructure.pgmq.PgmqWorker
 import maple.expectation.infrastructure.pgmq.PgmqWorkerConfig
 import maple.expectation.infrastructure.pgmq.WorkerQueueMetrics
 import maple.expectation.infrastructure.provider.EquipmentFetchProvider
+import maple.expectation.util.ExceptionUtils
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
@@ -101,9 +103,16 @@ class ExternalApiWorker(
                 true
             },
             { e ->
-                log.error("[jobId={}] Pipeline failed: {}", jobId, e.message)
-                handleFailure(jobId, e)
-                false
+                if (isCharacterNotFound(e)) {
+                    val errorMsg = (ExceptionUtils.unwrapAsyncException(e)?.message ?: "Character not found").take(200)
+                    jobPort.markFailed(jobId, "CHARACTER_NOT_FOUND", errorMsg)
+                    log.warn("[jobId={}] Character not found, skipping retry: {}", jobId, errorMsg)
+                    true
+                } else {
+                    log.error("[jobId={}] Pipeline failed: {}", jobId, e.message)
+                    handleFailure(jobId, e)
+                    false
+                }
             },
             context,
         )
@@ -219,14 +228,14 @@ class ExternalApiWorker(
             .handle { result, ex ->
                 if (ex != null) {
                     log.warn("[jobId={}] OCID resolve failed: {}", jobId, ex.message)
-                    null
+                    throw ExceptionUtils.unwrapAs(ex, CharacterNotFoundException::class.java) ?: ex
                 } else {
                     result
                 }
             }
             .thenApply { response ->
                 if (response == null || response.ocid.isBlank()) {
-                    throw IllegalStateException("OCID resolve returned empty for $userIgn")
+                    throw CharacterNotFoundException(userIgn)
                 }
                 response.ocid
             }
@@ -254,6 +263,8 @@ class ExternalApiWorker(
             jobService.retryExternalApiJob(jobId)
         }
     }
+
+    private fun isCharacterNotFound(e: Throwable): Boolean = ExceptionUtils.containsCause(e, CharacterNotFoundException::class.java)
 
     private fun generateObjectKey(jobId: UUID): String {
         val now = Instant.now()


### PR DESCRIPTION
## Summary
- Add DB-backed V5 throughput load-test runner that parses DB_URL from .env and samples view/queue counts.
- Add explicit transaction boundaries for V5 write adapters/read-model writes.
- Fix native character view upsert for JDBC Instant binding and jpa_version.
- Treat missing Nexon characters as terminal failures so they do not retry through PGMQ.
- Increase local PostgreSQL lock pool from 5 to 20 for load testing.
- Add repository agent instructions and planning docs.

## Verification
- ./gradlew check (via pre-commit)
- ./gradlew compileKotlin compileJava --continue
- ./gradlew :module-infra:test --tests "*OutboxEventPortAdapterTest" --tests "*CharacterViewQueryServicePostgresTest" --continue
- python3 -m py_compile load_test_v5.py
- bash -n load-test/run-v5-db-throughput.sh

## Load test notes
- RESET_VIEWS=1 COUNT=10000 CONCURRENCY=50 SAMPLE_INTERVAL=30 POST_SAMPLE_COUNT=2 ./load-test/run-v5-db-throughput.sh
- PostgreSQLLockPool max=20, active~8, pending=0, timeout=0 during observed run.
- CharacterNotFound no longer schedules external API retries.
