### PR TITLE
feat(kafka): Kafka pipeline transition (PR-1~3)

### DIFF
--- a/docs/09_Plans/2026-05-02-kafka-pipeline-transition-plan.md
+++ b/docs/09_Plans/2026-05-02-kafka-pipeline-transition-plan.md
@@ -1,0 +1,812 @@
+# Kafka Pipeline Transition Plan
+
+Date: 2026-05-02
+Branch: `feature/row-lease-leader-election`
+
+Companion document: `docs/superpowers/specs/2026-05-02-kafka-edge-cases-design.md` — covers concurrency, race conditions, idempotency, poison messages, DLQ, and dual-write in detail.
+
+## 1. Current Structure
+
+The current V5 pipeline uses PGMQ as the main durable queue.
+
+The hot path is:
+
+```text
+Client / API
+-> createOrFindActiveJob
+-> external_api_queue
+-> ExternalApiWorker
+   -> OCID resolve
+   -> Nexon equipment API fetch
+   -> snapshot/input staging
+   -> pure calculation
+   -> result serialize/gzip/hash
+   -> result persist
+   -> job complete
+   -> outbox insert
+-> outbox direct projection
+```
+
+The queue name `external_api_queue` no longer describes its actual responsibility. In consolidated mode it owns external API I/O, CPU-heavy calculation, DB persistence, and outbox publication. When a bottleneck appears, the metric attribution collapses into `external_api_queue` or `ExternalApiWorker:Pipeline`, which makes it hard to separate API latency, CPU pressure, DB write pressure, and projection delay.
+
+The existing split PGMQ path has `calculation_requested_queue` and `calculation_completed_queue`, but enabling every step-level queue increases PostgreSQL read/write/archive work because PGMQ is stored in the same primary database that also handles job state, result persistence, projection writes, outbox, and retry scanning.
+
+Docker Compose already includes Kafka:
+
+- Image: `confluentinc/cp-kafka:latest`
+- Mode: KRaft, no ZooKeeper
+- Host bootstrap server: `localhost:9092`
+- Advertised listener: `PLAINTEXT://localhost:9092`
+- Topic auto-create is not explicitly configured
+
+Spring Kafka is not currently wired for the calculation pipeline. `KafkaEventPublisher` exists, but it is a stub and belongs to a generic `EventPublisher` path rather than the V5 calculation pipeline.
+
+## 2. Target Kafka Structure
+
+Do not map every PGMQ queue to Kafka 1:1.
+
+Use Kafka to split the God MQ into two coarse-grained responsibilities:
+
+```text
+Client / API
+-> createOrFindActiveJob
+-> Kafka topic: external-api.requested
+
+ExternalApiConsumer
+-> OCID resolve
+-> Nexon equipment API fetch
+-> snapshot/input staging
+-> job status to SNAPSHOT_READY
+-> Kafka topic: calculation.requested
+
+CalculationConsumer
+-> calculation input load
+-> pure calculation
+-> result serialize/gzip/hash
+-> result persist
+-> job COMPLETED
+-> outbox insert
+
+OutboxProjectionConsumer
+-> outbox direct polling
+-> read model projection
+-> batch mark published
+```
+
+Projection stays on direct outbox polling. Do not introduce `result.ready`, `calculation.completed`, `snapshot.ready`, or `projection.requested` topics in the first implementation.
+
+## 3. Topic Design
+
+### `external-api.requested`
+
+Responsibility:
+
+- I/O-bound stage
+- OCID resolve
+- Nexon equipment API fetch
+- Calculation input and snapshot staging
+- API retry policy and API error classification
+
+Consumer group:
+
+- `maple-external-api`
+
+### `calculation.requested`
+
+Responsibility:
+
+- CPU-heavy calculation
+- Result serialization, gzip, hash
+- DB result persistence
+- Job completion
+- Outbox insert
+
+Consumer group:
+
+- `maple-calculation`
+
+Excluded from first implementation:
+
+- `calculation.completed`
+- `result.ready`
+- `snapshot.ready`
+- `projection.requested`
+
+## 4. Payload Schema
+
+Kafka payloads should contain references, not large JSON blobs.
+
+### `external-api.requested`
+
+```json
+{
+  "schemaVersion": 1,
+  "jobId": "uuid",
+  "requestKey": "calc:v1:ign:{normalizedUserIgn}:preset:{presetNo}:schema:1",
+  "userIgn": "string",
+  "presetNo": 1,
+  "traceId": "optional",
+  "createdAt": "iso-8601"
+}
+```
+
+Required fields:
+
+- `schemaVersion`
+- `jobId`
+- `requestKey`
+- `userIgn`
+- `presetNo`
+
+Optional fields:
+
+- `traceId`
+- `createdAt`
+
+### `calculation.requested`
+
+```json
+{
+  "schemaVersion": 1,
+  "jobId": "uuid",
+  "requestKey": "calc:v1:ign:{normalizedUserIgn}:preset:{presetNo}:schema:1",
+  "userIgn": "string",
+  "presetNo": 1,
+  "characterId": "ocid",
+  "characterClass": "string",
+  "snapshotId": "uuid",
+  "traceId": "optional",
+  "createdAt": "iso-8601"
+}
+```
+
+Required fields:
+
+- `schemaVersion`
+- `jobId`
+- `requestKey`
+- `userIgn`
+- `presetNo`
+- `characterId`
+- `characterClass`
+- `snapshotId`
+
+Do not put equipment snapshot JSON, calculation input JSON, result JSON, or gzip result bytes in Kafka payloads. Keep those in DB/object storage and pass references through Kafka.
+
+## 5. Key And Partition Strategy
+
+### `external-api.requested`
+
+Recommended key: `requestKey`
+
+Reasoning:
+
+- Available before OCID resolution
+- Aligns with active job dedup
+- Preserves ordering for the same user/preset request
+
+Tradeoff:
+
+- Hot user/preset keys can skew a partition
+
+Rejected first-pass keys:
+
+- `ocid`: not available before OCID resolve
+- `jobId`: distributes well, but weakens request-level ordering and dedup semantics
+
+### `calculation.requested`
+
+Recommended key: `jobId`
+
+Reasoning:
+
+- Calculation work is job-scoped and independent
+- Good partition distribution
+- DB idempotency and CAS are already job-based
+
+Rejected first-pass keys:
+
+- `calculationKey`: useful later when calculation-level convergence is introduced
+- `ocid:presetNo`: higher hot-key skew risk
+
+## 6. Consumer Responsibility Split
+
+### ExternalApiConsumer
+
+Can reuse most of `ExternalApiWorker`'s current external API portion:
+
+- OCID cache lookup and resolve
+- Nexon equipment fetch via `EquipmentFetchProvider`
+- equipment response to `CalculationInput`
+- snapshot object store write
+- `calculationInputPort.saveIfAbsent`
+- snapshot metadata save
+- job transition to `SNAPSHOT_READY`
+
+It must not run pure calculation or persist calculation result.
+
+The seam is the current `consolidatedEnabled=false` branch of `ExternalApiWorker`, but the publish target should become Kafka `calculation.requested`, not PGMQ `calculation_requested_queue`.
+
+### CalculationConsumer
+
+Can reuse the logic from `CalculationRequestedWorker` and `CalculationExecutionService`:
+
+- Check job status
+- CAS `SNAPSHOT_READY -> CALCULATING`
+- Load calculation input
+- Run pure calculation
+- Serialize/gzip/hash result
+- Persist result
+- CAS `CALCULATING -> COMPLETED`
+- Insert outbox event
+
+Do not add a `calculation.completed` Kafka topic in the first implementation. Persist result in the same consumer after CPU work.
+
+## 7. Retry And DLQ Strategy
+
+Use at-least-once processing. Correctness must come from DB idempotency and CAS:
+
+- `calculation_jobs.request_key` active unique index
+- `calculation_snapshot_inputs.job_id UNIQUE`
+- `calculation_results.job_id UNIQUE`
+- `outbox_events UNIQUE(job_id, event_type)`
+- status transition CAS
+
+Recommended first-pass Spring Kafka strategy:
+
+- `DefaultErrorHandler`
+- bounded backoff
+- DLT for unrecoverable technical failures
+- explicit non-retry handling for known business failures
+
+Error policy:
+
+- `CharacterNotFound` / `OPENAPI00004`: do not retry; mark job `FAILED/CHARACTER_NOT_FOUND`
+- 401 / 403: do not hot-loop; mark operational failure or DLT
+- 429 / timeout / 5xx: retry with exponential backoff
+- DB persist failure: retry `calculation.requested`; idempotent inserts and CAS protect duplicates
+
+Do not archive or commit a message before the business state transition for that stage is durable.
+
+### DLT Topics
+
+- `external-api.requested.DLT`
+- `calculation.requested.DLT`
+
+DLT payload format:
+
+```json
+{
+  "originalTopic": "external-api.requested",
+  "originalPartition": 0,
+  "originalOffset": 12345,
+  "consumerGroup": "maple-external-api",
+  "errorType": "SCHEMA_VALIDATION_FAILED",
+  "errorMessage": "missing required field: jobId",
+  "payload": "{ ... original raw ... }",
+  "failedAt": "2026-05-02T12:00:00Z"
+}
+```
+
+### DB Retry State Centric
+
+Job state is the source of truth for retries, not Kafka retry count.
+
+```
+Processing failure:
+  -> job status -> RETRYING + next_attempt_at + retry_count increment
+  -> Kafka message ack
+  -> retry scanner picks up expired jobs and re-publishes to topic
+
+Max retries exceeded:
+  -> job status -> FAILED + error_code
+  -> Kafka message ack
+  -> DLT for operational visibility
+```
+
+This avoids dual retry state (Kafka + DB) and leverages the existing job state machine.
+
+## 8. Consumer Rebalance And DB CAS Claim
+
+### Problem
+
+Consumer A reads message M from partition 0. Rebalance reassigns partition 0 to consumer B. B also reads M. Both try to process the same job.
+
+### Solution: Claim Before Side Effect
+
+Consumer must not call external APIs or write results until DB CAS claim succeeds.
+
+```
+ExternalApiConsumer:
+  1. Receive message (jobId)
+  2. DB CAS: UPDATE calculation_jobs SET status = 'API_IN_PROGRESS',
+     locked_until = now() + 60s WHERE job_id = :id AND status = 'API_REQUESTED'
+  3. If 0 rows affected: already claimed by another consumer -> ack
+  4. If claimed: proceed with Nexon API call
+  5. After success: CAS to SNAPSHOT_READY
+```
+
+### New Status: API_IN_PROGRESS
+
+```
+API_REQUESTED -> API_IN_PROGRESS -> SNAPSHOT_READY
+```
+
+- `API_REQUESTED`: eligible for claim
+- `API_IN_PROGRESS`: one consumer owns it, guarded by `locked_until`
+- `SNAPSHOT_READY`: API + snapshot done, eligible for calculation
+
+### locked_until for Crash Recovery
+
+```sql
+UPDATE calculation_jobs
+SET worker_id = :consumerId,
+    locked_until = now() + interval '60 seconds'
+WHERE id = :jobId
+  AND status IN ('API_REQUESTED',
+                  (SELECT status FROM calculation_jobs WHERE id = :jobId
+                   AND status = 'API_IN_PROGRESS' AND locked_until < now()))
+RETURNING id;
+```
+
+Expired `API_IN_PROGRESS` jobs are reclaimable. The retry publisher or a compensating scanner detects them and re-publishes to `external-api.requested`.
+
+### CalculationConsumer: Same Pattern
+
+```
+SNAPSHOT_READY -> CALCULATING -> COMPLETED
+```
+
+CAS claim before loading input and running calculation.
+
+## 9. Poison Message Handling
+
+### Problem
+
+Bad JSON, missing required fields, unsupported schema version. Consumer deserialization fails, triggering infinite retry. Partition stalls.
+
+### Solution: Immediate DLT + Ack
+
+Poison messages are never retried. They are isolated to DLT and the partition advances.
+
+### Consumer Flow
+
+```
+1. Receive raw String payload
+2. Parse JSON (catch JsonProcessingException -> DLT)
+3. Check schemaVersion (unsupported -> DLT)
+4. Validate required fields (missing -> DLT)
+5. Validation passed -> DB CAS claim
+```
+
+### Error Classification
+
+**Non-retryable (immediate DLT + ack):**
+
+- JSON parse failure
+- Unsupported schemaVersion
+- Missing required field
+- Invalid enum/status value
+- CharacterNotFound (domain terminal failure -> mark job FAILED + ack)
+
+**Retryable (backoff, then DB retry state):**
+
+- Nexon API timeout
+- 429 rate limited
+- Temporary DB connection failure
+- Kafka produce failure
+
+## 10. Transactional Outbox Pattern (Dual-Write Prevention)
+
+### Problem
+
+DB INSERT (job creation) + Kafka publish are not atomic. DB succeeds, Kafka fails -> orphan job in REQUESTED state forever.
+
+### Solution: Never Dual-Write
+
+Job creation and Kafka publish intent are recorded in the same DB transaction.
+
+```
+createOrFindActiveJob(created=true):
+  TX {
+    calculation_jobs INSERT
+    kafka_outbox_events INSERT (event_type='external-api.requested')
+  }
+  commit
+```
+
+### kafka_outbox_events Table
+
+```sql
+CREATE TABLE kafka_outbox_events (
+    id UUID PRIMARY KEY,
+    event_type TEXT NOT NULL,
+    aggregate_id UUID NOT NULL,
+    aggregate_type TEXT NOT NULL,
+    topic TEXT NOT NULL,
+    partition_key TEXT NOT NULL,
+    payload JSONB NOT NULL,
+    status TEXT NOT NULL DEFAULT 'PENDING',
+    retry_count INT NOT NULL DEFAULT 0,
+    next_attempt_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    published_at TIMESTAMPTZ,
+    last_error TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX ux_kafka_outbox_event_dedup
+ON kafka_outbox_events (event_type, aggregate_id)
+WHERE status IN ('PENDING', 'PUBLISHING', 'PUBLISHED');
+```
+
+### KafkaOutboxPublisher
+
+Separate scheduled component that polls the outbox and publishes to Kafka.
+
+Claim query:
+
+```sql
+WITH picked AS (
+    SELECT id FROM kafka_outbox_events
+    WHERE status = 'PENDING' AND next_attempt_at <= now()
+    ORDER BY created_at LIMIT :batchSize
+    FOR UPDATE SKIP LOCKED
+)
+UPDATE kafka_outbox_events e
+SET status = 'PUBLISHING', updated_at = now()
+FROM picked WHERE e.id = picked.id
+RETURNING e.*;
+```
+
+After Kafka publish success:
+
+```sql
+UPDATE kafka_outbox_events
+SET status = 'PUBLISHED', published_at = now(), updated_at = now()
+WHERE id = :id AND status = 'PUBLISHING';
+```
+
+After Kafka publish failure:
+
+```sql
+UPDATE kafka_outbox_events
+SET status = 'PENDING', retry_count = retry_count + 1,
+    next_attempt_at = now() + interval '10 seconds',
+    last_error = :error, updated_at = now()
+WHERE id = :id;
+```
+
+### Edge Case: Publish Succeeds, Mark Fails
+
+Kafka publish succeeds but DB `PUBLISHED` mark fails. Outbox stays in `PUBLISHING`. Next poll will re-publish the same message.
+
+This is safe because consumers are idempotent (DB CAS + ON CONFLICT guards). The at-least-once publish + idempotent consume combination handles this.
+
+## 11. Idempotency Chain (Existing Guards)
+
+All guards from the current PGMQ pipeline remain valid for Kafka:
+
+| Guard | Mechanism |
+|-------|-----------|
+| Job dedup | `request_key` partial unique index on active statuses |
+| Terminal state skip | Check COMPLETED/FAILED before processing |
+| CAS status transition | `UPDATE ... WHERE status = :from` returns affected rows |
+| Snapshot input | `ON CONFLICT (job_id) DO NOTHING` |
+| Result insert | `ON CONFLICT (job_id) DO NOTHING` |
+| Outbox event | `ON CONFLICT (job_id, event_type) DO NOTHING` |
+
+No new idempotency guards needed. Kafka consumers use the same DB-level protections.
+
+## 12. Metrics Design
+
+Kafka-level metrics:
+
+- `kafka.producer.send.latency{topic}`
+- `kafka.producer.error.total{topic}`
+- `kafka.consumer.process.latency{topic,group}`
+- `kafka.consumer.error.total{topic,group,errorCode}`
+- `kafka.consumer.lag{topic,group,partition}`
+
+External API stage metrics:
+
+- `ExternalApiConsumer:ResolveOcid`
+- `ExternalApiConsumer:FetchEquipment`
+- `ExternalApiConsumer:BuildCalculationInput`
+- `ExternalApiConsumer:SaveCalculationInput`
+- `ExternalApiConsumer:SnapshotPut`
+- `ExternalApiConsumer:SaveSnapshotMetadata`
+- `ExternalApiConsumer:PublishCalculationRequested`
+
+Calculation stage metrics:
+
+- `CalculationConsumer:LoadInput`
+- `CalculationConsumer:PureCalculate`
+- `CalculationConsumer:SerializeResult`
+- `CalculationConsumer:GzipResult`
+- `CalculationConsumer:HashResult`
+- `CalculationConsumer:PersistResult`
+
+Projection metrics:
+
+- `ResultProjection:ProjectBatch`
+- `PostgresQuery:BatchUpsertFromCalculation`
+- `ReadModel:BestEffortBatchWrite`
+- outbox unpublished count
+- outbox projection latency
+
+The goal is to stop reporting "external_api_queue is slow" as the only diagnosis. The slow stage must be visible directly.
+
+## 13. Feature Flag And Rollback
+
+Recommended flags:
+
+```yaml
+app:
+  messaging:
+    transport: pgmq # pgmq|kafka
+  kafka:
+    pipeline:
+      enabled: false
+```
+
+Rules:
+
+- `transport=pgmq`: existing PGMQ dispatch and PGMQ workers handle the pipeline
+- `transport=kafka`: Kafka dispatch and Kafka consumers handle the two-topic pipeline
+- Do not dual-dispatch in the first implementation
+- Do not allow PGMQ and Kafka to enqueue the same job at the same time
+- Rollback affects new requests by switching transport back to `pgmq`
+- Existing Kafka messages should be drained or made harmless through job-state idempotency
+
+Kafka publish failure after job creation needs an explicit policy:
+
+- preferred: keep job in `REQUESTED` and let a compensating scanner republish
+- acceptable for PoC: mark job failed with a publish error and return rejected receipt
+
+This decision must be explicit before PR-2.
+
+## 14. PR Implementation Plan
+
+### PR-1: Kafka Foundation
+
+Scope:
+
+- Add Spring Kafka dependency
+- Add Kafka configuration/properties
+- Define topic names
+- Add producer/consumer skeletons behind disabled feature flag
+- Create `kafka_outbox_events` table migration
+- Add `KafkaOutboxPublisher` skeleton (scheduled, behind feature flag)
+- No business dispatch change
+
+Success criteria:
+
+- App starts with Kafka disabled
+- Existing PGMQ flow unchanged
+- Kafka config can connect to local `localhost:9092` when enabled
+- `kafka_outbox_events` table exists
+- `KafkaOutboxPublisher` compiles but does not run when disabled
+
+### PR-2: `external-api.requested`
+
+Scope:
+
+- Introduce calculation pipeline dispatch abstraction
+- Route created jobs to Kafka outbox when `transport=kafka`
+- Publish only when `createOrFindActiveJob.created=true`
+- Implement ExternalApiConsumer with DB CAS claim
+- Add `API_IN_PROGRESS` status and `locked_until` to `calculation_jobs`
+- Parse/validate raw String payload (poison -> DLT)
+- Stop after input/snapshot staging and publish `calculation.requested` via outbox
+
+Success criteria:
+
+- New job reaches `SNAPSHOT_READY`
+- `calculation.requested` outbox event exists
+- No duplicate dispatch for reused active jobs
+- Poison messages routed to DLT
+- Expired `API_IN_PROGRESS` jobs reclaimable by scanner
+
+### PR-3: `calculation.requested`
+
+Scope:
+
+- Implement CalculationConsumer with DB CAS claim
+- Parse/validate raw String payload (poison -> DLT)
+- Claim `SNAPSHOT_READY -> CALCULATING`
+- Run pure calculation
+- Persist result and complete job
+- Insert outbox event
+
+Success criteria:
+
+- Job reaches `COMPLETED`
+- `calculation_results` has one row per job
+- `outbox_events` has one `CALCULATION_COMPLETED` per job
+- Outbox direct projection creates/updates `character_valuation_views`
+- Poison messages routed to DLT
+
+### PR-4: Load Test And Metrics
+
+Scope:
+
+- Compare PGMQ vs Kafka
+- Capture 6 samples at 30-second intervals for the standard cold-miss load test
+- Report stage p95, Kafka lag, DB pool pressure, outbox projection latency
+
+Success criteria:
+
+- Bottleneck attribution is stage-specific
+- Kafka path does not increase primary DB PGMQ pressure
+- Sustained throughput improves or the remaining DB bottleneck is clearly identified
+
+## 15. Candidate Files To Modify
+
+No files are modified by this plan except this document.
+
+Implementation candidates:
+
+- `gradle/libs.versions.toml`
+- `module-infra/build.gradle`
+- `module-app/src/main/resources/application.yml`
+- `module-app/src/main/resources/application-local.yml`
+- `module-core/src/main/kotlin/maple/expectation/core/port/out/QueueNames.kt`
+- new `TopicNames` or messaging port under `module-core`
+- new Kafka config under `module-infra`
+- new Kafka producer under `module-infra`
+- new Kafka consumers under `module-infra`
+- new `KafkaOutboxPublisher` scheduled component under `module-infra`
+- new `kafka_outbox_events` migration under `module-infra/src/main/resources/db/migration/`
+- new outbox repository under `module-infra`
+- `module-app/src/main/java/maple/expectation/application/service/expectation/queue/ExpectationCalculationQueue.java`
+- `module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/ExternalApiWorker.kt`
+- `module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/CalculationRequestedWorker.kt`
+- `module-infra/src/main/kotlin/maple/expectation/infrastructure/job/CalculationJobService.kt`
+- `module-infra/src/main/kotlin/maple/expectation/infrastructure/job/CalculationExecutionService.kt`
+
+## 16. Risks And Decision Points
+
+Risks:
+
+- Kafka adds hop latency
+- Topic over-splitting can recreate the current queue-hop problem
+- At-least-once delivery requires strict idempotency
+- Kafka publish and DB transaction are not atomic (addressed by Transactional Outbox)
+- Consumer lag can hide slow downstream stages
+- `requestKey` partitioning can create hot partitions
+- Postgres result/projection write bottleneck can remain even after PGMQ removal
+- Docker Compose Kafka adds local operational complexity
+- Consumer crash leaves `API_IN_PROGRESS` jobs stranded (addressed by `locked_until` + scanner)
+- Outbox re-publish after `PUBLISHING` mark failure duplicates Kafka messages (addressed by idempotent consumers)
+- Dual retry state (Kafka retry + DB retry) can cause confusion (addressed by DB-centric retry)
+
+Decision points:
+
+- Use `requestKey` or `jobId` for `external-api.requested` key
+- Decide publish-failure policy after job creation
+- Decide whether topic creation is app-managed or docker/admin-managed
+- Decide initial partitions for local and production
+- Decide when to remove the PGMQ split queues after Kafka path is proven
+- Decide `API_IN_PROGRESS` lease duration (default 60s, must exceed p99 API latency)
+- Decide outbox publisher poll interval and batch size
+- Decide DLT retention policy and alerting
+
+## 17. Office-Hours Decisions (2026-05-02)
+
+### Core Motivation (confirmed)
+
+God MQ separation + PGMQ DB load reduction. Both required.
+
+### Key Principle: Kafka = Event/Pointer
+
+Nexon API responses are 200-300KB. This data must NOT flow through Kafka topics.
+
+```
+Kafka message <= few KB (jobId, snapshotId, requestKey)
+Large data = snapshot object store / Postgres snapshot table
+Postgres = job state, results, idempotency constraints
+```
+
+This is already the plan's Section 4 design. Reinforced because:
+
+- 100 req/sec x 300KB = 30MB/sec raw, 90MB/sec with replication factor 3
+- PGMQ stores this in primary DB: row + index + WAL + claim update + archive + autovacuum
+- Kafka append-log + internal batching handles individual requests better than PGMQ
+
+### Decisions Resolved
+
+| Decision | Resolution |
+|----------|-----------|
+| Publish failure policy | Compensating scanner republishes |
+| Topic management | App-managed (Spring Kafka auto-create) |
+| Partition key `external-api.requested` | `requestKey` (pre-OCID, aligns with job dedup) |
+| Partition key `calculation.requested` | `jobId` (independent jobs, good distribution) |
+| Initial partitions | local: 1, production: 6 (external-api), `availableProcessors` (calculation) |
+| DLQ strategy | Spring Kafka DefaultErrorHandler + DLT, exponential backoff 1-16s, max 5 retries |
+| Idempotency | Existing DB UNIQUE constraints + CAS status transitions |
+| Feature flag | `app.messaging.transport: pgmq\|kafka`, matchIfMissing=pgmq |
+| Coexistence | Single transport active. Never dual-dispatch. |
+| Rollback | Set transport=pgmq. Kafka messages harmless via job-state idempotency. |
+| Dual-write prevention | Transactional Outbox (`kafka_outbox_events` table) |
+| Consumer rebalance safety | DB CAS claim + `API_IN_PROGRESS` status + `locked_until` |
+| Poison message handling | Raw String consumer, parse/validate before deserialization, immediate DLT + ack |
+| Retry state source of truth | Job table (DB), not Kafka retry count |
+
+### Operational Parameters
+
+`external-api.requested`:
+
+- Partitions: 6
+- Consumer threads: 6 (virtual thread for API I/O)
+- Poll timeout: 500ms
+- Max poll records: 10 (API ~1s each -> 10s processing window)
+- Auto offset reset: earliest
+
+`calculation.requested`:
+
+- Partitions: `availableProcessors`
+- Consumer threads: `availableProcessors` (Dispatchers.Default alignment)
+- Max poll records: 50 (CPU-bound, high batch efficiency)
+- Auto offset reset: earliest
+
+### Observability
+
+- Kafka lag per topic/partition (Kafka JMX -> Micrometer)
+- Stage-level p95 latency (TaskContext -> slow task log)
+- Error rate by errorCode (LogicExecutor + Kafka error handler)
+- DB pool usage (HikariCP metrics)
+- Outbox unpublished count (SQL query)
+
+## 18. Complete Pipeline Flow with All Guards
+
+```
+API Request
+-> createOrFindActiveJob (request_key dedup)
+-> kafka_outbox INSERT (same TX)
+-> commit
+
+KafkaOutboxPublisher
+-> claim outbox (FOR UPDATE SKIP LOCKED)
+-> publish external-api.requested
+-> mark PUBLISHED
+
+ExternalApiConsumer
+-> raw String -> parse -> validate (poison -> DLT)
+-> DB CAS claim: API_REQUESTED -> API_IN_PROGRESS + locked_until
+-> claim failed -> ack (another consumer owns it)
+-> claim success -> Nexon API call
+-> snapshot/input save (idempotent)
+-> kafka_outbox INSERT calculation.requested
+-> DB CAS: API_IN_PROGRESS -> SNAPSHOT_READY
+-> ack
+
+KafkaOutboxPublisher
+-> claim outbox
+-> publish calculation.requested
+-> mark PUBLISHED
+
+CalculationConsumer
+-> raw String -> parse -> validate (poison -> DLT)
+-> DB CAS claim: SNAPSHOT_READY -> CALCULATING
+-> claim failed -> ack
+-> claim success -> load input -> pure calculation
+-> result persist (ON CONFLICT DO NOTHING)
+-> outbox event INSERT (ON CONFLICT DO NOTHING)
+-> DB CAS: CALCULATING -> COMPLETED
+-> ack
+
+ResultReadyProjectionWorker (unchanged)
+-> outbox direct polling
+-> read model batch upsert
+```
+
+## 19. Design Principles Summary
+
+1. At-least-once delivery assumed. Kafka is a transport, not a correctness guarantee.
+2. All correctness comes from DB CAS + unique constraints + idempotent writes.
+3. External API calls are guarded by DB CAS claim. Only the claiming consumer calls the API.
+4. Poison messages are never retried. DLT + ack.
+5. Dual-write is forbidden. Transactional Outbox for all Kafka publishes.
+6. Retry state lives in the job table, not Kafka. Consumers ack after recording failure state.
+7. `locked_until` handles consumer crash. Expired leases are reclaimable.

