### PR TITLE
Split calculation pipeline workers

### DIFF
--- a/module-app/src/main/resources/application-local.yml
+++ b/module-app/src/main/resources/application-local.yml
@@ -199,6 +199,16 @@ pgmq:
       enabled: true
     external-api:
       enabled: true
+      batch-size: 50
+      max-retries: 3
+    calculation-requested:
+      enabled: true
+      batch-size: 50
+      max-retries: 3
+    calculation-completed:
+      enabled: true
+      batch-size: 50
+      max-retries: 3
 
 # Bulk Loading Configuration (Issue #611)
 bulk:

--- a/module-app/src/main/resources/application-pglocal.yml
+++ b/module-app/src/main/resources/application-pglocal.yml
@@ -138,6 +138,21 @@ pgmq:
       polling-interval-ms: 50
       batch-size: 50
       max-retries: 5
+    external-api:
+      enabled: true
+      polling-interval-ms: 50
+      batch-size: 50
+      max-retries: 3
+    calculation-requested:
+      enabled: true
+      polling-interval-ms: 50
+      batch-size: 50
+      max-retries: 3
+    calculation-completed:
+      enabled: true
+      polling-interval-ms: 50
+      batch-size: 50
+      max-retries: 3
 
 # Z.ai LangChain4j Configuration
 langchain4j:

--- a/module-app/src/main/resources/application-pgprod.yml
+++ b/module-app/src/main/resources/application-pgprod.yml
@@ -18,6 +18,21 @@ pgmq:
       polling-interval-ms: 500
       batch-size: 50
       max-retries: 3
+    external-api:
+      enabled: true
+      polling-interval-ms: 50
+      batch-size: 50
+      max-retries: 3
+    calculation-requested:
+      enabled: true
+      polling-interval-ms: 50
+      batch-size: 50
+      max-retries: 3
+    calculation-completed:
+      enabled: true
+      polling-interval-ms: 50
+      batch-size: 50
+      max-retries: 3
     nexon-fanout:
       enabled: true
       polling-interval-ms: 50

--- a/module-app/src/main/resources/application-prod.yml
+++ b/module-app/src/main/resources/application-prod.yml
@@ -77,6 +77,21 @@ pgmq:
       polling-interval-ms: 500
       batch-size: 50
       max-retries: 3
+    external-api:
+      enabled: true
+      polling-interval-ms: 50
+      batch-size: 50
+      max-retries: 3
+    calculation-requested:
+      enabled: true
+      polling-interval-ms: 50
+      batch-size: 50
+      max-retries: 3
+    calculation-completed:
+      enabled: true
+      polling-interval-ms: 50
+      batch-size: 50
+      max-retries: 3
     nexon-fanout:
       enabled: true
       polling-interval-ms: 50

--- a/module-app/src/main/resources/application-vultr.yml
+++ b/module-app/src/main/resources/application-vultr.yml
@@ -75,6 +75,21 @@ pgmq:
       enabled: false  # bypassed: Controller dispatches directly to external_api_queue
     expectation-calc-low:
       enabled: true
+    external-api:
+      enabled: true
+      polling-interval-ms: 50
+      batch-size: 50
+      max-retries: 3
+    calculation-requested:
+      enabled: true
+      polling-interval-ms: 50
+      batch-size: 50
+      max-retries: 3
+    calculation-completed:
+      enabled: true
+      polling-interval-ms: 50
+      batch-size: 50
+      max-retries: 3
 
 # Retry Budget — tryAcquire가 모든 API 호출마다 카운트되어
 # 100/min 예산으로는 8 RPS × 3 calls = 1440/min 감당 불가 → death spiral

--- a/module-core/src/main/kotlin/maple/expectation/core/port/out/CalculationJobPort.kt
+++ b/module-core/src/main/kotlin/maple/expectation/core/port/out/CalculationJobPort.kt
@@ -23,5 +23,6 @@ interface CalculationJobPort {
     fun findActiveJobByUserIgn(userIgn: String, presetNo: Int): CalculationJob?
     fun resolveOcidAndTransition(jobId: UUID, ocid: String): Boolean
     fun completeFromSnapshotReady(jobId: UUID): Boolean
+    fun completeFromCalculating(jobId: UUID): Boolean
     fun findCompletedJobsMissingOutboxEvents(limit: Int): List<UUID>
 }

