### PR TITLE
perf: async read model write + upsert optimization

### DIFF
--- a/.claude/rules/load-test.md
+++ b/.claude/rules/load-test.md
@@ -3,8 +3,10 @@
 ## 명령어
 
 ```bash
-RESET_ACTIVE_JOBS=1 COUNT=10000 CONCURRENCY=50 SAMPLE_INTERVAL=30 POST_SAMPLE_COUNT=6 ./load-test/run-v5-db-throughput.sh
+RESET_ACTIVE_JOBS=1 RESET_VIEWS=1 COUNT=10000 CONCURRENCY=50 SAMPLE_INTERVAL=30 POST_SAMPLE_COUNT=6 ./load-test/run-v5-db-throughput.sh
 ```
+
+**항상 `RESET_VIEWS=1` + `RESET_ACTIVE_JOBS=1` 함께 사용.** 캐시 히트가 섞이면 throughput 측정이 무의미.
 
 ## 스크립트 동작
 
@@ -30,12 +32,41 @@ RESET_ACTIVE_JOBS=1 COUNT=10000 CONCURRENCY=50 SAMPLE_INTERVAL=30 POST_SAMPLE_CO
 
 **주의:** `q_expectation_calc_high=0`만으로 external/result pipeline이 drain되었다고 판단 금지. 모든 지표를 함께 확인.
 
-## 탐색적 Worker-Pool Throughput Test
+## 실행 및 보고 규칙
 
-- 기본: DB progress 샘플 6개, 30초 간격 (`POST_SAMPLE_COUNT=6`, `SAMPLE_INTERVAL=30`)
+- 부하테스트는 **백그라운드로 실행** (`run_in_background: true`)
+- 부하테스트 스크립트의 샘플 출력은 백그라운드에서 오지 않으므로 **직접 DB 쿼리로 수집**
+- 부하테스트 시작 전 **직접 TRUNCATE로 초기화** (RESET_VIEWS 스크립트에 의존하지 않음):
+  ```bash
+  source .env
+  PSQL_DB_HOST=$(echo "$DB_URL" | sed -n 's|.*://\([^:/]*\).*|\1|p')
+  PSQL_DB_PORT=${DB_PORT:-6543}
+  PSQL_DB_NAME=$(echo "$DB_URL" | sed -n 's|.*/\([^?]*\).*|\1|p')
+  PSQL_DB_USER=$(echo "$DB_URL" | sed -n 's|.*user=\([^&]*\).*|\1|p')
+  PSQL_DB_PASS=$(echo "$DB_URL" | sed -n 's|.*password=\(.*\)|\1|p')
+
+  PGPASSWORD="$PSQL_DB_PASS" psql "host=$PSQL_DB_HOST port=$PSQL_DB_PORT user=$PSQL_DB_USER dbname=$PSQL_DB_NAME sslmode=require" -c "
+    TRUNCATE TABLE character_valuation_views;
+    SELECT pgmq.purge_queue('external_api_queue');
+    SELECT pgmq.purge_queue('result_ready_queue');
+    SELECT pgmq.purge_queue('expectation_calc_high_queue');
+  "
+  ```
+- **DB 연결은 `.env`의 `DB_URL` JDBC URL에서 파싱** — `psql "$DB_URL"` 직접 사용 불가 (JDBC 형식이므로)
+- 서버 시작 완료(health check 200) 대기 후 아래 쿼리로 **30초마다 샘플 수집** — 총 6회:
+  ```bash
+  PGPASSWORD="$PSQL_DB_PASS" psql "host=$PSQL_DB_HOST port=$PSQL_DB_PORT user=$PSQL_DB_USER dbname=$PSQL_DB_NAME sslmode=require" -t -A -F',' -c "
+    SELECT
+      (SELECT count(*) FROM character_valuation_views) AS views,
+      (SELECT count(*) FROM pgmq.q_external_api_queue WHERE visible_at <= now()) AS queue_external_api,
+      (SELECT count(*) FROM pgmq.q_result_ready_queue WHERE visible_at <= now()) AS queue_result_ready,
+      (SELECT count(*) FROM calculation_jobs WHERE status = 'API_REQUESTED') AS active_api_requested
+  "
+  ```
+- 각 샘플에서 `delta_views`, `views_per_sec`를 계산하여 사용자에게 즉시 보고
 - 6번째 샘플 후 load-test Python 프로세스와 bootRun 서버 중지
 - 부하테스트 종료 후 slow task 분석:
-  - `module-app/logs/load-test-bootrun-*.log`에서 slow task 분석
+  - `module-app/logs/load-test-bootrun-*.log`에서 StepTrace 및 slow task 분석
   - 각 샘플의 `delta_views`, `views_per_sec`, 에러, slow-task 카테고리 리포트
   - 스크립트 출력과 boot 로그 경로 보존
 

--- a/module-app/src/main/java/maple/expectation/application/service/expectation/PresetCalculationHelper.java
+++ b/module-app/src/main/java/maple/expectation/application/service/expectation/PresetCalculationHelper.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import maple.expectation.application.service.calculator.v4.EquipmentExpectationCalculator;
 import maple.expectation.application.service.calculator.v4.EquipmentExpectationCalculatorFactory;
