### PR TITLE
feat: add CHARACTER_BASIC pipeline + shard directory structure

### DIFF
--- a/module-external-api/src/main/kotlin/maple/externalapi/infra/storage/LocalExternalApiArtifactStoreAdapter.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/infra/storage/LocalExternalApiArtifactStoreAdapter.kt
@@ -54,9 +54,21 @@ class LocalExternalApiArtifactStoreAdapter(
         return GZIPInputStream(Files.readAllBytes(filePath).inputStream()).use { it.readAllBytes() }
     }
 
+    override fun listStoredKeys(endpoint: ExternalApiEndpoint): List<String> {
+        val dir = Paths.get(basePath, endpoint.storageSubDir())
+        if (!Files.exists(dir)) return emptyList()
+        return Files.walk(dir).use { stream ->
+            stream
+                .filter { it.fileName.toString().endsWith(".json.gz") }
+                .map { it.fileName.toString().removeSuffix(".json.gz") }
+                .toList()
+        }
+    }
+
     private fun resolvePath(endpoint: ExternalApiEndpoint, key: String): Path {
         val sanitized = key.replace("/", "_").replace("\\", "_")
-        return Paths.get(basePath, endpoint.storageSubDir(), "$sanitized.json.gz")
+        val shard = sanitized.take(2)
+        return Paths.get(basePath, endpoint.storageSubDir(), shard, "$sanitized.json.gz")
     }
 
     private fun gzipCompress(data: ByteArray): ByteArray {

--- a/module-external-api/src/main/kotlin/maple/externalapi/port/out/ExternalApiArtifactStorePort.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/port/out/ExternalApiArtifactStorePort.kt
@@ -15,4 +15,6 @@ interface ExternalApiArtifactStorePort {
         endpoint: ExternalApiEndpoint,
         key: String,
     ): ByteArray?
+
+    fun listStoredKeys(endpoint: ExternalApiEndpoint): List<String>
 }

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/ExternalApiScheduler.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/ExternalApiScheduler.kt
@@ -1,5 +1,6 @@
 package maple.externalapi.scheduler
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.github.bucket4j.Bandwidth
 import io.github.bucket4j.Bucket
 import java.time.Duration
@@ -11,6 +12,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import maple.externalapi.domain.ExternalApiEndpoint
 import maple.externalapi.domain.ExternalApiProvider
 import maple.externalapi.port.inbound.FetchExternalApiUseCase