--- a/docs/superpowers/specs/2026-05-02-kafka-edge-cases-design.md
+++ b/docs/superpowers/specs/2026-05-02-kafka-edge-cases-design.md
@@ -1,0 +1,290 @@
+# Kafka Pipeline Edge Cases Design
+
+Date: 2026-05-02
+Branch: `feature/row-lease-leader-election`
+Status: Draft
+
+Companion document to `docs/09_Plans/2026-05-02-kafka-pipeline-transition-plan.md`.
+Covers concurrency, race conditions, idempotency, poison messages, DLQ, and dual-write.
+
+## 1. At-Least-Once Delivery Assumption
+
+Kafka consumers must assume at-least-once delivery. Rebalance, crash, and offset commit failure can cause the same message to be processed by multiple consumers. Correctness comes from DB-level guards, not Kafka delivery guarantees.
+
+## 2. Consumer Rebalance: DB CAS Claim
+
+### Problem
+
+Consumer A reads message M from partition 0. Rebalance reassigns partition 0 to consumer B. B also reads M. Both try to process the same job.
+
+### Solution: Claim Before Side Effect
+
+Consumer must not call external APIs or write results until DB CAS claim succeeds.
+
+```
+ExternalApiConsumer:
+  1. Receive message (jobId)
+  2. DB CAS: UPDATE calculation_jobs SET status = 'API_IN_PROGRESS',
+     locked_until = now() + 60s WHERE job_id = :id AND status = 'API_REQUESTED'
+  3. If 0 rows affected: already claimed by another consumer → ack
+  4. If claimed: proceed with Nexon API call
+  5. After success: CAS to SNAPSHOT_READY
+```
+
+### New Status: API_IN_PROGRESS
+
+```
+API_REQUESTED → API_IN_PROGRESS → SNAPSHOT_READY
+```
+
+- `API_REQUESTED`: eligible for claim
+- `API_IN_PROGRESS`: one consumer owns it, guarded by `locked_until`
+- `SNAPSHOT_READY`: API + snapshot done, eligible for calculation
+
+### locked_until for Crash Recovery
+
+```sql
+UPDATE calculation_jobs
+SET worker_id = :consumerId,
+    locked_until = now() + interval '60 seconds'
+WHERE id = :jobId
+  AND status IN ('API_REQUESTED',
+                  (SELECT status FROM calculation_jobs WHERE id = :jobId
+                   AND status = 'API_IN_PROGRESS' AND locked_until < now()))
+RETURNING id;
+```
+
+Expired `API_IN_PROGRESS` jobs are reclaimable. The retry publisher or a compensating scanner detects them and re-publishes to `external-api.requested`.
+
+### CalculationConsumer: Same Pattern
+
+```
+CALCULATION_REQUESTED → CALCULATING → COMPLETED
+```
+
+CAS claim before loading input and running calculation.
+
+## 3. Poison Message Handling
+
+### Problem
+
+Bad JSON, missing required fields, unsupported schema version. Consumer deserialization fails, triggering infinite retry. Partition stalls.
+
+### Solution: Immediate DLT + Ack
+
+Poison messages are never retried. They are isolated to DLT and the partition advances.
+
+### Consumer Flow
+
+```
+1. Receive raw String payload
+2. Parse JSON (catch JsonProcessingException → DLT)
+3. Check schemaVersion (unsupported → DLT)
+4. Validate required fields (missing → DLT)
+5. Validation passed → DB CAS claim
+```
+
+### Error Classification
+
+**Non-retryable (immediate DLT + ack):**
+- JSON parse failure
+- Unsupported schemaVersion
+- Missing required field
+- Invalid enum/status value
+- CharacterNotFound (domain terminal failure → mark job FAILED + ack)
+
+**Retryable (backoff, then DB retry state):**
+- Nexon API timeout
+- 429 rate limited
+- Temporary DB connection failure
+- Kafka produce failure
+
+### DLT Payload Format
+
+```json
+{
+  "originalTopic": "external-api.requested",
+  "originalPartition": 0,
+  "originalOffset": 12345,
+  "consumerGroup": "maple-external-api",
+  "errorType": "SCHEMA_VALIDATION_FAILED",
+  "errorMessage": "missing required field: jobId",
+  "payload": "{ ... original raw ... }",
+  "failedAt": "2026-05-02T12:00:00Z"
+}
+```
+
+DLT topics: `external-api.requested.DLT`, `calculation.requested.DLT`
+
+## 4. Dual-Write: Transactional Outbox
+
+### Problem
+
+DB INSERT (job creation) + Kafka publish are not atomic. DB succeeds, Kafka fails → orphan job in REQUESTED state forever.
+
+### Solution: Transactional Outbox Pattern
+
+Never dual-write. Job creation and Kafka publish intent are recorded in the same DB transaction.
+
+```
+createOrFindActiveJob(created=true):
+  TX {
+    calculation_jobs INSERT
+    kafka_outbox_events INSERT (event_type='external-api.requested')
+  }
+  commit
+```
+
+### kafka_outbox_events Table
+
+```sql
+CREATE TABLE kafka_outbox_events (
+    id UUID PRIMARY KEY,
+    event_type TEXT NOT NULL,
+    aggregate_id UUID NOT NULL,
+    aggregate_type TEXT NOT NULL,
+    topic TEXT NOT NULL,
+    partition_key TEXT NOT NULL,
+    payload JSONB NOT NULL,
+    status TEXT NOT NULL DEFAULT 'PENDING',
+    retry_count INT NOT NULL DEFAULT 0,
+    next_attempt_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    published_at TIMESTAMPTZ,
+    last_error TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX ux_kafka_outbox_event_dedup
+ON kafka_outbox_events (event_type, aggregate_id)
+WHERE status IN ('PENDING', 'PUBLISHING', 'PUBLISHED');
+```
+
+### KafkaOutboxPublisher
+
+Separate scheduled component that polls the outbox and publishes to Kafka.
+
+Claim query:
+
+```sql
+WITH picked AS (
+    SELECT id FROM kafka_outbox_events
+    WHERE status = 'PENDING' AND next_attempt_at <= now()
+    ORDER BY created_at LIMIT :batchSize
+    FOR UPDATE SKIP LOCKED
+)
+UPDATE kafka_outbox_events e
+SET status = 'PUBLISHING', updated_at = now()
+FROM picked WHERE e.id = picked.id
+RETURNING e.*;
+```
+
+After Kafka publish success:
+
+```sql
+UPDATE kafka_outbox_events
+SET status = 'PUBLISHED', published_at = now(), updated_at = now()
+WHERE id = :id AND status = 'PUBLISHING';
+```
+
+After Kafka publish failure:
+
+```sql
+UPDATE kafka_outbox_events
+SET status = 'PENDING', retry_count = retry_count + 1,
+    next_attempt_at = now() + interval '10 seconds',
+    last_error = :error, updated_at = now()
+WHERE id = :id;
+```
+
+### Edge Case: Publish Succeeds, Mark Fails
+
+Kafka publish succeeds but DB `PUBLISHED` mark fails. Outbox stays in `PUBLISHING`. Next poll will re-publish the same message.
+
+This is safe because consumers are idempotent (DB CAS + ON CONFLICT guards). The at-least-once publish + idempotent consume combination handles this.
+
+## 5. Idempotency Chain (Existing Guards)
+
+All guards from the current PGMQ pipeline remain valid for Kafka:
+
+| Guard | Mechanism |
+|-------|-----------|
+| Job dedup | `request_key` partial unique index on active statuses |
+| Terminal state skip | Check COMPLETED/FAILED before processing |
+| CAS status transition | `UPDATE ... WHERE status = :from` returns affected rows |
+| Snapshot input | `ON CONFLICT (job_id) DO NOTHING` |
+| Result insert | `ON CONFLICT (job_id) DO NOTHING` |
+| Outbox event | `ON CONFLICT (job_id, event_type) DO NOTHING` |
+
+No new idempotency guards needed. Kafka consumers use the same DB-level protections.
+
+## 6. Retry Strategy: DB State Centric
+
+Job state is the source of truth for retries, not Kafka retry count.
+
+```
+Processing failure:
+  → job status → RETRYING + next_attempt_at + retry_count increment
+  → Kafka message ack
+  → retry scanner picks up expired jobs and re-publishes to topic
+
+Max retries exceeded:
+  → job status → FAILED + error_code
+  → Kafka message ack
+  → DLT for operational visibility
+```
+
+This avoids dual retry state (Kafka + DB) and leverages the existing job state machine.
+
+## 7. Complete Pipeline Flow with All Guards
+
+```
+API Request
+→ createOrFindActiveJob (request_key dedup)
+→ kafka_outbox INSERT (same TX)
+→ commit
+
+KafkaOutboxPublisher
+→ claim outbox (FOR UPDATE SKIP LOCKED)
+→ publish external-api.requested
+→ mark PUBLISHED
+
+ExternalApiConsumer
+→ raw String → parse → validate (poison → DLT)
+→ DB CAS claim: API_REQUESTED → API_IN_PROGRESS + locked_until
+→ claim failed → ack (another consumer owns it)
+→ claim success → Nexon API call
+→ snapshot/input save (idempotent)
+→ kafka_outbox INSERT calculation.requested
+→ DB CAS: API_IN_PROGRESS → SNAPSHOT_READY
+→ ack
+
+KafkaOutboxPublisher
+→ claim outbox
+→ publish calculation.requested
+→ mark PUBLISHED
+
+CalculationConsumer
+→ raw String → parse → validate (poison → DLT)
+→ DB CAS claim: SNAPSHOT_READY → CALCULATING
+→ claim failed → ack
+→ claim success → load input → pure calculation
+→ result persist (ON CONFLICT DO NOTHING)
+→ outbox event INSERT (ON CONFLICT DO NOTHING)
+→ DB CAS: CALCULATING → COMPLETED
+→ ack
+
+ResultReadyProjectionWorker (unchanged)
+→ outbox direct polling
+→ read model batch upsert
+```
+
+## 8. Design Principles Summary
+
+1. At-least-once delivery assumed. Kafka is a transport, not a correctness guarantee.
+2. All correctness comes from DB CAS + unique constraints + idempotent writes.
+3. External API calls are guarded by DB CAS claim. Only the claiming consumer calls the API.
+4. Poison messages are never retried. DLT + ack.
+5. Dual-write is forbidden. Transactional outbox for all Kafka publishes.
+6. Retry state lives in the job table, not Kafka. Consumers ack after recording failure state.
+7. `locked_until` handles consumer crash. Expired leases are reclaimable.

