### PR TITLE
feat(calculator): publish result chunk events

### DIFF
--- a/module-calculator/src/main/kotlin/maple/calculator/consumer/KafkaSnapshotChunkReadyConsumer.kt
+++ b/module-calculator/src/main/kotlin/maple/calculator/consumer/KafkaSnapshotChunkReadyConsumer.kt
@@ -6,6 +6,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+import maple.calculator.event.CalculatorResultChunkReadyEvent
+import maple.calculator.event.KafkaResultEventPublisher
 import maple.calculator.event.SnapshotChunkReadyEvent
 import maple.calculator.processor.SnapshotChunkProcessor
 import org.slf4j.LoggerFactory
@@ -17,6 +20,7 @@ import org.springframework.stereotype.Component
 class KafkaSnapshotChunkReadyConsumer(
     private val objectMapper: ObjectMapper,
     private val chunkProcessor: SnapshotChunkProcessor,
+    private val resultEventPublisher: KafkaResultEventPublisher,
 ) {
     private val log = LoggerFactory.getLogger(KafkaSnapshotChunkReadyConsumer::class.java)
     private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
@@ -30,7 +34,11 @@ class KafkaSnapshotChunkReadyConsumer(
         val event = objectMapper.readValue(message, SnapshotChunkReadyEvent::class.java)
         log.info(
             "[Consumer] received chunk-ready: runId={} endpoint={} chunkId={} objectKey={} recordCount={}",
-            event.runId, event.endpoint, event.chunkId, event.objectKey, event.recordCount,
+            event.runId,
+            event.endpoint,
+            event.chunkId,
+            event.objectKey,
+            event.recordCount,
         )
 
         if (event.endpoint != "item-equipment") {
@@ -40,18 +48,38 @@ class KafkaSnapshotChunkReadyConsumer(
         }
 
         scope.launch {
-            concurrency.acquire()
-            try {
-                val result = chunkProcessor.process(event.objectKey)
-                log.info(
-                    "[Consumer] processed chunk: runId={} chunkId={} records={} success={} items={}",
-                    event.runId, event.chunkId, result.recordCount, result.successCount, result.totalItems,
-                )
-                acknowledgment.acknowledge()
-            } catch (e: Exception) {
-                log.error("[Consumer] chunk processing failed: runId={} chunkId={}: {}", event.runId, event.chunkId, e.message)
-            } finally {
-                concurrency.release()
+            concurrency.withPermit {
+                runCatching {
+                    val result = chunkProcessor.process(event)
+                    resultEventPublisher.publishChunkReady(
+                        CalculatorResultChunkReadyEvent(
+                            sourceRunId = event.runId,
+                            sourceEndpoint = event.endpoint,
+                            sourceChunkId = event.chunkId,
+                            objectKey = result.resultObjectKey,
+                            sourceRecordCount = event.recordCount,
+                            resultCount = result.resultCount,
+                            errorCount = result.errorCount,
+                            uncompressedBytes = result.resultUncompressedBytes,
+                            compressedBytes = result.resultCompressedBytes,
+                        ),
+                    )
+                    result
+                }.onSuccess { result ->
+                    log.info(
+                        "[Consumer] processed chunk: runId={} chunkId={} records={} success={} items={} results={} errors={}",
+                        event.runId,
+                        event.chunkId,
+                        result.recordCount,
+                        result.successCount,
+                        result.totalItems,
+                        result.resultCount,
+                        result.errorCount,
+                    )
+                    acknowledgment.acknowledge()
+                }.onFailure { ex ->
+                    log.error("[Consumer] chunk processing failed: runId={} chunkId={}: {}", event.runId, event.chunkId, ex.message)
+                }
             }
         }
     }

--- a/module-calculator/src/main/kotlin/maple/calculator/event/CalculatorResultChunkReadyEvent.kt
+++ b/module-calculator/src/main/kotlin/maple/calculator/event/CalculatorResultChunkReadyEvent.kt
@@ -1,0 +1,20 @@
+package maple.calculator.event
+
+import java.time.Instant
+import java.util.UUID
+
+data class CalculatorResultChunkReadyEvent(
+    val eventId: String = UUID.randomUUID().toString(),
+    val eventType: String = "CALCULATOR_RESULT_CHUNK_READY",
+    val schemaVersion: Int = 1,
+    val sourceRunId: String,
+    val sourceEndpoint: String,
+    val sourceChunkId: String,
+    val objectKey: String,
+    val sourceRecordCount: Int,
+    val resultCount: Int,
+    val errorCount: Int,
+    val uncompressedBytes: Long,
+    val compressedBytes: Long,
+    val createdAt: Instant = Instant.now(),
+)

--- a/module-calculator/src/main/kotlin/maple/calculator/event/KafkaResultEventPublisher.kt
+++ b/module-calculator/src/main/kotlin/maple/calculator/event/KafkaResultEventPublisher.kt
@@ -1,0 +1,32 @@
+package maple.calculator.event
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import kotlinx.coroutines.future.await
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.stereotype.Component
+
+@Component
+class KafkaResultEventPublisher(
+    private val kafkaTemplate: KafkaTemplate<String, String>,
+    private val objectMapper: ObjectMapper,
+    @Value("\${calculator.kafka.result-chunk-ready-topic}")
+    private val resultChunkReadyTopic: String,
+) {
+    private val log = LoggerFactory.getLogger(KafkaResultEventPublisher::class.java)
+
+    suspend fun publishChunkReady(event: CalculatorResultChunkReadyEvent) {
+        val key = "${event.sourceRunId}:${event.sourceEndpoint}:${event.sourceChunkId}"
+        val payload = objectMapper.writeValueAsString(event)
+        kafkaTemplate.send(resultChunkReadyTopic, key, payload).await()
+        log.info(
+            "[Event] published calculator result chunk-ready: sourceRunId={} sourceEndpoint={} sourceChunkId={} objectKey={} results={}",
+            event.sourceRunId,
+            event.sourceEndpoint,
+            event.sourceChunkId,
+            event.objectKey,
+            event.resultCount,
+        )
+    }
+}

--- a/module-calculator/src/main/kotlin/maple/calculator/processor/SnapshotChunkProcessor.kt
+++ b/module-calculator/src/main/kotlin/maple/calculator/processor/SnapshotChunkProcessor.kt
@@ -1,25 +1,45 @@
 package maple.calculator.processor
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import maple.calculator.config.PipelineProperties
+import maple.calculator.event.SnapshotChunkReadyEvent
 import maple.calculator.parser.SnapshotEquipmentParser
 import maple.calculator.reader.GzipJsonlSnapshotRecordReader
 import maple.calculator.storage.ObjectStorage
-import maple.expectation.application.service.calculator.v4.EquipmentExpectationCalculatorFactory
+import maple.calculator.writer.CalculationResultWriter
 import maple.expectation.application.service.starforce.NoljangProbabilityTable
-import maple.expectation.core.domain.equipment.SecondaryWeaponCategory
 import maple.expectation.core.dto.cube.CubeCalculationInput
-import maple.expectation.core.dto.v4.EquipmentCalculationInput
 import maple.expectation.core.dto.v4.EquipmentItem
 import maple.expectation.core.dto.v4.EquipmentItemConverter
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
-import java.util.concurrent.atomic.AtomicInteger
+
+data class CalculationResult(
+    val ocid: String,
+    val presetNo: Int,
+    val itemName: String,
+    val itemLevel: Int,
+    val itemPart: String?,
+    val itemEquipmentPart: String?,
+    val potentialGrade: String?,
+    val potentialOptions: List<String?>,
+    val additionalGrade: String?,
+    val additionalOptions: List<String>,
+    val currentStar: Int,
+    val targetStar: Int,
+    val status: String,
+    val totalCost: Double?,
+    val blackCubeCost: Double?,
+    val additionalCubeCost: Double?,
+    val starforceCost: Double?,
+    val errorMessage: String? = null,
+)
 
 @Component
 class SnapshotChunkProcessor(
@@ -27,9 +47,9 @@ class SnapshotChunkProcessor(
     private val jsonlReader: GzipJsonlSnapshotRecordReader,
     private val equipmentParser: SnapshotEquipmentParser,
     private val calculationCache: CalculationCache,
-    private val calculatorFactory: EquipmentExpectationCalculatorFactory,
     private val objectMapper: ObjectMapper,
     private val properties: PipelineProperties,
+    private val resultWriter: CalculationResultWriter,
 ) {
     private val log = LoggerFactory.getLogger(SnapshotChunkProcessor::class.java)
     private val sampleCount = AtomicInteger(0)
@@ -46,39 +66,65 @@ class SnapshotChunkProcessor(
         val totalItems: Int,
         val calculatedCount: Int,
         val errorCount: Int,
+        val resultObjectKey: String,
+        val resultCount: Int,
+        val resultUncompressedBytes: Long,
+        val resultCompressedBytes: Long,
     )
 
-    fun process(objectKey: String): ChunkResult = runBlocking {
+    suspend fun process(event: SnapshotChunkReadyEvent): ChunkResult = coroutineScope {
         val lineChannel = Channel<String>(properties.channelCapacity)
         val itemChannel = Channel<FlatItem>(properties.channelCapacity)
+        val resultChannel = Channel<CalculationResult>(properties.channelCapacity)
         val recordCount = AtomicInteger(0)
         val successCount = AtomicInteger(0)
         val totalItems = AtomicInteger(0)
         val calculatedCount = AtomicInteger(0)
         val errorCount = AtomicInteger(0)
+        val resultObjectKey = resultObjectKeyFor(event)
 
-        coroutineScope {
-            // 1. reader: gzip에서 raw line만 순차 읽기
-            launch(Dispatchers.IO) { readLines(objectKey, lineChannel) }
+        launch(Dispatchers.IO) { readLines(event.objectKey, lineChannel) }
 
-            // 2. N parsers → itemChannel close when all done
-            launch {
-                coroutineScope {
-                    repeat(properties.workerCount) {
-                        launch(Dispatchers.Default) { parseLines(lineChannel, itemChannel, recordCount, successCount, totalItems) }
+        launch {
+            coroutineScope {
+                repeat(properties.workerCount) {
+                    launch(Dispatchers.Default) {
+                        parseLines(lineChannel, itemChannel, recordCount, successCount, totalItems)
                     }
                 }
-                itemChannel.close()
             }
-
-            // 3. N workers: 계산 (병렬)
-            repeat(properties.workerCount) {
-                launch(Dispatchers.Default) { processItems(itemChannel, calculatedCount, errorCount) }
-            }
+            itemChannel.close()
         }
 
-        ChunkResult(recordCount.get(), successCount.get(), totalItems.get(), calculatedCount.get(), errorCount.get())
+        launch {
+            coroutineScope {
+                repeat(properties.workerCount) {
+                    launch(Dispatchers.Default) {
+                        processItems(itemChannel, resultChannel, calculatedCount, errorCount)
+                    }
+                }
+            }
+            resultChannel.close()
+        }
+
+        val writeResult = async(Dispatchers.IO) {
+            resultWriter.write(resultObjectKey, resultChannel)
+        }.await()
+
+        ChunkResult(
+            recordCount = recordCount.get(),
+            successCount = successCount.get(),
+            totalItems = totalItems.get(),
+            calculatedCount = calculatedCount.get(),
+            errorCount = errorCount.get(),
+            resultObjectKey = writeResult.objectKey,
+            resultCount = writeResult.resultCount,
+            resultUncompressedBytes = writeResult.uncompressedBytes,
+            resultCompressedBytes = writeResult.compressedBytes,
+        )
     }
+
+    private fun resultObjectKeyFor(event: SnapshotChunkReadyEvent): String = "data/calculator/runs/${event.runId}/${event.endpoint}/chunks/result-${event.chunkId}.jsonl.gz"
 
     private suspend fun readLines(
         objectKey: String,
@@ -117,104 +163,129 @@ class SnapshotChunkProcessor(
     }
 
     private suspend fun processItems(
-        channel: Channel<FlatItem>,
+        itemChannel: Channel<FlatItem>,
+        resultChannel: Channel<CalculationResult>,
         calculatedCount: AtomicInteger,
         errorCount: AtomicInteger,
     ) {
-        for (flatItem in channel) {
-            calculateItem(flatItem, calculatedCount, errorCount)
+        for (flatItem in itemChannel) {
+            val result = calculateItem(flatItem)
+            if (result.status == "ERROR") {
+                errorCount.incrementAndGet()
+            } else {
+                calculatedCount.incrementAndGet()
+            }
+            resultChannel.send(result)
         }
     }
 
-    private fun calculateItem(
-        flatItem: FlatItem,
-        calculatedCount: AtomicInteger,
-        errorCount: AtomicInteger,
-    ) {
+    private fun calculateItem(flatItem: FlatItem): CalculationResult = runCatching {
         val cubeInput = EquipmentItemConverter.toCubeInput(flatItem.item)
-        if (!cubeInput.isReady()) {
-            calculatedCount.incrementAndGet()
-            return
-        }
-        try {
-            val shouldSample = sampleCount.incrementAndGet() <= 10
+        val componentCosts = calculateComponentCosts(cubeInput)
+        val status = if (componentCosts.hasAnyCost) "SUCCESS" else "SKIPPED"
+        val result = buildCalculationResult(flatItem, cubeInput, componentCosts, status, null)
+        logSample(result)
+        result
+    }.getOrElse { ex ->
+        val cubeInput = EquipmentItemConverter.toCubeInput(flatItem.item)
+        log.warn("Calculation error: ocid={} preset={}: {}", flatItem.ocid, flatItem.presetNo, ex.message)
+        buildCalculationResult(flatItem, cubeInput, ComponentCosts.empty(), "ERROR", ex.message)
+    }
 
-            if (shouldSample) {
-                val input = buildCalculationInput(cubeInput, flatItem.presetNo)
-                val calculator = calculatorFactory.createFullCalculator(input)
-                val cost = calculator.calculateCost()
-                val details = calculator.detailedCosts
-                val sample = mapOf(
-                    "ocid" to flatItem.ocid,
-                    "presetNo" to flatItem.presetNo,
-                    "itemName" to cubeInput.itemName,
-                    "itemLevel" to cubeInput.level,
-                    "potentialGrade" to cubeInput.grade,
-                    "potentialOption1" to cubeInput.options.getOrNull(0),
-                    "potentialOption2" to cubeInput.options.getOrNull(1),
-                    "potentialOption3" to cubeInput.options.getOrNull(2),
-                    "additionalGrade" to cubeInput.additionalGrade,
-                    "additionalOption1" to cubeInput.additionalOptions.getOrNull(0),
-                    "additionalOption2" to cubeInput.additionalOptions.getOrNull(1),
-                    "additionalOption3" to cubeInput.additionalOptions.getOrNull(2),
-                    "starforce" to cubeInput.starforce,
-                    "totalCost" to cost,
-                    "blackCubeCost" to details.blackCubeCost,
-                    "additionalCubeCost" to details.additionalCubeCost,
-                    "starforceCost" to details.starforceCost,
-                    "enhancePath" to calculator.enhancePath,
-                )
-                log.debug("[SAMPLE] {}", objectMapper.writeValueAsString(sample))
+    private fun calculateComponentCosts(cubeInput: CubeCalculationInput): ComponentCosts {
+        val potentialCost = if (cubeInput.isReady()) {
+            calculationCache.calculatePotential(cubeInput)
+        } else {
+            null
+        }
+
+        val additionalCost = if (hasAdditionalPotential(cubeInput)) {
+            calculationCache.calculateAdditional(cubeInput.toAdditionalCubeInput())
+        } else {
+            null
+        }
+
+        val starforceTarget = targetStar(cubeInput)
+        val starforceCost = if (starforceTarget > 0) {
+            calculationCache.calculateStarforce(cubeInput.itemName ?: "", cubeInput.level, 0, starforceTarget)
+        } else {
+            null
+        }
+
+        return ComponentCosts(
+            blackCubeCost = potentialCost,
+            additionalCubeCost = additionalCost,
+            starforceCost = starforceCost,
+        )
+    }
+
+    private fun hasAdditionalPotential(cubeInput: CubeCalculationInput): Boolean = cubeInput.additionalGrade != null &&
+        cubeInput.additionalOptions.any { it.trim().isNotEmpty() && !"null".equals(it, ignoreCase = true) }
+
+    private fun CubeCalculationInput.toAdditionalCubeInput(): CubeCalculationInput = copy(
+        grade = additionalGrade,
+        options = additionalOptions.toMutableList(),
+    )
+
+    private fun targetStar(cubeInput: CubeCalculationInput): Int {
+        if (cubeInput.starforce <= 0 || cubeInput.itemName.isNullOrBlank() || cubeInput.level <= 0) {
+            return 0
+        }
+        return if (cubeInput.isNoljangEquipment()) {
+            minOf(cubeInput.starforce, NoljangProbabilityTable.MAX_NOLJANG_STAR)
+        } else {
+            cubeInput.starforce
+        }
+    }
+
+    private fun buildCalculationResult(
+        flatItem: FlatItem,
+        cubeInput: CubeCalculationInput,
+        componentCosts: ComponentCosts,
+        status: String,
+        errorMessage: String?,
+    ): CalculationResult = CalculationResult(
+        ocid = flatItem.ocid,
+        presetNo = flatItem.presetNo,
+        itemName = cubeInput.itemName ?: "",
+        itemLevel = cubeInput.level,
+        itemPart = cubeInput.part,
+        itemEquipmentPart = cubeInput.itemEquipmentPart,
+        potentialGrade = cubeInput.grade,
+        potentialOptions = cubeInput.options,
+        additionalGrade = cubeInput.additionalGrade,
+        additionalOptions = cubeInput.additionalOptions,
+        currentStar = 0,
+        targetStar = targetStar(cubeInput),
+        status = status,
+        totalCost = componentCosts.totalCost,
+        blackCubeCost = componentCosts.blackCubeCost,
+        additionalCubeCost = componentCosts.additionalCubeCost,
+        starforceCost = componentCosts.starforceCost,
+        errorMessage = errorMessage,
+    )
+
+    private fun logSample(result: CalculationResult) {
+        if (sampleCount.incrementAndGet() <= 10) {
+            log.debug("[SAMPLE] {}", objectMapper.writeValueAsString(result))
+        }
+    }
+
+    private data class ComponentCosts(
+        val blackCubeCost: Double?,
+        val additionalCubeCost: Double?,
+        val starforceCost: Double?,
+    ) {
+        val hasAnyCost: Boolean = blackCubeCost != null || additionalCubeCost != null || starforceCost != null
+        val totalCost: Double?
+            get() = if (hasAnyCost) {
+                (blackCubeCost ?: 0.0) + (additionalCubeCost ?: 0.0) + (starforceCost ?: 0.0)
             } else {
-                if (cubeInput.grade != null && !cubeInput.options.isNullOrEmpty()) {
-                    calculationCache.calculatePotential(cubeInput)
-                }
-                if (cubeInput.additionalGrade != null && !cubeInput.additionalOptions.isNullOrEmpty()) {
-                    calculationCache.calculateAdditional(cubeInput)
-                }
-                if (cubeInput.starforce > 0) {
-                    val isNoljang = cubeInput.isNoljangEquipment()
-                    val targetStar = if (isNoljang)
-                        minOf(cubeInput.starforce, NoljangProbabilityTable.MAX_NOLJANG_STAR)
-                    else
-                        cubeInput.starforce
-                    calculationCache.calculateStarforce(cubeInput.itemName ?: "", cubeInput.level, 0, targetStar)
-                }
+                null
             }
 
-            calculatedCount.incrementAndGet()
-        } catch (e: Exception) {
-            errorCount.incrementAndGet()
-            log.warn("Calculation error: ocid={}, preset={}: {}", flatItem.ocid, flatItem.presetNo, e.message)
+        companion object {
+            fun empty(): ComponentCosts = ComponentCosts(null, null, null)
         }
-    }
-
-    private fun buildCalculationInput(
-        cubeInput: CubeCalculationInput,
-        presetNo: Int,
-    ): EquipmentCalculationInput {
-        val isNoljang = cubeInput.isNoljangEquipment()
-        val targetStar = if (isNoljang)
-            minOf(cubeInput.starforce, NoljangProbabilityTable.MAX_NOLJANG_STAR)
-        else
-            cubeInput.starforce
-        val potentialPart = SecondaryWeaponCategory.resolvePotentialPart(
-            cubeInput.part, cubeInput.itemEquipmentPart,
-        )
-        return EquipmentCalculationInput.builder()
-            .itemName(cubeInput.itemName ?: "")
-            .itemPart(potentialPart)
-            .itemEquipmentPart(cubeInput.itemEquipmentPart ?: "")
-            .itemIcon(cubeInput.itemIcon ?: "")
-            .itemLevel(cubeInput.level)
-            .presetNo(presetNo)
-            .isNoljang(isNoljang)
-            .potentialGrade(cubeInput.grade)
-            .potentialOptions(cubeInput.options?.filterNotNull())
-            .additionalPotentialGrade(cubeInput.additionalGrade)
-            .additionalPotentialOptions(cubeInput.additionalOptions?.filterNotNull())
-            .currentStar(0)
-            .targetStar(targetStar)
-            .build()
     }
 }

--- a/module-calculator/src/main/kotlin/maple/calculator/storage/LocalObjectStorageAdapter.kt
+++ b/module-calculator/src/main/kotlin/maple/calculator/storage/LocalObjectStorageAdapter.kt
@@ -1,10 +1,11 @@
 package maple.calculator.storage
 
-import org.springframework.beans.factory.annotation.Value
-import org.springframework.stereotype.Component
 import java.io.InputStream
+import java.io.OutputStream
 import java.nio.file.Files
 import java.nio.file.Paths
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
 
 @Component
 class LocalObjectStorageAdapter(
@@ -17,7 +18,11 @@ class LocalObjectStorageAdapter(
         return Files.newInputStream(path)
     }
 
-    override fun exists(objectKey: String): Boolean {
-        return Files.exists(Paths.get(basePath, objectKey))
+    override fun openOutputStream(objectKey: String): OutputStream {
+        val path = Paths.get(basePath, objectKey)
+        path.parent?.let { Files.createDirectories(it) }
+        return Files.newOutputStream(path)
     }
+
+    override fun exists(objectKey: String): Boolean = Files.exists(Paths.get(basePath, objectKey))
 }

--- a/module-calculator/src/main/kotlin/maple/calculator/storage/ObjectStorage.kt
+++ b/module-calculator/src/main/kotlin/maple/calculator/storage/ObjectStorage.kt
@@ -1,8 +1,10 @@
 package maple.calculator.storage
 
 import java.io.InputStream
+import java.io.OutputStream
 
 interface ObjectStorage {
     fun openInputStream(objectKey: String): InputStream
+    fun openOutputStream(objectKey: String): OutputStream
     fun exists(objectKey: String): Boolean
 }

--- a/module-calculator/src/main/kotlin/maple/calculator/writer/CalculationResultWriter.kt
+++ b/module-calculator/src/main/kotlin/maple/calculator/writer/CalculationResultWriter.kt
@@ -1,0 +1,81 @@
+package maple.calculator.writer
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import java.io.BufferedWriter
+import java.io.OutputStream
+import java.io.OutputStreamWriter
+import java.nio.charset.StandardCharsets
+import java.util.zip.GZIPOutputStream
+import kotlinx.coroutines.channels.ReceiveChannel
+import maple.calculator.processor.CalculationResult
+import maple.calculator.storage.ObjectStorage
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+@Component
+class CalculationResultWriter(
+    private val objectStorage: ObjectStorage,
+    private val objectMapper: ObjectMapper,
+) {
+    private val log = LoggerFactory.getLogger(CalculationResultWriter::class.java)
+
+    data class WriteResult(
+        val objectKey: String,
+        val resultCount: Int,
+        val uncompressedBytes: Long,
+        val compressedBytes: Long,
+    )
+
+    suspend fun write(
+        objectKey: String,
+        results: ReceiveChannel<CalculationResult>,
+    ): WriteResult {
+        val countingStream = CountingOutputStream(objectStorage.openOutputStream(objectKey))
+        var resultCount = 0
+        var uncompressedBytes = 0L
+
+        BufferedWriter(OutputStreamWriter(GZIPOutputStream(countingStream), StandardCharsets.UTF_8)).use { writer ->
+            for (result in results) {
+                val line = objectMapper.writeValueAsString(result)
+                writer.write(line)
+                writer.newLine()
+                resultCount += 1
+                uncompressedBytes += line.toByteArray(StandardCharsets.UTF_8).size + 1
+            }
+        }
+
+        log.info(
+            "[Writer] wrote calculator result chunk: objectKey={} results={} uncompressedBytes={} compressedBytes={}",
+            objectKey,
+            resultCount,
+            uncompressedBytes,
+            countingStream.bytesWritten,
+        )
+        return WriteResult(objectKey, resultCount, uncompressedBytes, countingStream.bytesWritten)
+    }
+
+    private class CountingOutputStream(
+        private val delegate: OutputStream,
+    ) : OutputStream() {
+        var bytesWritten: Long = 0
+            private set
+
+        override fun write(b: Int) {
+            delegate.write(b)
+            bytesWritten += 1
+        }
+
+        override fun write(b: ByteArray, off: Int, len: Int) {
+            delegate.write(b, off, len)
+            bytesWritten += len
+        }
+
+        override fun flush() {
+            delegate.flush()
+        }
+
+        override fun close() {
+            delegate.close()
+        }
+    }
+}

--- a/module-calculator/src/main/resources/application.yml
+++ b/module-calculator/src/main/resources/application.yml
@@ -20,6 +20,7 @@ spring:
 calculator:
   kafka:
     snapshot-chunk-ready-topic: external-api.snapshot.chunk-ready
+    result-chunk-ready-topic: calculator.result.chunk-ready
     consumer-group-id: calculator-snapshot-chunk-processor
   store:
     input-base-path: ../module-external-api/external-api-data


### PR DESCRIPTION
## Summary
- write calculator results as gzip JSONL chunks under data/calculator/runs/{sourceRunId}/{sourceEndpoint}/chunks/result-{sourceChunkId}.jsonl.gz
- publish calculator.result.chunk-ready after result storage succeeds
- keep Kafka ACK after result write and publish, and replace manual semaphore release with withPermit
- add ObjectStorage output stream support for local storage

## Verification
- ./gradlew :module-calculator:test

## Notes
- Existing untracked node_modules/ was left untouched.