+import maple.externalapi.port.out.ExternalApiArtifactStorePort
 import maple.externalapi.reader.UserIgnCsvReader
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
@@ -25,6 +27,8 @@ import org.springframework.stereotype.Component
 class ExternalApiScheduler(
     private val fetchUseCase: FetchExternalApiUseCase,
     private val csvReader: UserIgnCsvReader,
+    private val artifactStore: ExternalApiArtifactStorePort,
+    private val objectMapper: ObjectMapper,
     @Value("\${external-api.rate-limit.permits-per-second:200}")
     private val permitsPerSecond: Int,
     @Value("\${external-api.batch-size:1000}")
@@ -41,37 +45,31 @@ class ExternalApiScheduler(
     @EventListener(ApplicationReadyEvent::class)
     fun onStartup() {
         if (runOnStartup) {
-            log.info("[Scheduler] run-on-startup enabled, triggering OCID lookup")
-            triggerOcidLookup()
+            log.info("[Scheduler] run-on-startup enabled, triggering full pipeline")
+            triggerFullPipeline()
         }
     }
 
     @Scheduled(cron = "\${external-api.schedule.ocid-lookup-cron:0 0 3 * * *}")
-    fun scheduledOcidLookup() {
-        triggerOcidLookup()
+    fun scheduledPipeline() {
+        triggerFullPipeline()
     }
 
-    fun triggerOcidLookup() {
+    fun triggerFullPipeline() {
         if (!running.compareAndSet(false, true)) {
-            log.warn("[Scheduler] OCID lookup already running, skipping")
+            log.warn("[Scheduler] pipeline already running, skipping")
             return
         }
         try {
             doOcidLookup()
+            doCharacterBasicLookup()
         } finally {
             running.set(false)
         }
     }
 
     private fun doOcidLookup() {
-        val rateLimiter = Bucket.builder()
-            .addLimit(
-                Bandwidth.builder()
-                    .capacity(permitsPerSecond.toLong())
-                    .refillIntervally(permitsPerSecond.toLong(), Duration.ofSeconds(1))
-                    .build(),
-            )
-            .build()
+        val rateLimiter = newRateLimiter()
 
         val igns = csvReader.readAll()
         if (igns.isEmpty()) {
@@ -96,14 +94,8 @@ class ExternalApiScheduler(
         var lastProgressLog = 0
 
         while (processed < igns.size) {
-            val remaining = igns.size - processed
-            val maxBatch = minOf(batchSize, remaining)
-            val permits = rateLimiter.tryConsumeAsMuchAsPossible(maxBatch.toLong()).toInt()
-
-            if (permits == 0) {
-                Thread.sleep(Duration.ofMillis(100))
-                continue
-            }
+            val permits = acquirePermits(rateLimiter, igns.size - processed)
+            if (permits == 0) continue
 
             val chunk = igns.subList(processed, processed + permits)
             processed += permits
@@ -136,42 +128,152 @@ class ExternalApiScheduler(
             val progress = successCount.get() + failCount.get()
             if (progress - lastProgressLog >= 5000) {
                 lastProgressLog = progress
-                logProgress(progress, igns.size, storedCount.get(), failCount.get(), start)
+                logProgress("OCID lookup", progress, igns.size, storedCount.get(), failCount.get(), start)
             }
         }
 
-        val elapsed = Duration.between(start, Instant.now())
-        val elapsedSec = elapsed.toMillis() / 1000.0
-        val totalProcessed = successCount.get() + failCount.get()
-        val finalRate = if (elapsedSec > 0) "%.0f".format(totalProcessed / elapsedSec) else "?"
-        val storedRate = if (elapsedSec > 0) "%.0f".format(storedCount.get() / elapsedSec) else "?"
-        log.info("[Scheduler] ========== OCID lookup complete ==========")
-        log.info(
-            "[Scheduler] result: total={}, stored={} @{}files/s, success={}, fail={}, elapsed={}s, avgRate={}files/s",
-            igns.size,
-            storedCount.get(),
-            storedRate,
-            successCount.get(),
-            failCount.get(),
-            elapsed.seconds,
-            finalRate,
-        )
+        logSummary("OCID lookup", igns.size, successCount.get(), storedCount.get(), failCount.get(), start)
     }
 
-    private fun logProgress(progress: Int, total: Int, stored: Int, fails: Int, start: Instant) {
-        val elapsed = Duration.between(start, Instant.now())
-        val elapsedSec = elapsed.toMillis() / 1000.0
+    private fun doCharacterBasicLookup() {
+        val rateLimiter = newRateLimiter()
+
+        val ocidKeys = artifactStore.listStoredKeys(ExternalApiEndpoint.OCID_LOOKUP)
+        if (ocidKeys.isEmpty()) {
+            log.warn("[Scheduler] no stored OCIDs found, skipping CHARACTER_BASIC")
+            return
+        }
+
+        val ocidMap = readStoredOcids(ocidKeys)
+        if (ocidMap.isEmpty()) {
+            log.warn("[Scheduler] failed to parse any OCIDs, skipping CHARACTER_BASIC")
+            return
+        }
+
+        log.info("[Scheduler] ========== CHARACTER_BASIC lookup start ==========")
+        log.info(
+            "[Scheduler] config: total={}, rate={}/s, batchSize={}, threads=virtual",
+            ocidMap.size,
+            permitsPerSecond,
+            batchSize,
+        )
+
+        val start = Instant.now()
+        val successCount = AtomicInteger(0)
+        val failCount = AtomicInteger(0)
+        val storedCount = AtomicInteger(0)
+        var processed = 0
+        var lastProgressLog = 0
+        val entries = ocidMap.entries.toList()
+
+        while (processed < entries.size) {
+            val permits = acquirePermits(rateLimiter, entries.size - processed)
+            if (permits == 0) continue
+
+            val chunk = entries.subList(processed, processed + permits)
+            processed += permits
+
+            val futures = chunk.map { (ign, ocid) ->
+                executor.submit(
+                    Callable {
+                        try {
+                            val result = fetchUseCase.fetchSingle(
+                                provider = ExternalApiProvider.NEXON,
+                                endpoint = ExternalApiEndpoint.CHARACTER_BASIC,
+                                requestKey = ocid,
+                                characterName = ign,
+                            )
+                            if (result.success) {
+                                successCount.incrementAndGet()
+                                if (result.payloadRef != null) storedCount.incrementAndGet()
+                            } else {
+                                failCount.incrementAndGet()
+                            }
+                        } catch (ex: Exception) {
+                            failCount.incrementAndGet()
+                        }
+                    },
+                )
+            }
+
+            futures.forEach { it.get() }
+
+            val progress = successCount.get() + failCount.get()
+            if (progress - lastProgressLog >= 5000) {
+                lastProgressLog = progress
+                logProgress("CHARACTER_BASIC", progress, entries.size, storedCount.get(), failCount.get(), start)
+            }
+        }
+
+        logSummary("CHARACTER_BASIC", entries.size, successCount.get(), storedCount.get(), failCount.get(), start)
+    }
+
+    private fun readStoredOcids(keys: List<String>): Map<String, String> {
+        val result = mutableMapOf<String, String>()
+        for (key in keys) {
+            try {
+                val bytes = artifactStore.read(ExternalApiEndpoint.OCID_LOOKUP, key)
+                if (bytes != null) {
+                    val node = objectMapper.readTree(bytes)
+                    val ocid = node.get("ocid")?.asText()
+                    if (ocid != null) {
+                        result[key] = ocid
+                    }
+                }
+            } catch (ex: Exception) {
+                log.debug("[Scheduler] failed to parse OCID for key={}", key)
+            }
+        }
+        return result
+    }
+
+    private fun newRateLimiter(): Bucket = Bucket.builder()
+        .addLimit(
+            Bandwidth.builder()
+                .capacity(permitsPerSecond.toLong())
+                .refillIntervally(permitsPerSecond.toLong(), Duration.ofSeconds(1))
+                .build(),
+        )
+        .build()
+
+    private fun acquirePermits(rateLimiter: Bucket, remaining: Int): Int {
+        val maxBatch = minOf(batchSize, remaining)
+        return rateLimiter.tryConsumeAsMuchAsPossible(maxBatch.toLong()).toInt().also {
+            if (it == 0) Thread.sleep(Duration.ofMillis(100))
+        }
+    }
+
+    private fun logProgress(phase: String, progress: Int, total: Int, stored: Int, fails: Int, start: Instant) {
+        val elapsedSec = Duration.between(start, Instant.now()).toMillis() / 1000.0
         val rate = if (elapsedSec > 0) "%.0f".format(progress / elapsedSec) else "?"
         val storedRate = if (elapsedSec > 0) "%.0f".format(stored / elapsedSec) else "?"
         log.info(
-            "[Scheduler] progress: {}/{} (stored={} @{}files/s, fail={}, totalRate={}files/s, elapsed={}s)",
+            "[Scheduler] {}: {}/{} (stored={} @{}files/s, fail={}, rate={}files/s, elapsed={}s)",
+            phase,
             progress,
             total,
             stored,
             storedRate,
             fails,
             rate,
-            elapsed.seconds,
+            elapsedSec.toLong(),
+        )
+    }
+
+    private fun logSummary(phase: String, total: Int, success: Int, stored: Int, fails: Int, start: Instant) {
+        val elapsedSec = Duration.between(start, Instant.now()).toMillis() / 1000.0
+        val rate = if (elapsedSec > 0) "%.0f".format(total / elapsedSec) else "?"
+        val storedRate = if (elapsedSec > 0) "%.0f".format(stored / elapsedSec) else "?"
+        log.info("[Scheduler] ========== {} complete ==========", phase)
+        log.info(
+            "[Scheduler] result: total={}, stored={} @{}files/s, success={}, fail={}, elapsed={}s, avgRate={}files/s",
+            total,
+            stored,
+            storedRate,
+            success,
+            fails,
+            elapsedSec.toLong(),
+            rate,
         )
     }
 }


### PR DESCRIPTION
## Summary
- Add CHARACTER_BASIC endpoint to scheduler pipeline (OCID lookup → CHARACTER_BASIC)
- Shard stored files by first 2 chars of key (avoids flat 300K+ file directory)
- Extract common scheduler logic (rate limiter, progress logging) into helpers
- Add `listStoredKeys` to artifact store port for reading stored OCIDs

## Test plan
- [x] Unit tests pass
- [x] Runtime verified: OCID lookup + CHARACTER_BASIC pipeline with 3 test IGNs
- [x] Shard structure verified: `character-basic/46/46242ca5...json.gz`

🤖 Generated with [Claude Code](https://claude.com/claude-code)