### PR TITLE
Optimize V5 throughput pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,3 +13,14 @@ Important:
 - For performance work, preserve before/after metrics.
 - For backend changes, pay attention to transactions, idempotency, PGMQ/Kafka boundaries, and connection-pool pressure.
 - Run relevant tests before committing when feasible.
+
+Load test flow:
+- Use `RESET_VIEWS=1 RESET_ACTIVE_JOBS=1 COUNT=10000 CONCURRENCY=50 SAMPLE_INTERVAL=30 POST_SAMPLE_COUNT=2 ./load-test/run-v5-db-throughput.sh` for the V5 cold-miss DB throughput test unless the user asks for different parameters.
+- This flow starts `:module-app:bootRun` if `localhost:8080` is not already healthy, deletes `character_valuation_views` only when `RESET_VIEWS=1`, marks active `calculation_jobs` for the first `COUNT` CSV IGNs as `FAILED/LOAD_TEST_RESET` only when `RESET_ACTIVE_JOBS=1`, runs `load_test_v5.py`, and samples DB progress every `SAMPLE_INTERVAL` seconds.
+- The DB progress sampler reports `character_valuation_views`, `pgmq.q_expectation_calc_high`, `pgmq.q_external_api_queue`, `pgmq.q_result_ready_queue`, and active `API_REQUESTED` job count. Use these together; `q_expectation_calc_high=0` alone does not mean the external/result pipeline drained.
+- Treat `RESET_VIEWS=1` and `RESET_ACTIVE_JOBS=1` as destructive DB work. Only run them when explicitly requested by the user.
+- For a true cold-miss throughput test, use both reset flags. Resetting only `character_valuation_views` leaves active jobs in `API_REQUESTED`/`RETRYING` etc.; `createJob()` may return those existing active jobs, `dispatchToExternalApi()` may not enqueue new work, and throughput can appear capped by the timeout scanner batch size.
+- `RESET_ACTIVE_JOBS=1` loads the first `COUNT` IGNs from `module-app/src/main/resources/data/userIgn_List.csv` into a temporary table and updates only those matching active jobs. Keep that scoped reset behavior intact; do not replace it with a full-table job reset.
+- Preserve the script output and boot log path in reports. The boot log is written under `module-app/logs/load-test-bootrun-*.log`.
+- If view count does not increase while requests are being processed, check the boot log for `ResultReadyProjectionWorker`, `ResultProjection:ProjectBatch`, `ReadModel:BestEffortBatchWrite`, `UnexpectedRollbackException`, and JDBC type errors before assuming the external API is the bottleneck.
+- Stop any load-test server or Python process after interrupted runs: check `pgrep -af 'load_test_v5|python3 load_test|gradlew :module-app:bootRun|ExpectationApplication'` and terminate only those load-test processes.

--- a/load-test/run-v5-db-throughput.sh
+++ b/load-test/run-v5-db-throughput.sh
@@ -34,6 +34,7 @@ CONCURRENCY=${CONCURRENCY:-50}
 SAMPLE_INTERVAL=${SAMPLE_INTERVAL:-30}
 POST_SAMPLE_COUNT=${POST_SAMPLE_COUNT:-2}
 RESET_VIEWS=${RESET_VIEWS:-0}
+RESET_ACTIVE_JOBS=${RESET_ACTIVE_JOBS:-0}
 MAX_DRAIN_WAIT=${MAX_DRAIN_WAIT:-200}
 
 SERVER_PID=""