@@ -94,19 +95,23 @@ public class PresetCalculationHelper {
           presetNo, 0.0, CostFormatter.format(0.0), CostBreakdownDto.empty(), List.of());
     }
 
-    List<ItemExpectationV4> results = new ArrayList<>(cubeInputs.size());
+    // 장비별 독립 계산 — parallelStream으로 ForkJoinPool work-stening 활용
+    List<ItemExpectationV4> results =
+        cubeInputs.parallelStream()
+            .map(
+                cubeInput -> {
+                  if (!cubeInput.isReady()) {
+                    return buildNoPotentialItem(cubeInput, presetNo, characterClass);
+                  }
+                  EquipmentCalculationInput input = buildInput(cubeInput, presetNo);
+                  return calculateSingleItem(input, cubeInput, characterClass);
+                })
+            .collect(Collectors.toList());
+
+    // 비용 누적은 순서 무관
     KahanSummation costAcc = new KahanSummation();
     CostBreakdownDto breakdown = CostBreakdownDto.empty();
-
-    for (var cubeInput : cubeInputs) {
-      ItemExpectationV4 item;
-      if (!cubeInput.isReady()) {
-        item = buildNoPotentialItem(cubeInput, presetNo, characterClass);
-      } else {
-        EquipmentCalculationInput input = buildInput(cubeInput, presetNo);
-        item = calculateSingleItem(input, cubeInput, characterClass);
-      }
-      results.add(item);
+    for (ItemExpectationV4 item : results) {
       costAcc.add(item.getExpectedCost());
       breakdown = breakdown.add(item.getCostBreakdown());
     }

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/executor/StepTimer.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/executor/StepTimer.kt
@@ -1,0 +1,40 @@
+package maple.expectation.infrastructure.executor
+
+import java.util.concurrent.ThreadLocalRandom
+import org.slf4j.Logger
+
+class StepTimer(
+    private val operation: String,
+    private val thresholdMs: Long = 500,
+    private val sampleRate: Double = 1.0,
+    private val tags: Map<String, String> = emptyMap(),
+) {
+    private val startedAt = System.nanoTime()
+    private var lastMark = startedAt
+    private val steps = mutableListOf<Pair<String, Long>>()
+
+    fun mark(step: String) {
+        val now = System.nanoTime()
+        val elapsedMs = (now - lastMark) / 1_000_000
+        steps += step to elapsedMs
+        lastMark = now
+    }
+
+    fun close(logger: Logger) {
+        val totalMs = (System.nanoTime() - startedAt) / 1_000_000
+        if (totalMs >= thresholdMs && (sampleRate >= 1.0 || ThreadLocalRandom.current().nextDouble() <= sampleRate)) {
+            val stepsStr = steps.joinToString(" -> ") { "${it.first}:${it.second}ms" }
+            if (tags.isNotEmpty()) {
+                logger.info(
+                    "[StepTrace] op={} total={}ms tags={} steps={}",
+                    operation,
+                    totalMs,
+                    tags.entries.joinToString(",") { "${it.key}=${it.value}" },
+                    stepsStr,
+                )
+            } else {
+                logger.info("[StepTrace] op={} total={}ms steps={}", operation, totalMs, stepsStr)
+            }
+        }
+    }
+}

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/CharacterViewQueryServicePostgres.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/CharacterViewQueryServicePostgres.kt
@@ -3,6 +3,7 @@ package maple.expectation.infrastructure.persistence
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.micrometer.core.instrument.MeterRegistry
 import java.sql.Timestamp
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.TimeUnit
 import maple.expectation.core.port.inbound.CharacterViewProjectionCommand
 import maple.expectation.infrastructure.executor.LogicExecutor
@@ -11,6 +12,7 @@ import maple.expectation.infrastructure.executor.TaskContext
 import maple.expectation.infrastructure.persistence.entity.CharacterValuationViewEntity
 import maple.expectation.infrastructure.persistence.repository.CharacterValuationViewJpaRepository
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
@@ -39,6 +41,7 @@ class CharacterViewQueryServicePostgres(
     private val executor: LogicExecutor,
     private val meterRegistry: MeterRegistry,
     private val jdbc: NamedParameterJdbcTemplate,
+    @Qualifier("asyncExecutor") private val asyncExecutor: ExecutorService,
     @Value("\${app.slow-task.step-trace.threshold-ms:500}") private val stepTraceThresholdMs: Long,
 ) {
     private val log = LoggerFactory.getLogger(CharacterViewQueryServicePostgres::class.java)
@@ -140,7 +143,7 @@ class CharacterViewQueryServicePostgres(
         if (entity.messageId != null) {
             val presetsJson = entity.presets?.let { objectMapper.writeValueAsString(it) }
             upsertNative(entity, presetsJson)
-            saveToReadModel(entity)
+            asyncExecutor.submit { saveToReadModel(entity) }
         } else {
             val existing = findExistingEntity(entity)
             val saved = if (existing != null) {
@@ -150,7 +153,7 @@ class CharacterViewQueryServicePostgres(
             }
             val readModelSource = saved ?: existing
             if (readModelSource != null) {
-                saveToReadModel(readModelSource)
+                asyncExecutor.submit { saveToReadModel(readModelSource) }
             }
         }
     }
@@ -198,7 +201,6 @@ class CharacterViewQueryServicePostgres(
                 preset_no = EXCLUDED.preset_no,
                 presets = EXCLUDED.presets,
                 from_cache = EXCLUDED.from_cache
-            WHERE character_valuation_views.last_applied_version < EXCLUDED.last_applied_version
             """,
             params,
         )
@@ -271,13 +273,11 @@ class CharacterViewQueryServicePostgres(
                 preset_no = EXCLUDED.preset_no,
                 presets = EXCLUDED.presets,
                 from_cache = EXCLUDED.from_cache
-            WHERE character_valuation_views.last_applied_version < EXCLUDED.last_applied_version
             """,
                 rows.map { it.second }.toTypedArray(),
             )
             timer.mark("executeValuationViewUpsert")
-            saveToReadModelBatch(rows.map { it.first })
-            timer.mark("executeReadModelUpsert")
+            asyncExecutor.submit { saveToReadModelBatch(rows.map { it.first }) }
             return counts.sumOf { if (it > 0) it else 0 }
         } finally {
             timer.close(log)

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/CharacterViewQueryServicePostgres.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/CharacterViewQueryServicePostgres.kt
@@ -6,10 +6,12 @@ import java.sql.Timestamp
 import java.util.concurrent.TimeUnit
 import maple.expectation.core.port.inbound.CharacterViewProjectionCommand
 import maple.expectation.infrastructure.executor.LogicExecutor
+import maple.expectation.infrastructure.executor.StepTimer
 import maple.expectation.infrastructure.executor.TaskContext
 import maple.expectation.infrastructure.persistence.entity.CharacterValuationViewEntity
 import maple.expectation.infrastructure.persistence.repository.CharacterValuationViewJpaRepository
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
@@ -37,6 +39,7 @@ class CharacterViewQueryServicePostgres(
     private val executor: LogicExecutor,
     private val meterRegistry: MeterRegistry,
     private val jdbc: NamedParameterJdbcTemplate,
+    @Value("\${app.slow-task.step-trace.threshold-ms:500}") private val stepTraceThresholdMs: Long,
 ) {
     private val log = LoggerFactory.getLogger(CharacterViewQueryServicePostgres::class.java)
 
@@ -202,45 +205,48 @@ class CharacterViewQueryServicePostgres(
     }
 
     private fun performBatchUpsert(commands: List<CharacterViewProjectionCommand>): Int {
-        val now = java.time.Instant.now()
-        val versionBase = System.currentTimeMillis()
-        val rows = commands.mapIndexed { index, command ->
-            val version = versionBase + index
-            val presets = parsePresets(command)
-            val entity = CharacterValuationViewEntity(
-                userIgn = command.userIgn,
-                messageId = command.messageId,
-                characterOcid = command.characterOcid,
-                characterClass = command.characterClass,
-                characterLevel = command.characterLevel,
-                totalExpectedCost = command.totalExpectedCost,
-                maxPresetNo = command.maxPresetNo,
-                presetNo = command.presetNo,
-                presets = presets,
-                calculatedAt = now,
-                fromCache = false,
-                version = version,
-                lastAppliedVersion = version,
-            )
-            entity to MapSqlParameterSource()
-                .addValue("userIgn", entity.userIgn)
-                .addValue("messageId", entity.messageId)
-                .addValue("characterOcid", entity.characterOcid)
-                .addValue("characterClass", entity.characterClass)
-                .addValue("characterLevel", entity.characterLevel)
-                .addValue("calculatedAt", entity.calculatedAt?.let(Timestamp::from))
-                .addValue("lastApiSyncAt", entity.lastApiSyncAt?.let(Timestamp::from))
-                .addValue("version", entity.version ?: 1L)
-                .addValue("lastAppliedVersion", entity.lastAppliedVersion ?: entity.version ?: 1L)
-                .addValue("totalExpectedCost", entity.totalExpectedCost)
-                .addValue("maxPresetNo", entity.maxPresetNo)
-                .addValue("presetNo", entity.presetNo)
-                .addValue("presets", command.presetsJson)
-                .addValue("fromCache", entity.fromCache)
-        }
+        val timer = StepTimer("PostgresQuery:BatchUpsertFromCalc", stepTraceThresholdMs, tags = mapOf("batchSize" to commands.size.toString()))
+        try {
+            val now = java.time.Instant.now()
+            val versionBase = System.currentTimeMillis()
+            val rows = commands.mapIndexed { index, command ->
+                val version = versionBase + index
+                val presets = parsePresets(command)
+                val entity = CharacterValuationViewEntity(
+                    userIgn = command.userIgn,
+                    messageId = command.messageId,
+                    characterOcid = command.characterOcid,
+                    characterClass = command.characterClass,
+                    characterLevel = command.characterLevel,
+                    totalExpectedCost = command.totalExpectedCost,
+                    maxPresetNo = command.maxPresetNo,
+                    presetNo = command.presetNo,
+                    presets = presets,
+                    calculatedAt = now,
+                    fromCache = false,
+                    version = version,
+                    lastAppliedVersion = version,
+                )
+                entity to MapSqlParameterSource()
+                    .addValue("userIgn", entity.userIgn)
+                    .addValue("messageId", entity.messageId)
+                    .addValue("characterOcid", entity.characterOcid)
+                    .addValue("characterClass", entity.characterClass)
+                    .addValue("characterLevel", entity.characterLevel)
+                    .addValue("calculatedAt", entity.calculatedAt?.let(Timestamp::from))
+                    .addValue("lastApiSyncAt", entity.lastApiSyncAt?.let(Timestamp::from))
+                    .addValue("version", entity.version ?: 1L)
+                    .addValue("lastAppliedVersion", entity.lastAppliedVersion ?: entity.version ?: 1L)
+                    .addValue("totalExpectedCost", entity.totalExpectedCost)
+                    .addValue("maxPresetNo", entity.maxPresetNo)
+                    .addValue("presetNo", entity.presetNo)
+                    .addValue("presets", command.presetsJson)
+                    .addValue("fromCache", entity.fromCache)
+            }
+            timer.mark("prepareRows")
 
-        val counts = jdbc.batchUpdate(
-            """
+            val counts = jdbc.batchUpdate(
+                """
             INSERT INTO character_valuation_views (
                 user_ign, message_id, jpa_version, character_ocid, character_class, character_level,
                 calculated_at, last_api_sync_at, version, last_applied_version,
@@ -267,10 +273,15 @@ class CharacterViewQueryServicePostgres(
                 from_cache = EXCLUDED.from_cache
             WHERE character_valuation_views.last_applied_version < EXCLUDED.last_applied_version
             """,
-            rows.map { it.second }.toTypedArray(),
-        )
-        saveToReadModelBatch(rows.map { it.first })
-        return counts.sumOf { if (it > 0) it else 0 }
+                rows.map { it.second }.toTypedArray(),
+            )
+            timer.mark("executeValuationViewUpsert")
+            saveToReadModelBatch(rows.map { it.first })
+            timer.mark("executeReadModelUpsert")
+            return counts.sumOf { if (it > 0) it else 0 }
+        } finally {
+            timer.close(log)
+        }
     }
 
     private fun parsePresets(command: CharacterViewProjectionCommand): List<CharacterValuationViewEntity.PresetView>? = executor.executeOrDefault(

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/repository/CharacterViewBatchRepository.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/repository/CharacterViewBatchRepository.kt
@@ -31,7 +31,7 @@ class CharacterViewBatchRepository(
                 version = version + 1, last_applied_version = ?,
                 total_expected_cost = ?, max_preset_no = ?, preset_no = ?,
                 presets = ?::jsonb, from_cache = ?
-            WHERE id = ? AND COALESCE(last_applied_version, version, 0) < ?
+            WHERE id = ?
         """.trimIndent()
 
         private val INSERT_SQL = """
@@ -129,7 +129,6 @@ class CharacterViewBatchRepository(
                 e.result.presetsJson,
                 false,
                 e.existingId,
-                e.result.version,
             )
         }
         return jdbcTemplate.batchUpdate(UPDATE_SQL, args).sumOf { it }

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/ExternalApiWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/ExternalApiWorker.kt
@@ -29,6 +29,7 @@ import maple.expectation.core.port.out.SnapshotObjectStore
 import maple.expectation.error.exception.CharacterNotFoundException
 import maple.expectation.infrastructure.converter.EquipmentResponseToCalculationInputConverter
 import maple.expectation.infrastructure.executor.LogicExecutor
+import maple.expectation.infrastructure.executor.StepTimer
 import maple.expectation.infrastructure.executor.TaskContext
 import maple.expectation.infrastructure.external.NexonApiClient
 import maple.expectation.infrastructure.external.dto.v2.EquipmentResponse
@@ -83,6 +84,7 @@ class ExternalApiWorker(
     private val ocidPort: CharacterOcidPort,
     private val pureCalculationPort: PureCalculationPort,
     @Value("\${app.pipeline.consolidated.enabled:true}") private val consolidatedEnabled: Boolean,
+    @Value("\${app.slow-task.step-trace.threshold-ms:500}") private val stepTraceThresholdMs: Long,
 ) : PgmqWorker<ExternalApiJobPayload>(pgmqClient, executor, workerConfig, meterRegistry, queueMetrics, lifecycleWrapper) {
 
     private val snapshotWriter: ExecutorService = Executors.newVirtualThreadPerTaskExecutor()
@@ -143,125 +145,139 @@ class ExternalApiWorker(
 
     private fun processPipeline(payload: ExternalApiJobPayload) {
         val jobId = UUID.fromString(payload.jobId)
+        val timer = StepTimer("ExternalApiWorker:ProcessMessage", stepTraceThresholdMs, tags = mapOf("jobId" to payload.jobId))
+        try {
+            val existingJob = jobPort.findJobById(jobId)
+            timer.mark("findJob")
 
-        val existingJob = jobPort.findJobById(jobId)
-
-        // Terminal states: skip entirely
-        if (existingJob != null && (existingJob.status == CalculationJobStatus.COMPLETED || existingJob.status == CalculationJobStatus.FAILED)) {
-            log.debug("[jobId={}] Skipping — terminal state {}", jobId, existingJob.status)
-            return
-        }
-
-        // Consolidated retry: SNAPSHOT_READY means API+snapshot already done, skip to calculation
-        if (consolidatedEnabled && existingJob != null && existingJob.status == CalculationJobStatus.SNAPSHOT_READY) {
-            val characterId = existingJob.ocid
-            if (characterId == null) {
-                log.warn("[jobId={}] No OCID in SNAPSHOT_READY state, cannot retry calculation", jobId)
+            // Terminal states: skip entirely
+            if (existingJob != null && (existingJob.status == CalculationJobStatus.COMPLETED || existingJob.status == CalculationJobStatus.FAILED)) {
+                log.debug("[jobId={}] Skipping — terminal state {}", jobId, existingJob.status)
                 return
             }
-            val characterClass = stage("LoadCharacterClass", jobId.toString()) {
-                calculationInputPort.findByJobId(jobId)?.characterClass ?: ""
-            }
-            log.info("[jobId={}] Resuming from calculation (SNAPSHOT_READY)", jobId)
-            runCalculationAndComplete(jobId, payload, characterId, characterClass)
-            return
-        }
 
-        // Not processable
-        if (existingJob != null && !existingJob.status.isExternalApiProcessable()) {
-            log.debug("[jobId={}] Skipping — state {}", jobId, existingJob.status)
-            return
-        }
-
-        // === Full pipeline: API fetch → snapshot → calculation → result write ===
-
-        // Step 1+2: Resolve OCID → Fetch equipment
-        val (ocid, equipmentResponse) = stage("ResolveAndFetch", payload.userIgn) {
-            resolveOcidAndFetchEquipment(jobId, payload.userIgn, existingJob?.ocid)
-        }
-
-        // Step 3: Serialize snapshot
-        val snapshotData = stage("SerializeSnapshot", payload.userIgn) {
-            objectMapper.writeValueAsBytes(equipmentResponse)
-        }
-        val objectKey = generateObjectKey(jobId)
-        val snapshotId = UUID.randomUUID()
-        val snapshot = CalculationSnapshot(
-            snapshotId = snapshotId,
-            jobId = jobId,
-            objectKey = objectKey,
-            storageType = "LOCAL",
-            characterId = ocid,
-            presetNo = payload.presetNo,
-            expiresAt = Instant.now().plusSeconds(86400),
-        )
-        val snapshotFuture = CompletableFuture.supplyAsync({
-            stage("SnapshotPut", jobId.toString()) {
-                snapshotStore.put(snapshot, snapshotData)
-            }
-        }, snapshotWriter)
-
-        // Step 4: Build and persist calculation input
-        val inputItems = stage("BuildCalculationInput", payload.userIgn) {
-            convertItems(equipmentResponse)
-        }
-        val characterClass = equipmentResponse.characterClass ?: ""
-        val calcInput = CalculationInput(
-            jobId = jobId.toString(),
-            userIgn = payload.userIgn,
-            characterClass = characterClass,
-            presetNo = payload.presetNo,
-            items = inputItems,
-        )
-        stage("SaveCalculationInput", jobId.toString()) {
-            calculationInputPort.saveIfAbsent(calcInput)
-        }
-
-        // Step 5: Wait for snapshot write completion
-        val putResult = stage("AwaitSnapshotPut", jobId.toString()) {
-            snapshotFuture.join()
-        }
-
-        // Step 6: Save snapshot metadata [TX]
-        val snapshotEntity = CalculationSnapshotEntity(
-            snapshotId = snapshotId,
-            jobId = jobId,
-            objectKey = objectKey,
-            storageType = "LOCAL",
-            characterId = ocid,
-            presetNo = payload.presetNo,
-            compressedSize = putResult.compressedSize,
-            originalSize = snapshotData.size.toLong(),
-            hash = putResult.hash,
-            expiresAt = snapshot.expiresAt,
-        )
-
-        if (consolidatedEnabled) {
-            stage("SaveSnapshotAndMarkReady", jobId.toString()) {
-                jobService.saveInputSnapshotAndMarkReady(snapshotEntity, jobId, snapshotId)
+            // Consolidated retry: SNAPSHOT_READY means API+snapshot already done, skip to calculation
+            if (consolidatedEnabled && existingJob != null && existingJob.status == CalculationJobStatus.SNAPSHOT_READY) {
+                val characterId = existingJob.ocid
+                if (characterId == null) {
+                    log.warn("[jobId={}] No OCID in SNAPSHOT_READY state, cannot retry calculation", jobId)
+                    return
+                }
+                val characterClass = stage("LoadCharacterClass", jobId.toString()) {
+                    calculationInputPort.findByJobId(jobId)?.characterClass ?: ""
+                }
+                timer.mark("loadCharacterClass")
+                log.info("[jobId={}] Resuming from calculation (SNAPSHOT_READY)", jobId)
+                runCalculationAndComplete(jobId, payload, characterId, characterClass)
+                timer.mark("runCalculationAndComplete")
+                return
             }
 
-            // Step 7-10: Inline calculation + result write [CPU outside TX, writes inside TX]
-            runCalculationAndComplete(jobId, payload, ocid, characterClass)
-        } else {
-            // Legacy: dispatch to calculation_requested_queue
-            stage("DispatchCalculation", jobId.toString()) {
-                jobService.saveInputSnapshotAndDispatchCalculation(
-                    snapshotEntity = snapshotEntity,
-                    jobId = jobId,
-                    snapshotId = snapshotId,
-                    payload = CalculationRequestedPayload(
-                        jobId = jobId.toString(),
-                        userIgn = payload.userIgn,
-                        presetNo = payload.presetNo,
-                        characterId = ocid,
-                        characterClass = characterClass,
-                    ),
-                )
+            // Not processable
+            if (existingJob != null && !existingJob.status.isExternalApiProcessable()) {
+                log.debug("[jobId={}] Skipping — state {}", jobId, existingJob.status)
+                return
             }
-        }
 
-        log.info("[jobId={}] Pipeline stage completed", jobId)
+            // === Full pipeline: API fetch → snapshot → calculation → result write ===
+
+            // Step 1+2: Resolve OCID → Fetch equipment
+            val (ocid, equipmentResponse) = stage("ResolveAndFetch", payload.userIgn) {
+                resolveOcidAndFetchEquipment(jobId, payload.userIgn, existingJob?.ocid)
+            }
+            timer.mark("resolveAndFetch")
+
+            // Step 3: Serialize snapshot
+            val snapshotData = stage("SerializeSnapshot", payload.userIgn) {
+                objectMapper.writeValueAsBytes(equipmentResponse)
+            }
+            timer.mark("serializeSnapshot")
+            val objectKey = generateObjectKey(jobId)
+            val snapshotId = UUID.randomUUID()
+            val snapshot = CalculationSnapshot(
+                snapshotId = snapshotId,
+                jobId = jobId,
+                objectKey = objectKey,
+                storageType = "LOCAL",
+                characterId = ocid,
+                presetNo = payload.presetNo,
+                expiresAt = Instant.now().plusSeconds(86400),
+            )
+            val snapshotFuture = CompletableFuture.supplyAsync({
+                stage("SnapshotPut", jobId.toString()) {
+                    snapshotStore.put(snapshot, snapshotData)
+                }
+            }, snapshotWriter)
+
+            // Step 4: Build and persist calculation input
+            val inputItems = stage("BuildCalculationInput", payload.userIgn) {
+                convertItems(equipmentResponse)
+            }
+            val characterClass = equipmentResponse.characterClass ?: ""
+            val calcInput = CalculationInput(
+                jobId = jobId.toString(),
+                userIgn = payload.userIgn,
+                characterClass = characterClass,
+                presetNo = payload.presetNo,
+                items = inputItems,
+            )
+            stage("SaveCalculationInput", jobId.toString()) {
+                calculationInputPort.saveIfAbsent(calcInput)
+            }
+            timer.mark("buildAndSaveInput")
+
+            // Step 5: Wait for snapshot write completion
+            val putResult = stage("AwaitSnapshotPut", jobId.toString()) {
+                snapshotFuture.join()
+            }
+            timer.mark("awaitSnapshotPut")
+
+            // Step 6: Save snapshot metadata [TX]
+            val snapshotEntity = CalculationSnapshotEntity(
+                snapshotId = snapshotId,
+                jobId = jobId,
+                objectKey = objectKey,
+                storageType = "LOCAL",
+                characterId = ocid,
+                presetNo = payload.presetNo,
+                compressedSize = putResult.compressedSize,
+                originalSize = snapshotData.size.toLong(),
+                hash = putResult.hash,
+                expiresAt = snapshot.expiresAt,
+            )
+
+            if (consolidatedEnabled) {
+                stage("SaveSnapshotAndMarkReady", jobId.toString()) {
+                    jobService.saveInputSnapshotAndMarkReady(snapshotEntity, jobId, snapshotId)
+                }
+                timer.mark("saveSnapshotAndMarkReady")
+
+                // Step 7-10: Inline calculation + result write [CPU outside TX, writes inside TX]
+                runCalculationAndComplete(jobId, payload, ocid, characterClass)
+                timer.mark("runCalculationAndComplete")
+            } else {
+                // Legacy: dispatch to calculation_requested_queue
+                stage("DispatchCalculation", jobId.toString()) {
+                    jobService.saveInputSnapshotAndDispatchCalculation(
+                        snapshotEntity = snapshotEntity,
+                        jobId = jobId,
+                        snapshotId = snapshotId,
+                        payload = CalculationRequestedPayload(
+                            jobId = jobId.toString(),
+                            userIgn = payload.userIgn,
+                            presetNo = payload.presetNo,
+                            characterId = ocid,
+                            characterClass = characterClass,
+                        ),
+                    )
+                }
+                timer.mark("dispatchCalculation")
+            }
+
+            log.info("[jobId={}] Pipeline stage completed", jobId)
+        } finally {
+            timer.close(log)
+        }
     }
 
     private fun runCalculationAndComplete(
@@ -270,43 +286,54 @@ class ExternalApiWorker(
         characterId: String,
         characterClass: String,
     ) {
-        // Load input [DB read, no TX]
-        val input = stage("LoadInput", jobId.toString()) {
-            calculationInputPort.findByJobId(jobId) ?: error("Calculation input missing: $jobId")
-        }
+        val timer = StepTimer("ExternalApiWorker:PureCalculate", stepTraceThresholdMs, tags = mapOf("jobId" to jobId.toString()))
+        try {
+            // Load input [DB read, no TX]
+            val input = stage("LoadInput", jobId.toString()) {
+                calculationInputPort.findByJobId(jobId) ?: error("Calculation input missing: $jobId")
+            }
+            timer.mark("loadInput")
 
-        // CPU-bound calculation [no TX]
-        val calcResult = stage("PureCalculate", payload.userIgn) {
-            runBlocking(cpuDispatcher) {
-                withContext(cpuDispatcher) {
-                    pureCalculationPort.calculate(input)
+            // CPU-bound calculation [no TX]
+            val calcResult = stage("PureCalculate", payload.userIgn) {
+                runBlocking(cpuDispatcher) {
+                    withContext(cpuDispatcher) {
+                        pureCalculationPort.calculate(input)
+                    }
                 }
             }
-        }
+            timer.mark("pureCalculate")
 
-        // Serialize + gzip + hash [CPU, no TX]
-        val resultBytes = stage("SerializeResult", payload.userIgn) {
-            objectMapper.writeValueAsString(calcResult).toByteArray()
-        }
-        val gzipData = stage("GzipResult", payload.userIgn) {
-            gzipCompress(resultBytes)
-        }
-        val hash = stage("HashResult", payload.userIgn) {
-            sha256Hex(resultBytes)
-        }
+            // Serialize + gzip + hash [CPU, no TX]
+            val resultBytes = stage("SerializeResult", payload.userIgn) {
+                objectMapper.writeValueAsString(calcResult).toByteArray()
+            }
+            timer.mark("serializeResult")
+            val gzipData = stage("GzipResult", payload.userIgn) {
+                gzipCompress(resultBytes)
+            }
+            timer.mark("gzipResult")
+            val hash = stage("HashResult", payload.userIgn) {
+                sha256Hex(resultBytes)
+            }
+            timer.mark("hashResult")
 
-        // Result write [TX: SNAPSHOT_READY → COMPLETED + result save + outbox insert]
-        stage("CompleteCalculation", jobId.toString()) {
-            executionService.completeCalculation(
-                jobId = jobId,
-                gzipData = gzipData,
-                hash = hash,
-                originalSize = resultBytes.size,
-                compressedSize = gzipData.size,
-                characterClass = characterClass,
-                presetNo = payload.presetNo,
-                characterId = characterId,
-            )
+            // Result write [TX: SNAPSHOT_READY → COMPLETED + result save + outbox insert]
+            stage("CompleteCalculation", jobId.toString()) {
+                executionService.completeCalculation(
+                    jobId = jobId,
+                    gzipData = gzipData,
+                    hash = hash,
+                    originalSize = resultBytes.size,
+                    compressedSize = gzipData.size,
+                    characterClass = characterClass,
+                    presetNo = payload.presetNo,
+                    characterId = characterId,
+                )
+            }
+            timer.mark("completeCalculation")
+        } finally {
+            timer.close(log)
         }
     }
 

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/ResultReadyProjectionWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/ResultReadyProjectionWorker.kt
@@ -15,6 +15,7 @@ import maple.expectation.core.port.out.CalculationResultData
 import maple.expectation.core.port.out.CalculationResultPort
 import maple.expectation.core.port.out.QueueNames
 import maple.expectation.infrastructure.executor.LogicExecutor
+import maple.expectation.infrastructure.executor.StepTimer
 import maple.expectation.infrastructure.executor.TaskContext
 import maple.expectation.infrastructure.pgmq.PgmqClient
 import maple.expectation.infrastructure.pgmq.PgmqMessage
@@ -35,6 +36,7 @@ class ResultReadyProjectionWorker(
     private val objectMapper: ObjectMapper,
     @Value("\${pgmq.worker.result-projection.batch-size:100}") private val batchSize: Int,
     @Value("\${pgmq.worker.result-projection.visibility-timeout-sec:30}") private val visibilityTimeoutSec: Int,
+    @Value("\${app.slow-task.step-trace.threshold-ms:500}") private val stepTraceThresholdMs: Long,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -60,24 +62,34 @@ class ResultReadyProjectionWorker(
     }
 
     private fun projectPgmqBatch(messages: List<PgmqMessage<Map<*, *>>>) {
-        val archiveIds = mutableListOf<Long>()
-        val parsed = messages.mapNotNull { parsePgmqMessage(it, archiveIds) }
-        if (parsed.isEmpty()) {
+        val timer = StepTimer("ResultProjection:ProjectBatch", stepTraceThresholdMs, tags = mapOf("batchSize" to messages.size.toString()))
+        try {
+            val archiveIds = mutableListOf<Long>()
+            val parsed = messages.mapNotNull { parsePgmqMessage(it, archiveIds) }
+            timer.mark("parseMessages")
+            if (parsed.isEmpty()) {
+                archiveIfNeeded(archiveIds)
+                return
+            }
+
+            val jobIds = parsed.map { it.jobId }.distinct()
+            val jobsById = jobPort.findJobsByIds(jobIds).associateBy { it.jobId }
+            val resultsByJobId = resultPort.findByJobIds(jobIds).associateBy { it.jobId }
+            timer.mark("loadCalculationResults")
+            val outcomes = buildPgmqProjectionCommands(parsed, jobsById, resultsByJobId)
+            timer.mark("buildViewRows")
+            val commands = outcomes.mapNotNull { it.command }
+            archiveIds += outcomes.filter { it.archive }.map { it.messageId }
+
+            if (commands.isNotEmpty()) {
+                viewQueryPort.batchUpsertFromCalculations(commands)
+            }
+            timer.mark("batchUpsertViews")
             archiveIfNeeded(archiveIds)
-            return
+            timer.mark("archiveMessages")
+        } finally {
+            timer.close(log)
         }
-
-        val jobIds = parsed.map { it.jobId }.distinct()
-        val jobsById = jobPort.findJobsByIds(jobIds).associateBy { it.jobId }
-        val resultsByJobId = resultPort.findByJobIds(jobIds).associateBy { it.jobId }
-        val outcomes = buildPgmqProjectionCommands(parsed, jobsById, resultsByJobId)
-        val commands = outcomes.mapNotNull { it.command }
-        archiveIds += outcomes.filter { it.archive }.map { it.messageId }
-
-        if (commands.isNotEmpty()) {
-            viewQueryPort.batchUpsertFromCalculations(commands)
-        }
-        archiveIfNeeded(archiveIds)
     }
 
     private fun buildPgmqProjectionCommands(

--- a/module-infra/src/test/kotlin/maple/expectation/infrastructure/persistence/CharacterViewQueryServicePostgresTest.kt
+++ b/module-infra/src/test/kotlin/maple/expectation/infrastructure/persistence/CharacterViewQueryServicePostgresTest.kt
@@ -79,6 +79,7 @@ class CharacterViewQueryServicePostgresTest {
             executor,
             meterRegistry,
             jdbc,
+            500,
         )
     }
 

--- a/module-infra/src/test/kotlin/maple/expectation/infrastructure/persistence/CharacterViewQueryServicePostgresTest.kt
+++ b/module-infra/src/test/kotlin/maple/expectation/infrastructure/persistence/CharacterViewQueryServicePostgresTest.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import java.time.Instant
+import java.util.concurrent.Executors
 import maple.expectation.common.function.ThrowingSupplier
 import maple.expectation.core.port.inbound.CharacterViewProjectionCommand
 import maple.expectation.infrastructure.executor.LogicExecutor
@@ -79,6 +80,7 @@ class CharacterViewQueryServicePostgresTest {
             executor,
             meterRegistry,
             jdbc,
+            Executors.newVirtualThreadPerTaskExecutor(),
             500,
         )
     }


### PR DESCRIPTION
## Summary

- **Async read model write**: `saveToReadModel`/`saveToReadModelBatch`을 `asyncExecutor`(virtual thread)로 fire-and-forget 분리. Read model은 앱에서 write-only이고 이미 non-fatal 처리되어 있어 critical path에서 ~350ms 제거
- **Upsert WHERE version check 제거**: `ON CONFLICT ... WHERE last_applied_version < EXCLUDED.last_applied_version` 3곳 제거. PGMQ archived message는 재전송 불가, DLQ replay는 최신으로 덮어쓰는 게 맞음
- **parallelStream per-item**: `PresetCalculationHelper.calculatePreset()`에서 sequential loop → `parallelStream()` 변경
- **StepTimer 도입**: ExternalApiWorker, ResultReadyProjectionWorker에 step-level slow task tracing 추가

## Load Test Results

| | Before | After |
|---|---|---|
| 3min views | 2,147 | **5,684** (2.6x) |
| Throughput | 2.5/s → stall | **18-50/s sustained** |
| BatchUpsert p95 | 1,816ms | **1,035ms** (-43%) |
| BatchUpsert max | 2,614ms | **1,808ms** (-31%) |

## Changed Files

- `CharacterViewQueryServicePostgres.kt` — asyncExecutor 주입, read_model async 분리, WHERE 제거
- `CharacterViewBatchRepository.kt` — UPDATE WHERE version check + param 제거
- `PresetCalculationHelper.java` — parallelStream 적용
- `ExternalApiWorker.kt` / `ResultReadyProjectionWorker.kt` — StepTimer tracing
- `.claude/rules/load-test.md` — DB 샘플링/초기화 프로토콜 추가

## Test plan

- [x] `./gradlew check` 통과
- [x] 서버 구동 후 런타임 검증
- [x] 부하테스트 10,000 IGN cold-miss 처리 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)