--- a/module-app/src/main/java/maple/expectation/application/service/expectation/queue/ExpectationCalculationQueue.java
+++ b/module-app/src/main/java/maple/expectation/application/service/expectation/queue/ExpectationCalculationQueue.java
@@ -5,12 +5,10 @@ import maple.expectation.core.model.job.CalculationJob;
 import maple.expectation.core.model.job.CalculationJobClaim;
 import maple.expectation.core.model.job.CalculationJobStatus;
 import maple.expectation.core.port.inbound.TaskReceipt;
+import maple.expectation.core.port.out.CalculationDispatchPort;
 import maple.expectation.core.port.out.CalculationJobPort;
-import maple.expectation.core.port.out.PgmqPort;
-import maple.expectation.core.port.out.QueueNames;
 import maple.expectation.infrastructure.executor.LogicExecutor;
 import maple.expectation.infrastructure.executor.TaskContext;
-import maple.expectation.infrastructure.pgmq.ExternalApiJobPayload;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,13 +28,13 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 public class ExpectationCalculationQueue {
 
-  private final PgmqPort pgmqPort;
+  private final CalculationDispatchPort dispatchPort;
   private final CalculationJobPort jobPort;
   private final LogicExecutor executor;
 
   public ExpectationCalculationQueue(
-      PgmqPort pgmqPort, CalculationJobPort jobPort, LogicExecutor executor) {
-    this.pgmqPort = pgmqPort;
+      CalculationDispatchPort dispatchPort, CalculationJobPort jobPort, LogicExecutor executor) {
+    this.dispatchPort = dispatchPort;
     this.jobPort = jobPort;
     this.executor = executor;
   }
@@ -129,10 +127,8 @@ public class ExpectationCalculationQueue {
           jobPort.transitionStatus(
               job.getJobId(), CalculationJobStatus.REQUESTED, CalculationJobStatus.OCID_RESOLVING);
       if (transitioned) {
-        pgmqPort.send(
-            QueueNames.EXTERNAL_API,
-            new ExternalApiJobPayload(
-                job.getJobId().toString(), task.getUserIgn(), task.getPresetNo()));
+        dispatchPort.dispatchExternalApiRequest(
+            job.getJobId().toString(), task.getUserIgn(), task.getPresetNo());
         log.debug(
             "[Queue] Job dispatched: jobId={}, userIgn={}, presetNo={}",
             job.getJobId(),

--- a/module-app/src/main/resources/application-local.yml
+++ b/module-app/src/main/resources/application-local.yml
@@ -118,6 +118,19 @@ app:
       enabled: true   # PostgreSQL buffer
   event-publisher:
     type: pgmq  # Use PGMQ (PostgreSQL)
+  kafka:
+    pipeline:
+      enabled: false  # Kafka pipeline disabled in local; PGMQ handles everything
+      outbox:
+        poll-interval-ms: 2000
+        batch-size: 20
+      consumer:
+        external-api:
+          concurrency: 2
+          max-poll-records: 5
+        calculation:
+          concurrency: 2
+          max-poll-records: 20
   aop:
     trace:
       enabled: true  # TraceAspect 활성화 (V5 로그 분석용)

--- a/module-app/src/main/resources/application.yml
+++ b/module-app/src/main/resources/application.yml
@@ -39,6 +39,30 @@ spring:
     job:
       enabled: true  # 스케줄러 사용 시 true
 
+  # Kafka Configuration (Kafka Pipeline Transition Plan)
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+      acks: all
+      retries: 3
+      properties:
+        linger.ms: 5
+        batch.size: 16384
+    consumer:
+      group-id: maple-pipeline
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      enable-auto-commit: false
+      properties:
+        max.poll.records: 50
+        max.poll.interval.ms: 300000
+    listener:
+      ack-mode: manual_immediate
+      concurrency: 1
+
 # Batch Job Schedule Configuration (Issue #356)
 batch:
   equipment-refresh:
@@ -243,6 +267,26 @@ ratelimit:
 
 app:
   instance-id: ${HOSTNAME:${random.uuid}}  # Issue #278: Scale-out Pub/Sub Self-skip용
+  messaging:
+    transport: pgmq  # pgmq | kafka — single transport active, never dual-dispatch
+  kafka:
+    pipeline:
+      enabled: false  # Master switch for Kafka pipeline consumers and outbox publisher
+      outbox:
+        poll-interval-ms: 1000    # KafkaOutboxPublisher poll interval
+        batch-size: 50            # Outbox claim batch size
+        max-retry-count: 5        # Max outbox publish retries before DLT
+        retry-delay-ms: 10000     # Delay between outbox publish retries
+      consumer:
+        external-api:
+          concurrency: 6          # Consumer threads (virtual threads for API I/O)
+          poll-timeout-ms: 500
+          max-poll-records: 10    # API ~1s each → 10s processing window
+          lease-duration-seconds: 60  # locked_until duration for API_IN_PROGRESS
+        calculation:
+          concurrency: 4          # Consumer threads (CPU-bound, align with availableProcessors)
+          poll-timeout-ms: 500
+          max-poll-records: 50    # CPU-bound, high batch efficiency
   pipeline:
     consolidated:
       enabled: true  # Consolidated pipeline: ExternalApiWorker handles API + calculation + result write inline

--- a/module-app/src/test/java/maple/expectation/service/v5/ExpectationCalculationQueueTest.java
+++ b/module-app/src/test/java/maple/expectation/service/v5/ExpectationCalculationQueueTest.java
@@ -3,8 +3,8 @@ package maple.expectation.service.v5;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -19,8 +19,8 @@ import maple.expectation.core.model.job.CalculationJob;
 import maple.expectation.core.model.job.CalculationJobClaim;
 import maple.expectation.core.model.job.CalculationJobStatus;
 import maple.expectation.core.port.inbound.TaskReceipt;
+import maple.expectation.core.port.out.CalculationDispatchPort;
 import maple.expectation.core.port.out.CalculationJobPort;
-import maple.expectation.core.port.out.PgmqPort;
 import maple.expectation.infrastructure.executor.LogicExecutor;
 import maple.expectation.infrastructure.executor.TaskContext;
 import maple.expectation.infrastructure.executor.function.ThrowingRunnable;
@@ -35,16 +35,16 @@ import org.junit.jupiter.api.Test;
 class ExpectationCalculationQueueTest {
 
   private LogicExecutor executor;
-  private PgmqPort pgmqPort;
+  private CalculationDispatchPort dispatchPort;
   private CalculationJobPort jobPort;
   private ExpectationCalculationQueue queue;
 
   @BeforeEach
   void setUp() {
     executor = new TestLogicExecutor();
-    pgmqPort = mock(PgmqPort.class);
+    dispatchPort = mock(CalculationDispatchPort.class);
     jobPort = mock(CalculationJobPort.class);
-    queue = new ExpectationCalculationQueue(pgmqPort, jobPort, executor);
+    queue = new ExpectationCalculationQueue(dispatchPort, jobPort, executor);
   }
 
   @Test
@@ -57,13 +57,11 @@ class ExpectationCalculationQueueTest {
     when(jobPort.transitionStatus(
             jobId, CalculationJobStatus.REQUESTED, CalculationJobStatus.OCID_RESOLVING))
         .thenReturn(true);
-    when(pgmqPort.send(eq("external_api_queue"), any())).thenReturn(1L);
-
     ExpectationCalculationTask highTask = ExpectationCalculationTask.highPriority("user1", false);
     assertThat(queue.offer(highTask)).isTrue();
 
     verify(jobPort).createOrFindActiveJob(null, "user1", 1);
-    verify(pgmqPort).send(eq("external_api_queue"), any());
+    verify(dispatchPort).dispatchExternalApiRequest(jobId.toString(), "user1", 1);
   }
 
   @Test
@@ -79,7 +77,7 @@ class ExpectationCalculationQueueTest {
 
     verify(jobPort).createOrFindActiveJob(null, "user1", 1);
     verify(jobPort, never()).transitionStatus(any(), any(), any());
-    verify(pgmqPort, never()).send(anyString(), any());
+    verify(dispatchPort, never()).dispatchExternalApiRequest(anyString(), anyString(), anyInt());
   }
 
   @Test
@@ -92,7 +90,6 @@ class ExpectationCalculationQueueTest {
     when(jobPort.transitionStatus(
             jobId, CalculationJobStatus.REQUESTED, CalculationJobStatus.OCID_RESOLVING))
         .thenReturn(true);
-    when(pgmqPort.send(eq("external_api_queue"), any())).thenReturn(1L);
 
     TaskReceipt receipt =
         queue.offerWithReceipt(ExpectationCalculationTask.highPriority("user1", false));
@@ -111,7 +108,6 @@ class ExpectationCalculationQueueTest {
     when(jobPort.transitionStatus(
             jobId, CalculationJobStatus.REQUESTED, CalculationJobStatus.OCID_RESOLVING))
         .thenReturn(true);
-    when(pgmqPort.send(anyString(), any())).thenReturn(1L);
 
     assertThat(queue.addHighPriorityTask("user1", true)).isTrue();
   }
@@ -126,7 +122,6 @@ class ExpectationCalculationQueueTest {
     when(jobPort.transitionStatus(
             jobId, CalculationJobStatus.REQUESTED, CalculationJobStatus.OCID_RESOLVING))
         .thenReturn(true);
-    when(pgmqPort.send(anyString(), any())).thenReturn(1L);
 
     assertThat(queue.addLowPriorityTask("user1")).isTrue();
   }

--- a/module-core/src/main/kotlin/maple/expectation/core/port/out/CalculationDispatchPort.kt
+++ b/module-core/src/main/kotlin/maple/expectation/core/port/out/CalculationDispatchPort.kt
@@ -1,0 +1,22 @@
+package maple.expectation.core.port.out
+
+/**
+ * Port for dispatching calculation pipeline jobs.
+ *
+ * Implementations route to PGMQ or Kafka based on `app.messaging.transport`.
+ * All methods must be safe to call within an existing @Transactional boundary
+ * so the dispatch shares the same DB transaction as job state transitions.
+ */
+interface CalculationDispatchPort {
+
+    fun dispatchExternalApiRequest(jobId: String, userIgn: String, presetNo: Int)
+
+    fun dispatchCalculationRequest(
+        jobId: String,
+        userIgn: String,
+        presetNo: Int,
+        characterId: String,
+        characterClass: String,
+        snapshotId: String,
+    )
+}

--- a/module-core/src/main/kotlin/maple/expectation/core/port/out/KafkaTopicNames.kt
+++ b/module-core/src/main/kotlin/maple/expectation/core/port/out/KafkaTopicNames.kt
@@ -1,0 +1,14 @@
+package maple.expectation.core.port.out
+
+/**
+ * Kafka topic name constants for the calculation pipeline.
+ *
+ * Two-topic design: external-api (I/O-bound) and calculation (CPU-bound).
+ * DLT topics for poison message isolation.
+ */
+object KafkaTopicNames {
+    const val EXTERNAL_API_REQUESTED = "external-api.requested"
+    const val EXTERNAL_API_REQUESTED_DLT = "external-api.requested.DLT"
+    const val CALCULATION_REQUESTED = "calculation.requested"
+    const val CALCULATION_REQUESTED_DLT = "calculation.requested.DLT"
+}

--- a/module-infra/build.gradle
+++ b/module-infra/build.gradle
@@ -98,6 +98,10 @@ dependencies {
 	// Spring Batch (for equipment refresh job)
 	implementation(libs.spring.boot.starter.batch)
 
+	// Spring Kafka (BOM-managed at 3.3.8 via spring-boot-dependencies 3.5.4)
+	implementation "org.springframework.kafka:spring-kafka"
+	testImplementation "org.springframework.kafka:spring-kafka-test"
+
 	// JWT
 	implementation(libs.jjwt.api)
 	runtimeOnly(libs.jjwt.impl)

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/config/KafkaPipelineConfig.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/config/KafkaPipelineConfig.kt
@@ -1,0 +1,47 @@
+package maple.expectation.infrastructure.config
+
+import maple.expectation.core.port.out.KafkaTopicNames
+import org.apache.kafka.clients.admin.NewTopic
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.kafka.config.TopicBuilder
+
+@Configuration
+@ConditionalOnProperty(prefix = "app.kafka.pipeline", name = ["enabled"], havingValue = "true")
+@EnableConfigurationProperties(KafkaPipelineProperties::class)
+class KafkaPipelineConfig(
+    private val properties: KafkaPipelineProperties,
+) {
+    private val log = LoggerFactory.getLogger(KafkaPipelineConfig::class.java)
+
+    @Bean
+    fun externalApiRequestedTopic(): NewTopic = TopicBuilder.name(KafkaTopicNames.EXTERNAL_API_REQUESTED)
+        .partitions(6)
+        .replicas(1)
+        .compact()
+        .build()
+        .also { log.info("[KafkaPipeline] Topic bean registered: {}", KafkaTopicNames.EXTERNAL_API_REQUESTED) }
+
+    @Bean
+    fun externalApiRequestedDltTopic(): NewTopic = TopicBuilder.name(KafkaTopicNames.EXTERNAL_API_REQUESTED_DLT)
+        .partitions(1)
+        .replicas(1)
+        .build()
+
+    @Bean
+    fun calculationRequestedTopic(): NewTopic = TopicBuilder.name(KafkaTopicNames.CALCULATION_REQUESTED)
+        .partitions(properties.consumer.calculation.concurrency)
+        .replicas(1)
+        .compact()
+        .build()
+        .also { log.info("[KafkaPipeline] Topic bean registered: {}", KafkaTopicNames.CALCULATION_REQUESTED) }
+
+    @Bean
+    fun calculationRequestedDltTopic(): NewTopic = TopicBuilder.name(KafkaTopicNames.CALCULATION_REQUESTED_DLT)
+        .partitions(1)
+        .replicas(1)
+        .build()
+}

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/config/KafkaPipelineProperties.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/config/KafkaPipelineProperties.kt
@@ -1,0 +1,43 @@
+package maple.expectation.infrastructure.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.bind.DefaultValue
+import org.springframework.validation.annotation.Validated
+
+@Validated
+@ConfigurationProperties(prefix = "app.kafka.pipeline")
+data class KafkaPipelineProperties(
+    @DefaultValue("false")
+    val enabled: Boolean = false,
+
+    @DefaultValue("1000")
+    val outbox: OutboxProperties = OutboxProperties(),
+
+    @DefaultValue("")
+    val consumer: ConsumerProperties = ConsumerProperties(),
+) {
+    data class OutboxProperties(
+        @DefaultValue("1000") val pollIntervalMs: Long = 1000,
+        @DefaultValue("50") val batchSize: Int = 50,
+        @DefaultValue("5") val maxRetryCount: Int = 5,
+        @DefaultValue("10000") val retryDelayMs: Long = 10000,
+    )
+
+    data class ConsumerProperties(
+        @DefaultValue("") val externalApi: ExternalApiConsumerProperties = ExternalApiConsumerProperties(),
+        @DefaultValue("") val calculation: CalculationConsumerProperties = CalculationConsumerProperties(),
+    )
+
+    data class ExternalApiConsumerProperties(
+        @DefaultValue("6") val concurrency: Int = 6,
+        @DefaultValue("500") val pollTimeoutMs: Long = 500,
+        @DefaultValue("10") val maxPollRecords: Int = 10,
+        @DefaultValue("60") val leaseDurationSeconds: Long = 60,
+    )
+
+    data class CalculationConsumerProperties(
+        @DefaultValue("4") val concurrency: Int = 4,
+        @DefaultValue("500") val pollTimeoutMs: Long = 500,
+        @DefaultValue("50") val maxPollRecords: Int = 50,
+    )
+}

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/config/KafkaPipelineProperties.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/config/KafkaPipelineProperties.kt
@@ -39,5 +39,6 @@ data class KafkaPipelineProperties(
         @DefaultValue("4") val concurrency: Int = 4,
         @DefaultValue("500") val pollTimeoutMs: Long = 500,
         @DefaultValue("50") val maxPollRecords: Int = 50,
+        @DefaultValue("300") val leaseDurationSeconds: Long = 300,
     )
 }

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/messaging/KafkaCalculationDispatch.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/messaging/KafkaCalculationDispatch.kt
@@ -1,0 +1,79 @@
+package maple.expectation.infrastructure.messaging
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import java.time.Instant
+import java.util.UUID
+import maple.expectation.core.port.out.CalculationDispatchPort
+import maple.expectation.core.port.out.KafkaTopicNames
+import maple.expectation.infrastructure.persistence.repository.KafkaOutboxEventRepository
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+
+@Component
+@ConditionalOnProperty(name = ["app.messaging.transport"], havingValue = "kafka")
+class KafkaCalculationDispatch(
+    private val outboxRepository: KafkaOutboxEventRepository,
+    private val objectMapper: ObjectMapper,
+) : CalculationDispatchPort {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    override fun dispatchExternalApiRequest(jobId: String, userIgn: String, presetNo: Int) {
+        val payload = mapOf(
+            "schemaVersion" to 1,
+            "jobId" to jobId,
+            "requestKey" to buildRequestKey(userIgn, presetNo),
+            "userIgn" to userIgn,
+            "presetNo" to presetNo,
+            "createdAt" to Instant.now().toString(),
+        )
+
+        outboxRepository.insertIfAbsent(
+            id = UUID.randomUUID(),
+            eventType = KafkaTopicNames.EXTERNAL_API_REQUESTED,
+            aggregateId = UUID.fromString(jobId),
+            aggregateType = "calculation_job",
+            topic = KafkaTopicNames.EXTERNAL_API_REQUESTED,
+            partitionKey = buildRequestKey(userIgn, presetNo),
+            payload = objectMapper.writeValueAsString(payload),
+        )
+
+        log.debug("[KafkaDispatch] External API request enqueued: jobId={}", jobId)
+    }
+
+    override fun dispatchCalculationRequest(
+        jobId: String,
+        userIgn: String,
+        presetNo: Int,
+        characterId: String,
+        characterClass: String,
+        snapshotId: String,
+    ) {
+        val payload = mapOf(
+            "schemaVersion" to 1,
+            "jobId" to jobId,
+            "requestKey" to buildRequestKey(userIgn, presetNo),
+            "userIgn" to userIgn,
+            "presetNo" to presetNo,
+            "characterId" to characterId,
+            "characterClass" to characterClass,
+            "snapshotId" to snapshotId,
+            "createdAt" to Instant.now().toString(),
+        )
+
+        outboxRepository.insertIfAbsent(
+            id = UUID.randomUUID(),
+            eventType = KafkaTopicNames.CALCULATION_REQUESTED,
+            aggregateId = UUID.fromString(jobId),
+            aggregateType = "calculation_job",
+            topic = KafkaTopicNames.CALCULATION_REQUESTED,
+            partitionKey = jobId,
+            payload = objectMapper.writeValueAsString(payload),
+        )
+
+        log.debug("[KafkaDispatch] Calculation request enqueued: jobId={}", jobId)
+    }
+
+    private fun buildRequestKey(userIgn: String, presetNo: Int): String = "calc:v1:ign:${userIgn.lowercase()}:preset:$presetNo:schema:1"
+}

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/messaging/KafkaEventPublisher.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/messaging/KafkaEventPublisher.kt
@@ -8,6 +8,7 @@ import maple.expectation.infrastructure.executor.LogicExecutor
 import maple.expectation.infrastructure.executor.TaskContext
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.stereotype.Component
 
 @Component
@@ -19,45 +20,56 @@ import org.springframework.stereotype.Component
 )
 class KafkaEventPublisher(
     private val objectMapper: ObjectMapper,
+    private val kafkaTemplate: KafkaTemplate<String, String>,
     private val executor: LogicExecutor,
 ) : EventPublisher {
 
     private val logger = LoggerFactory.getLogger(KafkaEventPublisher::class.java)
 
     override fun publish(topic: String, event: IntegrationEvent<*>) {
-        executor.executeOrCatch(
-            {
-                publishInternal(topic, event)
-                null
-            },
-            { e ->
-                logger.error("[KafkaEventPublisher] Publish failed for topic: {}", topic, e)
-                null
-            },
+        executor.executeVoid(
+            { publishInternal(topic, event) },
             TaskContext.of("KafkaEventPublisher", "Publish", topic),
         )
     }
 
     private fun publishInternal(topic: String, event: IntegrationEvent<*>) {
         val jsonPayload = objectMapper.writeValueAsString(event)
+        val key = event.jobId ?: event.eventId
 
-        logger.warn(
-            "[KafkaEventPublisher] STUB MODE - Event not published to Kafka. " +
-                "topic={}, eventId={}, eventType={}, payload={}",
-            topic,
-            event.eventId,
-            event.eventType,
-            jsonPayload,
-        )
+        kafkaTemplate.send(topic, key, jsonPayload)
+            .whenComplete { _, ex ->
+                if (ex != null) {
+                    logger.error(
+                        "[KafkaEventPublisher] Publish failed for topic={}, eventId={}: {}",
+                        topic,
+                        event.eventId,
+                        ex.message,
+                    )
+                } else {
+                    logger.debug("[KafkaEventPublisher] Published eventId={} to topic={}", event.eventId, topic)
+                }
+            }
     }
 
     override fun publishAsync(topic: String, event: IntegrationEvent<*>): CompletableFuture<Void> {
-        logger.warn(
-            "[KafkaEventPublisher] STUB MODE - Async publish not implemented. topic={}, eventId={}",
-            topic,
-            event.eventId,
+        val jsonPayload = executor.executeOrDefault(
+            { objectMapper.writeValueAsString(event) },
+            "",
+            TaskContext.of("KafkaEventPublisher", "Serialize", topic),
         )
 
-        return CompletableFuture.runAsync { publish(topic, event) }
+        val key = event.jobId ?: event.eventId
+        return kafkaTemplate.send(topic, key, jsonPayload)
+            .thenAccept {}
+            .exceptionally { ex ->
+                logger.error(
+                    "[KafkaEventPublisher] Async publish failed for topic={}, eventId={}: {}",
+                    topic,
+                    event.eventId,
+                    ex.message,
+                )
+                null
+            }
     }
 }

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/messaging/KafkaOutboxPublisher.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/messaging/KafkaOutboxPublisher.kt
@@ -1,0 +1,103 @@
+package maple.expectation.infrastructure.messaging
+
+import java.util.UUID
+import maple.expectation.infrastructure.config.KafkaPipelineProperties
+import maple.expectation.infrastructure.executor.LogicExecutor
+import maple.expectation.infrastructure.executor.TaskContext
+import maple.expectation.infrastructure.persistence.repository.KafkaOutboxEventRepository
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+@Component
+@ConditionalOnProperty(prefix = "app.kafka.pipeline", name = ["enabled"], havingValue = "true")
+class KafkaOutboxPublisher(
+    private val jdbcTemplate: JdbcTemplate,
+    private val kafkaTemplate: KafkaTemplate<String, String>,
+    private val outboxRepository: KafkaOutboxEventRepository,
+    private val properties: KafkaPipelineProperties,
+    private val executor: LogicExecutor,
+) {
+    private val log = LoggerFactory.getLogger(KafkaOutboxPublisher::class.java)
+
+    data class ClaimedEvent(
+        val id: UUID,
+        val topic: String,
+        val partitionKey: String,
+        val payload: String,
+    )
+
+    @Scheduled(fixedDelayString = "\${app.kafka.pipeline.outbox.poll-interval-ms:1000}")
+    fun publishPendingEvents() {
+        executor.executeVoid(
+            { publishBatch() },
+            TaskContext.of("KafkaOutboxPublisher", "PublishBatch"),
+        )
+    }
+
+    private fun publishBatch() {
+        val events = claimBatch()
+        if (events.isEmpty()) return
+
+        log.debug("[KafkaOutboxPublisher] Claimed {} events", events.size)
+
+        for (event in events) {
+            publishSingleAsync(event)
+        }
+    }
+
+    private fun publishSingleAsync(event: ClaimedEvent) {
+        val future = kafkaTemplate.send(event.topic, event.partitionKey, event.payload)
+        future.whenComplete { _, ex ->
+            executor.executeVoid(
+                {
+                    if (ex == null) {
+                        handlePublishSuccess(event)
+                    } else {
+                        handlePublishFailure(event, ex)
+                    }
+                },
+                TaskContext.of("KafkaOutboxPublisher", "PublishCallback", event.topic),
+            )
+        }
+    }
+
+    private fun handlePublishSuccess(event: ClaimedEvent) {
+        outboxRepository.markPublished(event.id)
+        log.debug("[KafkaOutboxPublisher] Published event {} to {}", event.id, event.topic)
+    }
+
+    private fun handlePublishFailure(event: ClaimedEvent, ex: Throwable) {
+        val errorMsg = ex.message ?: "Unknown error"
+        outboxRepository.markRetryPending(event.id, errorMsg, properties.outbox.retryDelayMs)
+        log.warn("[KafkaOutboxPublisher] Publish failed for event {} to {}: {}", event.id, event.topic, errorMsg)
+    }
+
+    private fun claimBatch(): List<ClaimedEvent> {
+        val batchSize = properties.outbox.batchSize
+        val sql = """
+            WITH picked AS (
+                SELECT id FROM kafka_outbox_events
+                WHERE status = 'PENDING' AND next_attempt_at <= now()
+                ORDER BY created_at LIMIT ?
+                FOR UPDATE SKIP LOCKED
+            )
+            UPDATE kafka_outbox_events e
+            SET status = 'PUBLISHING', updated_at = now()
+            FROM picked WHERE e.id = picked.id
+            RETURNING e.id, e.topic, e.partition_key, e.payload
+        """.trimIndent()
+
+        return jdbcTemplate.query(sql, { rs, _ ->
+            ClaimedEvent(
+                id = rs.getObject("id", UUID::class.java),
+                topic = rs.getString("topic"),
+                partitionKey = rs.getString("partition_key"),
+                payload = rs.getString("payload"),
+            )
+        }, batchSize)
+    }
+}

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/messaging/PgmqCalculationDispatch.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/messaging/PgmqCalculationDispatch.kt
@@ -1,0 +1,34 @@
+package maple.expectation.infrastructure.messaging
+
+import maple.expectation.core.port.out.CalculationDispatchPort
+import maple.expectation.core.port.out.QueueNames
+import maple.expectation.infrastructure.pgmq.CalculationRequestedPayload
+import maple.expectation.infrastructure.pgmq.ExternalApiJobPayload
+import maple.expectation.infrastructure.pgmq.PgmqClient
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+
+@Component
+@ConditionalOnProperty(name = ["app.messaging.transport"], havingValue = "pgmq", matchIfMissing = true)
+class PgmqCalculationDispatch(
+    private val pgmqClient: PgmqClient,
+) : CalculationDispatchPort {
+
+    override fun dispatchExternalApiRequest(jobId: String, userIgn: String, presetNo: Int) {
+        pgmqClient.send(QueueNames.EXTERNAL_API, ExternalApiJobPayload(jobId, userIgn, presetNo))
+    }
+
+    override fun dispatchCalculationRequest(
+        jobId: String,
+        userIgn: String,
+        presetNo: Int,
+        characterId: String,
+        characterClass: String,
+        snapshotId: String,
+    ) {
+        pgmqClient.send(
+            QueueNames.CALCULATION_REQUESTED,
+            CalculationRequestedPayload(jobId, userIgn, presetNo, characterId, characterClass),
+        )
+    }
+}

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/messaging/kafka/CalculationKafkaTopic.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/messaging/kafka/CalculationKafkaTopic.kt
@@ -2,10 +2,16 @@ package maple.expectation.infrastructure.messaging.kafka
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
+import java.util.UUID
+import maple.expectation.core.model.job.CalculationJobStatus
+import maple.expectation.core.port.out.CalculationInputPort
+import maple.expectation.core.port.out.CalculationJobPort
 import maple.expectation.core.port.out.KafkaTopicNames
+import maple.expectation.core.port.out.PureCalculationPort
 import maple.expectation.infrastructure.config.KafkaPipelineProperties
 import maple.expectation.infrastructure.executor.LogicExecutor
 import maple.expectation.infrastructure.executor.TaskContext
+import maple.expectation.infrastructure.job.CalculationExecutionService
 import maple.expectation.infrastructure.persistence.repository.KafkaOutboxEventRepository
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
@@ -24,6 +30,10 @@ class CalculationKafkaTopic(
     executor: LogicExecutor,
     kafkaTemplate: KafkaTemplate<String, String>,
     properties: KafkaPipelineProperties,
+    private val jobPort: CalculationJobPort,
+    private val calculationInputPort: CalculationInputPort,
+    private val pureCalculationPort: PureCalculationPort,
+    private val executionService: CalculationExecutionService,
 ) : KafkaTopicGroup(outboxRepository, objectMapper, executor, kafkaTemplate, properties),
     PipelineTopic {
 
@@ -33,9 +43,10 @@ class CalculationKafkaTopic(
     override val dltTopicName: String = KafkaTopicNames.CALCULATION_REQUESTED_DLT
     override val consumerGroup: String = "maple-calculation"
 
-    override val requiredFields: List<String> = listOf("schemaVersion", "jobId", "requestKey", "userIgn", "presetNo", "characterId", "characterClass", "snapshotId")
+    override val requiredFields: List<String> = listOf("schemaVersion", "jobId", "requestKey", "userIgn", "presetNo", "characterId", "characterClass")
     override val schemaVersion: Int = 1
-    override val leaseDurationSeconds: Long = 0L // CPU-bound, no lease needed
+    override val leaseDurationSeconds: Long
+        get() = properties.consumer.calculation.leaseDurationSeconds
 
     @KafkaListener(
         topics = [KafkaTopicNames.CALCULATION_REQUESTED],
@@ -63,14 +74,116 @@ class CalculationKafkaTopic(
             return
         }
 
-        val jobId = parsed.path("jobId").asText()
-        log.info("[CalculationKafkaTopic] Processing jobId={} from {}[{}]", jobId, topic, partition)
+        val jobId = UUID.fromString(parsed.path("jobId").asText())
+        val userIgn = parsed.path("userIgn").asText()
+        val presetNo = parsed.path("presetNo").asInt()
+        val characterId = parsed.path("characterId").asText()
+        val characterClass = parsed.path("characterClass").asText()
 
-        // PR-3: DB CAS claim SNAPSHOT_READY → CALCULATING + calculation + result persist
-        log.info("[CalculationKafkaTopic] SKIPPED (PR-1 skeleton) jobId={}", jobId)
+        executor.executeOrCatch(
+            { processJob(jobId, userIgn, presetNo, characterId, characterClass) },
+            { e -> handleJobError(jobId, e) },
+            TaskContext.of("CalculationKafkaTopic", "Process", jobId.toString()),
+        )
 
         ack.acknowledge()
     }
+
+    private fun processJob(jobId: UUID, userIgn: String, presetNo: Int, characterId: String, characterClass: String) {
+        val existingJob = jobPort.findJobById(jobId)
+
+        // Terminal states: skip entirely
+        if (existingJob != null && (existingJob.status == CalculationJobStatus.COMPLETED || existingJob.status == CalculationJobStatus.FAILED)) {
+            log.debug("[jobId={}] Skipping — terminal state {}", jobId, existingJob.status)
+            return
+        }
+
+        // Only process SNAPSHOT_READY jobs
+        if (existingJob != null && existingJob.status != CalculationJobStatus.SNAPSHOT_READY) {
+            log.debug("[jobId={}] Skipping — state {} (expected SNAPSHOT_READY)", jobId, existingJob.status)
+            return
+        }
+
+        // CAS claim
+        val claimed = jobPort.lockForProcessing(jobId, "kafka-calc", CalculationJobStatus.SNAPSHOT_READY)
+        if (!claimed) {
+            log.info("[jobId={}] Already claimed by another consumer", jobId)
+            return
+        }
+
+        // Pipeline with guaranteed unlock
+        executor.executeWithFinally(
+            { processCalculation(jobId, userIgn, presetNo, characterId, characterClass) },
+            {
+                executor.executeVoid(
+                    { jobPort.unlock(jobId) },
+                    TaskContext.of("CalculationKafkaTopic", "Unlock", jobId.toString()),
+                )
+            },
+            TaskContext.of("CalculationKafkaTopic", "Pipeline", jobId.toString()),
+        )
+    }
+
+    private fun processCalculation(jobId: UUID, userIgn: String, presetNo: Int, characterId: String, characterClass: String) {
+        // Load input [DB read, no TX]
+        val input = stage("LoadInput", jobId.toString()) {
+            calculationInputPort.findByJobId(jobId)
+                ?: error("Calculation input missing for job: $jobId")
+        }
+
+        // CPU-bound calculation [no TX]
+        val calcResult = stage("PureCalculate", userIgn) {
+            pureCalculationPort.calculate(input)
+        }
+
+        // Serialize + gzip + hash [CPU, no TX]
+        val resultBytes = stage("SerializeResult", userIgn) {
+            objectMapper.writeValueAsString(calcResult).toByteArray()
+        }
+        val gzipData = stage("GzipResult", userIgn) {
+            gzipCompress(resultBytes)
+        }
+        val hash = stage("HashResult", userIgn) {
+            sha256Hex(resultBytes)
+        }
+
+        // Complete: SNAPSHOT_READY → COMPLETED + result save + outbox insert [TX]
+        stage("CompleteCalculation", jobId.toString()) {
+            executionService.completeCalculation(
+                jobId = jobId,
+                gzipData = gzipData,
+                hash = hash,
+                originalSize = resultBytes.size,
+                compressedSize = gzipData.size,
+                characterClass = characterClass,
+                presetNo = presetNo,
+                characterId = characterId,
+            )
+        }
+
+        log.info("[jobId={}] Calculation completed", jobId)
+    }
+
+    private fun handleJobError(jobId: UUID, e: Throwable) {
+        log.error("[jobId={}] Calculation pipeline error: {}", jobId, e.message)
+        val job = jobPort.findJobById(jobId) ?: return
+        val errorCode = "CALCULATION_ERROR"
+        val errorMsg = (e.message ?: "Unknown error").take(200)
+
+        if (job.retryCount >= job.maxRetries) {
+            executor.executeVoid(
+                { jobPort.markFailed(jobId, errorCode, errorMsg) },
+                TaskContext.of("CalculationKafkaTopic", "MarkFailed", jobId.toString()),
+            )
+        } else {
+            executor.executeVoid(
+                { executionService.handleCalculationFailure(jobId, errorCode, errorMsg) },
+                TaskContext.of("CalculationKafkaTopic", "HandleFailure", jobId.toString()),
+            )
+        }
+    }
+
+    // ===== Helpers =====
 
     override fun parseAndValidate(payload: String): JsonNode? {
         val node = runCatching { objectMapper.readTree(payload) }
@@ -85,9 +198,21 @@ class CalculationKafkaTopic(
         return node
     }
 
-    override fun claimJob(jobId: String): Boolean {
-        // PR-3: DB CAS claim SNAPSHOT_READY → CALCULATING
-        log.debug("[CalculationKafkaTopic] claimJob stub for jobId={}", jobId)
-        return true
+    override fun claimJob(jobId: String): Boolean = jobPort.lockForProcessing(UUID.fromString(jobId), "kafka-calc", CalculationJobStatus.SNAPSHOT_READY)
+
+    private fun <T> stage(name: String, key: String, block: () -> T): T = executor.execute(
+        { block() },
+        TaskContext.of("CalculationKafkaTopic", name, key),
+    )
+
+    private fun gzipCompress(data: ByteArray): ByteArray {
+        val bos = java.io.ByteArrayOutputStream()
+        java.util.zip.GZIPOutputStream(bos).use { it.write(data) }
+        return bos.toByteArray()
+    }
+
+    private fun sha256Hex(data: ByteArray): String {
+        val digest = java.security.MessageDigest.getInstance("SHA-256")
+        return digest.digest(data).joinToString("") { "%02x".format(it) }
     }
 }

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/messaging/kafka/CalculationKafkaTopic.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/messaging/kafka/CalculationKafkaTopic.kt
@@ -1,0 +1,93 @@
+package maple.expectation.infrastructure.messaging.kafka
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import maple.expectation.core.port.out.KafkaTopicNames
+import maple.expectation.infrastructure.config.KafkaPipelineProperties
+import maple.expectation.infrastructure.executor.LogicExecutor
+import maple.expectation.infrastructure.executor.TaskContext
+import maple.expectation.infrastructure.persistence.repository.KafkaOutboxEventRepository
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.support.Acknowledgment
+import org.springframework.messaging.handler.annotation.Header
+import org.springframework.messaging.handler.annotation.Payload
+import org.springframework.stereotype.Component
+
+@Component
+@ConditionalOnProperty(prefix = "app.kafka.pipeline", name = ["enabled"], havingValue = "true")
+class CalculationKafkaTopic(
+    outboxRepository: KafkaOutboxEventRepository,
+    objectMapper: ObjectMapper,
+    executor: LogicExecutor,
+    kafkaTemplate: KafkaTemplate<String, String>,
+    properties: KafkaPipelineProperties,
+) : KafkaTopicGroup(outboxRepository, objectMapper, executor, kafkaTemplate, properties),
+    PipelineTopic {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    override val name: String = KafkaTopicNames.CALCULATION_REQUESTED
+    override val dltTopicName: String = KafkaTopicNames.CALCULATION_REQUESTED_DLT
+    override val consumerGroup: String = "maple-calculation"
+
+    override val requiredFields: List<String> = listOf("schemaVersion", "jobId", "requestKey", "userIgn", "presetNo", "characterId", "characterClass", "snapshotId")
+    override val schemaVersion: Int = 1
+    override val leaseDurationSeconds: Long = 0L // CPU-bound, no lease needed
+
+    @KafkaListener(
+        topics = [KafkaTopicNames.CALCULATION_REQUESTED],
+        groupId = "maple-calculation",
+        containerFactory = "kafkaListenerContainerFactory",
+    )
+    fun consume(
+        @Payload payload: String,
+        @Header("kafka_receivedTopic") topic: String,
+        @Header("kafka_receivedPartitionId") partition: Int,
+        @Header("kafka_offset") offset: Long,
+        ack: Acknowledgment,
+    ) {
+        executor.executeVoid(
+            { processMessage(payload, topic, partition, offset, ack) },
+            TaskContext.of("CalculationKafkaTopic", "Consume"),
+        )
+    }
+
+    private fun processMessage(payload: String, topic: String, partition: Int, offset: Long, ack: Acknowledgment) {
+        val parsed = parseAndValidate(payload)
+        if (parsed == null) {
+            sendToDlt(payload, topic, partition, offset, consumerGroup, "VALIDATION_FAILED", "Parse/validation error")
+            ack.acknowledge()
+            return
+        }
+
+        val jobId = parsed.path("jobId").asText()
+        log.info("[CalculationKafkaTopic] Processing jobId={} from {}[{}]", jobId, topic, partition)
+
+        // PR-3: DB CAS claim SNAPSHOT_READY → CALCULATING + calculation + result persist
+        log.info("[CalculationKafkaTopic] SKIPPED (PR-1 skeleton) jobId={}", jobId)
+
+        ack.acknowledge()
+    }
+
+    override fun parseAndValidate(payload: String): JsonNode? {
+        val node = runCatching { objectMapper.readTree(payload) }
+            .getOrElse { return null }
+
+        val version = node.path("schemaVersion").asInt(-1)
+        if (version != schemaVersion) return null
+
+        val missing = requiredFields.filter { !node.has(it) || node.path(it).isNull }
+        if (missing.isNotEmpty()) return null
+
+        return node
+    }
+
+    override fun claimJob(jobId: String): Boolean {
+        // PR-3: DB CAS claim SNAPSHOT_READY → CALCULATING
+        log.debug("[CalculationKafkaTopic] claimJob stub for jobId={}", jobId)
+        return true
+    }
+}

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/messaging/kafka/ExternalApiKafkaTopic.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/messaging/kafka/ExternalApiKafkaTopic.kt
@@ -1,0 +1,93 @@
+package maple.expectation.infrastructure.messaging.kafka
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import maple.expectation.core.port.out.KafkaTopicNames
+import maple.expectation.infrastructure.config.KafkaPipelineProperties
+import maple.expectation.infrastructure.executor.LogicExecutor
+import maple.expectation.infrastructure.executor.TaskContext
+import maple.expectation.infrastructure.persistence.repository.KafkaOutboxEventRepository
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.support.Acknowledgment
+import org.springframework.messaging.handler.annotation.Header
+import org.springframework.messaging.handler.annotation.Payload
+import org.springframework.stereotype.Component
+
+@Component
+@ConditionalOnProperty(prefix = "app.kafka.pipeline", name = ["enabled"], havingValue = "true")
+class ExternalApiKafkaTopic(
+    outboxRepository: KafkaOutboxEventRepository,
+    objectMapper: ObjectMapper,
+    executor: LogicExecutor,
+    kafkaTemplate: KafkaTemplate<String, String>,
+    properties: KafkaPipelineProperties,
+) : KafkaTopicGroup(outboxRepository, objectMapper, executor, kafkaTemplate, properties),
+    PipelineTopic {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    override val name: String = KafkaTopicNames.EXTERNAL_API_REQUESTED
+    override val dltTopicName: String = KafkaTopicNames.EXTERNAL_API_REQUESTED_DLT
+    override val consumerGroup: String = "maple-external-api"
+
+    override val requiredFields: List<String> = listOf("schemaVersion", "jobId", "requestKey", "userIgn", "presetNo")
+    override val schemaVersion: Int = 1
+    override val leaseDurationSeconds: Long = properties.consumer.externalApi.leaseDurationSeconds
+
+    @KafkaListener(
+        topics = [KafkaTopicNames.EXTERNAL_API_REQUESTED],
+        groupId = "maple-external-api",
+        containerFactory = "kafkaListenerContainerFactory",
+    )
+    fun consume(
+        @Payload payload: String,
+        @Header("kafka_receivedTopic") topic: String,
+        @Header("kafka_receivedPartitionId") partition: Int,
+        @Header("kafka_offset") offset: Long,
+        ack: Acknowledgment,
+    ) {
+        executor.executeVoid(
+            { processMessage(payload, topic, partition, offset, ack) },
+            TaskContext.of("ExternalApiKafkaTopic", "Consume"),
+        )
+    }
+
+    private fun processMessage(payload: String, topic: String, partition: Int, offset: Long, ack: Acknowledgment) {
+        val parsed = parseAndValidate(payload)
+        if (parsed == null) {
+            sendToDlt(payload, topic, partition, offset, consumerGroup, "VALIDATION_FAILED", "Parse/validation error")
+            ack.acknowledge()
+            return
+        }
+
+        val jobId = parsed.path("jobId").asText()
+        log.info("[ExternalApiKafkaTopic] Processing jobId={} from {}[{}]", jobId, topic, partition)
+
+        // PR-2: DB CAS claim + Nexon API call + snapshot staging
+        log.info("[ExternalApiKafkaTopic] SKIPPED (PR-1 skeleton) jobId={}", jobId)
+
+        ack.acknowledge()
+    }
+
+    override fun parseAndValidate(payload: String): JsonNode? {
+        val node = runCatching { objectMapper.readTree(payload) }
+            .getOrElse { return null }
+
+        val version = node.path("schemaVersion").asInt(-1)
+        if (version != schemaVersion) return null
+
+        val missing = requiredFields.filter { !node.has(it) || node.path(it).isNull }
+        if (missing.isNotEmpty()) return null
+
+        return node
+    }
+
+    override fun claimJob(jobId: String): Boolean {
+        // PR-2: DB CAS claim API_REQUESTED → API_IN_PROGRESS + locked_until
+        log.debug("[ExternalApiKafkaTopic] claimJob stub for jobId={}", jobId)
+        return true
+    }
+}

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/messaging/kafka/ExternalApiKafkaTopic.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/messaging/kafka/ExternalApiKafkaTopic.kt
@@ -2,11 +2,32 @@ package maple.expectation.infrastructure.messaging.kafka
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
+import maple.expectation.core.dto.v4.CalculationInput
+import maple.expectation.core.dto.v4.EquipmentItem
+import maple.expectation.core.model.job.CalculationJobStatus
+import maple.expectation.core.model.snapshot.CalculationSnapshot
+import maple.expectation.core.port.out.CalculationInputPort
+import maple.expectation.core.port.out.CalculationJobPort
+import maple.expectation.core.port.out.CharacterOcidPort
 import maple.expectation.core.port.out.KafkaTopicNames
+import maple.expectation.core.port.out.SnapshotObjectStore
+import maple.expectation.error.exception.CharacterNotFoundException
 import maple.expectation.infrastructure.config.KafkaPipelineProperties
+import maple.expectation.infrastructure.converter.EquipmentResponseToCalculationInputConverter
 import maple.expectation.infrastructure.executor.LogicExecutor
 import maple.expectation.infrastructure.executor.TaskContext
+import maple.expectation.infrastructure.external.NexonApiClient
+import maple.expectation.infrastructure.external.dto.v2.EquipmentResponse
+import maple.expectation.infrastructure.job.CalculationJobService
+import maple.expectation.infrastructure.persistence.entity.CalculationSnapshotEntity
 import maple.expectation.infrastructure.persistence.repository.KafkaOutboxEventRepository
+import maple.expectation.infrastructure.provider.EquipmentFetchProvider
+import maple.expectation.util.ExceptionUtils
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.kafka.annotation.KafkaListener
@@ -15,6 +36,7 @@ import org.springframework.kafka.support.Acknowledgment
 import org.springframework.messaging.handler.annotation.Header
 import org.springframework.messaging.handler.annotation.Payload
 import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClientResponseException
 
 @Component
 @ConditionalOnProperty(prefix = "app.kafka.pipeline", name = ["enabled"], havingValue = "true")
@@ -24,6 +46,14 @@ class ExternalApiKafkaTopic(
     executor: LogicExecutor,
     kafkaTemplate: KafkaTemplate<String, String>,
     properties: KafkaPipelineProperties,
+    private val jobPort: CalculationJobPort,
+    private val ocidPort: CharacterOcidPort,
+    private val nexonApiClient: NexonApiClient,
+    private val equipmentFetchProvider: EquipmentFetchProvider,
+    private val snapshotStore: SnapshotObjectStore,
+    private val jobService: CalculationJobService,
+    private val converter: EquipmentResponseToCalculationInputConverter,
+    private val calculationInputPort: CalculationInputPort,
 ) : KafkaTopicGroup(outboxRepository, objectMapper, executor, kafkaTemplate, properties),
     PipelineTopic {
 
@@ -35,7 +65,8 @@ class ExternalApiKafkaTopic(
 
     override val requiredFields: List<String> = listOf("schemaVersion", "jobId", "requestKey", "userIgn", "presetNo")
     override val schemaVersion: Int = 1
-    override val leaseDurationSeconds: Long = properties.consumer.externalApi.leaseDurationSeconds
+    override val leaseDurationSeconds: Long
+        get() = properties.consumer.externalApi.leaseDurationSeconds
 
     @KafkaListener(
         topics = [KafkaTopicNames.EXTERNAL_API_REQUESTED],
@@ -63,14 +94,238 @@ class ExternalApiKafkaTopic(
             return
         }
 
-        val jobId = parsed.path("jobId").asText()
-        log.info("[ExternalApiKafkaTopic] Processing jobId={} from {}[{}]", jobId, topic, partition)
+        val jobId = UUID.fromString(parsed.path("jobId").asText())
+        val userIgn = parsed.path("userIgn").asText()
+        val presetNo = parsed.path("presetNo").asInt()
 
-        // PR-2: DB CAS claim + Nexon API call + snapshot staging
-        log.info("[ExternalApiKafkaTopic] SKIPPED (PR-1 skeleton) jobId={}", jobId)
+        executor.executeOrCatch(
+            { processJob(jobId, userIgn, presetNo) },
+            { e -> handleJobError(jobId, userIgn, presetNo, e) },
+            TaskContext.of("ExternalApiKafkaTopic", "Process", jobId.toString()),
+        )
 
         ack.acknowledge()
     }
+
+    private fun processJob(jobId: UUID, userIgn: String, presetNo: Int) {
+        val existingJob = jobPort.findJobById(jobId)
+
+        // Terminal states: skip entirely
+        if (existingJob != null && (existingJob.status == CalculationJobStatus.COMPLETED || existingJob.status == CalculationJobStatus.FAILED)) {
+            log.debug("[jobId={}] Skipping — terminal state {}", jobId, existingJob.status)
+            return
+        }
+
+        // SNAPSHOT_READY: API+snapshot already done, dispatch to calculation
+        if (existingJob != null && existingJob.status == CalculationJobStatus.SNAPSHOT_READY) {
+            val characterId = existingJob.ocid
+            if (characterId == null) {
+                log.warn("[jobId={}] No OCID in SNAPSHOT_READY, cannot dispatch calculation", jobId)
+                return
+            }
+            val characterClass = stage("LoadCharacterClass", jobId.toString()) {
+                calculationInputPort.findByJobId(jobId)?.characterClass ?: ""
+            }
+            dispatchCalculationRequested(jobId, userIgn, presetNo, characterId, characterClass)
+            return
+        }
+
+        // Not processable
+        if (existingJob != null && !isExternalApiProcessable(existingJob.status)) {
+            log.debug("[jobId={}] Skipping — state {}", jobId, existingJob.status)
+            return
+        }
+
+        // CAS claim
+        val fromStatus = existingJob?.status ?: CalculationJobStatus.OCID_RESOLVING
+        val workerId = "kafka-ext-api"
+        val claimed = jobPort.lockForProcessing(jobId, workerId, fromStatus)
+        if (!claimed) {
+            log.info("[jobId={}] Already claimed by another consumer", jobId)
+            return
+        }
+
+        // Pipeline with guaranteed unlock
+        executor.executeWithFinally(
+            { processExternalApiPipeline(jobId, userIgn, presetNo, existingJob?.ocid) },
+            {
+                executor.executeVoid(
+                    { jobPort.unlock(jobId) },
+                    TaskContext.of("ExternalApiKafkaTopic", "Unlock", jobId.toString()),
+                )
+            },
+            TaskContext.of("ExternalApiKafkaTopic", "Pipeline", jobId.toString()),
+        )
+    }
+
+    private fun processExternalApiPipeline(jobId: UUID, userIgn: String, presetNo: Int, cachedOcid: String?) {
+        // Step 1+2: Resolve OCID → Fetch equipment
+        val (ocid, equipmentResponse) = stage("ResolveAndFetch", userIgn) {
+            resolveOcidAndFetchEquipment(jobId, userIgn, cachedOcid)
+        }
+
+        // Step 3: Serialize snapshot + write to object store
+        val snapshotData = stage("SerializeSnapshot", userIgn) {
+            objectMapper.writeValueAsBytes(equipmentResponse)
+        }
+        val objectKey = generateObjectKey(jobId)
+        val snapshotId = UUID.randomUUID()
+        val snapshot = CalculationSnapshot(
+            snapshotId = snapshotId,
+            jobId = jobId,
+            objectKey = objectKey,
+            storageType = "LOCAL",
+            characterId = ocid,
+            presetNo = presetNo,
+            expiresAt = Instant.now().plusSeconds(86400),
+        )
+        val putResult = stage("SnapshotPut", jobId.toString()) {
+            snapshotStore.put(snapshot, snapshotData)
+        }
+
+        // Step 4: Build and persist calculation input
+        val inputItems = stage("BuildCalculationInput", userIgn) {
+            convertItems(equipmentResponse)
+        }
+        val characterClass = equipmentResponse.characterClass ?: ""
+        val calcInput = CalculationInput(
+            jobId = jobId.toString(),
+            userIgn = userIgn,
+            characterClass = characterClass,
+            presetNo = presetNo,
+            items = inputItems,
+        )
+        stage("SaveCalculationInput", jobId.toString()) {
+            calculationInputPort.saveIfAbsent(calcInput)
+        }
+
+        // Step 5+6: Save snapshot metadata + transition to SNAPSHOT_READY [TX]
+        val snapshotEntity = CalculationSnapshotEntity(
+            snapshotId = snapshotId,
+            jobId = jobId,
+            objectKey = objectKey,
+            storageType = "LOCAL",
+            characterId = ocid,
+            presetNo = presetNo,
+            compressedSize = putResult.compressedSize,
+            originalSize = snapshotData.size.toLong(),
+            hash = putResult.hash,
+            expiresAt = snapshot.expiresAt,
+        )
+        stage("SaveSnapshotAndMarkReady", jobId.toString()) {
+            jobService.saveInputSnapshotAndMarkReady(snapshotEntity, jobId, snapshotId)
+        }
+
+        // Step 7: Dispatch calculation.requested via outbox
+        dispatchCalculationRequested(jobId, userIgn, presetNo, ocid, characterClass)
+
+        log.info("[jobId={}] External API pipeline completed, calculation dispatched", jobId)
+    }
+
+    private fun handleJobError(jobId: UUID, userIgn: String, presetNo: Int, e: Throwable) {
+        if (isCharacterNotFound(e)) {
+            val msg = (ExceptionUtils.unwrapAsyncException(e)?.message ?: "Character not found").take(200)
+            executor.executeVoid(
+                { jobPort.markFailed(jobId, "CHARACTER_NOT_FOUND", msg) },
+                TaskContext.of("ExternalApiKafkaTopic", "MarkFailed", jobId.toString()),
+            )
+            log.warn("[jobId={}] Character not found, marked FAILED: {}", jobId, msg)
+        } else {
+            log.error("[jobId={}] External API pipeline error: {}", jobId, e.message)
+            handlePipelineFailure(jobId, e)
+        }
+    }
+
+    private fun handlePipelineFailure(jobId: UUID, e: Throwable) {
+        val job = jobPort.findJobById(jobId) ?: return
+        val errorCode = classifyExternalApiError(e)
+        val errorMsg = (e.message ?: "Unknown error").take(200)
+
+        if (job.retryCount >= job.maxRetries) {
+            executor.executeVoid(
+                { jobPort.markFailed(jobId, errorCode, errorMsg) },
+                TaskContext.of("ExternalApiKafkaTopic", "MarkFailed", jobId.toString()),
+            )
+        } else {
+            executor.executeVoid(
+                { jobPort.incrementRetry(jobId, errorCode) },
+                TaskContext.of("ExternalApiKafkaTopic", "IncrementRetry", jobId.toString()),
+            )
+            log.info("[jobId={}] Pipeline error recorded, retry={}/{}, code={}", jobId, job.retryCount + 1, job.maxRetries, errorCode)
+        }
+    }
+
+    // ===== OCID Resolve + Equipment Fetch (from ExternalApiWorker) =====
+
+    private fun resolveOcidAndFetchEquipment(jobId: UUID, userIgn: String, jobOcid: String?): Pair<String, EquipmentResponse> {
+        val cached = jobOcid ?: ocidPort.resolveOcid(userIgn)
+        if (cached != null) {
+            jobService.resolveOcidInPlace(jobId, cached)
+            return Pair(cached, equipmentFetchProvider.fetchWithCache(cached))
+        }
+
+        return nexonApiClient.getOcidByCharacterName(userIgn)
+            .handle { result, ex ->
+                if (ex != null) {
+                    log.warn("[jobId={}] OCID resolve failed: {}", jobId, ex.message)
+                    throw ExceptionUtils.unwrapAs(ex, CharacterNotFoundException::class.java) ?: ex
+                } else {
+                    result
+                }
+            }
+            .thenApply { response ->
+                if (response == null || response.ocid.isBlank()) {
+                    throw CharacterNotFoundException(userIgn)
+                }
+                response.ocid
+            }
+            .thenApply { ocid ->
+                jobService.resolveOcidInPlace(jobId, ocid)
+                ocid
+            }
+            .thenCompose { ocid ->
+                CompletableFuture.supplyAsync({
+                    Pair(ocid, equipmentFetchProvider.fetchWithCache(ocid))
+                })
+            }
+            .orTimeout(15, TimeUnit.SECONDS)
+            .join()
+    }
+
+    // ===== Outbox Dispatch =====
+
+    private fun dispatchCalculationRequested(
+        jobId: UUID,
+        userIgn: String,
+        presetNo: Int,
+        characterId: String,
+        characterClass: String,
+    ) {
+        val payload = mapOf(
+            "schemaVersion" to 1,
+            "jobId" to jobId.toString(),
+            "requestKey" to buildRequestKey(userIgn, presetNo),
+            "userIgn" to userIgn,
+            "presetNo" to presetNo,
+            "characterId" to characterId,
+            "characterClass" to characterClass,
+            "createdAt" to Instant.now().toString(),
+        )
+
+        outboxRepository.insertIfAbsent(
+            id = UUID.randomUUID(),
+            eventType = KafkaTopicNames.CALCULATION_REQUESTED,
+            aggregateId = jobId,
+            aggregateType = "calculation_job",
+            topic = KafkaTopicNames.CALCULATION_REQUESTED,
+            partitionKey = jobId.toString(),
+            payload = objectMapper.writeValueAsString(payload),
+        )
+
+        log.debug("[ExternalApiKafkaTopic] Calculation request enqueued: jobId={}", jobId)
+    }
+
+    // ===== Helpers =====
 
     override fun parseAndValidate(payload: String): JsonNode? {
         val node = runCatching { objectMapper.readTree(payload) }
@@ -86,8 +341,54 @@ class ExternalApiKafkaTopic(
     }
 
     override fun claimJob(jobId: String): Boolean {
-        // PR-2: DB CAS claim API_REQUESTED → API_IN_PROGRESS + locked_until
-        log.debug("[ExternalApiKafkaTopic] claimJob stub for jobId={}", jobId)
-        return true
+        val fromStatus = jobPort.findJobById(UUID.fromString(jobId))?.status ?: CalculationJobStatus.OCID_RESOLVING
+        return jobPort.lockForProcessing(UUID.fromString(jobId), "kafka-ext-api", fromStatus)
+    }
+
+    private fun convertItems(equipmentResponse: EquipmentResponse): List<EquipmentItem> {
+        val items = equipmentResponse.itemEquipment ?: return emptyList()
+        return items.map { convertItem(it) }
+    }
+
+    private fun convertItem(item: Any): EquipmentItem {
+        val itemMap = objectMapper.convertValue(item, Map::class.java) as Map<*, *>
+        return converter.convertItem(itemMap)
+    }
+
+    private fun generateObjectKey(jobId: UUID): String {
+        val now = Instant.now()
+        val zoned = now.atZone(ZoneOffset.UTC)
+        val datePath = "%04d/%02d/%02d".format(zoned.year, zoned.monthValue, zoned.dayOfMonth)
+        return "snapshots/$datePath/$jobId.gz"
+    }
+
+    private fun buildRequestKey(userIgn: String, presetNo: Int): String = "calc:v1:ign:${userIgn.lowercase()}:preset:$presetNo:schema:1"
+
+    private fun <T> stage(name: String, key: String, block: () -> T): T = executor.execute(
+        { block() },
+        TaskContext.of("ExternalApiKafkaTopic", name, key),
+    )
+
+    private fun isCharacterNotFound(e: Throwable): Boolean = ExceptionUtils.containsCause(e, CharacterNotFoundException::class.java)
+
+    private fun isExternalApiProcessable(status: CalculationJobStatus): Boolean = status == CalculationJobStatus.REQUESTED ||
+        status == CalculationJobStatus.OCID_RESOLVING ||
+        status == CalculationJobStatus.API_REQUESTED ||
+        status == CalculationJobStatus.RETRYING
+
+    private fun classifyExternalApiError(e: Throwable): String {
+        val responseException = ExceptionUtils.unwrapAs(e, WebClientResponseException::class.java) ?: return "EXTERNAL_API_ERROR"
+        return when (responseException.statusCode.value()) {
+            400 -> if (responseException.responseBodyAsString.contains("OPENAPI00004")) {
+                "CHARACTER_NOT_FOUND"
+            } else {
+                "NEXON_BAD_REQUEST"
+            }
+            401 -> "NEXON_UNAUTHORIZED"
+            403 -> "NEXON_FORBIDDEN"
+            429 -> "NEXON_RATE_LIMITED"
+            in 500..599 -> "NEXON_SERVER_ERROR"
+            else -> "EXTERNAL_API_ERROR"
+        }
     }
 }

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/messaging/kafka/KafkaTopicGroup.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/messaging/kafka/KafkaTopicGroup.kt
@@ -1,0 +1,95 @@
+package maple.expectation.infrastructure.messaging.kafka
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicReference
+import maple.expectation.core.domain.event.IntegrationEvent
+import maple.expectation.core.port.out.mq.ConsumeResult
+import maple.expectation.core.port.out.mq.MQTopicGroup
+import maple.expectation.core.port.out.mq.MessageHandle
+import maple.expectation.infrastructure.config.KafkaPipelineProperties
+import maple.expectation.infrastructure.executor.LogicExecutor
+import maple.expectation.infrastructure.executor.TaskContext
+import maple.expectation.infrastructure.persistence.repository.KafkaOutboxEventRepository
+import org.slf4j.LoggerFactory
+import org.springframework.kafka.core.KafkaTemplate
+
+abstract class KafkaTopicGroup(
+    protected val outboxRepository: KafkaOutboxEventRepository,
+    protected val objectMapper: ObjectMapper,
+    protected val executor: LogicExecutor,
+    protected val kafkaTemplate: KafkaTemplate<String, String>,
+    protected val properties: KafkaPipelineProperties,
+) : MQTopicGroup {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+    private val handlerRef = AtomicReference<(IntegrationEvent<*>, MessageHandle) -> ConsumeResult>()
+
+    override fun publish(message: IntegrationEvent<*>): MessageHandle {
+        val context = TaskContext.of("KafkaTopic", "Publish", name)
+        return executor.execute({
+            val eventId = UUID.randomUUID()
+            val payload = objectMapper.writeValueAsString(message)
+            val key = message.jobId ?: message.eventId
+
+            outboxRepository.insertIfAbsent(
+                id = eventId,
+                eventType = message.eventType,
+                aggregateId = UUID.fromString(message.jobId ?: message.eventId),
+                aggregateType = "calculation_job",
+                topic = name,
+                partitionKey = key,
+                payload = payload,
+            )
+
+            MessageHandle(id = eventId, raw = eventId)
+        }, context)
+    }
+
+    override fun subscribe(handler: (IntegrationEvent<*>, MessageHandle) -> ConsumeResult) {
+        handlerRef.set(handler)
+    }
+
+    fun getHandler(): ((IntegrationEvent<*>, MessageHandle) -> ConsumeResult)? = handlerRef.get()
+
+    fun clearHandler() {
+        handlerRef.set(null)
+    }
+
+    fun sendToDlt(
+        payload: String,
+        originalTopic: String,
+        partition: Int,
+        offset: Long,
+        consumerGroup: String,
+        errorType: String,
+        errorMessage: String,
+    ) {
+        log.warn(
+            "[KafkaTopicGroup] DLT: errorType={}, message={}, topic={}[{}]",
+            errorType,
+            errorMessage,
+            originalTopic,
+            partition,
+        )
+
+        val dltPayload = mapOf(
+            "originalTopic" to originalTopic,
+            "originalPartition" to partition,
+            "originalOffset" to offset,
+            "consumerGroup" to consumerGroup,
+            "errorType" to errorType,
+            "errorMessage" to errorMessage,
+            "payload" to payload,
+            "failedAt" to java.time.Instant.now().toString(),
+        )
+
+        kafkaTemplate.send(
+            dltTopicName,
+            objectMapper.writeValueAsString(dltPayload),
+        )
+    }
+
+    abstract val dltTopicName: String
+    abstract val consumerGroup: String
+}

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/messaging/kafka/PipelineTopic.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/messaging/kafka/PipelineTopic.kt
@@ -1,0 +1,32 @@
+package maple.expectation.infrastructure.messaging.kafka
+
+import com.fasterxml.jackson.databind.JsonNode
+
+/**
+ * Pipeline-specific behavior for Kafka topics.
+ *
+ * Extends MQTopicGroup with CAS claim, payload validation,
+ * and lease-based processing semantics.
+ */
+interface PipelineTopic {
+    /** Required fields in the JSON payload */
+    val requiredFields: List<String>
+
+    /** Required schema version */
+    val schemaVersion: Int
+
+    /** DB CAS claim duration in seconds (locked_until) */
+    val leaseDurationSeconds: Long
+
+    /**
+     * Parse and validate raw String payload.
+     * Returns null if poison (routed to DLT by caller).
+     */
+    fun parseAndValidate(payload: String): JsonNode?
+
+    /**
+     * DB CAS claim before side effect.
+     * Returns true if claim succeeded, false if already claimed.
+     */
+    fun claimJob(jobId: String): Boolean
+}

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/entity/KafkaOutboxEventEntity.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/entity/KafkaOutboxEventEntity.kt
@@ -1,0 +1,30 @@
+package maple.expectation.infrastructure.persistence.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.OffsetDateTime
+import java.util.UUID
+import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.type.SqlTypes
+
+@Entity
+@Table(name = "kafka_outbox_events")
+class KafkaOutboxEventEntity(
+    @Id val id: UUID = UUID.randomUUID(),
+    @Column(nullable = false) val eventType: String,
+    @Column(nullable = false) val aggregateId: UUID,
+    @Column(nullable = false) val aggregateType: String,
+    @Column(nullable = false) val topic: String,
+    @Column(nullable = false) val partitionKey: String,
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb", nullable = false) val payload: String,
+    @Column(nullable = false) var status: String = "PENDING",
+    @Column(nullable = false) var retryCount: Int = 0,
+    @Column(nullable = false) var nextAttemptAt: OffsetDateTime = OffsetDateTime.now(),
+    var publishedAt: OffsetDateTime? = null,
+    var lastError: String? = null,
+    @Column(nullable = false) val createdAt: OffsetDateTime = OffsetDateTime.now(),
+    @Column(nullable = false) var updatedAt: OffsetDateTime = OffsetDateTime.now(),
+)

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/repository/KafkaOutboxEventRepository.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/repository/KafkaOutboxEventRepository.kt
@@ -1,0 +1,60 @@
+package maple.expectation.infrastructure.persistence.repository
+
+import java.util.UUID
+import maple.expectation.infrastructure.persistence.entity.KafkaOutboxEventEntity
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+
+interface KafkaOutboxEventRepository : JpaRepository<KafkaOutboxEventEntity, UUID> {
+
+    @Modifying
+    @Query(
+        nativeQuery = true,
+        value = """
+            INSERT INTO kafka_outbox_events (id, event_type, aggregate_id, aggregate_type, topic, partition_key, payload, status, created_at, updated_at, next_attempt_at)
+            VALUES (:id, :eventType, :aggregateId, :aggregateType, :topic, :partitionKey, CAST(:payload AS jsonb), 'PENDING', now(), now(), now())
+            ON CONFLICT (event_type, aggregate_id) WHERE status IN ('PENDING', 'PUBLISHING', 'PUBLISHED') DO NOTHING
+        """,
+    )
+    fun insertIfAbsent(
+        @Param("id") id: UUID,
+        @Param("eventType") eventType: String,
+        @Param("aggregateId") aggregateId: UUID,
+        @Param("aggregateType") aggregateType: String,
+        @Param("topic") topic: String,
+        @Param("partitionKey") partitionKey: String,
+        @Param("payload") payload: String,
+    ): Int
+
+    @Modifying
+    @Query(
+        nativeQuery = true,
+        value = """
+            UPDATE kafka_outbox_events
+            SET status = 'PUBLISHED', published_at = now(), updated_at = now()
+            WHERE id = :id AND status = 'PUBLISHING'
+        """,
+    )
+    fun markPublished(@Param("id") id: UUID): Int
+
+    @Modifying
+    @Query(
+        nativeQuery = true,
+        value = """
+            UPDATE kafka_outbox_events
+            SET status = 'PENDING', retry_count = retry_count + 1,
+                next_attempt_at = now() + :retryDelayMs * interval '1 millisecond',
+                last_error = :error, updated_at = now()
+            WHERE id = :id
+        """,
+    )
+    fun markRetryPending(@Param("id") id: UUID, @Param("error") error: String, @Param("retryDelayMs") retryDelayMs: Long): Int
+
+    @Query(
+        nativeQuery = true,
+        value = "SELECT COUNT(*) FROM kafka_outbox_events WHERE status IN ('PENDING', 'PUBLISHING')",
+    )
+    fun countPending(): Long
+}

--- a/module-infra/src/main/resources/db/migration/V123__kafka_outbox_events.sql
+++ b/module-infra/src/main/resources/db/migration/V123__kafka_outbox_events.sql
@@ -1,0 +1,36 @@
+-- Kafka Transactional Outbox: kafka_outbox_events
+-- Kafka Pipeline Transition Plan Section 10
+-- Stores Kafka publish intents in the same DB transaction as job creation.
+-- KafkaOutboxPublisher polls and publishes to Kafka asynchronously.
+
+CREATE TABLE IF NOT EXISTS kafka_outbox_events (
+    id UUID PRIMARY KEY,
+    event_type TEXT NOT NULL,
+    aggregate_id UUID NOT NULL,
+    aggregate_type TEXT NOT NULL,
+    topic TEXT NOT NULL,
+    partition_key TEXT NOT NULL,
+    payload JSONB NOT NULL,
+    status TEXT NOT NULL DEFAULT 'PENDING',
+    retry_count INT NOT NULL DEFAULT 0,
+    next_attempt_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    published_at TIMESTAMPTZ,
+    last_error TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Prevent duplicate outbox events for the same event type + aggregate
+-- Only active statuses are indexed (PENDING, PUBLISHING, PUBLISHED)
+CREATE UNIQUE INDEX IF NOT EXISTS ux_kafka_outbox_event_dedup
+ON kafka_outbox_events (event_type, aggregate_id)
+WHERE status IN ('PENDING', 'PUBLISHING', 'PUBLISHED');
+
+-- Outbox publisher claim query uses this index
+CREATE INDEX IF NOT EXISTS ix_kafka_outbox_events_pending
+ON kafka_outbox_events (status, next_attempt_at, created_at)
+WHERE status = 'PENDING';
+
+COMMENT ON TABLE kafka_outbox_events IS 'Transactional outbox for Kafka publish intents. Populated in same TX as job creation.';
+COMMENT ON COLUMN kafka_outbox_events.status IS 'PENDING -> PUBLISHING -> PUBLISHED. Retryable: PENDING with backoff.';
+COMMENT ON COLUMN kafka_outbox_events.partition_key IS 'Kafka partition key (requestKey or jobId)';


### PR DESCRIPTION
## Summary
- **PR-1**: Kafka foundation — Spring Kafka 설정, 토픽 정의, outbox 테이블 마이그레이션, KafkaOutboxPublisher, KafkaTopicGroup/PipelineTopic 추상화
- **PR-2**: external-api.requested — CalculationDispatchPort 추상화, ExternalApiKafkaTopic 비즈니스 로직 (CAS claim + OCID resolve + equipment fetch + snapshot staging + calculation.requested outbox dispatch)
- **PR-3**: calculation.requested — CalculationKafkaTopic 비즈니스 로직 (CAS claim + 순수 계산 + result/gzip/hash + COMPLETED 전환 + outbox insert)

## Design
- Two-topic Kafka pipeline: `external-api.requested` (I/O) + `calculation.requested` (CPU)
- Transactional Outbox for dual-write prevention
- Feature flag: `app.messaging.transport: pgmq|kafka`
- DB CAS claim via `lockForProcessing` + `executeWithFinally` unlock 보장
- Idempotency: 기존 DB UNIQUE constraints + CAS status transitions 재사용

## Test plan
- [x] `./gradlew check` 전체 통과 (pre-commit hook)
- [ ] 서버 구동 후 PGMQ 경로 정상 동작 확인 (`transport=pgmq`)
- [ ] Kafka 활성화 후 end-to-end 파이프라인 확인 (`transport=kafka`)
- [ ] PR-4: 부하테스트로 PGMQ vs Kafka throughput 비교

🤖 Generated with [Claude Code](https://claude.com/claude-code)