@@ -71,20 +72,66 @@ db_counts() {
   psql_db -At -c "
     SELECT
       (SELECT count(*) FROM character_valuation_views),
-      (SELECT count(*) FROM pgmq.q_expectation_calc_high);
+      (SELECT count(*) FROM pgmq.q_expectation_calc_high),
+      (SELECT count(*) FROM pgmq.q_external_api_queue),
+      (SELECT count(*) FROM pgmq.q_result_ready_queue),
+      (SELECT count(*) FROM calculation_jobs WHERE status = 'API_REQUESTED');
   "
+}
+
+reset_active_jobs() {
+  if ! [[ "$COUNT" =~ ^[0-9]+$ ]]; then
+    echo "COUNT must be a positive integer for RESET_ACTIVE_JOBS=1" >&2
+    return 1
+  fi
+
+  local ign_file
+  ign_file=$(mktemp)
+  head -n "$COUNT" module-app/src/main/resources/data/userIgn_List.csv >"$ign_file"
+
+  if ! psql_db <<SQL
+CREATE TEMP TABLE load_test_igns(user_ign text PRIMARY KEY);
+\\copy load_test_igns(user_ign) FROM '$ign_file' WITH (FORMAT text);
+
+WITH reset_jobs AS (
+  UPDATE calculation_jobs j
+  SET status = 'FAILED',
+      last_error_code = 'LOAD_TEST_RESET',
+      error_message = 'Reset before V5 DB throughput load test',
+      completed_at = NOW(),
+      locked_by = NULL,
+      locked_until = NULL,
+      updated_at = NOW()
+  FROM load_test_igns i
+  WHERE j.user_ign = i.user_ign
+    AND j.preset_no = 1
+    AND j.status IN ('REQUESTED', 'OCID_RESOLVING', 'API_REQUESTED', 'SNAPSHOT_READY', 'CALCULATING', 'RETRYING')
+  RETURNING j.job_id
+)
+SELECT count(*) AS reset_active_jobs FROM reset_jobs;
+DROP TABLE load_test_igns;
+SQL
+  then
+    rm -f "$ign_file"
+    return 1
+  fi
+
+  rm -f "$ign_file"
 }
 
 monitor_db() {
   local prev_views=""
   local prev_ts=""
 
-  printf '%s\n' "timestamp,elapsed_s,views,queue_high,delta_views,views_per_sec"
+  printf '%s\n' "timestamp,elapsed_s,views,queue_high,queue_external_api,queue_result_ready,active_api_requested,delta_views,views_per_sec"
   while true; do
     local ts
     local counts
     local views
     local queue_high
+    local queue_external_api
+    local queue_result_ready
+    local active_api_requested
     local delta=0
     local rate=0
 
@@ -92,6 +139,9 @@ monitor_db() {
     counts=$(db_counts)
     views=$(echo "$counts" | awk -F'|' '{print $1}')
     queue_high=$(echo "$counts" | awk -F'|' '{print $2}')
+    queue_external_api=$(echo "$counts" | awk -F'|' '{print $3}')
+    queue_result_ready=$(echo "$counts" | awk -F'|' '{print $4}')
+    active_api_requested=$(echo "$counts" | awk -F'|' '{print $5}')
 
     if [[ -n "$prev_ts" ]]; then
       local dt=$((ts - prev_ts))
@@ -101,7 +151,9 @@ monitor_db() {
       fi
     fi
 
-    printf '%s,%s,%s,%s,%s,%s\n' "$(date -Is)" "$((ts - START_TS))" "$views" "$queue_high" "$delta" "$rate"
+    printf '%s,%s,%s,%s,%s,%s,%s,%s,%s\n' \
+      "$(date -Is)" "$((ts - START_TS))" "$views" "$queue_high" "$queue_external_api" \
+      "$queue_result_ready" "$active_api_requested" "$delta" "$rate"
 
     prev_views=$views
     prev_ts=$ts
@@ -127,9 +179,19 @@ else
   echo "Skipping view reset. Set RESET_VIEWS=1 to delete character_valuation_views before the run."
 fi
 
+if [[ "$RESET_ACTIVE_JOBS" == "1" ]]; then
+  echo "Resetting active calculation_jobs for the first $COUNT load-test IGNs"
+  reset_active_jobs
+else
+  echo "Skipping active job reset. Set RESET_ACTIVE_JOBS=1 to mark active load-test jobs as FAILED before the run."
+fi
+
 echo "Initial DB state"
 psql_db -c "SELECT count(*) AS character_valuation_views FROM character_valuation_views;"
 psql_db -c "SELECT count(*) AS expectation_calc_high_queue FROM pgmq.q_expectation_calc_high;"
+psql_db -c "SELECT count(*) AS external_api_queue FROM pgmq.q_external_api_queue;"
+psql_db -c "SELECT count(*) AS result_ready_queue FROM pgmq.q_result_ready_queue;"
+psql_db -c "SELECT status, count(*) FROM calculation_jobs GROUP BY status ORDER BY status;"
 
 START_TS=$(date +%s)
 monitor_db &
@@ -144,3 +206,6 @@ done
 echo "Final DB state"
 psql_db -c "SELECT count(*) AS character_valuation_views FROM character_valuation_views;"
 psql_db -c "SELECT count(*) AS expectation_calc_high_queue FROM pgmq.q_expectation_calc_high;"
+psql_db -c "SELECT count(*) AS external_api_queue FROM pgmq.q_external_api_queue;"
+psql_db -c "SELECT count(*) AS result_ready_queue FROM pgmq.q_result_ready_queue;"
+psql_db -c "SELECT status, count(*) FROM calculation_jobs GROUP BY status ORDER BY status;"

--- a/module-core/src/main/kotlin/maple/expectation/core/port/inbound/CharacterViewQueryPort.kt
+++ b/module-core/src/main/kotlin/maple/expectation/core/port/inbound/CharacterViewQueryPort.kt
@@ -3,6 +3,18 @@ package maple.expectation.core.port.inbound
 import java.util.Optional
 import maple.expectation.core.domain.model.character.CharacterView
 
+data class CharacterViewProjectionCommand(
+    val userIgn: String,
+    val messageId: String,
+    val characterOcid: String?,
+    val characterClass: String?,
+    val characterLevel: Int?,
+    val totalExpectedCost: Long,
+    val maxPresetNo: Int,
+    val presetNo: Int,
+    val presetsJson: String,
+)
+
 /**
  * V5 CQRS Query Side Port (ADR-005, Issue #639)
  *
@@ -49,4 +61,6 @@ interface CharacterViewQueryPort {
         presetNo: Int,
         presetsJson: String,
     )
+
+    fun batchUpsertFromCalculations(commands: List<CharacterViewProjectionCommand>): Int
 }

--- a/module-core/src/main/kotlin/maple/expectation/core/port/out/CalculationResultPort.kt
+++ b/module-core/src/main/kotlin/maple/expectation/core/port/out/CalculationResultPort.kt
@@ -24,5 +24,6 @@ interface CalculationResultPort {
     fun save(result: CalculationResultData): CalculationResultData
     fun saveIfAbsent(result: CalculationResultData): Boolean
     fun findByJobId(jobId: UUID): CalculationResultData?
+    fun findByJobIds(jobIds: List<UUID>): List<CalculationResultData>
     fun existsByJobId(jobId: UUID): Boolean
 }

--- a/module-infra/src/main/kotlin/maple/expectation/adapter/outgoing/CalculationResultPortAdapter.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/adapter/outgoing/CalculationResultPortAdapter.kt
@@ -56,6 +56,12 @@ class CalculationResultPortAdapter(
     override fun findByJobId(jobId: UUID): CalculationResultData? = repo.findByJobId(jobId)?.toData()
 
     @Transactional(value = "transactionManager", readOnly = true)
+    override fun findByJobIds(jobIds: List<UUID>): List<CalculationResultData> {
+        if (jobIds.isEmpty()) return emptyList()
+        return repo.findByJobIdIn(jobIds).map { it.toData() }
+    }
+
+    @Transactional(value = "transactionManager", readOnly = true)
     override fun existsByJobId(jobId: UUID): Boolean = repo.existsByJobId(jobId)
 
     @Transactional(value = "transactionManager", readOnly = false)

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/external/impl/RealNexonApiClient.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/external/impl/RealNexonApiClient.kt
@@ -59,16 +59,14 @@ class RealNexonApiClient(
             .onErrorResume(
                 WebClientResponseException::class.java,
             ) { ex ->
-                if (ex.statusCode.is4xxClientError) {
-                    // Issue #196: 상태 코드 + 실제 에러 메시지 로깅 (디버깅 가시성)
-                    logger.warn(
-                        "[NexonApi] OCID lookup failed. Status: {}, Body: {}",
-                        ex.statusCode,
-                        ex.responseBodyAsString,
-                    )
+                logger.warn(
+                    "[NexonApi] OCID lookup failed. Status: {}, Body: {}",
+                    ex.statusCode,
+                    ex.responseBodyAsString,
+                )
+                if (isInvalidOcidLookupParameter(ex)) {
                     return@onErrorResume Mono.error(CharacterNotFoundException(characterName))
                 }
-                // 5xx: 서킷브레이커 동작을 위해 상위 전파
                 Mono.error(ex)
             }
             .timeout(timeoutProperties.apiCall)
@@ -133,4 +131,6 @@ class RealNexonApiClient(
             .timeout(timeoutProperties.apiCall)
             .toFuture()
     }
+
+    private fun isInvalidOcidLookupParameter(ex: WebClientResponseException): Boolean = ex.statusCode.value() == 400 && ex.responseBodyAsString.contains("OPENAPI00004")
 }

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/job/CalculationJobService.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/job/CalculationJobService.kt
@@ -177,15 +177,31 @@ class CalculationJobService(
     }
 
     @Transactional
-    fun retryExternalApiJob(jobId: UUID) {
-        val job = jobPort.findJobById(jobId) ?: return
+    fun retryExternalApiJob(jobId: UUID, errorCode: String = "EXTERNAL_API_ERROR"): Boolean {
+        val job = jobPort.findJobById(jobId) ?: return false
         if (job.retryCount >= job.maxRetries) {
-            jobPort.markFailed(jobId, "EXTERNAL_API_ERROR", "Max retries exceeded")
+            jobPort.markFailed(jobId, errorCode, "Max retries exceeded")
             log.warn("[jobId={}] External API failed after {} retries", jobId, job.retryCount)
-            return
+            return true
         }
-        jobPort.incrementRetry(jobId, "EXTERNAL_API_ERROR")
+        val incremented = when (job.status) {
+            CalculationJobStatus.OCID_RESOLVING -> jobPort.incrementRetryForOcid(jobId, errorCode)
+            CalculationJobStatus.API_REQUESTED,
+            CalculationJobStatus.RETRYING,
+            -> jobPort.incrementRetry(jobId, errorCode)
+            CalculationJobStatus.REQUESTED -> jobPort.transitionStatus(
+                jobId,
+                CalculationJobStatus.REQUESTED,
+                CalculationJobStatus.OCID_RESOLVING,
+            )
+            else -> false
+        }
+        if (!incremented) {
+            log.warn("[jobId={}] External API retry not scheduled from state {}", jobId, job.status)
+            return false
+        }
         pgmqClient.send(QueueNames.EXTERNAL_API, ExternalApiJobPayload(job.jobId.toString(), job.userIgn, job.presetNo))
         log.info("[jobId={}] External API retry scheduled (attempt {})", jobId, job.retryCount + 1)
+        return true
     }
 }

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/CharacterViewQueryPortAdapter.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/CharacterViewQueryPortAdapter.kt
@@ -2,6 +2,7 @@ package maple.expectation.infrastructure.persistence
 
 import java.util.Optional
 import maple.expectation.core.domain.model.character.CharacterView
+import maple.expectation.core.port.inbound.CharacterViewProjectionCommand
 import maple.expectation.core.port.inbound.CharacterViewQueryPort
 import maple.expectation.infrastructure.persistence.entity.CharacterValuationViewEntity
 import org.slf4j.LoggerFactory
@@ -51,6 +52,8 @@ class CharacterViewQueryPortAdapter(
             totalExpectedCost, maxPresetNo, presetNo, presetsJson,
         )
     }
+
+    override fun batchUpsertFromCalculations(commands: List<CharacterViewProjectionCommand>): Int = queryService.batchUpsertFromCalculations(commands)
 
     /**
      * JPA Entity를 CharacterView 인터페이스로 어댑트

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/CharacterViewQueryServicePostgres.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/CharacterViewQueryServicePostgres.kt
@@ -4,12 +4,14 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import io.micrometer.core.instrument.MeterRegistry
 import java.sql.Timestamp
 import java.util.concurrent.TimeUnit
+import maple.expectation.core.port.inbound.CharacterViewProjectionCommand
 import maple.expectation.infrastructure.executor.LogicExecutor
 import maple.expectation.infrastructure.executor.TaskContext
 import maple.expectation.infrastructure.persistence.entity.CharacterValuationViewEntity
 import maple.expectation.infrastructure.persistence.repository.CharacterValuationViewJpaRepository
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -83,6 +85,13 @@ class CharacterViewQueryServicePostgres(
             )
             upsert(entity)
         }, context)
+    }
+
+    @Transactional(value = "transactionManager", readOnly = false)
+    fun batchUpsertFromCalculations(commands: List<CharacterViewProjectionCommand>): Int {
+        if (commands.isEmpty()) return 0
+        val context = TaskContext.of("PostgresQuery", "BatchUpsertFromCalculation", commands.size.toString())
+        return executor.executeOrDefault({ performBatchUpsert(commands) }, 0, context)
     }
 
     // ==================== Internal Methods ====================
@@ -191,6 +200,89 @@ class CharacterViewQueryServicePostgres(
             params,
         )
     }
+
+    private fun performBatchUpsert(commands: List<CharacterViewProjectionCommand>): Int {
+        val now = java.time.Instant.now()
+        val versionBase = System.currentTimeMillis()
+        val rows = commands.mapIndexed { index, command ->
+            val version = versionBase + index
+            val presets = parsePresets(command)
+            val entity = CharacterValuationViewEntity(
+                userIgn = command.userIgn,
+                messageId = command.messageId,
+                characterOcid = command.characterOcid,
+                characterClass = command.characterClass,
+                characterLevel = command.characterLevel,
+                totalExpectedCost = command.totalExpectedCost,
+                maxPresetNo = command.maxPresetNo,
+                presetNo = command.presetNo,
+                presets = presets,
+                calculatedAt = now,
+                fromCache = false,
+                version = version,
+                lastAppliedVersion = version,
+            )
+            entity to MapSqlParameterSource()
+                .addValue("userIgn", entity.userIgn)
+                .addValue("messageId", entity.messageId)
+                .addValue("characterOcid", entity.characterOcid)
+                .addValue("characterClass", entity.characterClass)
+                .addValue("characterLevel", entity.characterLevel)
+                .addValue("calculatedAt", entity.calculatedAt?.let(Timestamp::from))
+                .addValue("lastApiSyncAt", entity.lastApiSyncAt?.let(Timestamp::from))
+                .addValue("version", entity.version ?: 1L)
+                .addValue("lastAppliedVersion", entity.lastAppliedVersion ?: entity.version ?: 1L)
+                .addValue("totalExpectedCost", entity.totalExpectedCost)
+                .addValue("maxPresetNo", entity.maxPresetNo)
+                .addValue("presetNo", entity.presetNo)
+                .addValue("presets", command.presetsJson)
+                .addValue("fromCache", entity.fromCache)
+        }
+
+        val counts = jdbc.batchUpdate(
+            """
+            INSERT INTO character_valuation_views (
+                user_ign, message_id, jpa_version, character_ocid, character_class, character_level,
+                calculated_at, last_api_sync_at, version, last_applied_version,
+                total_expected_cost, max_preset_no, preset_no, presets, from_cache
+            ) VALUES (
+                :userIgn, :messageId, 0, :characterOcid, :characterClass, :characterLevel,
+                :calculatedAt, :lastApiSyncAt, :version + 1, :lastAppliedVersion,
+                :totalExpectedCost, :maxPresetNo, :presetNo, CAST(:presets AS jsonb), :fromCache
+            )
+            ON CONFLICT (message_id) DO UPDATE SET
+                user_ign = EXCLUDED.user_ign,
+                jpa_version = character_valuation_views.jpa_version + 1,
+                character_ocid = COALESCE(EXCLUDED.character_ocid, character_valuation_views.character_ocid),
+                character_class = COALESCE(EXCLUDED.character_class, character_valuation_views.character_class),
+                character_level = COALESCE(EXCLUDED.character_level, character_valuation_views.character_level),
+                calculated_at = EXCLUDED.calculated_at,
+                last_api_sync_at = COALESCE(EXCLUDED.last_api_sync_at, character_valuation_views.last_api_sync_at),
+                version = character_valuation_views.version + 1,
+                last_applied_version = EXCLUDED.last_applied_version,
+                total_expected_cost = EXCLUDED.total_expected_cost,
+                max_preset_no = EXCLUDED.max_preset_no,
+                preset_no = EXCLUDED.preset_no,
+                presets = EXCLUDED.presets,
+                from_cache = EXCLUDED.from_cache
+            WHERE character_valuation_views.last_applied_version < EXCLUDED.last_applied_version
+            """,
+            rows.map { it.second }.toTypedArray(),
+        )
+        saveToReadModelBatch(rows.map { it.first })
+        return counts.sumOf { if (it > 0) it else 0 }
+    }
+
+    private fun parsePresets(command: CharacterViewProjectionCommand): List<CharacterValuationViewEntity.PresetView>? = executor.executeOrDefault(
+        {
+            objectMapper.readValue(
+                command.presetsJson,
+                objectMapper.typeFactory.constructCollectionType(List::class.java, CharacterValuationViewEntity.PresetView::class.java),
+            )
+        },
+        null,
+        TaskContext.of("PostgresQuery", "ParsePresets", command.userIgn),
+    )
 
     private fun updateOrSkipExisting(
         existing: CharacterValuationViewEntity,
@@ -316,6 +408,26 @@ class CharacterViewQueryServicePostgres(
                 log.warn("[ReadModel] Non-fatal write failure (will retry on next calculation): userIgn={}", entity.userIgn, e)
             },
             TaskContext.of("ReadModel", "BestEffortWrite", entity.userIgn),
+        )
+    }
+
+    private fun saveToReadModelBatch(entities: List<CharacterValuationViewEntity>) {
+        val commands = entities.map { entity ->
+            val calculatedAt = entity.calculatedAt
+                ?: throw IllegalStateException("calculatedAt must be set before writing to read model: userIgn=${entity.userIgn}")
+            ReadModelWriteCommand(
+                userIgn = entity.userIgn,
+                json = serializeEntityToJson(entity),
+                calculatedAt = calculatedAt,
+            )
+        }
+        executor.executeOrCatch(
+            { readModelWriteService.writeToReadModelRawBatch(commands) },
+            { e ->
+                log.warn("[ReadModel] Non-fatal batch write failure (will retry on next calculation): rows={}", entities.size, e)
+                0
+            },
+            TaskContext.of("ReadModel", "BestEffortBatchWrite", entities.size.toString()),
         )
     }
 

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/ExpectationReadModelWriteService.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/ExpectationReadModelWriteService.kt
@@ -1,5 +1,6 @@
 package maple.expectation.infrastructure.persistence
 
+import java.sql.Timestamp
 import java.time.Instant
 import maple.expectation.infrastructure.executor.LogicExecutor
 import maple.expectation.infrastructure.executor.TaskContext
@@ -7,6 +8,8 @@ import maple.expectation.infrastructure.persistence.repository.ExpectationReadMo
 import maple.expectation.util.GzipUtils
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -26,6 +29,7 @@ import org.springframework.transaction.annotation.Transactional
 @ConditionalOnProperty(name = ["v5.enabled"], havingValue = "true", matchIfMissing = false)
 class ExpectationReadModelWriteService(
     private val repository: ExpectationReadModelRepository,
+    private val jdbc: NamedParameterJdbcTemplate,
     private val executor: LogicExecutor,
 ) {
     private val log = LoggerFactory.getLogger(ExpectationReadModelWriteService::class.java)
@@ -63,4 +67,39 @@ class ExpectationReadModelWriteService(
         repository.upsertNative(userIgn, compressed, calculatedAt)
         log.debug("[ReadModel] Saved: userIgn={}, compressedSize={}", userIgn, compressed.size)
     }
+
+    /**
+     * Batch raw write method without executor wrapping.
+     * Used by projection batches that already have executor/recovery wrapping.
+     */
+    @Transactional(value = "transactionManager", readOnly = false)
+    fun writeToReadModelRawBatch(commands: List<ReadModelWriteCommand>): Int {
+        if (commands.isEmpty()) return 0
+        val params = commands.map { command ->
+            MapSqlParameterSource()
+                .addValue("userIgn", command.userIgn)
+                .addValue("payload", GzipUtils.compressUnchecked(command.json))
+                .addValue("calculatedAt", Timestamp.from(command.calculatedAt))
+        }
+        val counts = jdbc.batchUpdate(
+            """
+            INSERT INTO character_expectation_read_model (user_ign, payload, calculated_at, updated_at)
+            VALUES (:userIgn, :payload, :calculatedAt, NOW())
+            ON CONFLICT (user_ign) DO UPDATE SET
+                payload = EXCLUDED.payload,
+                calculated_at = EXCLUDED.calculated_at,
+                updated_at = NOW()
+            WHERE EXCLUDED.calculated_at >= character_expectation_read_model.calculated_at
+            """,
+            params.toTypedArray(),
+        )
+        log.debug("[ReadModel] Batch saved: rows={}", commands.size)
+        return counts.sumOf { if (it > 0) it else 0 }
+    }
 }
+
+data class ReadModelWriteCommand(
+    val userIgn: String,
+    val json: String,
+    val calculatedAt: Instant,
+)

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/repository/CalculationResultRepository.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/repository/CalculationResultRepository.kt
@@ -9,6 +9,7 @@ import org.springframework.data.repository.query.Param
 
 interface CalculationResultRepository : JpaRepository<CalculationResultEntity, UUID> {
     fun findByJobId(jobId: UUID): CalculationResultEntity?
+    fun findByJobIdIn(jobIds: Collection<UUID>): List<CalculationResultEntity>
     fun existsByJobId(jobId: UUID): Boolean
 
     @Modifying

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/ratelimit/NexonRateLimiter.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/ratelimit/NexonRateLimiter.kt
@@ -23,7 +23,7 @@ import org.springframework.stereotype.Component
  */
 @Component
 class NexonRateLimiter(
-    @Value("\${nexon.rate-limit.max-concurrent:50}") maxConcurrent: Int,
+    @Value("\${nexon.api.rate-limit.max-concurrent:\${nexon.rate-limit.max-concurrent:50}}") maxConcurrent: Int,
     meterRegistry: MeterRegistry,
 ) {
     private val lock = ReentrantLock()

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/ExternalApiWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/ExternalApiWorker.kt
@@ -40,6 +40,7 @@ import maple.expectation.util.ExceptionUtils
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClientResponseException
 
 /**
  * Consolidated External API Worker (extends PgmqWorker for parallel processing)
@@ -111,7 +112,6 @@ class ExternalApiWorker(
                 } else {
                     log.error("[jobId={}] Pipeline failed: {}", jobId, e.message)
                     handleFailure(jobId, e)
-                    false
                 }
             },
             context,
@@ -134,13 +134,13 @@ class ExternalApiWorker(
 
         // Early exit: skip expensive API calls if job already completed/processing
         val existingJob = jobPort.findJobById(jobId)
-        if (existingJob != null && existingJob.status != CalculationJobStatus.OCID_RESOLVING && existingJob.status != CalculationJobStatus.REQUESTED) {
+        if (existingJob != null && !existingJob.status.isExternalApiProcessable()) {
             log.debug("[jobId={}] Skipping — already in state {}", jobId, existingJob.status)
             return
         }
 
         // Step 1+2: Resolve OCID → Fetch equipment (thenCompose chain, single block point on cache miss)
-        val (ocid, equipmentResponse) = resolveOcidAndFetchEquipment(jobId, payload.userIgn)
+        val (ocid, equipmentResponse) = resolveOcidAndFetchEquipment(jobId, payload.userIgn, existingJob?.ocid)
 
         // Step 3: Submit snapshot write to overlap with calculation
         val snapshotData = objectMapper.writeValueAsBytes(equipmentResponse)
@@ -217,8 +217,8 @@ class ExternalApiWorker(
      * OCID cache miss: chains OCID API → equipment API via thenCompose,
      * blocking once at .join() instead of twice.
      */
-    private fun resolveOcidAndFetchEquipment(jobId: UUID, userIgn: String): Pair<String, EquipmentResponse> {
-        val cached = ocidPort.resolveOcid(userIgn)
+    private fun resolveOcidAndFetchEquipment(jobId: UUID, userIgn: String, jobOcid: String?): Pair<String, EquipmentResponse> {
+        val cached = jobOcid ?: ocidPort.resolveOcid(userIgn)
         if (cached != null) {
             jobService.resolveOcidInPlace(jobId, cached)
             return Pair(cached, equipmentFetchProvider.fetchWithCache(cached))
@@ -253,18 +253,41 @@ class ExternalApiWorker(
             .join()
     }
 
-    private fun handleFailure(jobId: UUID, e: Throwable) {
-        val job = jobPort.findJobById(jobId) ?: return
+    private fun handleFailure(jobId: UUID, e: Throwable): Boolean {
+        val job = jobPort.findJobById(jobId) ?: return false
+        val errorCode = classifyExternalApiError(e)
         val errorMsg = (e.message ?: "Unknown error").take(200)
 
         if (job.retryCount >= job.maxRetries) {
-            jobPort.markFailed(jobId, "EXTERNAL_API_ERROR", errorMsg)
+            jobPort.markFailed(jobId, errorCode, errorMsg)
+            return true
         } else {
-            jobService.retryExternalApiJob(jobId)
+            return jobService.retryExternalApiJob(jobId, errorCode)
         }
     }
 
     private fun isCharacterNotFound(e: Throwable): Boolean = ExceptionUtils.containsCause(e, CharacterNotFoundException::class.java)
+
+    private fun CalculationJobStatus.isExternalApiProcessable(): Boolean = this == CalculationJobStatus.REQUESTED ||
+        this == CalculationJobStatus.OCID_RESOLVING ||
+        this == CalculationJobStatus.API_REQUESTED ||
+        this == CalculationJobStatus.RETRYING
+
+    private fun classifyExternalApiError(e: Throwable): String {
+        val responseException = ExceptionUtils.unwrapAs(e, WebClientResponseException::class.java) ?: return "EXTERNAL_API_ERROR"
+        return when (responseException.statusCode.value()) {
+            400 -> if (responseException.responseBodyAsString.contains("OPENAPI00004")) {
+                "CHARACTER_NOT_FOUND"
+            } else {
+                "NEXON_BAD_REQUEST"
+            }
+            401 -> "NEXON_UNAUTHORIZED"
+            403 -> "NEXON_FORBIDDEN"
+            429 -> "NEXON_RATE_LIMITED"
+            in 500..599 -> "NEXON_SERVER_ERROR"
+            else -> "EXTERNAL_API_ERROR"
+        }
+    }
 
     private fun generateObjectKey(jobId: UUID): String {
         val now = Instant.now()

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/ResultReadyProjectionWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/ResultReadyProjectionWorker.kt
@@ -1,0 +1,158 @@
+package maple.expectation.infrastructure.worker
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import java.util.UUID
+import java.util.zip.GZIPInputStream
+import maple.expectation.core.model.job.CalculationJob
+import maple.expectation.core.port.inbound.CharacterViewProjectionCommand
+import maple.expectation.core.port.inbound.CharacterViewQueryPort
+import maple.expectation.core.port.out.CalculationJobPort
+import maple.expectation.core.port.out.CalculationResultData
+import maple.expectation.core.port.out.CalculationResultPort
+import maple.expectation.core.port.out.QueueNames
+import maple.expectation.infrastructure.executor.LogicExecutor
+import maple.expectation.infrastructure.executor.TaskContext
+import maple.expectation.infrastructure.pgmq.PgmqClient
+import maple.expectation.infrastructure.pgmq.PgmqMessage
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+@Component
+@ConditionalOnProperty(name = ["v5.enabled"], havingValue = "true", matchIfMissing = false)
+class ResultReadyProjectionWorker(
+    private val pgmqClient: PgmqClient,
+    private val jobPort: CalculationJobPort,
+    private val resultPort: CalculationResultPort,
+    private val viewQueryPort: CharacterViewQueryPort,
+    private val executor: LogicExecutor,
+    private val objectMapper: ObjectMapper,
+    @Value("\${pgmq.worker.result-projection.batch-size:100}") private val batchSize: Int,
+    @Value("\${pgmq.worker.result-projection.visibility-timeout-sec:30}") private val visibilityTimeoutSec: Int,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Scheduled(
+        fixedDelayString = "\${pgmq.worker.result-projection.polling-interval-ms:300}",
+        initialDelayString = "\${pgmq.worker.result-projection.initial-delay-ms:5000}",
+    )
+    fun project() {
+        val messages = pgmqClient.read(
+            QueueNames.RESULT_READY,
+            Map::class.java,
+            batchSize = batchSize,
+            visibilityTimeoutSec = visibilityTimeoutSec,
+        )
+        if (messages.isEmpty()) return
+
+        val context = TaskContext.of("ResultProjection", "ProjectBatch", messages.size.toString())
+        executor.executeVoid({ projectBatch(messages) }, context)
+    }
+
+    private fun projectBatch(messages: List<PgmqMessage<Map<*, *>>>) {
+        val archiveIds = mutableListOf<Long>()
+        val parsed = messages.mapNotNull { parseMessage(it, archiveIds) }
+        if (parsed.isEmpty()) {
+            archiveIfNeeded(archiveIds)
+            return
+        }
+
+        val jobIds = parsed.map { it.jobId }.distinct()
+        val jobsById = jobPort.findJobsByIds(jobIds).associateBy { it.jobId }
+        val resultsByJobId = resultPort.findByJobIds(jobIds).associateBy { it.jobId }
+        val commands = parsed.mapNotNull { message ->
+            val job = jobsById[message.jobId]
+            val resultData = resultsByJobId[message.jobId]
+            when {
+                job == null -> {
+                    log.warn("[jobId={}] Job not found, skipping", message.jobId)
+                    archiveIds += message.messageId
+                    null
+                }
+                resultData == null -> {
+                    log.warn("[jobId={}] Result not found, skipping", message.jobId)
+                    archiveIds += message.messageId
+                    null
+                }
+                else -> toProjectionCommand(message, job, resultData, archiveIds)
+            }
+        }
+
+        if (commands.isNotEmpty()) {
+            viewQueryPort.batchUpsertFromCalculations(commands)
+        }
+        archiveIfNeeded(archiveIds)
+        log.debug("[ResultProjection] projected={}, archived={}", commands.size, archiveIds.size)
+    }
+
+    private fun parseMessage(message: PgmqMessage<Map<*, *>>, archiveIds: MutableList<Long>): ProjectionMessage? {
+        val payload = message.payload
+        val jobIdStr = payload["jobId"]?.toString() ?: run {
+            log.warn("[msgId={}] Missing jobId, skipping", message.messageId)
+            archiveIds += message.messageId
+            return null
+        }
+        val jobId = runCatching { UUID.fromString(jobIdStr) }.getOrNull() ?: run {
+            log.warn("[msgId={}] Invalid jobId: {}", message.messageId, jobIdStr)
+            archiveIds += message.messageId
+            return null
+        }
+        return ProjectionMessage(message.messageId, payload, jobId)
+    }
+
+    private fun toProjectionCommand(
+        message: ProjectionMessage,
+        job: CalculationJob,
+        resultData: CalculationResultData,
+        archiveIds: MutableList<Long>,
+    ): CharacterViewProjectionCommand? {
+        val resultJson = decompress(resultData.responseBody)
+        val tree = objectMapper.readTree(resultJson)
+
+        val totalExpectedCost = tree.get("totalExpectedCost")?.asLong() ?: run {
+            log.warn("[jobId={}] Missing totalExpectedCost in result", message.jobId)
+            archiveIds += message.messageId
+            return null
+        }
+        val maxPresetNo = tree.get("maxPresetNo")?.asInt() ?: run {
+            log.warn("[jobId={}] Missing maxPresetNo in result", message.jobId)
+            archiveIds += message.messageId
+            return null
+        }
+        val presetsNode = tree.get("presets")
+        val presetNo = (message.payload["presetNo"] as? Number)?.toInt() ?: 1
+        val characterId = message.payload["characterId"]?.toString()
+        val presetsJson = if (presetsNode != null) objectMapper.writeValueAsString(presetsNode) else "[]"
+
+        archiveIds += message.messageId
+        return CharacterViewProjectionCommand(
+            userIgn = job.userIgn,
+            messageId = message.messageId.toString(),
+            characterOcid = characterId,
+            characterClass = resultData.characterClass,
+            characterLevel = null,
+            totalExpectedCost = totalExpectedCost,
+            maxPresetNo = maxPresetNo,
+            presetNo = presetNo,
+            presetsJson = presetsJson,
+        )
+    }
+
+    private fun archiveIfNeeded(messageIds: List<Long>) {
+        if (messageIds.isNotEmpty()) {
+            pgmqClient.archiveBatch(QueueNames.RESULT_READY, messageIds)
+        }
+    }
+
+    private fun decompress(data: ByteArray): String {
+        GZIPInputStream(data.inputStream()).use { return String(it.readAllBytes()) }
+    }
+
+    private data class ProjectionMessage(
+        val messageId: Long,
+        val payload: Map<*, *>,
+        val jobId: UUID,
+    )
+}

--- a/module-infra/src/test/kotlin/maple/expectation/infrastructure/job/CalculationJobServiceTest.kt
+++ b/module-infra/src/test/kotlin/maple/expectation/infrastructure/job/CalculationJobServiceTest.kt
@@ -1,0 +1,154 @@
+package maple.expectation.infrastructure.job
+
+import java.util.UUID
+import maple.expectation.core.model.job.CalculationJob
+import maple.expectation.core.model.job.CalculationJobStatus
+import maple.expectation.core.port.out.CalculationJobPort
+import maple.expectation.core.port.out.QueueNames
+import maple.expectation.core.port.out.mq.DomainEventAppender
+import maple.expectation.infrastructure.mq.pgmq.topic.NexonApiRequestTopic
+import maple.expectation.infrastructure.mq.pgmq.topic.NexonApiResponseTopic
+import maple.expectation.infrastructure.mq.pgmq.topic.OcidResolveTopic
+import maple.expectation.infrastructure.persistence.repository.CalculationSnapshotRepository
+import maple.expectation.infrastructure.pgmq.ExternalApiJobPayload
+import maple.expectation.infrastructure.pgmq.PgmqClient
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@ExtendWith(MockitoExtension::class)
+class CalculationJobServiceTest {
+
+    @Mock lateinit var jobPort: CalculationJobPort
+
+    @Mock lateinit var eventAppender: DomainEventAppender
+
+    @Mock lateinit var pgmqClient: PgmqClient
+
+    @Mock lateinit var ocidResolveTopic: OcidResolveTopic
+
+    @Mock lateinit var nexonApiRequestTopic: NexonApiRequestTopic
+
+    @Mock lateinit var nexonApiResponseTopic: NexonApiResponseTopic
+
+    @Mock lateinit var snapshotRepository: CalculationSnapshotRepository
+
+    private lateinit var service: CalculationJobService
+
+    @BeforeEach
+    fun setUp() {
+        service = CalculationJobService(
+            jobPort = jobPort,
+            eventAppender = eventAppender,
+            pgmqClient = pgmqClient,
+            ocidResolveTopic = ocidResolveTopic,
+            nexonApiRequestTopic = nexonApiRequestTopic,
+            nexonApiResponseTopic = nexonApiResponseTopic,
+            snapshotRepository = snapshotRepository,
+        )
+    }
+
+    @Test
+    fun `retryExternalApiJob increments OCID retry when job is resolving OCID`() {
+        val job = job(status = CalculationJobStatus.OCID_RESOLVING)
+        whenever(jobPort.findJobById(job.jobId)).thenReturn(job)
+        whenever(jobPort.incrementRetryForOcid(job.jobId, "OCID_RESOLVE_ERROR")).thenReturn(true)
+
+        val result = service.retryExternalApiJob(job.jobId, "OCID_RESOLVE_ERROR")
+
+        assertThat(result).isTrue()
+        verify(jobPort).incrementRetryForOcid(job.jobId, "OCID_RESOLVE_ERROR")
+        verify(jobPort, never()).incrementRetry(eq(job.jobId), any())
+        verify(pgmqClient).send(QueueNames.EXTERNAL_API, ExternalApiJobPayload(job.jobId.toString(), job.userIgn, job.presetNo))
+    }
+
+    @Test
+    fun `retryExternalApiJob increments API retry when job is API requested`() {
+        val job = job(status = CalculationJobStatus.API_REQUESTED, ocid = "ocid-1")
+        whenever(jobPort.findJobById(job.jobId)).thenReturn(job)
+        whenever(jobPort.incrementRetry(job.jobId, "EXTERNAL_API_ERROR")).thenReturn(true)
+
+        val result = service.retryExternalApiJob(job.jobId)
+
+        assertThat(result).isTrue()
+        verify(jobPort).incrementRetry(job.jobId, "EXTERNAL_API_ERROR")
+        verify(jobPort, never()).incrementRetryForOcid(eq(job.jobId), any())
+        verify(pgmqClient).send(QueueNames.EXTERNAL_API, ExternalApiJobPayload(job.jobId.toString(), job.userIgn, job.presetNo))
+    }
+
+    @Test
+    fun `retryExternalApiJob stores provided API error code`() {
+        val job = job(status = CalculationJobStatus.API_REQUESTED, ocid = "ocid-1")
+        whenever(jobPort.findJobById(job.jobId)).thenReturn(job)
+        whenever(jobPort.incrementRetry(job.jobId, "NEXON_RATE_LIMITED")).thenReturn(true)
+
+        val result = service.retryExternalApiJob(job.jobId, "NEXON_RATE_LIMITED")
+
+        assertThat(result).isTrue()
+        verify(jobPort).incrementRetry(job.jobId, "NEXON_RATE_LIMITED")
+        verify(pgmqClient).send(QueueNames.EXTERNAL_API, ExternalApiJobPayload(job.jobId.toString(), job.userIgn, job.presetNo))
+    }
+
+    @Test
+    fun `retryExternalApiJob increments API retry when job is retrying`() {
+        val job = job(status = CalculationJobStatus.RETRYING, ocid = "ocid-1", retryCount = 1)
+        whenever(jobPort.findJobById(job.jobId)).thenReturn(job)
+        whenever(jobPort.incrementRetry(job.jobId, "EXTERNAL_API_ERROR")).thenReturn(true)
+
+        val result = service.retryExternalApiJob(job.jobId)
+
+        assertThat(result).isTrue()
+        verify(jobPort).incrementRetry(job.jobId, "EXTERNAL_API_ERROR")
+        verify(jobPort, never()).incrementRetryForOcid(eq(job.jobId), any())
+        verify(pgmqClient).send(QueueNames.EXTERNAL_API, ExternalApiJobPayload(job.jobId.toString(), job.userIgn, job.presetNo))
+    }
+
+    @Test
+    fun `retryExternalApiJob marks exhausted job failed and archives current message`() {
+        val job = job(status = CalculationJobStatus.API_REQUESTED, retryCount = 3, maxRetries = 3)
+        whenever(jobPort.findJobById(job.jobId)).thenReturn(job)
+
+        val result = service.retryExternalApiJob(job.jobId)
+
+        assertThat(result).isTrue()
+        verify(jobPort).markFailed(job.jobId, "EXTERNAL_API_ERROR", "Max retries exceeded")
+        verify(pgmqClient, never()).send(eq(QueueNames.EXTERNAL_API), any<ExternalApiJobPayload>())
+    }
+
+    @Test
+    fun `retryExternalApiJob returns false for non external API processable job`() {
+        val job = job(status = CalculationJobStatus.COMPLETED)
+        whenever(jobPort.findJobById(job.jobId)).thenReturn(job)
+
+        val result = service.retryExternalApiJob(job.jobId)
+
+        assertThat(result).isFalse()
+        verify(jobPort, never()).incrementRetry(eq(job.jobId), any())
+        verify(jobPort, never()).incrementRetryForOcid(eq(job.jobId), any())
+        verify(jobPort, never()).markFailed(eq(job.jobId), any(), any())
+        verify(pgmqClient, never()).send(eq(QueueNames.EXTERNAL_API), any<ExternalApiJobPayload>())
+    }
+
+    private fun job(
+        status: CalculationJobStatus,
+        ocid: String? = null,
+        retryCount: Int = 0,
+        maxRetries: Int = 3,
+    ) = CalculationJob(
+        jobId = UUID.randomUUID(),
+        ocid = ocid,
+        userIgn = "test-character",
+        presetNo = 1,
+        status = status,
+        retryCount = retryCount,
+        maxRetries = maxRetries,
+    )
+}

--- a/module-infra/src/test/kotlin/maple/expectation/infrastructure/persistence/CharacterViewQueryPortAdapterTest.kt
+++ b/module-infra/src/test/kotlin/maple/expectation/infrastructure/persistence/CharacterViewQueryPortAdapterTest.kt
@@ -1,6 +1,7 @@
 package maple.expectation.infrastructure.persistence
 
 import java.time.Instant
+import maple.expectation.core.port.inbound.CharacterViewProjectionCommand
 import maple.expectation.infrastructure.persistence.entity.CharacterValuationViewEntity
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -203,6 +204,30 @@ class CharacterViewQueryPortAdapterTest {
             eq(1), // presetNo default
             eq(presetsJson),
         )
+    }
+
+    @Test
+    @DisplayName("batchUpsertFromCalculations는 queryService에 위임한다")
+    fun batchUpsertFromCalculations_delegatesToQueryService() {
+        val commands = listOf(
+            CharacterViewProjectionCommand(
+                userIgn = "testUser",
+                messageId = "123",
+                characterOcid = "ocid-123",
+                characterClass = "전체계산가",
+                characterLevel = null,
+                totalExpectedCost = 1000000L,
+                maxPresetNo = 3,
+                presetNo = 1,
+                presetsJson = "[]",
+            ),
+        )
+        whenever(queryService.batchUpsertFromCalculations(commands)).thenReturn(1)
+
+        val result = adapter.batchUpsertFromCalculations(commands)
+
+        assertThat(result).isEqualTo(1)
+        verify(queryService).batchUpsertFromCalculations(commands)
     }
 
     @Test

--- a/module-infra/src/test/kotlin/maple/expectation/infrastructure/persistence/CharacterViewQueryServicePostgresTest.kt
+++ b/module-infra/src/test/kotlin/maple/expectation/infrastructure/persistence/CharacterViewQueryServicePostgresTest.kt
@@ -6,6 +6,7 @@ import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import java.time.Instant
 import maple.expectation.common.function.ThrowingSupplier
+import maple.expectation.core.port.inbound.CharacterViewProjectionCommand
 import maple.expectation.infrastructure.executor.LogicExecutor
 import maple.expectation.infrastructure.executor.TaskContext
 import maple.expectation.infrastructure.executor.function.ThrowingRunnable
@@ -25,6 +26,7 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.jdbc.core.namedparam.SqlParameterSource
 
 /**
  * Unit tests for [CharacterViewQueryServicePostgres].
@@ -228,6 +230,46 @@ class CharacterViewQueryServicePostgresTest {
         assertThat(params["totalExpectedCost"]).isEqualTo(totalExpectedCost)
         assertThat(params["maxPresetNo"]).isEqualTo(maxPresetNo)
         assertThat(params["presetNo"]).isEqualTo(1)
+    }
+
+    @Test
+    @DisplayName("batchUpsertFromCalculations는 JDBC batch upsert를 수행한다")
+    fun batchUpsertFromCalculations_usesJdbcBatchUpsert() {
+        val commands = listOf(
+            CharacterViewProjectionCommand(
+                userIgn = "testUser1",
+                messageId = "101",
+                characterOcid = "ocid-101",
+                characterClass = "전체계산가",
+                characterLevel = null,
+                totalExpectedCost = 1000000L,
+                maxPresetNo = 3,
+                presetNo = 1,
+                presetsJson = "[]",
+            ),
+            CharacterViewProjectionCommand(
+                userIgn = "testUser2",
+                messageId = "102",
+                characterOcid = "ocid-102",
+                characterClass = "전체계산가",
+                characterLevel = null,
+                totalExpectedCost = 2000000L,
+                maxPresetNo = 4,
+                presetNo = 2,
+                presetsJson = "[]",
+            ),
+        )
+        whenever(jdbc.batchUpdate(any<String>(), any<Array<SqlParameterSource>>())).thenReturn(intArrayOf(1, 1))
+
+        val result = service.batchUpsertFromCalculations(commands)
+
+        val captor = argumentCaptor<Array<SqlParameterSource>>()
+        verify(jdbc).batchUpdate(any<String>(), captor.capture())
+        assertThat(result).isEqualTo(2)
+        assertThat(captor.firstValue).hasSize(2)
+        assertThat(captor.firstValue[0].getValue("userIgn")).isEqualTo("testUser1")
+        assertThat(captor.firstValue[0].getValue("messageId")).isEqualTo("101")
+        assertThat(captor.firstValue[1].getValue("totalExpectedCost")).isEqualTo(2000000L)
     }
 
     private fun createTestEntity(

--- a/module-infra/src/test/kotlin/maple/expectation/infrastructure/persistence/ExpectationReadModelWriteServiceTest.kt
+++ b/module-infra/src/test/kotlin/maple/expectation/infrastructure/persistence/ExpectationReadModelWriteServiceTest.kt
@@ -1,5 +1,6 @@
 package maple.expectation.infrastructure.persistence
 
+import java.sql.Timestamp
 import java.time.Instant
 import maple.expectation.common.function.ThrowingSupplier
 import maple.expectation.infrastructure.executor.LogicExecutor
@@ -19,6 +20,8 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.jdbc.core.namedparam.SqlParameterSource
 
 /**
  * Unit tests for [ExpectationReadModelWriteService].
@@ -40,11 +43,14 @@ class ExpectationReadModelWriteServiceTest {
     @Mock
     private lateinit var repository: ExpectationReadModelRepository
 
+    @Mock
+    private lateinit var jdbc: NamedParameterJdbcTemplate
+
     private lateinit var service: ExpectationReadModelWriteService
 
     @BeforeEach
     fun setUp() {
-        service = ExpectationReadModelWriteService(repository, executor)
+        service = ExpectationReadModelWriteService(repository, jdbc, executor)
     }
 
     @Test
@@ -105,6 +111,29 @@ class ExpectationReadModelWriteServiceTest {
             service.writeToReadModel(userIgn, json, calculatedAt)
         }
         assert(exception.message?.contains("DB connection failed") == true)
+    }
+
+    @Test
+    fun `writeToReadModelRawBatch compresses JSON and calls jdbc batchUpdate`() {
+        val calculatedAt = Instant.now()
+        val commands = listOf(
+            ReadModelWriteCommand("testUser1", """{"userIgn":"testUser1"}""", calculatedAt),
+            ReadModelWriteCommand("testUser2", """{"userIgn":"testUser2"}""", calculatedAt),
+        )
+        whenever(jdbc.batchUpdate(any<String>(), any<Array<SqlParameterSource>>())).thenReturn(intArrayOf(1, 1))
+
+        val result = service.writeToReadModelRawBatch(commands)
+
+        val captor = argumentCaptor<Array<SqlParameterSource>>()
+        verify(jdbc).batchUpdate(any<String>(), captor.capture())
+        assert(result == 2)
+        assert(captor.firstValue.size == 2)
+        assert(captor.firstValue[0].getValue("userIgn") == "testUser1")
+        assert(captor.firstValue[0].getValue("calculatedAt") == Timestamp.from(calculatedAt))
+        val payload = captor.firstValue[0].getValue("payload") as ByteArray
+        assert(payload[0] == 0x1f.toByte())
+        assert(payload[1] == 0x8b.toByte())
+        assert(GzipUtils.decompress(payload) == """{"userIgn":"testUser1"}""")
     }
 
     /**

--- a/module-web/src/test/kotlin/maple/expectation/web/controller/v5/GameCharacterControllerV5Test.kt
+++ b/module-web/src/test/kotlin/maple/expectation/web/controller/v5/GameCharacterControllerV5Test.kt
@@ -7,6 +7,7 @@ import java.util.concurrent.Executor
 import maple.expectation.common.executor.TaskContext
 import maple.expectation.core.domain.model.character.CharacterView
 import maple.expectation.core.port.inbound.CalculationQueuePort
+import maple.expectation.core.port.inbound.CharacterViewProjectionCommand
 import maple.expectation.core.port.inbound.CharacterViewQueryPort
 import maple.expectation.core.port.inbound.ExecutorPort
 import maple.expectation.core.port.inbound.TaskReceipt
@@ -176,6 +177,8 @@ class GameCharacterControllerV5Test {
             presetsJson: String,
         ) {
         }
+
+        override fun batchUpsertFromCalculations(commands: List<CharacterViewProjectionCommand>): Int = commands.size
     }
 
     private class FakeCalculationQueuePort : CalculationQueuePort {


### PR DESCRIPTION
## Summary
- Batch result-ready projection into read model writes and archive processed PGMQ messages in batches
- Fix external API retry handling, 4xx classification, and Nexon rate-limit property path
- Extend V5 DB throughput load-test script and AGENTS.md workflow notes

## Verification
- ./gradlew :module-infra:test --tests 'maple.expectation.infrastructure.job.CalculationJobServiceTest' --tests 'maple.expectation.infrastructure.external.impl.MetricsNexonApiClientWrapperTest' --tests 'maple.expectation.infrastructure.persistence.CharacterViewQueryServicePostgresTest' --tests 'maple.expectation.infrastructure.persistence.ExpectationReadModelWriteServiceTest'
- ./gradlew check via pre-commit hook
- RESET_VIEWS=1 RESET_ACTIVE_JOBS=1 COUNT=10000 CONCURRENCY=50 SAMPLE_INTERVAL=30 POST_SAMPLE_COUNT=2 ./load-test/run-v5-db-throughput.sh was started and interrupted after reset + first sample; reset_active_jobs=8379, first 30s sample views=184

## Notes
- Server runtime verification in pre-commit was skipped because the server was stopped at commit time.
