### PR TITLE
feat: chunked JSONL snapshot storage with Kafka event publishing

### DIFF
--- a/docs/18_Portfolio/external-api-pipeline-evolution.md
+++ b/docs/18_Portfolio/external-api-pipeline-evolution.md
@@ -1,0 +1,412 @@
+# External API Pipeline Evolution
+
+## 1. 출발점: "외부 API 기반 계산 서비스"가 생각보다 무거운 워크로드였음
+
+처음엔 단순히 Nexon Open API를 호출해서 계산 결과를 만들고, DB에 저장하고, ReadPath에서 조회하는 구조였다.
+
+실제 워크로드를 뜯어보니 단순 CRUD가 아니었음.
+
+```
+1 view 처리 =
+  외부 API 호출
+  + 200~300KB JSON 응답 다운로드
+  + JSON 파싱 / 정규화
+  + 확률 계산
+  + 결과 직렬화 / 압축 / 해시
+  + DB 저장
+  + Projection / Read Model 반영
+```
+
+워크로드 규모:
+
+| 기준 | 수치 |
+|------|------|
+| 30 TPS | 하루 약 2,592,000건 (약 260만 건/day) |
+| 건당 200~300KB | 하루 약 0.5~0.8TB raw external API payload |
+| CHARACTER_BASIC 200/sec | 하루 약 17,280,000건 (약 1,728만 건/day) |
+| 200 TPS x 300KB | 약 60MB/sec = 약 5.2TB/day raw payload |
+
+## 2. 기존 구조의 문제: 강결합 God Worker
+
+하나의 worker가 너무 많은 책임을 가지고 있었음.
+
+```
+Client Request
+→ Job 생성
+→ External API 호출
+→ Snapshot/Input 저장
+→ 계산
+→ 결과 저장
+→ Outbox/Projection
+→ Read Model 반영
+```
+
+`external_api_queue`는 이름은 External API queue였지만 실제로는 "종합 메시지 허브"였음.
+
+### external_api_queue 실제 책임
+- OCID resolve
+- Nexon API fetch
+- snapshot 저장
+- calculation input 생성
+- pure calculation
+- result serialize/gzip/hash
+- result persist
+- job complete
+- outbox/projection trigger
+
+병목 로그가 `ExternalApiWorker slow`로 나와도, 실제로 느린 게 외부 API인지, 계산인지, DB write인지, projection인지 알기 어려웠음.
+
+## 3. PGMQ의 한계: SRP vs 처리량 딜레마
+
+### PGMQ 장점
+- Postgres 내장
+- 운영 단순
+- 별도 Kafka 인프라 불필요
+- DB transaction과 함께 다루기 쉬움
+
+### PGMQ 문제
+PGMQ는 결국 Postgres-backed MQ.
+
+```
+PGMQ hop = Postgres insert/read/update/archive/WAL
+```
+
+**큐를 잘게 나누면:**
+- 책임 분리 좋아짐
+- 병목 관측 쉬워짐
+- 하지만 PGMQ hop 증가 → Postgres read/write/archive/WAL 증가
+
+**큐를 합치면:**
+- hop 비용 감소
+- 처리량 나아질 수 있음
+- 하지만 God MQ가 됨
+- 병목 진단 어려움
+- retry 정책이 섞임
+
+**핵심 딜레마:** PGMQ 위에서는 SRP와 처리량이 서로 충돌한다.
+
+## 4. Supabase Pooler 마이그레이션과 커넥션 풀 병목
+
+Vultr 직접 PostgreSQL → Supabase Pooler 전환 시 새로운 문제 발생.
+
+실험 결과:
+
+| 설정 | 결과 |
+|------|------|
+| pool=50 | 더 느림 |
+| pool=15 | 더 좋음 |
+
+**교훈:** 커넥션 수를 늘린다고 빨라지는 게 아니다. DB/Pooler가 감당 가능한 동시성보다 많으면 오히려 느려진다.
+
+### ResultProjection 병목 상세
+
+```
+loadCalculationResults: 1,000~7,500ms
+batchUpsertViews:       600~2,400ms
+archiveMessages:          90~400ms
+```
+
+DB 쿼리 비용 + Supabase Pooler hop + 네트워크 RTT + projection write + PGMQ archive가 모두 섞여 있었음.
+
+## 5. 최적화와 롤백 경험
+
+### 성공한 것들
+
+**Compute Key Dedup**
+- 같은 캐릭터/프리셋 계산이 중복으로 들어올 때 제거
+- Before: 1000 messages → 1000 calculations
+- After: 1000 messages → 200 calculations (dedup 후)
+
+**Projection 최적화**
+- 단건 markPublished → batch markAllPublished
+- 16~21 views/sec → 46~52 views/sec
+
+**BYTEA decompress / JSON parse 제거**
+- write 시점에 필요한 field 미리 추출
+- read/projection에서 가볍게 조회
+
+### 롤백한 것들
+
+**Kafka 시도 → 롤백**
+- 당시 30 TPS 수준에서는 PGMQ가 병목이 아니었음
+- Kafka는 인프라 복잡도만 늘림
+- 단, stage scale-out / Object Storage artifact pipeline으로 가면 재검토 가능
+
+**Outbox 폴링 → 롤백**
+- PGMQ가 Postgres 내장이라 same-TX publish 가능
+- Outbox polling은 오히려 latency와 추가 DB write가 비용
+
+**DB 왕복 병합 → 롤백**
+- TX가 길어지고 커넥션 점유 시간 증가
+- Supabase Pooler latency가 더 큰 병목
+
+**공통 교훈:**
+- 정석 패턴도 현재 인프라 맥락에 맞아야 한다
+- 병목이 아닌 곳을 최적화하면 역효과가 난다
+
+## 6. 단일 노드 30 TPS의 의미 재해석
+
+30 TPS가 낮아 보이지만 실제 워크로드는:
+
+```
+30 TPS = 하루 약 260만 건 = 하루 0.5~0.8TB raw external API ingress
+```
+
+단순 이벤트 30 TPS가 아니라, 건당 200~300KB live external API payload를 받아서 파싱/계산/저장/projection하는 30 TPS.
+
+30 TPS가 낮은 이유도 여러 자원이 섞인 결과:
+- 외부 API latency
+- 한국-일본/클라우드 네트워크 RTT
+- 서버 NIC 대역폭 (600 Mbit/s ≈ 75MB/s)
+- Supabase Pooler RTT
+- PGMQ/Postgres queue hop
+- DB write/projection
+- JSON parse/gzip/hash
+
+예: `300KB × 200/sec = 60MB/sec` — 이미 단일 600Mbit/s 포트의 큰 비중
+
+## 7. 스케일아웃의 의미
+
+스케일아웃은 단순히 "CPU 더 필요해서"가 아님.
+
+**Stage별 병목 자원이 다름:**
+
+| Stage | 병목 자원 |
+|-------|----------|
+| External API | network I/O, latency, rate-limit |
+| Calculation | CPU, JSON parsing |
+| DB Sync | batch upsert, connection pool |
+| ReadPath | latency-sensitive |
+
+한 노드에 몰아넣으면 서로 자원을 뺏어먹음.
+
+## 8. Kafka의 의미 재정의
+
+Kafka는 "PGMQ보다 빠른 MQ"가 아니라:
+
+```
+queue/backlog/transport 역할을 Postgres 밖으로 빼는 도구
+```
+
+### Kafka 가치
+- Postgres를 MQ 역할에서 해방
+- stage별 consumer group scale-out
+- lag 기반 병목 관측
+- External API / Calculation / WritePath 분리
+- ReadPath와 ingest workload 격리
+
+### Kafka가 가져오는 새 복잡도
+- transactional outbox
+- consumer idempotency
+- poison message DLT
+- rebalance 중복 처리
+- lag monitoring
+- schema/version 관리
+
+**결론:** Kafka는 복잡도를 줄이는 도구가 아니라, 복잡도를 통제 가능한 위치로 옮기는 도구다.
+
+## 9. Object Storage / S3 Artifact 설계
+
+큰 payload를 Kafka/DB에 직접 싣지 않고 참조만 전달:
+
+```
+Kafka payload:
+  jobId, artifactUri, artifactHash, schemaVersion, traceId
+
+S3/Object Storage:
+  raw-response/{jobId}.json.gz
+  calculation-input/{jobId}.json.gz
+  calculation-result/{jobId}.json.gz
+
+DB:
+  job state, artifact manifest, artifact uri/hash/size/schemaVersion
+  result summary, read model, idempotency key
+```
+
+이건 Claim-check pattern / Artifact-based pipeline이라 부름.
+
+## 10. Streaming Ingest
+
+외부 API 응답이 200~300KB, 수백 TPS면 통째로 들고 다니기 부담.
+
+초기 구현 (안전):
+```
+HTTP stream → raw 저장 → raw 다시 읽어서 input 생성
+```
+
+고도화:
+```
+HTTP stream → Tee
+  ├─ raw artifact 저장
+  └─ streaming parser로 input 추출
+```
+
+핵심: ingest 시점에 필요한 부분만 calculation-input artifact로 만들어둔다.
+
+## 11. Observability: Scale-out하면 tail -f는 끝남
+
+여러 노드에 로그가 흩어지면 centralized logging 필수.
+
+```
+Metrics  = 어디가 이상한지 발견
+Trace    = 요청 하나가 어디서 오래 걸렸는지 확인
+Logs     = 왜 실패했는지 원인 확인
+```
+
+성공 로그는 샘플링, 실패/retry/DLT는 전량 기록.
+
+## 12. V6: External API 분리
+
+### Before
+```
+Main App / Worker
+  - 요청 접수
+  - External API 호출
+  - 계산
+  - DB write
+  - projection
+  - read path
+```
+
+### After
+```
+External API Ingestor
+  - OCID lookup (400/sec)
+  - CHARACTER_BASIC fetch (200/sec)
+  - ITEM_EQUIPMENT fetch (continuous)
+  - gzip JSONL chunk artifact 저장
+  - manifest / _SUCCESS 생성
+  - Kafka chunk-ready event 발행
+
+Main App / Calculator / WritePath
+  - artifact 기반 계산
+  - result persist
+  - projection
+  - read path
+```
+
+### V6 수치
+
+| Stage | Rate | 하루 처리량 | 하루 payload |
+|-------|------|-----------|-------------|
+| OCID lookup | 400/sec | 약 3,456만 건 | - |
+| CHARACTER_BASIC | 200/sec | 약 1,728만 건 | 최대 5.2TB |
+| ITEM_EQUIPMENT | ~160/sec | 약 1,382만 건 | TBD |
+
+### Chunk Storage 구조
+```
+data/external-api/runs/{runId}/{endpoint}/
+  chunks/
+    part-000001.jsonl.gz  (CHARACTER_BASIC: 2000 records, ITEM_EQUIPMENT: 500 records)
+    part-000002.jsonl.gz
+  failed.jsonl
+  manifest.json
+  _SUCCESS
+```
+
+### Kafka Event (Claim-check Pattern)
+```json
+{
+  "eventType": "SNAPSHOT_CHUNK_READY",
+  "runId": "20260504-030000",
+  "endpoint": "item-equipment",
+  "chunkId": "part-000001",
+  "objectKey": "runs/20260504-030000/item-equipment/chunks/part-000001.jsonl.gz",
+  "recordCount": 500,
+  "compressedBytes": 18422311
+}
+```
+
+## 13. 포트폴리오 서사
+
+### 핵심 문장
+
+```
+30 TPS, 약 7.5MB/s 수준에서 병목을 분석했는데,
+튜닝을 해도 병목이 사라지는 게 아니라 다른 구간으로 이동했습니다.
+
+그래서 단순 튜닝이 아니라,
+수집 / 계산 / DB 반영 / ReadPath를 stage로 분리하고,
+큰 payload는 chunk artifact로 저장하며,
+Kafka에는 metadata event만 흘리는 구조로 재설계했습니다.
+```
+
+### 병목 이동이 핵심
+
+```
+특정 병목 하나를 제거하면 전체 처리량이 계속 올라갈 줄 알았지만,
+실제로는 PGMQ → DB write → Projection → Network → Pooler처럼
+병목 지점이 이동했습니다.
+
+그래서 특정 함수나 쿼리 하나의 문제가 아니라,
+워크로드를 하나의 파이프라인에 강하게 결합한 구조 자체가 문제라고 봤습니다.
+```
+
+### MSA 서사
+
+```
+수집 stage는 network I/O와 external API rate limit이 병목이고,
+계산 stage는 CPU와 JSON parsing이 병목이며,
+DB sync stage는 batch upsert와 connection pool이 병목이었다.
+
+각 stage의 병목 자원과 scale-out 방식이 달랐기 때문에
+하나의 worker로 묶기보다 service/module 경계를 나누는 게 더 적합하다고 판단했다.
+
+MSA를 목표로 한 것이 아니라,
+병목 자원이 다른 stage를 독립적으로 튜닝하고 확장하기 위해
+자연스럽게 service boundary가 생겼습니다.
+```
+
+### 차별점
+
+```
+병목을 튜닝하다가,
+튜닝 가능한 병목과 구조적 병목을 구분했다.
+```
+
+### 이력서 bullet
+
+```
+- 건당 200~300KB 외부 API 응답을 처리하는 계산 파이프라인에서 30 TPS / 약 7.5MB/s 처리량 한계를 분석
+- 커넥션 풀, PGMQ batch, Projection, JSON parse, DB write 최적화 후에도 병목이 stage 간 이동하는 구조적 한계 확인
+- External API Ingest / Calculator / DB Sync / ReadPath를 분리하고, gzip JSONL chunk artifact + Kafka metadata event 기반 파이프라인으로 재설계
+- per-record 저장 대신 500~2000 records 단위 chunk 저장으로 Object Storage 요청 수와 Kafka event 수를 약 1/500~1/2000 수준으로 절감
+```
+
+### 면접 요약
+
+```
+이 프로젝트에서 가장 크게 배운 건,
+성능 문제를 항상 튜닝으로만 해결할 수는 없다는 점이었습니다.
+
+처음에는 병목을 하나씩 제거하려고 했지만,
+처리량이 30 TPS / 7.5MB/s 부근에서 더 이상 올라가지 않았고
+병목이 계속 다른 stage로 이동했습니다.
+
+그래서 이건 특정 코드의 문제가 아니라
+외부 API I/O, 계산, DB write, projection이 강하게 결합된 구조의 문제라고 보고,
+chunk artifact 기반의 stage pipeline으로 재설계했습니다.
+```
+
+## 14. 향후 방향
+
+### Stage별 측정치 (필수)
+- OCID lookup TPS
+- CHARACTER_BASIC TPS
+- ITEM_EQUIPMENT TPS
+- artifact write TPS
+- calculation TPS
+- DB persist TPS
+- projection TPS
+- ReadPath RPS
+
+전체 completed TPS는 이 중 가장 느린 stage가 결정함.
+
+### PR 로드맵
+```
+PR-1: chunked jsonl.gz 저장 완료 ✅
+PR-2: chunk-ready event publisher 추가 ✅
+PR-3: Calculate chunk consumer
+PR-4: Calculate result chunk writer
+PR-5: PostgreSQL sync chunk consumer
+```

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -94,6 +94,7 @@ spring-boot-starter-data-jpa = { module = "org.springframework.boot:spring-boot-
 spring-boot-starter-cache = { module = "org.springframework.boot:spring-boot-starter-cache" }
 spring-boot-starter-batch = { module = "org.springframework.boot:spring-boot-starter-batch" }
 spring-boot-starter-aop = { module = "org.springframework.boot:spring-boot-starter-aop" }
+spring-kafka = { module = "org.springframework.kafka:spring-kafka" }
 spring-boot-starter-thymeleaf = { module = "org.springframework.boot:spring-boot-starter-thymeleaf" }
 spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test" }
 

--- a/module-external-api/build.gradle
+++ b/module-external-api/build.gradle
@@ -24,6 +24,9 @@ dependencies {
 	implementation(libs.spring.boot.starter.web)
 	implementation(libs.spring.boot.starter.webflux)
 
+	// Kafka (chunk-ready event publishing)
+	implementation(libs.spring.kafka)
+
 	// Rate limiting
 	implementation(libs.bucket4j.core)
 

--- a/module-external-api/src/main/kotlin/maple/externalapi/ExternalApiApplication.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/ExternalApiApplication.kt
@@ -1,10 +1,14 @@
 package maple.externalapi
 
+import maple.externalapi.snapshot.SnapshotChunkingProperties
+import maple.externalapi.snapshot.event.SnapshotEventProperties
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication
 @EnableScheduling
+@EnableConfigurationProperties(SnapshotChunkingProperties::class, SnapshotEventProperties::class)
 class ExternalApiApplication
 
 fun main(args: Array<String>) {

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/ExternalApiScheduler.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/ExternalApiScheduler.kt
@@ -4,18 +4,16 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import io.github.bucket4j.Bandwidth
 import io.github.bucket4j.Bucket
 import jakarta.annotation.PreDestroy
-import java.time.Duration
-import java.time.Instant
-import java.util.concurrent.Callable
-import java.util.concurrent.Executors
-import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicInteger
-import java.util.concurrent.atomic.AtomicReference
 import maple.externalapi.domain.ExternalApiEndpoint
 import maple.externalapi.domain.ExternalApiProvider
-import maple.externalapi.port.inbound.FetchExternalApiUseCase
-import maple.externalapi.port.out.ExternalApiArtifactStorePort
+import maple.externalapi.port.out.ExternalApiClientPort
 import maple.externalapi.reader.UserIgnCsvReader
+import maple.externalapi.snapshot.ChunkedSnapshotSink
+import maple.externalapi.snapshot.SnapshotChunkRecord
+import maple.externalapi.snapshot.SnapshotChunkingProperties
+import maple.externalapi.snapshot.event.SnapshotChunkEventPublisher
+import maple.externalapi.port.out.ExternalApiArtifactStorePort
+import maple.externalapi.port.inbound.FetchExternalApiUseCase
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
@@ -23,14 +21,27 @@ import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.context.event.EventListener
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.concurrent.Callable
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
 
 @Component
 @ConditionalOnProperty(name = ["external-api.schedule.enabled"], havingValue = "true")
 class ExternalApiScheduler(
     private val fetchUseCase: FetchExternalApiUseCase,
+    private val clientPort: ExternalApiClientPort,
     private val csvReader: UserIgnCsvReader,
     private val artifactStore: ExternalApiArtifactStorePort,
     private val objectMapper: ObjectMapper,
+    private val chunkingProperties: SnapshotChunkingProperties,
+    private val eventPublisher: SnapshotChunkEventPublisher,
     @Value("\${external-api.rate-limit.permits-per-second:200}")
     private val permitsPerSecond: Int,
     @Value("\${external-api.rate-limit.ocid-lookup-permits-per-second:400}")
@@ -118,16 +129,13 @@ class ExternalApiScheduler(
         log.info("[Scheduler] ========== OCID lookup start ==========")
         log.info(
             "[Scheduler] config: total={}, rate={}/s, batchSize={}, store={}",
-            igns.size,
-            ocidLookupPermitsPerSecond,
-            batchSize,
-            storeBasePath,
+            igns.size, ocidLookupPermitsPerSecond, batchSize, storeBasePath,
         )
 
         val start = Instant.now()
-        val successCount = AtomicInteger(0)
-        val failCount = AtomicInteger(0)
-        val storedCount = AtomicInteger(0)
+        val successCount = java.util.concurrent.atomic.AtomicInteger(0)
+        val failCount = java.util.concurrent.atomic.AtomicInteger(0)
+        val storedCount = java.util.concurrent.atomic.AtomicInteger(0)
         var processed = 0
         var lastProgressLog = 0
 
@@ -186,123 +194,183 @@ class ExternalApiScheduler(
             return
         }
 
+        val runId = newRunId()
+        val endpoint = "character-basic"
+        val config = chunkingProperties.configFor(endpoint)
+        val runDir = Paths.get(storeBasePath, "runs", runId)
+        val sink = ChunkedSnapshotSink(
+            runDir = runDir,
+            endpoint = endpoint,
+            maxRecords = config.maxRecords,
+            maxUncompressedBytes = config.maxUncompressedBytes,
+            queueCapacity = chunkingProperties.queueCapacity,
+            objectMapper = objectMapper,
+            eventPublisher = eventPublisher,
+        )
+
         val rateLimiter = newRateLimiter(permitsPerSecond)
 
         log.info("[Scheduler] ========== CHARACTER_BASIC lookup start ==========")
         log.info(
-            "[Scheduler] config: total={}, rate={}/s, batchSize={}, threads=virtual",
-            entries.size,
-            permitsPerSecond,
-            batchSize,
+            "[Scheduler] config: total={}, rate={}/s, batchSize={}, chunk={}records/{}bytes, runId={}",
+            entries.size, permitsPerSecond, batchSize, config.maxRecords, config.maxUncompressedBytes, runId,
         )
 
         val start = Instant.now()
-        val successCount = AtomicInteger(0)
-        val failCount = AtomicInteger(0)
-        val storedCount = AtomicInteger(0)
+        val successCount = java.util.concurrent.atomic.AtomicInteger(0)
+        val failCount = java.util.concurrent.atomic.AtomicInteger(0)
         var processed = 0
         var lastProgressLog = 0
 
-        while (processed < entries.size) {
-            val permits = acquirePermits(rateLimiter, entries.size - processed)
-            if (permits == 0) continue
+        try {
+            while (processed < entries.size) {
+                val permits = acquirePermits(rateLimiter, entries.size - processed)
+                if (permits == 0) continue
 
-            val chunk = entries.subList(processed, processed + permits)
-            processed += permits
+                val chunk = entries.subList(processed, processed + permits)
+                processed += permits
 
-            val futures = chunk.map { (ign, ocid) ->
-                executor.submit(
-                    Callable {
-                        try {
-                            val result = fetchUseCase.fetchSingle(
-                                provider = ExternalApiProvider.NEXON,
-                                endpoint = ExternalApiEndpoint.CHARACTER_BASIC,
-                                requestKey = ocid,
-                                characterName = ign,
-                            )
-                            if (result.success) {
+                val futures = chunk.map { (ign, ocid) ->
+                    executor.submit(
+                        Callable {
+                            try {
+                                val bodyBytes = clientPort.fetch(
+                                    ExternalApiProvider.NEXON,
+                                    ExternalApiEndpoint.CHARACTER_BASIC,
+                                    ocid,
+                                ).join()
+                                sink.submit(
+                                    SnapshotChunkRecord.Success(
+                                        key = ocid,
+                                        endpoint = endpoint,
+                                        keyType = "OCID",
+                                        httpStatus = 200,
+                                        fetchedAt = Instant.now(),
+                                        bodyBytes = bodyBytes,
+                                    ),
+                                )
                                 successCount.incrementAndGet()
-                                if (result.payloadRef != null) storedCount.incrementAndGet()
-                            } else {
+                            } catch (ex: Exception) {
+                                val httpStatus = extractHttpStatus(ex)
+                                sink.submit(
+                                    SnapshotChunkRecord.Failure(
+                                        key = ocid,
+                                        endpoint = endpoint,
+                                        keyType = "OCID",
+                                        httpStatus = httpStatus,
+                                        fetchedAt = Instant.now(),
+                                        errorMessage = ex.message ?: "unknown",
+                                    ),
+                                )
                                 failCount.incrementAndGet()
                             }
-                        } catch (ex: Exception) {
-                            failCount.incrementAndGet()
-                        }
-                    },
-                )
-            }
+                        },
+                    )
+                }
 
-            futures.forEach { it.get() }
+                futures.forEach { it.get() }
 
-            val progress = successCount.get() + failCount.get()
-            if (progress - lastProgressLog >= 5000) {
-                lastProgressLog = progress
-                logProgress("CHARACTER_BASIC", progress, entries.size, storedCount.get(), failCount.get(), start)
+                val progress = successCount.get() + failCount.get()
+                if (progress - lastProgressLog >= 5000) {
+                    lastProgressLog = progress
+                    logProgress("CHARACTER_BASIC", progress, entries.size, successCount.get(), failCount.get(), start)
+                }
             }
+        } finally {
+            sink.close()
         }
 
-        logSummary("CHARACTER_BASIC", entries.size, successCount.get(), storedCount.get(), failCount.get(), start)
+        logSummary("CHARACTER_BASIC", entries.size, successCount.get(), successCount.get(), failCount.get(), start)
     }
 
     private fun doItemEquipmentLookup(entries: List<Map.Entry<String, String>>) {
+        val runId = newRunId()
+        val endpoint = "item-equipment"
+        val config = chunkingProperties.configFor(endpoint)
+        val runDir = Paths.get(storeBasePath, "runs", runId)
+        val sink = ChunkedSnapshotSink(
+            runDir = runDir,
+            endpoint = endpoint,
+            maxRecords = config.maxRecords,
+            maxUncompressedBytes = config.maxUncompressedBytes,
+            queueCapacity = chunkingProperties.queueCapacity,
+            objectMapper = objectMapper,
+            eventPublisher = eventPublisher,
+        )
+
         val rateLimiter = newRateLimiter(permitsPerSecond)
 
         log.info("[Scheduler] ========== ITEM_EQUIPMENT lookup start ==========")
         log.info(
-            "[Scheduler] config: total={}, rate={}/s, batchSize={}, threads=virtual",
-            entries.size,
-            permitsPerSecond,
-            batchSize,
+            "[Scheduler] config: total={}, rate={}/s, batchSize={}, chunk={}records/{}bytes, runId={}",
+            entries.size, permitsPerSecond, batchSize, config.maxRecords, config.maxUncompressedBytes, runId,
         )
 
         val start = Instant.now()
-        val successCount = AtomicInteger(0)
-        val failCount = AtomicInteger(0)
-        val storedCount = AtomicInteger(0)
+        val successCount = java.util.concurrent.atomic.AtomicInteger(0)
+        val failCount = java.util.concurrent.atomic.AtomicInteger(0)
         var processed = 0
         var lastProgressLog = 0
 
-        while (processed < entries.size) {
-            val permits = acquirePermits(rateLimiter, entries.size - processed)
-            if (permits == 0) continue
+        try {
+            while (processed < entries.size) {
+                val permits = acquirePermits(rateLimiter, entries.size - processed)
+                if (permits == 0) continue
 
-            val chunk = entries.subList(processed, processed + permits)
-            processed += permits
+                val chunk = entries.subList(processed, processed + permits)
+                processed += permits
 
-            val futures = chunk.map { (ign, ocid) ->
-                executor.submit(
-                    Callable {
-                        try {
-                            val result = fetchUseCase.fetchSingle(
-                                provider = ExternalApiProvider.NEXON,
-                                endpoint = ExternalApiEndpoint.ITEM_EQUIPMENT,
-                                requestKey = ocid,
-                                characterName = ign,
-                            )
-                            if (result.success) {
+                val futures = chunk.map { (ign, ocid) ->
+                    executor.submit(
+                        Callable {
+                            try {
+                                val bodyBytes = clientPort.fetch(
+                                    ExternalApiProvider.NEXON,
+                                    ExternalApiEndpoint.ITEM_EQUIPMENT,
+                                    ocid,
+                                ).join()
+                                sink.submit(
+                                    SnapshotChunkRecord.Success(
+                                        key = ocid,
+                                        endpoint = endpoint,
+                                        keyType = "OCID",
+                                        httpStatus = 200,
+                                        fetchedAt = Instant.now(),
+                                        bodyBytes = bodyBytes,
+                                    ),
+                                )
                                 successCount.incrementAndGet()
-                                if (result.payloadRef != null) storedCount.incrementAndGet()
-                            } else {
+                            } catch (ex: Exception) {
+                                val httpStatus = extractHttpStatus(ex)
+                                sink.submit(
+                                    SnapshotChunkRecord.Failure(
+                                        key = ocid,
+                                        endpoint = endpoint,
+                                        keyType = "OCID",
+                                        httpStatus = httpStatus,
+                                        fetchedAt = Instant.now(),
+                                        errorMessage = ex.message ?: "unknown",
+                                    ),
+                                )
                                 failCount.incrementAndGet()
                             }
-                        } catch (ex: Exception) {
-                            failCount.incrementAndGet()
-                        }
-                    },
-                )
-            }
+                        },
+                    )
+                }
 
-            futures.forEach { it.get() }
+                futures.forEach { it.get() }
 
-            val progress = successCount.get() + failCount.get()
-            if (progress - lastProgressLog >= 5000) {
-                lastProgressLog = progress
-                logProgress("ITEM_EQUIPMENT", progress, entries.size, storedCount.get(), failCount.get(), start)
+                val progress = successCount.get() + failCount.get()
+                if (progress - lastProgressLog >= 5000) {
+                    lastProgressLog = progress
+                    logProgress("ITEM_EQUIPMENT", progress, entries.size, successCount.get(), failCount.get(), start)
+                }
             }
+        } finally {
+            sink.close()
         }
 
-        logSummary("ITEM_EQUIPMENT", entries.size, successCount.get(), storedCount.get(), failCount.get(), start)
+        logSummary("ITEM_EQUIPMENT", entries.size, successCount.get(), successCount.get(), failCount.get(), start)
     }
 
     private fun loadOcidCache() {
@@ -356,37 +424,35 @@ class ExternalApiScheduler(
         }
     }
 
+    private fun newRunId(): String {
+        val formatter = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss").withZone(ZoneId.systemDefault())
+        return formatter.format(Instant.now())
+    }
+
+    private fun extractHttpStatus(ex: Throwable): Int {
+        val cause = if (ex is java.util.concurrent.CompletionException) ex.cause else ex
+        return when (cause) {
+            is org.springframework.web.reactive.function.client.WebClientResponseException -> cause.statusCode.value()
+            else -> 0
+        }
+    }
+
     private fun logProgress(phase: String, progress: Int, total: Int, stored: Int, fails: Int, start: Instant) {
         val elapsedSec = Duration.between(start, Instant.now()).toMillis() / 1000.0
         val rate = if (elapsedSec > 0) "%.0f".format(progress / elapsedSec) else "?"
-        val storedRate = if (elapsedSec > 0) "%.0f".format(stored / elapsedSec) else "?"
         log.info(
-            "[Scheduler] {}: {}/{} (stored={} @{}files/s, fail={}, rate={}files/s, elapsed={}s)",
-            phase,
-            progress,
-            total,
-            stored,
-            storedRate,
-            fails,
-            rate,
-            elapsedSec.toLong(),
+            "[Scheduler] {}: {}/{} (success={}, fail={}, rate={}files/s, elapsed={}s)",
+            phase, progress, total, stored, fails, rate, elapsedSec.toLong(),
         )
     }
 
     private fun logSummary(phase: String, total: Int, success: Int, stored: Int, fails: Int, start: Instant) {
         val elapsedSec = Duration.between(start, Instant.now()).toMillis() / 1000.0
         val rate = if (elapsedSec > 0) "%.0f".format(total / elapsedSec) else "?"
-        val storedRate = if (elapsedSec > 0) "%.0f".format(stored / elapsedSec) else "?"
         log.info("[Scheduler] ========== {} complete ==========", phase)
         log.info(
-            "[Scheduler] result: total={}, stored={} @{}files/s, success={}, fail={}, elapsed={}s, avgRate={}files/s",
-            total,
-            stored,
-            storedRate,
-            success,
-            fails,
-            elapsedSec.toLong(),
-            rate,
+            "[Scheduler] result: total={}, success={}, fail={}, elapsed={}s, avgRate={}files/s",
+            total, success, fails, elapsedSec.toLong(), rate,
         )
     }
 

--- a/module-external-api/src/main/kotlin/maple/externalapi/snapshot/ChunkedSnapshotSink.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/snapshot/ChunkedSnapshotSink.kt
@@ -1,0 +1,241 @@
+package maple.externalapi.snapshot
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import maple.externalapi.snapshot.event.SnapshotChunkEventPublisher
+import maple.externalapi.snapshot.event.SnapshotChunkReadyEvent
+import maple.externalapi.snapshot.event.SnapshotRunCompletedEvent
+import maple.externalapi.snapshot.event.SnapshotRunFailedEvent
+import org.slf4j.LoggerFactory
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Instant
+import java.util.UUID
+import java.util.concurrent.ArrayBlockingQueue
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+
+class ChunkedSnapshotSink(
+    runDir: Path,
+    private val endpoint: String,
+    private val maxRecords: Int,
+    private val maxUncompressedBytes: Long,
+    private val queueCapacity: Int,
+    private val objectMapper: ObjectMapper,
+    private val eventPublisher: SnapshotChunkEventPublisher,
+) {
+    private val log = LoggerFactory.getLogger(ChunkedSnapshotSink::class.java)
+
+    private val chunksDir: Path = runDir.resolve(endpoint).resolve("chunks")
+    private val failedPath: Path = runDir.resolve(endpoint).resolve("failed.jsonl")
+    private val manifestPath: Path = runDir.resolve(endpoint).resolve("manifest.json")
+    private val successPath: Path = runDir.resolve(endpoint).resolve("_SUCCESS")
+
+    private val queue = ArrayBlockingQueue<SnapshotChunkRecord>(queueCapacity)
+    private val accepting = AtomicBoolean(true)
+    private val writerError = AtomicReference<Throwable?>(null)
+
+    private val manifest = SnapshotChunkManifest(
+        runId = runDir.fileName.toString(),
+        endpoint = endpoint,
+        startedAt = Instant.now(),
+    )
+
+    private val failedWriter = SnapshotFailedRecordWriter(failedPath, objectMapper)
+    private var currentWriter: GzipJsonlChunkWriter
+    private var nextPartIndex = 2
+
+    init {
+        Files.createDirectories(chunksDir)
+        Files.createDirectories(failedPath.parent)
+        currentWriter = newChunkWriter(1)
+    }
+
+    private val writerThread: Thread = Thread.ofPlatform().name("snapshot-writer-$endpoint").start {
+        runWriterLoop()
+    }
+
+    fun submit(record: SnapshotChunkRecord) {
+        if (!accepting.get()) {
+            val err = writerError.get()
+            if (err != null) {
+                throw IllegalStateException("sink closed due to writer error: ${err.message}", err)
+            }
+            throw IllegalStateException("sink is closed, cannot submit")
+        }
+        queue.put(record)
+    }
+
+    fun close() {
+        accepting.set(false)
+        queue.put(SnapshotChunkRecord.CloseSignal)
+
+        writerThread.join()
+
+        val err = writerError.get()
+        if (err != null) {
+            cleanupOnFailure()
+            publishRunFailed(err.message ?: "unknown")
+            throw RuntimeException("writer thread failed: ${err.message}", err)
+        }
+
+        // close current chunk
+        closeCurrentChunk()
+
+        // close failed writer
+        manifest.totalFailed = failedWriter.count()
+
+        // write manifest
+        manifest.finishedAt = Instant.now()
+        val manifestWriter = SnapshotChunkManifestWriter(manifestPath, objectMapper)
+        manifestWriter.write(manifest)
+
+        // create _SUCCESS
+        Files.writeString(successPath, "")
+
+        log.info(
+            "[Sink] closed: endpoint={}, chunks={}, records={}, failed={}",
+            endpoint, manifest.chunks.size, manifest.totalRecords, manifest.totalFailed,
+        )
+
+        // publish run completed (after _SUCCESS)
+        publishRunCompleted()
+    }
+
+    private fun runWriterLoop() {
+        try {
+            while (true) {
+                val record = queue.take()
+                when (record) {
+                    is SnapshotChunkRecord.Success -> handleSuccess(record)
+                    is SnapshotChunkRecord.Failure -> failedWriter.append(record)
+                    is SnapshotChunkRecord.CloseSignal -> return
+                }
+            }
+        } catch (ex: Exception) {
+            writerError.set(ex)
+            accepting.set(false)
+            log.error("[Sink] writer thread error: {}", ex.message, ex)
+        }
+    }
+
+    private fun handleSuccess(record: SnapshotChunkRecord.Success) {
+        try {
+            currentWriter.append(record)
+            manifest.totalRecords++
+
+            if (currentWriter.shouldRotate()) {
+                rotateChunk()
+            }
+        } catch (ex: Exception) {
+            log.warn("[Sink] invalid bodyBytes for key={}, treating as failure: {}", record.key, ex.message)
+            failedWriter.append(
+                SnapshotChunkRecord.Failure(
+                    key = record.key,
+                    endpoint = record.endpoint,
+                    keyType = record.keyType,
+                    httpStatus = record.httpStatus,
+                    fetchedAt = record.fetchedAt,
+                    errorMessage = "invalid body: ${ex.message}",
+                ),
+            )
+        }
+    }
+
+    private fun rotateChunk() {
+        val stats = currentWriter.close()
+        if (stats.recordCount > 0) {
+            val entry = ChunkEntry(
+                path = stats.path,
+                recordCount = stats.recordCount,
+                uncompressedBytes = stats.uncompressedBytes,
+                compressedBytes = stats.compressedBytes,
+                startedAt = stats.startedAt,
+                finishedAt = stats.finishedAt,
+            )
+            manifest.chunks.add(entry)
+            publishChunkReady(stats)
+        }
+        currentWriter = newChunkWriter(nextPartIndex++)
+    }
+
+    private fun closeCurrentChunk() {
+        val stats = currentWriter.close()
+        if (stats.recordCount > 0) {
+            val entry = ChunkEntry(
+                path = stats.path,
+                recordCount = stats.recordCount,
+                uncompressedBytes = stats.uncompressedBytes,
+                compressedBytes = stats.compressedBytes,
+                startedAt = stats.startedAt,
+                finishedAt = stats.finishedAt,
+            )
+            manifest.chunks.add(entry)
+            publishChunkReady(stats)
+        }
+    }
+
+    private fun cleanupOnFailure() {
+        currentWriter.deleteTmp()
+        log.warn("[Sink] cleaned up .tmp files after failure")
+    }
+
+    private fun newChunkWriter(partIndex: Int): GzipJsonlChunkWriter =
+        GzipJsonlChunkWriter(chunksDir, partIndex, maxRecords, maxUncompressedBytes, objectMapper)
+
+    private fun objectKeyFor(stats: ChunkStats): String =
+        "runs/${manifest.runId}/${endpoint}/${stats.path}"
+
+    private fun publishChunkReady(stats: ChunkStats) {
+        val event = SnapshotChunkReadyEvent(
+            eventId = UUID.randomUUID().toString(),
+            runId = manifest.runId,
+            endpoint = endpoint,
+            chunkId = String.format("part-%06d", stats.partIndex),
+            objectKey = objectKeyFor(stats),
+            recordCount = stats.recordCount,
+            uncompressedBytes = stats.uncompressedBytes,
+            compressedBytes = stats.compressedBytes,
+            createdAt = Instant.now(),
+        )
+        try {
+            eventPublisher.publishChunkReady(event)
+        } catch (ex: Exception) {
+            log.warn("[Sink] failed to publish chunk-ready event for chunkId={}: {}", event.chunkId, ex.message)
+        }
+    }
+
+    private fun publishRunCompleted() {
+        val event = SnapshotRunCompletedEvent(
+            eventId = UUID.randomUUID().toString(),
+            runId = manifest.runId,
+            endpoint = endpoint,
+            manifestPath = "runs/${manifest.runId}/${endpoint}/manifest.json",
+            totalRecords = manifest.totalRecords,
+            totalFailed = manifest.totalFailed,
+            chunkCount = manifest.chunks.size,
+            startedAt = manifest.startedAt,
+            finishedAt = requireNotNull(manifest.finishedAt),
+            createdAt = Instant.now(),
+        )
+        try {
+            eventPublisher.publishRunCompleted(event)
+        } catch (ex: Exception) {
+            log.warn("[Sink] failed to publish run-completed event for runId={}: {}", manifest.runId, ex.message)
+        }
+    }
+
+    private fun publishRunFailed(errorMessage: String) {
+        val event = SnapshotRunFailedEvent(
+            eventId = UUID.randomUUID().toString(),
+            runId = manifest.runId,
+            endpoint = endpoint,
+            errorMessage = errorMessage,
+            createdAt = Instant.now(),
+        )
+        try {
+            eventPublisher.publishRunFailed(event)
+        } catch (ex: Exception) {
+            log.warn("[Sink] failed to publish run-failed event for runId={}: {}", manifest.runId, ex.message)
+        }
+    }
+}

--- a/module-external-api/src/main/kotlin/maple/externalapi/snapshot/GzipJsonlChunkWriter.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/snapshot/GzipJsonlChunkWriter.kt
@@ -1,0 +1,118 @@
+package maple.externalapi.snapshot
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import java.io.BufferedOutputStream
+import java.io.FileOutputStream
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.time.Instant
+
+data class ChunkStats(
+    val partIndex: Int,
+    val path: String,
+    val recordCount: Int,
+    val uncompressedBytes: Long,
+    val compressedBytes: Long,
+    val startedAt: Instant,
+    val finishedAt: Instant,
+)
+
+class GzipJsonlChunkWriter(
+    private val chunksDir: Path,
+    private val partIndex: Int,
+    private val maxRecords: Int,
+    private val maxUncompressedBytes: Long,
+    private val objectMapper: ObjectMapper,
+) {
+    private val startedAt = Instant.now()
+    private val tmpFile: Path = chunksDir.resolve(String.format("part-%06d.jsonl.gz.tmp", partIndex))
+    private val finalFile: Path = chunksDir.resolve(String.format("part-%06d.jsonl.gz", partIndex))
+
+    private val fos = FileOutputStream(tmpFile.toFile())
+    private val bos = BufferedOutputStream(fos)
+    private val gzip = java.util.zip.GZIPOutputStream(bos)
+
+    private var recordCount = 0
+    private var uncompressedBytes = 0L
+
+    fun append(record: SnapshotChunkRecord.Success) {
+        require(record.bodyBytes.isNotEmpty()) { "bodyBytes must not be empty for key=${record.key}" }
+
+        val line = buildRecordLine(record)
+        gzip.write(line)
+        gzip.flush()
+
+        recordCount++
+        uncompressedBytes += line.size
+    }
+
+    fun shouldRotate(): Boolean =
+        recordCount >= maxRecords || uncompressedBytes >= maxUncompressedBytes
+
+    fun close(): ChunkStats {
+        gzip.finish()
+        bos.flush()
+        fos.fd.sync()
+        fos.close()
+
+        if (recordCount == 0) {
+            Files.deleteIfExists(tmpFile)
+            return ChunkStats(
+                partIndex = partIndex,
+                path = "chunks/${finalFile.fileName}",
+                recordCount = 0,
+                uncompressedBytes = 0,
+                compressedBytes = 0,
+                startedAt = startedAt,
+                finishedAt = Instant.now(),
+            )
+        }
+
+        Files.move(tmpFile, finalFile, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
+        val compressedBytes = Files.size(finalFile)
+
+        return ChunkStats(
+            partIndex = partIndex,
+            path = "chunks/${finalFile.fileName}",
+            recordCount = recordCount,
+            uncompressedBytes = uncompressedBytes,
+            compressedBytes = compressedBytes,
+            startedAt = startedAt,
+            finishedAt = Instant.now(),
+        )
+    }
+
+    fun deleteTmp() {
+        try {
+            gzip.close()
+        } catch (_: Exception) {
+        }
+        Files.deleteIfExists(tmpFile)
+    }
+
+    private fun buildRecordLine(record: SnapshotChunkRecord.Success): ByteArray {
+        val buf = java.io.ByteArrayOutputStream()
+
+        // metadata prefix
+        buf.write("{\"endpoint\":".toByteArray())
+        buf.write(objectMapper.writeValueAsBytes(record.endpoint))
+        buf.write(",\"keyType\":".toByteArray())
+        buf.write(objectMapper.writeValueAsBytes(record.keyType))
+        buf.write(",\"key\":".toByteArray())
+        buf.write(objectMapper.writeValueAsBytes(record.key))
+        buf.write(",\"status\":\"SUCCESS\",\"httpStatus\":".toByteArray())
+        buf.write(record.httpStatus.toString().toByteArray())
+        buf.write(",\"fetchedAt\":".toByteArray())
+        buf.write(objectMapper.writeValueAsBytes(record.fetchedAt.toString()))
+        buf.write(",\"body\":".toByteArray())
+
+        // body: raw JSON bytes directly (no parse/re-serialize)
+        buf.write(record.bodyBytes)
+
+        // closing
+        buf.write("}\n".toByteArray())
+
+        return buf.toByteArray()
+    }
+}

--- a/module-external-api/src/main/kotlin/maple/externalapi/snapshot/SnapshotChunkManifest.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/snapshot/SnapshotChunkManifest.kt
@@ -1,0 +1,35 @@
+package maple.externalapi.snapshot
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Instant
+
+data class SnapshotChunkManifest(
+    val runId: String,
+    val endpoint: String,
+    val startedAt: Instant,
+    var finishedAt: Instant = Instant.EPOCH,
+    val chunks: MutableList<ChunkEntry> = mutableListOf(),
+    var totalRecords: Int = 0,
+    var totalFailed: Int = 0,
+)
+
+data class ChunkEntry(
+    val path: String,
+    val recordCount: Int,
+    val uncompressedBytes: Long,
+    val compressedBytes: Long,
+    val startedAt: Instant,
+    val finishedAt: Instant,
+)
+
+class SnapshotChunkManifestWriter(
+    private val manifestPath: Path,
+    private val objectMapper: ObjectMapper,
+) {
+    fun write(manifest: SnapshotChunkManifest) {
+        val json = objectMapper.writeValueAsBytes(manifest)
+        Files.write(manifestPath, json)
+    }
+}

--- a/module-external-api/src/main/kotlin/maple/externalapi/snapshot/SnapshotChunkRecord.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/snapshot/SnapshotChunkRecord.kt
@@ -1,0 +1,40 @@
+package maple.externalapi.snapshot
+
+import java.time.Instant
+
+sealed interface SnapshotChunkRecord {
+    val key: String
+    val endpoint: String
+    val keyType: String
+    val httpStatus: Int
+    val fetchedAt: Instant
+
+    data class Success(
+        override val key: String,
+        override val endpoint: String,
+        override val keyType: String,
+        override val httpStatus: Int,
+        override val fetchedAt: Instant,
+        val bodyBytes: ByteArray,
+    ) : SnapshotChunkRecord {
+        override fun equals(other: Any?): Boolean = this === other
+        override fun hashCode(): Int = System.identityHashCode(this)
+    }
+
+    data class Failure(
+        override val key: String,
+        override val endpoint: String,
+        override val keyType: String,
+        override val httpStatus: Int,
+        override val fetchedAt: Instant,
+        val errorMessage: String,
+    ) : SnapshotChunkRecord
+
+    data object CloseSignal : SnapshotChunkRecord {
+        override val key: String = ""
+        override val endpoint: String = ""
+        override val keyType: String = ""
+        override val httpStatus: Int = 0
+        override val fetchedAt: Instant = Instant.EPOCH
+    }
+}

--- a/module-external-api/src/main/kotlin/maple/externalapi/snapshot/SnapshotChunkingProperties.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/snapshot/SnapshotChunkingProperties.kt
@@ -1,0 +1,25 @@
+package maple.externalapi.snapshot
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "external-api.snapshot")
+data class SnapshotChunkingProperties(
+    val chunk: ChunkConfig = ChunkConfig(),
+    val queueCapacity: Int = 1000,
+) {
+    data class ChunkConfig(
+        val characterBasic: EndpointChunkConfig = EndpointChunkConfig(maxRecords = 2000),
+        val itemEquipment: EndpointChunkConfig = EndpointChunkConfig(maxRecords = 500),
+    )
+
+    data class EndpointChunkConfig(
+        val maxRecords: Int = 1000,
+        val maxUncompressedBytes: Long = 134217728L,
+    )
+
+    fun configFor(endpoint: String): EndpointChunkConfig = when (endpoint) {
+        "character-basic" -> chunk.characterBasic
+        "item-equipment" -> chunk.itemEquipment
+        else -> EndpointChunkConfig()
+    }
+}

--- a/module-external-api/src/main/kotlin/maple/externalapi/snapshot/SnapshotFailedRecordWriter.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/snapshot/SnapshotFailedRecordWriter.kt
@@ -1,0 +1,39 @@
+package maple.externalapi.snapshot
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+
+class SnapshotFailedRecordWriter(
+    private val filePath: Path,
+    private val objectMapper: ObjectMapper,
+) {
+    private var count = 0
+
+    fun append(record: SnapshotChunkRecord.Failure) {
+        val line = buildFailureLine(record)
+        Files.write(filePath, line, StandardOpenOption.CREATE, StandardOpenOption.APPEND)
+        count++
+    }
+
+    fun count(): Int = count
+
+    private fun buildFailureLine(record: SnapshotChunkRecord.Failure): ByteArray {
+        val buf = java.io.ByteArrayOutputStream()
+        buf.write("{\"endpoint\":".toByteArray())
+        buf.write(objectMapper.writeValueAsBytes(record.endpoint))
+        buf.write(",\"keyType\":".toByteArray())
+        buf.write(objectMapper.writeValueAsBytes(record.keyType))
+        buf.write(",\"key\":".toByteArray())
+        buf.write(objectMapper.writeValueAsBytes(record.key))
+        buf.write(",\"status\":\"FAILURE\",\"httpStatus\":".toByteArray())
+        buf.write(record.httpStatus.toString().toByteArray())
+        buf.write(",\"fetchedAt\":".toByteArray())
+        buf.write(objectMapper.writeValueAsBytes(record.fetchedAt.toString()))
+        buf.write(",\"error\":".toByteArray())
+        buf.write(objectMapper.writeValueAsBytes(record.errorMessage))
+        buf.write("}\n".toByteArray())
+        return buf.toByteArray()
+    }
+}

--- a/module-external-api/src/main/kotlin/maple/externalapi/snapshot/event/KafkaSnapshotChunkEventPublisher.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/snapshot/event/KafkaSnapshotChunkEventPublisher.kt
@@ -1,0 +1,54 @@
+package maple.externalapi.snapshot.event
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.slf4j.LoggerFactory
+import org.springframework.kafka.core.KafkaTemplate
+
+class KafkaSnapshotChunkEventPublisher(
+    private val kafkaTemplate: KafkaTemplate<String, String>,
+    private val objectMapper: ObjectMapper,
+    private val chunkReadyTopic: String,
+    private val runCompletedTopic: String,
+    private val runFailedTopic: String,
+) : SnapshotChunkEventPublisher {
+    private val log = LoggerFactory.getLogger(KafkaSnapshotChunkEventPublisher::class.java)
+
+    override fun publishChunkReady(event: SnapshotChunkReadyEvent) {
+        val key = "${event.runId}:${event.endpoint}:${event.chunkId}"
+        val payload = objectMapper.writeValueAsString(event)
+        kafkaTemplate.send(chunkReadyTopic, key, payload)
+            .whenComplete { _, ex ->
+                if (ex != null) {
+                    log.warn("[Event] failed to publish chunk-ready: runId={} chunkId={}: {}", event.runId, event.chunkId, ex.message)
+                } else {
+                    log.info("[Event] published chunk-ready: runId={} endpoint={} chunkId={}", event.runId, event.endpoint, event.chunkId)
+                }
+            }
+    }
+
+    override fun publishRunCompleted(event: SnapshotRunCompletedEvent) {
+        val key = "${event.runId}:${event.endpoint}"
+        val payload = objectMapper.writeValueAsString(event)
+        kafkaTemplate.send(runCompletedTopic, key, payload)
+            .whenComplete { _, ex ->
+                if (ex != null) {
+                    log.warn("[Event] failed to publish run-completed: runId={}: {}", event.runId, ex.message)
+                } else {
+                    log.info("[Event] published run-completed: runId={} endpoint={} chunks={}", event.runId, event.endpoint, event.chunkCount)
+                }
+            }
+    }
+
+    override fun publishRunFailed(event: SnapshotRunFailedEvent) {
+        val key = "${event.runId}:${event.endpoint}"
+        val payload = objectMapper.writeValueAsString(event)
+        kafkaTemplate.send(runFailedTopic, key, payload)
+            .whenComplete { _, ex ->
+                if (ex != null) {
+                    log.warn("[Event] failed to publish run-failed: runId={}: {}", event.runId, ex.message)
+                } else {
+                    log.info("[Event] published run-failed: runId={} endpoint={}", event.runId, event.endpoint)
+                }
+            }
+    }
+}

--- a/module-external-api/src/main/kotlin/maple/externalapi/snapshot/event/NoOpSnapshotChunkEventPublisher.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/snapshot/event/NoOpSnapshotChunkEventPublisher.kt
@@ -1,0 +1,19 @@
+package maple.externalapi.snapshot.event
+
+import org.slf4j.LoggerFactory
+
+class NoOpSnapshotChunkEventPublisher : SnapshotChunkEventPublisher {
+    private val log = LoggerFactory.getLogger(NoOpSnapshotChunkEventPublisher::class.java)
+
+    override fun publishChunkReady(event: SnapshotChunkReadyEvent) {
+        log.debug("[Event] NoOp: chunk ready runId={} endpoint={} chunkId={}", event.runId, event.endpoint, event.chunkId)
+    }
+
+    override fun publishRunCompleted(event: SnapshotRunCompletedEvent) {
+        log.debug("[Event] NoOp: run completed runId={} endpoint={}", event.runId, event.endpoint)
+    }
+
+    override fun publishRunFailed(event: SnapshotRunFailedEvent) {
+        log.debug("[Event] NoOp: run failed runId={} endpoint={}", event.runId, event.endpoint)
+    }
+}

--- a/module-external-api/src/main/kotlin/maple/externalapi/snapshot/event/SnapshotChunkEventPublisher.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/snapshot/event/SnapshotChunkEventPublisher.kt
@@ -1,0 +1,7 @@
+package maple.externalapi.snapshot.event
+
+interface SnapshotChunkEventPublisher {
+    fun publishChunkReady(event: SnapshotChunkReadyEvent)
+    fun publishRunCompleted(event: SnapshotRunCompletedEvent)
+    fun publishRunFailed(event: SnapshotRunFailedEvent)
+}

--- a/module-external-api/src/main/kotlin/maple/externalapi/snapshot/event/SnapshotChunkReadyEvent.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/snapshot/event/SnapshotChunkReadyEvent.kt
@@ -1,0 +1,18 @@
+package maple.externalapi.snapshot.event
+
+import java.time.Instant
+
+data class SnapshotChunkReadyEvent(
+    val eventId: String,
+    val eventType: String = "SNAPSHOT_CHUNK_READY",
+    val schemaVersion: Int = 1,
+    val runId: String,
+    val endpoint: String,
+    val chunkId: String,
+    val objectKey: String,
+    val recordCount: Int,
+    val uncompressedBytes: Long,
+    val compressedBytes: Long,
+    val sha256: String? = null,
+    val createdAt: Instant,
+)

--- a/module-external-api/src/main/kotlin/maple/externalapi/snapshot/event/SnapshotEventProperties.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/snapshot/event/SnapshotEventProperties.kt
@@ -1,0 +1,16 @@
+package maple.externalapi.snapshot.event
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "external-api.snapshot.events")
+data class SnapshotEventProperties(
+    val enabled: Boolean = true,
+    val kafka: KafkaConfig = KafkaConfig(),
+) {
+    data class KafkaConfig(
+        val enabled: Boolean = false,
+        val chunkReadyTopic: String = "external-api.snapshot.chunk-ready",
+        val runCompletedTopic: String = "external-api.snapshot.run-completed",
+        val runFailedTopic: String = "external-api.snapshot.run-failed",
+    )
+}

--- a/module-external-api/src/main/kotlin/maple/externalapi/snapshot/event/SnapshotEventPublisherConfig.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/snapshot/event/SnapshotEventPublisherConfig.kt
@@ -1,0 +1,40 @@
+package maple.externalapi.snapshot.event
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.kafka.core.KafkaTemplate
+
+@Configuration
+class SnapshotEventPublisherConfig {
+
+    @Bean
+    @ConditionalOnProperty(
+        prefix = "external-api.snapshot.events.kafka",
+        name = ["enabled"],
+        havingValue = "false",
+        matchIfMissing = true,
+    )
+    fun noOpSnapshotChunkEventPublisher(): SnapshotChunkEventPublisher =
+        NoOpSnapshotChunkEventPublisher()
+
+    @Bean
+    @ConditionalOnProperty(
+        prefix = "external-api.snapshot.events.kafka",
+        name = ["enabled"],
+        havingValue = "true",
+    )
+    fun kafkaSnapshotChunkEventPublisher(
+        kafkaTemplate: KafkaTemplate<String, String>,
+        objectMapper: ObjectMapper,
+        properties: SnapshotEventProperties,
+    ): SnapshotChunkEventPublisher =
+        KafkaSnapshotChunkEventPublisher(
+            kafkaTemplate = kafkaTemplate,
+            objectMapper = objectMapper,
+            chunkReadyTopic = properties.kafka.chunkReadyTopic,
+            runCompletedTopic = properties.kafka.runCompletedTopic,
+            runFailedTopic = properties.kafka.runFailedTopic,
+        )
+}

--- a/module-external-api/src/main/kotlin/maple/externalapi/snapshot/event/SnapshotRunCompletedEvent.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/snapshot/event/SnapshotRunCompletedEvent.kt
@@ -1,0 +1,18 @@
+package maple.externalapi.snapshot.event
+
+import java.time.Instant
+
+data class SnapshotRunCompletedEvent(
+    val eventId: String,
+    val eventType: String = "SNAPSHOT_RUN_COMPLETED",
+    val schemaVersion: Int = 1,
+    val runId: String,
+    val endpoint: String,
+    val manifestPath: String,
+    val totalRecords: Int,
+    val totalFailed: Int,
+    val chunkCount: Int,
+    val startedAt: Instant,
+    val finishedAt: Instant,
+    val createdAt: Instant,
+)

--- a/module-external-api/src/main/kotlin/maple/externalapi/snapshot/event/SnapshotRunFailedEvent.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/snapshot/event/SnapshotRunFailedEvent.kt
@@ -1,0 +1,13 @@
+package maple.externalapi.snapshot.event
+
+import java.time.Instant
+
+data class SnapshotRunFailedEvent(
+    val eventId: String,
+    val eventType: String = "SNAPSHOT_RUN_FAILED",
+    val schemaVersion: Int = 1,
+    val runId: String,
+    val endpoint: String,
+    val errorMessage: String,
+    val createdAt: Instant,
+)

--- a/module-external-api/src/main/resources/application.yml
+++ b/module-external-api/src/main/resources/application.yml
@@ -6,6 +6,13 @@ spring:
     name: external-api-collector
   main:
     banner-mode: off
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+      acks: all
+      retries: 3
 
 nexon:
   api:
@@ -24,6 +31,22 @@ external-api:
     daily-cron: "0 0 3 * * *"  # 매일 새벽 3시 — OCID + CHARACTER_BASIC
     enabled: true
     run-on-startup: true
+  snapshot:
+    chunk:
+      character-basic:
+        max-records: 2000
+        max-uncompressed-bytes: 134217728
+      item-equipment:
+        max-records: 500
+        max-uncompressed-bytes: 134217728
+    queue-capacity: 1000
+    events:
+      enabled: true
+      kafka:
+        enabled: false
+        chunk-ready-topic: external-api.snapshot.chunk-ready
+        run-completed-topic: external-api.snapshot.run-completed
+        run-failed-topic: external-api.snapshot.run-failed
 
 logging:
   level:


### PR DESCRIPTION
## Summary
- OCID별 개별 `.json.gz` 파일 저장을 streaming gzip JSONL chunk 파일로 교체
- 단일 writer thread + bounded queue로 backpressure 보장
- Kafka claim-check 패턴으로 chunk-ready/run-completed/run-failed 이벤트 발행 (default: disabled)
- manifest.json + `_SUCCESS` 마커로 run 완전성 추적

## Key Components
- `ChunkedSnapshotSink`: ArrayBlockingQueue 기반 단일 writer thread
- `GzipJsonlChunkWriter`: maxRecords/maxUncompressedBytes 기반 자동 rotation
- `SnapshotChunkEventPublisher`: NoOp(기본) / Kafka(conditional) 전환
- `SnapshotChunkingProperties`: per-endpoint chunk 설정

## Soak Test Results (5시간)
- CHARACTER_BASIC: 288,422 records, 145 chunks, 0 failures
- ITEM_EQUIPMENT: 288,422 records, 577 chunks, 0 failures
- G1GC heap: 363-416MB / 520MB, Full GC 없음
- 속도: CHARACTER_BASIC ~200 files/s, ITEM_EQUIPMENT 150-165 files/s

## Test plan
- [x] `./gradlew :module-external-api:compileKotlin` 컴파일 통과
- [x] Kafka 이벤트 발행 검증 (chunk-ready per chunk, run-completed after _SUCCESS)
- [x] 5시간 soak test 안정성 확인
- [x] manifest.json 무결성 검증 (chunks == disk files == totalRecords)

🤖 Generated with [Claude Code](https://claude.com/claude-code)