### PR TITLE
perf: extract projection fields at write time to skip BYTEA decompress

### DIFF
--- a/module-core/src/main/kotlin/maple/expectation/core/port/out/CalculationResultPort.kt
+++ b/module-core/src/main/kotlin/maple/expectation/core/port/out/CalculationResultPort.kt
@@ -15,6 +15,9 @@ data class CalculationResultData(
     val compressedSize: Int,
     val hash: String,
     val status: String,
+    val totalExpectedCost: Long? = null,
+    val maxPresetNo: Int? = null,
+    val presetsJson: String? = null,
 ) {
     override fun equals(other: Any?) = this === other
     override fun hashCode() = System.identityHashCode(this)

--- a/module-core/src/main/kotlin/maple/expectation/core/port/out/CalculationResultPort.kt
+++ b/module-core/src/main/kotlin/maple/expectation/core/port/out/CalculationResultPort.kt
@@ -23,10 +23,21 @@ data class CalculationResultData(
     override fun hashCode() = System.identityHashCode(this)
 }
 
+data class CalculationResultLight(
+    val jobId: UUID,
+    val characterClass: String?,
+    val presetNo: Int,
+    val totalExpectedCost: Long?,
+    val maxPresetNo: Int?,
+    val presetsJson: String?,
+)
+
 interface CalculationResultPort {
     fun save(result: CalculationResultData): CalculationResultData
     fun saveIfAbsent(result: CalculationResultData): Boolean
     fun findByJobId(jobId: UUID): CalculationResultData?
     fun findByJobIds(jobIds: List<UUID>): List<CalculationResultData>
+    fun findByJobIdsLight(jobIds: List<UUID>): List<CalculationResultLight>
+    fun findByJobIdsWithBody(jobIds: List<UUID>): List<CalculationResultData>
     fun existsByJobId(jobId: UUID): Boolean
 }

--- a/module-infra/src/main/kotlin/maple/expectation/adapter/outgoing/CalculationResultPortAdapter.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/adapter/outgoing/CalculationResultPortAdapter.kt
@@ -33,23 +33,13 @@ class CalculationResultPortAdapter(
                     compressedSize = result.compressedSize,
                     hash = result.hash,
                     status = result.status,
+                    totalExpectedCost = result.totalExpectedCost,
+                    maxPresetNo = result.maxPresetNo,
+                    presets = result.presetsJson,
                 ),
             )
         }
-        return CalculationResultData(
-            resultId = entity.resultId,
-            jobId = entity.jobId,
-            characterClass = entity.characterClass,
-            presetNo = entity.presetNo,
-            schemaVersion = entity.schemaVersion,
-            contentType = entity.contentType,
-            contentEncoding = entity.contentEncoding,
-            responseBody = entity.responseBody,
-            originalSize = entity.originalSize,
-            compressedSize = entity.compressedSize,
-            hash = entity.hash ?: "",
-            status = entity.status,
-        )
+        return entity.toData()
     }
 
     @Transactional(value = "transactionManager", readOnly = true)
@@ -78,6 +68,9 @@ class CalculationResultPortAdapter(
         result.compressedSize,
         result.hash,
         result.status,
+        result.totalExpectedCost,
+        result.maxPresetNo,
+        result.presetsJson,
     ) > 0
 
     private fun CalculationResultEntity.toData() = CalculationResultData(
@@ -86,5 +79,7 @@ class CalculationResultPortAdapter(
         contentType = contentType, contentEncoding = contentEncoding,
         responseBody = responseBody, originalSize = originalSize,
         compressedSize = compressedSize, hash = hash ?: "", status = status,
+        totalExpectedCost = totalExpectedCost, maxPresetNo = maxPresetNo,
+        presetsJson = presets,
     )
 }

--- a/module-infra/src/main/kotlin/maple/expectation/adapter/outgoing/CalculationResultPortAdapter.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/adapter/outgoing/CalculationResultPortAdapter.kt
@@ -2,15 +2,18 @@ package maple.expectation.adapter.outgoing
 
 import java.util.UUID
 import maple.expectation.core.port.out.CalculationResultData
+import maple.expectation.core.port.out.CalculationResultLight
 import maple.expectation.core.port.out.CalculationResultPort
 import maple.expectation.infrastructure.persistence.entity.CalculationResultEntity
 import maple.expectation.infrastructure.persistence.repository.CalculationResultRepository