--- a/module-core/src/main/kotlin/maple/expectation/core/port/out/QueueNames.kt
+++ b/module-core/src/main/kotlin/maple/expectation/core/port/out/QueueNames.kt
@@ -12,8 +12,14 @@ object QueueNames {
     /** Low priority expectation calculation queue (batch/scheduled updates) */
     const val EXPECTATION_CALC_LOW = "expectation_calc_low"
 
-    /** Consolidated external API pipeline (OCID resolve + equipment fetch + calculation) */
+    /** External API pipeline (OCID resolve + equipment fetch + input/snapshot staging) */
     const val EXTERNAL_API = "external_api_queue"
+
+    /** CPU-bound calculation pipeline after external API input staging */
+    const val CALCULATION_REQUESTED = "calculation_requested_queue"
+
+    /** DB-bound result persistence pipeline after calculation completes */
+    const val CALCULATION_COMPLETED = "calculation_completed_queue"
 
     const val NEXON_API_REQUEST = "nexon_api_request_queue"
     const val NEXON_API_RESPONSE = "nexon_api_response_queue"

--- a/module-infra/src/main/kotlin/maple/expectation/adapter/outgoing/CalculationJobPortAdapter.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/adapter/outgoing/CalculationJobPortAdapter.kt
@@ -113,6 +113,8 @@ class CalculationJobPortAdapter(
 
     override fun completeFromSnapshotReady(jobId: UUID): Boolean = jobRepository.completeFromSnapshotReady(jobId) > 0
 
+    override fun completeFromCalculating(jobId: UUID): Boolean = jobRepository.completeFromCalculating(jobId) > 0
+
     override fun findCompletedJobsMissingOutboxEvents(limit: Int): List<UUID> {
         val sql = """
             SELECT j.job_id FROM calculation_jobs j

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/job/CalculationExecutionService.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/job/CalculationExecutionService.kt
@@ -86,6 +86,56 @@ class CalculationExecutionService(
         return true
     }
 
+    /**
+     * Split-pipeline complete: single UPDATE (CALCULATING → COMPLETED) + INSERT ON CONFLICT.
+     * No CPU work inside transaction — gzip/hash must be pre-computed by CalculationWorker.
+     */
+    @Transactional
+    fun completeCalculatedResult(
+        jobId: UUID,
+        gzipData: ByteArray,
+        hash: String,
+        originalSize: Int,
+        compressedSize: Int,
+        characterClass: String,
+        presetNo: Int,
+        characterId: String,
+    ): Boolean {
+        val completed = jobPort.completeFromCalculating(jobId)
+        if (!completed) return false
+
+        resultPort.saveIfAbsent(
+            CalculationResultData(
+                resultId = UUID.randomUUID(),
+                jobId = jobId,
+                characterClass = characterClass,
+                presetNo = presetNo,
+                schemaVersion = 1,
+                contentType = "application/json",
+                contentEncoding = "gzip",
+                responseBody = gzipData,
+                originalSize = originalSize,
+                compressedSize = compressedSize,
+                hash = hash,
+                status = "SUCCESS",
+            ),
+        )
+
+        val eventPayload = objectMapper.writeValueAsString(
+            mapOf(
+                "jobId" to jobId.toString(),
+                "characterId" to characterId,
+                "presetNo" to presetNo,
+                "contentEncoding" to "gzip",
+                "schemaVersion" to 1,
+            ),
+        )
+        outboxPort.insertIfAbsent("CALCULATION_COMPLETED", jobId, eventPayload)
+
+        log.info("[jobId={}] Calculation completed from split pipeline", jobId)
+        return true
+    }
+
     @Transactional
     fun startAndCompleteCalculation(
         jobId: UUID,

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/job/CalculationJobService.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/job/CalculationJobService.kt
@@ -15,6 +15,8 @@ import maple.expectation.infrastructure.mq.pgmq.topic.NexonApiResponseTopic
 import maple.expectation.infrastructure.mq.pgmq.topic.OcidResolveTopic
 import maple.expectation.infrastructure.persistence.entity.CalculationSnapshotEntity
 import maple.expectation.infrastructure.persistence.repository.CalculationSnapshotRepository
+import maple.expectation.infrastructure.pgmq.CalculationCompletedPayload
+import maple.expectation.infrastructure.pgmq.CalculationRequestedPayload
 import maple.expectation.infrastructure.pgmq.ExternalApiJobPayload
 import maple.expectation.infrastructure.pgmq.PgmqClient
 import org.slf4j.LoggerFactory
@@ -186,6 +188,30 @@ class CalculationJobService(
     ): Boolean {
         snapshotRepository.save(snapshotEntity)
         return jobPort.markSnapshotReady(jobId, snapshotId, CalculationJobStatus.API_REQUESTED)
+    }
+
+    @Transactional
+    fun saveInputSnapshotAndDispatchCalculation(
+        snapshotEntity: CalculationSnapshotEntity,
+        jobId: UUID,
+        snapshotId: UUID,
+        payload: CalculationRequestedPayload,
+    ): Boolean {
+        snapshotRepository.save(snapshotEntity)
+        val ready = jobPort.markSnapshotReady(jobId, snapshotId, CalculationJobStatus.API_REQUESTED)
+        if (!ready) {
+            log.warn("[jobId={}] Cannot mark SNAPSHOT_READY before calculation dispatch", jobId)
+            return false
+        }
+        pgmqClient.send(QueueNames.CALCULATION_REQUESTED, payload)
+        log.info("[jobId={}] Calculation requested", jobId)
+        return true
+    }
+
+    @Transactional
+    fun dispatchCalculationCompleted(payload: CalculationCompletedPayload) {
+        pgmqClient.send(QueueNames.CALCULATION_COMPLETED, payload)
+        log.info("[jobId={}] Calculation completed payload dispatched", payload.jobId)
     }
 
     @Transactional

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/repository/CalculationJobRepository.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/repository/CalculationJobRepository.kt
@@ -187,6 +187,20 @@ interface CalculationJobRepository : JpaRepository<CalculationJobEntity, UUID> {
     @Query(
         """
         UPDATE CalculationJobEntity j
+        SET j.status = 'COMPLETED',
+            j.completedAt = CURRENT_TIMESTAMP,
+            j.lockedBy = NULL,
+            j.lockedUntil = NULL,
+            j.updatedAt = CURRENT_TIMESTAMP
+        WHERE j.jobId = :jobId AND j.status = 'CALCULATING'
+    """,
+    )
+    fun completeFromCalculating(@Param("jobId") jobId: UUID): Int
+
+    @Modifying
+    @Query(
+        """
+        UPDATE CalculationJobEntity j
         SET j.lockedBy = NULL, j.lockedUntil = NULL, j.updatedAt = CURRENT_TIMESTAMP
         WHERE j.jobId = :jobId
     """,

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/CalculationCompletedPayload.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/CalculationCompletedPayload.kt
@@ -1,0 +1,12 @@
+package maple.expectation.infrastructure.pgmq
+
+data class CalculationCompletedPayload(
+    val jobId: String,
+    val characterId: String,
+    val characterClass: String,
+    val presetNo: Int,
+    val gzipData: ByteArray,
+    val hash: String,
+    val originalSize: Int,
+    val compressedSize: Int,
+)

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/CalculationRequestedPayload.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/CalculationRequestedPayload.kt
@@ -1,0 +1,9 @@
+package maple.expectation.infrastructure.pgmq
+
+data class CalculationRequestedPayload(
+    val jobId: String,
+    val userIgn: String,
+    val presetNo: Int,
+    val characterId: String,
+    val characterClass: String,
+)

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/PgmqWorkerConfig.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/PgmqWorkerConfig.kt
@@ -42,8 +42,14 @@ class PgmqWorkerConfig {
     /** Nexon FanOut Worker 설정 (429 재시도 전용) */
     var nexonFanout: WorkerSettings = WorkerSettings()
 
-    /** External API Consolidated Worker 설정 (OCID + Equipment + Calculation) */
+    /** External API Worker 설정 (OCID + Equipment + input/snapshot staging) */
     var externalApi: WorkerSettings = WorkerSettings()
+
+    /** CPU-bound Calculation Worker 설정 */
+    var calculationRequested: WorkerSettings = WorkerSettings()
+
+    /** DB-bound Result Persist Worker 설정 */
+    var calculationCompleted: WorkerSettings = WorkerSettings()
 
     data class CommonSettings(
         /** 폴링 간격 (ms) (ADR-355) */

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/CalculationCompletedWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/CalculationCompletedWorker.kt
@@ -1,0 +1,105 @@
+package maple.expectation.infrastructure.worker
+
+import io.micrometer.core.instrument.MeterRegistry
+import java.util.UUID
+import maple.expectation.core.model.job.CalculationJobStatus
+import maple.expectation.core.port.out.CalculationJobPort
+import maple.expectation.core.port.out.QueueNames
+import maple.expectation.infrastructure.executor.LogicExecutor
+import maple.expectation.infrastructure.executor.TaskContext
+import maple.expectation.infrastructure.job.CalculationExecutionService
+import maple.expectation.infrastructure.lifecycle.ScheduledTaskLifecycleWrapper
+import maple.expectation.infrastructure.pgmq.CalculationCompletedPayload
+import maple.expectation.infrastructure.pgmq.PgmqClient
+import maple.expectation.infrastructure.pgmq.PgmqMessage
+import maple.expectation.infrastructure.pgmq.PgmqWorker
+import maple.expectation.infrastructure.pgmq.PgmqWorkerConfig
+import maple.expectation.infrastructure.pgmq.WorkerQueueMetrics
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+
+@Component
+@ConditionalOnProperty(name = ["app.worker.calculation-completed.enabled"], havingValue = "true", matchIfMissing = true)
+class CalculationCompletedWorker(
+    pgmqClient: PgmqClient,
+    executor: LogicExecutor,
+    private val workerConfig: PgmqWorkerConfig,
+    meterRegistry: MeterRegistry,
+    queueMetrics: WorkerQueueMetrics,
+    lifecycleWrapper: ScheduledTaskLifecycleWrapper,
+    private val jobPort: CalculationJobPort,
+    private val executionService: CalculationExecutionService,
+) : PgmqWorker<CalculationCompletedPayload>(pgmqClient, executor, workerConfig, meterRegistry, queueMetrics, lifecycleWrapper) {
+
+    override val queueName: String = QueueNames.CALCULATION_COMPLETED
+    override val payloadClass: Class<CalculationCompletedPayload> = CalculationCompletedPayload::class.java
+    override val workerSettings: PgmqWorkerConfig.WorkerSettings = workerConfig.calculationCompleted
+
+    override fun process(message: PgmqMessage<CalculationCompletedPayload>): Boolean {
+        val payload = message.payload
+        val jobId = UUID.fromString(payload.jobId)
+        val context = TaskContext.of("ResultPersistWorker", "ProcessMessage", payload.jobId)
+
+        return executor.executeOrCatch(
+            {
+                persistResult(jobId, payload)
+            },
+            { e ->
+                log.error("[jobId={}] Result persist failed: {}", jobId, e.message)
+                handleFailure(message, jobId)
+            },
+            context,
+        )
+    }
+
+    private fun persistResult(jobId: UUID, payload: CalculationCompletedPayload): Boolean {
+        val job = jobPort.findJobById(jobId)
+        if (job == null) {
+            log.warn("[jobId={}] Job not found, archiving completed payload", jobId)
+            return true
+        }
+        if (job.status == CalculationJobStatus.COMPLETED) {
+            log.debug("[jobId={}] Already completed, archiving duplicate completed payload", jobId)
+            return true
+        }
+        if (job.status != CalculationJobStatus.CALCULATING) {
+            log.warn("[jobId={}] Completed payload ignored in state {}", jobId, job.status)
+            return job.status == CalculationJobStatus.FAILED
+        }
+
+        return stage("PersistResult", jobId.toString()) {
+            executionService.completeCalculatedResult(
+                jobId = jobId,
+                gzipData = payload.gzipData,
+                hash = payload.hash,
+                originalSize = payload.originalSize,
+                compressedSize = payload.compressedSize,
+                characterClass = payload.characterClass,
+                presetNo = payload.presetNo,
+                characterId = payload.characterId,
+            )
+        }
+    }
+
+    private fun handleFailure(message: PgmqMessage<CalculationCompletedPayload>, jobId: UUID): Boolean {
+        val maxRetries = workerSettings.maxRetries ?: workerConfig.common.maxRetries
+        if (message.readCount >= maxRetries) {
+            jobPort.markFailed(jobId, "RESULT_PERSIST_ERROR", "Max retries exceeded (attempts=${message.readCount})")
+            log.error("[jobId={}] Result persist failed permanently after {} attempts", jobId, message.readCount)
+            return true
+        }
+
+        log.warn("[jobId={}] Result persist will retry (attempt {})", jobId, message.readCount)
+        return false
+    }
+
+    private fun <T> stage(name: String, key: String, block: () -> T): T = executor.execute(
+        { block() },
+        TaskContext.of("ResultPersistWorker", name, key),
+    )
+
+    companion object {
+        private val log = LoggerFactory.getLogger(CalculationCompletedWorker::class.java)
+    }
+}

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/CalculationRequestedWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/CalculationRequestedWorker.kt
@@ -1,0 +1,161 @@
+package maple.expectation.infrastructure.worker
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.micrometer.core.instrument.MeterRegistry
+import java.util.UUID
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import maple.expectation.core.model.job.CalculationJobStatus
+import maple.expectation.core.port.out.CalculationInputPort
+import maple.expectation.core.port.out.CalculationJobPort
+import maple.expectation.core.port.out.PureCalculationPort
+import maple.expectation.core.port.out.QueueNames
+import maple.expectation.infrastructure.executor.LogicExecutor
+import maple.expectation.infrastructure.executor.TaskContext
+import maple.expectation.infrastructure.job.CalculationJobService
+import maple.expectation.infrastructure.lifecycle.ScheduledTaskLifecycleWrapper
+import maple.expectation.infrastructure.pgmq.CalculationCompletedPayload
+import maple.expectation.infrastructure.pgmq.CalculationRequestedPayload
+import maple.expectation.infrastructure.pgmq.PgmqClient
+import maple.expectation.infrastructure.pgmq.PgmqMessage
+import maple.expectation.infrastructure.pgmq.PgmqWorker
+import maple.expectation.infrastructure.pgmq.PgmqWorkerConfig
+import maple.expectation.infrastructure.pgmq.WorkerQueueMetrics
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@Component
+@ConditionalOnProperty(name = ["app.worker.calculation-requested.enabled"], havingValue = "true", matchIfMissing = true)
+class CalculationRequestedWorker(
+    pgmqClient: PgmqClient,
+    executor: LogicExecutor,
+    private val workerConfig: PgmqWorkerConfig,
+    meterRegistry: MeterRegistry,
+    queueMetrics: WorkerQueueMetrics,
+    lifecycleWrapper: ScheduledTaskLifecycleWrapper,
+    private val jobPort: CalculationJobPort,
+    private val calculationInputPort: CalculationInputPort,
+    private val pureCalculationPort: PureCalculationPort,
+    private val jobService: CalculationJobService,
+    private val objectMapper: ObjectMapper,
+) : PgmqWorker<CalculationRequestedPayload>(pgmqClient, executor, workerConfig, meterRegistry, queueMetrics, lifecycleWrapper) {
+
+    override val queueName: String = QueueNames.CALCULATION_REQUESTED
+    override val payloadClass: Class<CalculationRequestedPayload> = CalculationRequestedPayload::class.java
+    override val workerSettings: PgmqWorkerConfig.WorkerSettings = workerConfig.calculationRequested
+
+    private val cpuDispatcher = Dispatchers.Default.limitedParallelism(
+        Runtime.getRuntime().availableProcessors().coerceAtLeast(1),
+    )
+
+    override fun process(message: PgmqMessage<CalculationRequestedPayload>): Boolean {
+        val payload = message.payload
+        val jobId = UUID.fromString(payload.jobId)
+        val context = TaskContext.of("CalculationWorker", "ProcessMessage", payload.userIgn)
+
+        return executor.executeOrCatch(
+            {
+                processCalculation(jobId, payload)
+                true
+            },
+            { e ->
+                log.error("[jobId={}] Calculation failed: {}", jobId, e.message)
+                handleFailure(message, jobId)
+            },
+            context,
+        )
+    }
+
+    private fun processCalculation(jobId: UUID, payload: CalculationRequestedPayload) {
+        val job = jobPort.findJobById(jobId)
+        if (job == null) {
+            log.warn("[jobId={}] Job not found, archiving calculation request", jobId)
+            return
+        }
+        if (job.status == CalculationJobStatus.COMPLETED || job.status == CalculationJobStatus.FAILED) {
+            log.debug("[jobId={}] Skipping calculation in terminal state {}", jobId, job.status)
+            return
+        }
+        if (job.status == CalculationJobStatus.SNAPSHOT_READY) {
+            val claimed = jobPort.transitionStatus(jobId, CalculationJobStatus.SNAPSHOT_READY, CalculationJobStatus.CALCULATING)
+            if (!claimed) {
+                log.warn("[jobId={}] Could not claim calculation", jobId)
+                return
+            }
+        } else if (job.status != CalculationJobStatus.CALCULATING) {
+            log.warn("[jobId={}] Calculation request ignored in state {}", jobId, job.status)
+            return
+        }
+
+        val input = stage("LoadInput", jobId.toString()) {
+            calculationInputPort.findByJobId(jobId) ?: error("Calculation input missing: $jobId")
+        }
+        val calcResult = stage("PureCalculate", payload.userIgn) {
+            runBlocking(cpuDispatcher) {
+                withContext(cpuDispatcher) {
+                    pureCalculationPort.calculate(input)
+                }
+            }
+        }
+        val resultBytes = stage("SerializeResult", payload.userIgn) {
+            objectMapper.writeValueAsString(calcResult).toByteArray()
+        }
+        val gzipData = stage("GzipResult", payload.userIgn) {
+            gzipCompress(resultBytes)
+        }
+        val hash = stage("HashResult", payload.userIgn) {
+            sha256Hex(resultBytes)
+        }
+
+        stage("DispatchCompleted", jobId.toString()) {
+            jobService.dispatchCalculationCompleted(
+                CalculationCompletedPayload(
+                    jobId = jobId.toString(),
+                    characterId = payload.characterId,
+                    characterClass = payload.characterClass,
+                    presetNo = payload.presetNo,
+                    gzipData = gzipData,
+                    hash = hash,
+                    originalSize = resultBytes.size,
+                    compressedSize = gzipData.size,
+                ),
+            )
+        }
+    }
+
+    private fun handleFailure(message: PgmqMessage<CalculationRequestedPayload>, jobId: UUID): Boolean {
+        val maxRetries = workerSettings.maxRetries ?: workerConfig.common.maxRetries
+        if (message.readCount >= maxRetries) {
+            jobPort.markFailed(jobId, "CALCULATION_ERROR", "Max retries exceeded (attempts=${message.readCount})")
+            log.error("[jobId={}] Calculation failed permanently after {} attempts", jobId, message.readCount)
+            return true
+        }
+
+        log.warn("[jobId={}] Calculation will retry (attempt {})", jobId, message.readCount)
+        return false
+    }
+
+    private fun <T> stage(name: String, key: String, block: () -> T): T = executor.execute(
+        { block() },
+        TaskContext.of("CalculationWorker", name, key),
+    )
+
+    private fun gzipCompress(data: ByteArray): ByteArray {
+        val bos = java.io.ByteArrayOutputStream()
+        java.util.zip.GZIPOutputStream(bos).use { it.write(data) }
+        return bos.toByteArray()
+    }
+
+    private fun sha256Hex(data: ByteArray): String {
+        val digest = java.security.MessageDigest.getInstance("SHA-256")
+        return digest.digest(data).joinToString("") { "%02x".format(it) }
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(CalculationRequestedWorker::class.java)
+    }
+}

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/ExternalApiWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/ExternalApiWorker.kt
@@ -21,7 +21,6 @@ import maple.expectation.core.model.snapshot.CalculationSnapshot
 import maple.expectation.core.port.out.CalculationInputPort
 import maple.expectation.core.port.out.CalculationJobPort
 import maple.expectation.core.port.out.CharacterOcidPort
-import maple.expectation.core.port.out.PureCalculationPort
 import maple.expectation.core.port.out.QueueNames
 import maple.expectation.core.port.out.SnapshotObjectStore
 import maple.expectation.error.exception.CharacterNotFoundException
@@ -30,10 +29,10 @@ import maple.expectation.infrastructure.executor.LogicExecutor
 import maple.expectation.infrastructure.executor.TaskContext
 import maple.expectation.infrastructure.external.NexonApiClient
 import maple.expectation.infrastructure.external.dto.v2.EquipmentResponse
-import maple.expectation.infrastructure.job.CalculationExecutionService
 import maple.expectation.infrastructure.job.CalculationJobService
 import maple.expectation.infrastructure.lifecycle.ScheduledTaskLifecycleWrapper
 import maple.expectation.infrastructure.persistence.entity.CalculationSnapshotEntity
+import maple.expectation.infrastructure.pgmq.CalculationRequestedPayload
 import maple.expectation.infrastructure.pgmq.ExternalApiJobPayload
 import maple.expectation.infrastructure.pgmq.PgmqClient
 import maple.expectation.infrastructure.pgmq.PgmqMessage
@@ -48,15 +47,10 @@ import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClientResponseException
 
 /**
- * Consolidated External API Worker (extends PgmqWorker for parallel processing)
+ * External API stage worker.
  *
- * Replaces OcidResolveWorker + NexonApiWorker + ApiResponseWorker.
- * Processes messages in parallel on a thread pool (worker-pool-size threads).
- *
- * Pipeline per message (~500ms):
- *   OCID resolve (~200ms) -> Equipment API (~300ms) -> Snapshot save -> Calculate -> Result save
- *
- * Throughput: ~workerPoolSize × 2 messages/sec (vs ~2/sec sequential with PgmqTopicGroup)
+ * Resolves OCID, fetches equipment data, persists calculation input/snapshot metadata,
+ * then dispatches CPU-bound calculation to calculation_requested_queue.
  */
 @Component
 @ConditionalOnProperty(name = ["app.worker.external-api.enabled"], havingValue = "true", matchIfMissing = true)
@@ -74,10 +68,8 @@ class ExternalApiWorker(
     private val objectMapper: ObjectMapper,
     private val converter: EquipmentResponseToCalculationInputConverter,
     private val calculationInputPort: CalculationInputPort,
-    private val pureCalculationPort: PureCalculationPort,
     private val jobPort: CalculationJobPort,
     private val ocidPort: CharacterOcidPort,
-    private val executionService: CalculationExecutionService,
 ) : PgmqWorker<ExternalApiJobPayload>(pgmqClient, executor, workerConfig, meterRegistry, queueMetrics, lifecycleWrapper) {
 
     private val snapshotWriter: ExecutorService = Executors.newVirtualThreadPerTaskExecutor()
@@ -113,7 +105,7 @@ class ExternalApiWorker(
                     log.warn("[jobId={}] Character not found, skipping retry: {}", jobId, errorMsg)
                     true
                 } else {
-                    log.error("[jobId={}] Pipeline failed: {}", jobId, e.message)
+                    log.error("[jobId={}] External API stage failed: {}", jobId, e.message)
                     handleFailure(jobId, e)
                 }
             },
@@ -126,9 +118,9 @@ class ExternalApiWorker(
         val maxRetries = workerSettings.maxRetries ?: workerConfig.common.maxRetries
         if (message.readCount >= maxRetries) {
             jobPort.markFailed(jobId, "EXTERNAL_API_ERROR", "Max retries exceeded (attempts=${message.readCount})")
-            log.error("[jobId={}] Pipeline failed permanently after {} attempts", jobId, message.readCount)
+            log.error("[jobId={}] External API stage failed permanently after {} attempts", jobId, message.readCount)
         } else {
-            log.warn("[jobId={}] Pipeline will retry (attempt {})", jobId, message.readCount)
+            log.warn("[jobId={}] External API stage will retry (attempt {})", jobId, message.readCount)
         }
     }
 
@@ -168,14 +160,15 @@ class ExternalApiWorker(
             }
         }, snapshotWriter)
 
-        // Step 4: Build input items + calculate (overlaps with snapshot file I/O)
+        // Step 4: Build and persist calculation input while snapshot file I/O is in flight.
         val inputItems = stage("BuildCalculationInput", payload.userIgn) {
             convertItems(equipmentResponse)
         }
+        val characterClass = equipmentResponse.characterClass ?: ""
         val calcInput = CalculationInput(
             jobId = jobId.toString(),
             userIgn = payload.userIgn,
-            characterClass = equipmentResponse.characterClass ?: "",
+            characterClass = characterClass,
             presetNo = payload.presetNo,
             items = inputItems,
         )
@@ -183,26 +176,12 @@ class ExternalApiWorker(
             calculationInputPort.saveIfAbsent(calcInput)
         }
 
-        // Step 5: Calculate (pure CPU) + pre-compute gzip/hash outside transaction
-        val calcResult = stage("PureCalculate", payload.userIgn) {
-            pureCalculationPort.calculate(calcInput)
-        }
-        val resultBytes = stage("SerializeResult", payload.userIgn) {
-            objectMapper.writeValueAsString(calcResult).toByteArray()
-        }
-        val gzipData = stage("GzipResult", payload.userIgn) {
-            gzipCompress(resultBytes)
-        }
-        val hash = stage("HashResult", payload.userIgn) {
-            sha256Hex(resultBytes)
-        }
-
-        // Wait for snapshot write completion before transactional save
+        // Step 5: Wait for snapshot write completion before publishing CPU-bound calculation work.
         val putResult = stage("AwaitSnapshotPut", jobId.toString()) {
             snapshotFuture.join()
         }
 
-        // Step 6: Save snapshot metadata + result in transaction
+        // Step 6: Save snapshot metadata and dispatch CPU-bound calculation in one transaction.
         val snapshotEntity = CalculationSnapshotEntity(
             snapshotId = snapshotId,
             jobId = jobId,
@@ -215,24 +194,22 @@ class ExternalApiWorker(
             hash = putResult.hash,
             expiresAt = snapshot.expiresAt,
         )
-        stage("SaveSnapshotMetadata", jobId.toString()) {
-            jobService.saveInputSnapshotAndMarkReady(snapshotEntity, jobId, snapshotId)
-        }
-
-        stage("PersistResult", jobId.toString()) {
-            executionService.completeCalculation(
+        stage("DispatchCalculation", jobId.toString()) {
+            jobService.saveInputSnapshotAndDispatchCalculation(
+                snapshotEntity = snapshotEntity,
                 jobId = jobId,
-                gzipData = gzipData,
-                hash = hash,
-                originalSize = resultBytes.size,
-                compressedSize = gzipData.size,
-                characterClass = calcInput.characterClass,
-                presetNo = payload.presetNo,
-                characterId = ocid,
+                snapshotId = snapshotId,
+                payload = CalculationRequestedPayload(
+                    jobId = jobId.toString(),
+                    userIgn = payload.userIgn,
+                    presetNo = payload.presetNo,
+                    characterId = ocid,
+                    characterClass = characterClass,
+                ),
             )
         }
 
-        log.info("[jobId={}] Pipeline completed", jobId)
+        log.info("[jobId={}] External API stage completed", jobId)
     }
 
     private fun convertItems(equipmentResponse: EquipmentResponse): List<EquipmentItem> {
@@ -344,17 +321,6 @@ class ExternalApiWorker(
         val zoned = now.atZone(ZoneOffset.UTC)
         val datePath = "%04d/%02d/%02d".format(zoned.year, zoned.monthValue, zoned.dayOfMonth)
         return "snapshots/$datePath/$jobId.gz"
-    }
-
-    private fun gzipCompress(data: ByteArray): ByteArray {
-        val bos = java.io.ByteArrayOutputStream()
-        java.util.zip.GZIPOutputStream(bos).use { it.write(data) }
-        return bos.toByteArray()
-    }
-
-    private fun sha256Hex(data: ByteArray): String {
-        val digest = java.security.MessageDigest.getInstance("SHA-256")
-        return digest.digest(data).joinToString("") { "%02x".format(it) }
     }
 
     companion object {

--- a/module-infra/src/main/resources/db/migration/V121__split_calculation_pipeline_queues.sql
+++ b/module-infra/src/main/resources/db/migration/V121__split_calculation_pipeline_queues.sql
@@ -1,0 +1,7 @@
+-- V121: Split external API, CPU calculation, and result persistence pipeline stages.
+--
+-- External API workers now publish calculation work after input/snapshot staging.
+-- Calculation workers publish completed compressed results for DB-bound persistence.
+
+SELECT pgmq.create('calculation_requested_queue');
+SELECT pgmq.create('calculation_completed_queue');


### PR DESCRIPTION
## Summary
- Split `ExternalApiWorker` so it only resolves OCID, fetches equipment, saves input/snapshot metadata, then dispatches `calculation_requested_queue`
- Add `CalculationRequestedWorker` for CPU-bound pure calculation, JSON serialization, gzip, and hash work
- Add `CalculationCompletedWorker` for DB-bound result persistence and completion from `CALCULATING`
- Add PGMQ queue names, payloads, worker config, application profile settings, and migration for the two new queues

## Verification
- `./gradlew :module-infra:compileKotlin`
- `./gradlew :module-infra:test`
- `./gradlew check`

## Notes
- Existing unrelated local changes were not included: `docker-compose.yml`, generated snapshot directories, `node_modules/`, and `scripts/install-git-hooks.sh`.
- Server runtime verification was skipped by the pre-commit hook because no local server was running.