### PR TITLE
feat: skip OCID lookup when already completed

### DIFF
--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/ExternalApiScheduler.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/ExternalApiScheduler.kt
@@ -61,7 +61,12 @@ class ExternalApiScheduler(
             return
         }
         try {
-            doOcidLookup()
+            val existingOcids = artifactStore.listStoredKeys(ExternalApiEndpoint.OCID_LOOKUP)
+            if (existingOcids.isEmpty()) {
+                doOcidLookup()
+            } else {
+                log.info("[Scheduler] OCID lookup already done ({} files), skipping", existingOcids.size)
+            }
             doCharacterBasicLookup()
         } finally {
             running.set(false)


### PR DESCRIPTION
## Summary
- Skip OCID lookup phase if stored OCID files already exist
- Go straight to CHARACTER_BASIC pipeline on startup
- Log count of existing OCID files when skipping

## Test plan
- [x] Unit tests pass
- [x] Compile + spotless pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)