+import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 
 @Component
 class CalculationResultPortAdapter(
     private val repo: CalculationResultRepository,
+    private val jdbc: JdbcTemplate,
 ) : CalculationResultPort {
 
     @Transactional(value = "transactionManager", readOnly = false)
@@ -47,6 +50,34 @@ class CalculationResultPortAdapter(
 
     @Transactional(value = "transactionManager", readOnly = true)
     override fun findByJobIds(jobIds: List<UUID>): List<CalculationResultData> {
+        if (jobIds.isEmpty()) return emptyList()
+        return repo.findByJobIdIn(jobIds).map { it.toData() }
+    }
+
+    @Transactional(value = "transactionManager", readOnly = true)
+    override fun findByJobIdsLight(jobIds: List<UUID>): List<CalculationResultLight> {
+        if (jobIds.isEmpty()) return emptyList()
+        val placeholders = jobIds.joinToString(",") { "?" }
+        return jdbc.query(
+            "SELECT job_id, character_class, preset_no, total_expected_cost, max_preset_no, presets FROM calculation_results WHERE job_id IN ($placeholders)",
+            { rs, _ ->
+                val tec = rs.getLong("total_expected_cost")
+                val mpn = rs.getInt("max_preset_no")
+                CalculationResultLight(
+                    jobId = rs.getObject("job_id", UUID::class.java),
+                    characterClass = rs.getString("character_class"),
+                    presetNo = rs.getInt("preset_no"),
+                    totalExpectedCost = if (rs.wasNull()) null else tec,
+                    maxPresetNo = if (rs.wasNull()) null else mpn,
+                    presetsJson = rs.getString("presets"),
+                )
+            },
+            *jobIds.toTypedArray(),
+        )
+    }
+
+    @Transactional(value = "transactionManager", readOnly = true)
+    override fun findByJobIdsWithBody(jobIds: List<UUID>): List<CalculationResultData> {
         if (jobIds.isEmpty()) return emptyList()
         return repo.findByJobIdIn(jobIds).map { it.toData() }
     }

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/job/CalculationExecutionService.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/job/CalculationExecutionService.kt
@@ -49,6 +49,9 @@ class CalculationExecutionService(
         characterClass: String,
         presetNo: Int,
         characterId: String,
+        totalExpectedCost: Long? = null,
+        maxPresetNo: Int? = null,
+        presetsJson: String? = null,
     ): Boolean {
         val completed = jobPort.completeFromSnapshotReady(jobId)
         if (!completed) return false
@@ -67,6 +70,9 @@ class CalculationExecutionService(
                 compressedSize = compressedSize,
                 hash = hash,
                 status = "SUCCESS",
+                totalExpectedCost = totalExpectedCost,
+                maxPresetNo = maxPresetNo,
+                presetsJson = presetsJson,
             ),
         )
 
@@ -99,6 +105,9 @@ class CalculationExecutionService(
         characterClass: String,
         presetNo: Int,
         characterId: String,
+        totalExpectedCost: Long? = null,
+        maxPresetNo: Int? = null,
+        presetsJson: String? = null,
     ): Boolean {
         val completed = jobPort.completeFromCalculating(jobId)
         if (!completed) return false
@@ -117,6 +126,9 @@ class CalculationExecutionService(
                 compressedSize = compressedSize,
                 hash = hash,
                 status = "SUCCESS",
+                totalExpectedCost = totalExpectedCost,
+                maxPresetNo = maxPresetNo,
+                presetsJson = presetsJson,
             ),
         )
 

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/CharacterViewQueryServicePostgres.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/CharacterViewQueryServicePostgres.kt
@@ -11,6 +11,7 @@ import maple.expectation.infrastructure.executor.StepTimer
 import maple.expectation.infrastructure.executor.TaskContext
 import maple.expectation.infrastructure.persistence.entity.CharacterValuationViewEntity
 import maple.expectation.infrastructure.persistence.repository.CharacterValuationViewJpaRepository
+import org.postgresql.util.PGobject
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
@@ -172,7 +173,7 @@ class CharacterViewQueryServicePostgres(
             "totalExpectedCost" to entity.totalExpectedCost,
             "maxPresetNo" to entity.maxPresetNo,
             "presetNo" to entity.presetNo,
-            "presets" to presetsJson,
+            "presets" to presetsJson?.toJsonb(),
             "fromCache" to entity.fromCache,
         )
         jdbc.update(
@@ -184,7 +185,7 @@ class CharacterViewQueryServicePostgres(
             ) VALUES (
                 :userIgn, :messageId, 0, :characterOcid, :characterClass, :characterLevel,
                 :calculatedAt, :lastApiSyncAt, :version + 1, :lastAppliedVersion,
-                :totalExpectedCost, :maxPresetNo, :presetNo, CAST(:presets AS jsonb), :fromCache
+                :totalExpectedCost, :maxPresetNo, :presetNo, :presets, :fromCache
             )
             ON CONFLICT (message_id) DO UPDATE SET
                 user_ign = EXCLUDED.user_ign,
@@ -242,7 +243,7 @@ class CharacterViewQueryServicePostgres(
                     .addValue("totalExpectedCost", entity.totalExpectedCost)
                     .addValue("maxPresetNo", entity.maxPresetNo)
                     .addValue("presetNo", entity.presetNo)
-                    .addValue("presets", command.presetsJson)
+                    .addValue("presets", command.presetsJson.toJsonb())
                     .addValue("fromCache", entity.fromCache)
             }
             timer.mark("prepareRows")
@@ -256,7 +257,7 @@ class CharacterViewQueryServicePostgres(
             ) VALUES (
                 :userIgn, :messageId, 0, :characterOcid, :characterClass, :characterLevel,
                 :calculatedAt, :lastApiSyncAt, :version + 1, :lastAppliedVersion,
-                :totalExpectedCost, :maxPresetNo, :presetNo, CAST(:presets AS jsonb), :fromCache
+                :totalExpectedCost, :maxPresetNo, :presetNo, :presets, :fromCache
             )
             ON CONFLICT (message_id) DO UPDATE SET
                 user_ign = EXCLUDED.user_ign,
@@ -454,4 +455,12 @@ class CharacterViewQueryServicePostgres(
      * serialization, allowing module-web to provide the correct mapping implementation.
      */
     private fun serializeEntityToJson(entity: CharacterValuationViewEntity): String = objectMapper.writeValueAsString(entity)
+}
+
+internal fun String?.toJsonb(): PGobject? {
+    if (this == null) return null
+    return PGobject().apply {
+        type = "jsonb"
+        value = this@toJsonb
+    }
 }

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/entity/CalculationResultEntity.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/entity/CalculationResultEntity.kt
@@ -24,4 +24,7 @@ class CalculationResultEntity(
     @Column(nullable = false) val status: String = "SUCCESS",
     val createdAt: OffsetDateTime = OffsetDateTime.now(),
     val expiresAt: OffsetDateTime? = null,
+    val totalExpectedCost: Long? = null,
+    val maxPresetNo: Int? = null,
+    @Column(columnDefinition = "jsonb") val presets: String? = null,
 )

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/repository/CalculationResultRepository.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/repository/CalculationResultRepository.kt
@@ -16,9 +16,11 @@ interface CalculationResultRepository : JpaRepository<CalculationResultEntity, U
     @Query(
         value = """
             INSERT INTO calculation_results (result_id, job_id, character_class, preset_no, schema_version,
-                content_type, content_encoding, response_body, original_size, compressed_size, hash, status, created_at)
+                content_type, content_encoding, response_body, original_size, compressed_size, hash, status, created_at,
+                total_expected_cost, max_preset_no, presets)
             VALUES (:resultId, :jobId, :characterClass, :presetNo, :schemaVersion,
-                :contentType, :contentEncoding, :responseBody, :originalSize, :compressedSize, :hash, :status, now())
+                :contentType, :contentEncoding, :responseBody, :originalSize, :compressedSize, :hash, :status, now(),
+                :totalExpectedCost, :maxPresetNo, :presetsJson::jsonb)
             ON CONFLICT (job_id) DO NOTHING
         """,
         nativeQuery = true,
@@ -36,5 +38,8 @@ interface CalculationResultRepository : JpaRepository<CalculationResultEntity, U
         @Param("compressedSize") compressedSize: Int,
         @Param("hash") hash: String,
         @Param("status") status: String,
+        @Param("totalExpectedCost") totalExpectedCost: Long?,
+        @Param("maxPresetNo") maxPresetNo: Int?,
+        @Param("presetsJson") presetsJson: String?,
     ): Int
 }

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/repository/CalculationResultRepository.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/repository/CalculationResultRepository.kt
@@ -20,7 +20,7 @@ interface CalculationResultRepository : JpaRepository<CalculationResultEntity, U
                 total_expected_cost, max_preset_no, presets)
             VALUES (:resultId, :jobId, :characterClass, :presetNo, :schemaVersion,
                 :contentType, :contentEncoding, :responseBody, :originalSize, :compressedSize, :hash, :status, now(),
-                :totalExpectedCost, :maxPresetNo, :presetsJson::jsonb)
+                :totalExpectedCost, :maxPresetNo, CAST(:presetsJson AS jsonb))
             ON CONFLICT (job_id) DO NOTHING
         """,
         nativeQuery = true,

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/repository/CharacterViewBatchRepository.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/repository/CharacterViewBatchRepository.kt
@@ -4,6 +4,7 @@ import java.sql.Timestamp
 import java.time.Instant
 import maple.expectation.infrastructure.executor.LogicExecutor
 import maple.expectation.infrastructure.executor.TaskContext
+import maple.expectation.infrastructure.persistence.toJsonb
 import org.slf4j.LoggerFactory
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.stereotype.Component
@@ -30,7 +31,7 @@ class CharacterViewBatchRepository(
                 calculated_at = ?, jpa_version = COALESCE(jpa_version, 0) + 1,
                 version = version + 1, last_applied_version = ?,
                 total_expected_cost = ?, max_preset_no = ?, preset_no = ?,
-                presets = ?::jsonb, from_cache = ?
+                presets = ?, from_cache = ?
             WHERE id = ?
         """.trimIndent()
 
@@ -39,7 +40,7 @@ class CharacterViewBatchRepository(
                 user_ign, message_id, character_ocid, character_class,
                 calculated_at, version, last_applied_version,
                 total_expected_cost, max_preset_no, preset_no, presets, from_cache, jpa_version
-            ) VALUES (?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?::jsonb, ?, 0)
+            ) VALUES (?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?, 0)
         """.trimIndent()
     }
 
@@ -126,7 +127,7 @@ class CharacterViewBatchRepository(
                 e.result.totalExpectedCost,
                 e.result.maxPresetNo,
                 e.result.presetNo,
-                e.result.presetsJson,
+                e.result.presetsJson.toJsonb(),
                 false,
                 e.existingId,
             )
@@ -147,7 +148,7 @@ class CharacterViewBatchRepository(
                 r.totalExpectedCost,
                 r.maxPresetNo,
                 r.presetNo,
-                r.presetsJson,
+                r.presetsJson.toJsonb(),
                 false,
             )
         }

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/CalculationCompletedPayload.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/CalculationCompletedPayload.kt
@@ -9,4 +9,7 @@ data class CalculationCompletedPayload(
     val hash: String,
     val originalSize: Int,
     val compressedSize: Int,
+    val totalExpectedCost: Long? = null,
+    val maxPresetNo: Int? = null,
+    val presetsJson: String? = null,
 )

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/CalculationCompletedWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/CalculationCompletedWorker.kt
@@ -78,6 +78,9 @@ class CalculationCompletedWorker(
                 characterClass = payload.characterClass,
                 presetNo = payload.presetNo,
                 characterId = payload.characterId,
+                totalExpectedCost = payload.totalExpectedCost,
+                maxPresetNo = payload.maxPresetNo,
+                presetsJson = payload.presetsJson,
             )
         }
     }

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/CalculationRequestedWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/CalculationRequestedWorker.kt
@@ -122,6 +122,9 @@ class CalculationRequestedWorker(
                     hash = hash,
                     originalSize = resultBytes.size,
                     compressedSize = gzipData.size,
+                    totalExpectedCost = calcResult.totalExpectedCost.toLong(),
+                    maxPresetNo = calcResult.maxPresetNo,
+                    presetsJson = objectMapper.writeValueAsString(calcResult.presets),
                 ),
             )
         }

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/ExternalApiWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/ExternalApiWorker.kt
@@ -329,6 +329,9 @@ class ExternalApiWorker(
                     characterClass = characterClass,
                     presetNo = payload.presetNo,
                     characterId = characterId,
+                    totalExpectedCost = calcResult.totalExpectedCost.toLong(),
+                    maxPresetNo = calcResult.maxPresetNo,
+                    presetsJson = objectMapper.writeValueAsString(calcResult.presets),
                 )
             }
             timer.mark("completeCalculation")

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/ResultReadyProjectionWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/ResultReadyProjectionWorker.kt
@@ -143,15 +143,29 @@ class ResultReadyProjectionWorker(
         job: CalculationJob,
         resultData: CalculationResultData,
     ): CharacterViewProjectionCommand? {
-        val resultJson = decompress(resultData.responseBody)
-        val tree = objectMapper.readTree(resultJson)
+        val totalExpectedCost: Long
+        val maxPresetNo: Int
+        val presetsJson: String
 
-        val totalExpectedCost = tree.get("totalExpectedCost")?.asLong() ?: return null
-        val maxPresetNo = tree.get("maxPresetNo")?.asInt() ?: return null
-        val presetsNode = tree.get("presets")
+        val tec = resultData.totalExpectedCost
+        val mpn = resultData.maxPresetNo
+        val pj = resultData.presetsJson
+
+        if (tec != null && mpn != null && pj != null) {
+            totalExpectedCost = tec
+            maxPresetNo = mpn
+            presetsJson = pj
+        } else {
+            val resultJson = decompress(resultData.responseBody)
+            val tree = objectMapper.readTree(resultJson)
+            totalExpectedCost = tree.get("totalExpectedCost")?.asLong() ?: return null
+            maxPresetNo = tree.get("maxPresetNo")?.asInt() ?: return null
+            val presetsNode = tree.get("presets")
+            presetsJson = if (presetsNode != null) objectMapper.writeValueAsString(presetsNode) else "[]"
+        }
+
         val presetNo = (message.payload["presetNo"] as? Number)?.toInt() ?: 1
         val characterId = message.payload["characterId"]?.toString()
-        val presetsJson = if (presetsNode != null) objectMapper.writeValueAsString(presetsNode) else "[]"
 
         return CharacterViewProjectionCommand(
             userIgn = job.userIgn,

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/ResultReadyProjectionWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/ResultReadyProjectionWorker.kt
@@ -14,6 +14,7 @@ import maple.expectation.core.port.inbound.CharacterViewProjectionCommand
 import maple.expectation.core.port.inbound.CharacterViewQueryPort
 import maple.expectation.core.port.out.CalculationJobPort
 import maple.expectation.core.port.out.CalculationResultData
+import maple.expectation.core.port.out.CalculationResultLight
 import maple.expectation.core.port.out.CalculationResultPort
 import maple.expectation.core.port.out.QueueNames
 import maple.expectation.infrastructure.executor.LogicExecutor
@@ -81,14 +82,24 @@ class ResultReadyProjectionWorker(
                 { jobPort.findJobsByIds(jobIds).associateBy { it.jobId } },
                 asyncExecutor,
             )
-            val resultsFuture = CompletableFuture.supplyAsync(
-                { resultPort.findByJobIds(jobIds).associateBy { it.jobId } },
+            val lightResultsFuture = CompletableFuture.supplyAsync(
+                { resultPort.findByJobIdsLight(jobIds).associateBy { it.jobId } },
                 asyncExecutor,
             )
             val jobsById = jobsFuture.join()
-            val resultsByJobId = resultsFuture.join()
+            val lightByJobId = lightResultsFuture.join()
             timer.mark("loadCalculationResults")
-            val outcomes = buildPgmqProjectionCommands(parsed, jobsById, resultsByJobId)
+
+            val fallbackIds = lightByJobId.values
+                .filter { it.totalExpectedCost == null || it.maxPresetNo == null || it.presetsJson == null }
+                .map { it.jobId }
+            val fallbackByJobId = if (fallbackIds.isNotEmpty()) {
+                resultPort.findByJobIdsWithBody(fallbackIds).associateBy { it.jobId }
+            } else {
+                emptyMap()
+            }
+
+            val outcomes = buildPgmqProjectionCommands(parsed, jobsById, lightByJobId, fallbackByJobId)
             timer.mark("buildViewRows")
             val commands = outcomes.mapNotNull { it.command }
             archiveIds += outcomes.filter { it.archive }.map { it.messageId }
@@ -107,17 +118,18 @@ class ResultReadyProjectionWorker(
     private fun buildPgmqProjectionCommands(
         parsed: List<PgmqProjectionMessage>,
         jobsById: Map<UUID, CalculationJob>,
-        resultsByJobId: Map<UUID, CalculationResultData>,
+        lightByJobId: Map<UUID, CalculationResultLight>,
+        fallbackByJobId: Map<UUID, CalculationResultData>,
     ): List<PgmqProjectionOutcome> = runBlocking(Dispatchers.Default) {
         parsed.map { message ->
             async(Dispatchers.Default) {
                 val job = jobsById[message.jobId]
-                val resultData = resultsByJobId[message.jobId]
+                val light = lightByJobId[message.jobId]
                 when {
-                    job == null || resultData == null -> PgmqProjectionOutcome(message.messageId, archive = true)
+                    job == null || light == null -> PgmqProjectionOutcome(message.messageId, archive = true)
                     else -> PgmqProjectionOutcome(
                         messageId = message.messageId,
-                        command = toPgmqProjectionCommand(message, job, resultData),
+                        command = toPgmqProjectionCommand(message, job, light, fallbackByJobId[message.jobId]),
                         archive = true,
                     )
                 }
@@ -141,22 +153,24 @@ class ResultReadyProjectionWorker(
     private fun toPgmqProjectionCommand(
         message: PgmqProjectionMessage,
         job: CalculationJob,
-        resultData: CalculationResultData,
+        light: CalculationResultLight,
+        fallback: CalculationResultData?,
     ): CharacterViewProjectionCommand? {
         val totalExpectedCost: Long
         val maxPresetNo: Int
         val presetsJson: String
 
-        val tec = resultData.totalExpectedCost
-        val mpn = resultData.maxPresetNo
-        val pj = resultData.presetsJson
+        val tec = light.totalExpectedCost
+        val mpn = light.maxPresetNo
+        val pj = light.presetsJson
 
         if (tec != null && mpn != null && pj != null) {
             totalExpectedCost = tec
             maxPresetNo = mpn
             presetsJson = pj
         } else {
-            val resultJson = decompress(resultData.responseBody)
+            val fb = fallback ?: return null
+            val resultJson = decompress(fb.responseBody)
             val tree = objectMapper.readTree(resultJson)
             totalExpectedCost = tree.get("totalExpectedCost")?.asLong() ?: return null
             maxPresetNo = tree.get("maxPresetNo")?.asInt() ?: return null
@@ -171,7 +185,7 @@ class ResultReadyProjectionWorker(
             userIgn = job.userIgn,
             messageId = message.messageId.toString(),
             characterOcid = characterId,
-            characterClass = resultData.characterClass,
+            characterClass = light.characterClass,
             characterLevel = null,
             totalExpectedCost = totalExpectedCost,
             maxPresetNo = maxPresetNo,

--- a/module-infra/src/main/resources/db/migration/V122__calculation_results_projection_fields.sql
+++ b/module-infra/src/main/resources/db/migration/V122__calculation_results_projection_fields.sql
@@ -1,0 +1,11 @@
+-- V122__calculation_results_projection_fields.sql
+-- Add projection fields to avoid BYTEA transfer + GZIP decompression + JSON parsing in ResultReadyProjectionWorker
+
+ALTER TABLE calculation_results
+    ADD COLUMN IF NOT EXISTS total_expected_cost BIGINT,
+    ADD COLUMN IF NOT EXISTS max_preset_no INT,
+    ADD COLUMN IF NOT EXISTS presets JSONB;
+
+COMMENT ON COLUMN calculation_results.total_expected_cost IS 'Pre-extracted total expected cost for projection (avoids BYTEA decompress)';
+COMMENT ON COLUMN calculation_results.max_preset_no IS 'Pre-extracted max preset number for projection (avoids BYTEA decompress)';
+COMMENT ON COLUMN calculation_results.presets IS 'Pre-extracted presets JSON for projection (avoids BYTEA decompress)';


### PR DESCRIPTION
## Summary
- Add `total_expected_cost`, `max_preset_no`, `presets` columns to `calculation_results` table (V122 migration)
- Extract these fields from `calcResult` at write time in `ExternalApiWorker` and `CalculationRequestedWorker`
- `ResultReadyProjectionWorker` uses pre-extracted fields (fast path), falls back to BYTEA decompress for pre-deploy messages
- Eliminates GZIP decompression + JSON parsing for projection (avg 85ms/step, batch 100 rows)

## Test plan
- [x] `./gradlew compileKotlin compileJava --continue` passes
- [x] `./gradlew test` passes (all unit tests)
- [ ] Load test with `RESET_VIEWS=1 RESET_ACTIVE_JOBS=1` to verify fast path
- [ ] Check StepTrace for `buildViewRows` step time reduction

🤖 Generated with [Claude Code](https://claude.com/claude-code)