### PR TITLE
fix: address code review findings (P1/P2)

### DIFF
--- a/module-calculator/src/main/kotlin/maple/calculator/consumer/KafkaSnapshotChunkReadyConsumer.kt
+++ b/module-calculator/src/main/kotlin/maple/calculator/consumer/KafkaSnapshotChunkReadyConsumer.kt
@@ -1,10 +1,7 @@
 package maple.calculator.consumer
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 import maple.calculator.event.CalculatorResultChunkReadyEvent
@@ -23,7 +20,6 @@ class KafkaSnapshotChunkReadyConsumer(
     private val resultEventPublisher: KafkaResultEventPublisher,
 ) {
     private val log = LoggerFactory.getLogger(KafkaSnapshotChunkReadyConsumer::class.java)
-    private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
     private val concurrency = Semaphore(2)
 
     @KafkaListener(
@@ -47,7 +43,7 @@ class KafkaSnapshotChunkReadyConsumer(
             return
         }
 
-        scope.launch {
+        runBlocking {
             concurrency.withPermit {
                 runCatching {
                     val result = chunkProcessor.process(event)

--- a/module-external-api/src/main/kotlin/maple/externalapi/application/ExternalApiIngestionService.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/application/ExternalApiIngestionService.kt
@@ -44,6 +44,17 @@ class ExternalApiIngestionService(
             eventPublisherPort.publishFetchCompleted(result)
             log.info("[ExternalApi] fetch completed: jobId={}, key={}, size={}bytes", jobId, requestKey, payloadRef.sizeBytes)
             result
+        } catch (ex: java.util.concurrent.CompletionException) {
+            val cause = ex.cause ?: ex
+            log.error("[ExternalApi] fetch failed: jobId={}, endpoint={}, key={}", jobId, endpoint, requestKey, cause)
+            ExternalApiFetchResult(
+                jobId = jobId,
+                endpoint = endpoint,
+                requestKey = requestKey,
+                payloadRef = null,
+                success = false,
+                errorMessage = cause.message,
+            )
         } catch (ex: Exception) {
             log.error("[ExternalApi] fetch failed: jobId={}, endpoint={}, key={}", jobId, endpoint, requestKey, ex)
             ExternalApiFetchResult(

--- a/module-external-api/src/main/kotlin/maple/externalapi/infra/nexon/NexonExternalApiClientAdapter.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/infra/nexon/NexonExternalApiClientAdapter.kt
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
+import org.springframework.http.client.reactive.ReactorClientHttpConnector
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import org.springframework.web.util.DefaultUriBuilderFactory
@@ -36,6 +37,7 @@ class NexonExternalApiClientAdapter(
         WebClient.builder()
             .uriBuilderFactory(factory)
             .baseUrl("https://open.api.nexon.com")
+            .clientConnector(ReactorClientHttpConnector(httpClient))
             .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
             .codecs { it.defaultCodecs().maxInMemorySize(2 * 1024 * 1024) }
             .build()

--- a/module-external-api/src/main/kotlin/maple/externalapi/snapshot/ChunkedSnapshotSink.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/snapshot/ChunkedSnapshotSink.kt
@@ -62,14 +62,22 @@ class ChunkedSnapshotSink(
             }
             throw IllegalStateException("sink is closed, cannot submit")
         }
-        queue.put(record)
+        if (!queue.offer(record, 30, java.util.concurrent.TimeUnit.SECONDS)) {
+            throw IllegalStateException("sink queue full after 30s, likely writer thread stuck")
+        }
     }
 
     fun close() {
         accepting.set(false)
-        queue.put(SnapshotChunkRecord.CloseSignal)
+        if (!queue.offer(SnapshotChunkRecord.CloseSignal, 30, java.util.concurrent.TimeUnit.SECONDS)) {
+            throw IllegalStateException("failed to enqueue close signal after 30s")
+        }
 
-        writerThread.join()
+        writerThread.join(60_000)
+        if (writerThread.isAlive) {
+            log.warn("[Sink] writer thread did not terminate within 60s, interrupting")
+            writerThread.interrupt()
+        }
 
         val err = writerError.get()
         if (err != null) {

--- a/module-external-api/src/main/kotlin/maple/externalapi/snapshot/event/KafkaSnapshotChunkEventPublisher.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/snapshot/event/KafkaSnapshotChunkEventPublisher.kt
@@ -3,6 +3,7 @@ package maple.externalapi.snapshot.event
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.slf4j.LoggerFactory
 import org.springframework.kafka.core.KafkaTemplate
+import java.util.concurrent.TimeUnit
 
 class KafkaSnapshotChunkEventPublisher(
     private val kafkaTemplate: KafkaTemplate<String, String>,
@@ -16,39 +17,21 @@ class KafkaSnapshotChunkEventPublisher(
     override fun publishChunkReady(event: SnapshotChunkReadyEvent) {
         val key = "${event.runId}:${event.endpoint}:${event.chunkId}"
         val payload = objectMapper.writeValueAsString(event)
-        kafkaTemplate.send(chunkReadyTopic, key, payload)
-            .whenComplete { _, ex ->
-                if (ex != null) {
-                    log.warn("[Event] failed to publish chunk-ready: runId={} chunkId={}: {}", event.runId, event.chunkId, ex.message)
-                } else {
-                    log.info("[Event] published chunk-ready: runId={} endpoint={} chunkId={}", event.runId, event.endpoint, event.chunkId)
-                }
-            }
+        kafkaTemplate.send(chunkReadyTopic, key, payload).get(30, TimeUnit.SECONDS)
+        log.info("[Event] published chunk-ready: runId={} endpoint={} chunkId={}", event.runId, event.endpoint, event.chunkId)
     }
 
     override fun publishRunCompleted(event: SnapshotRunCompletedEvent) {
         val key = "${event.runId}:${event.endpoint}"
         val payload = objectMapper.writeValueAsString(event)
-        kafkaTemplate.send(runCompletedTopic, key, payload)
-            .whenComplete { _, ex ->
-                if (ex != null) {
-                    log.warn("[Event] failed to publish run-completed: runId={}: {}", event.runId, ex.message)
-                } else {
-                    log.info("[Event] published run-completed: runId={} endpoint={} chunks={}", event.runId, event.endpoint, event.chunkCount)
-                }
-            }
+        kafkaTemplate.send(runCompletedTopic, key, payload).get(30, TimeUnit.SECONDS)
+        log.info("[Event] published run-completed: runId={} endpoint={} chunks={}", event.runId, event.endpoint, event.chunkCount)
     }
 
     override fun publishRunFailed(event: SnapshotRunFailedEvent) {
         val key = "${event.runId}:${event.endpoint}"
         val payload = objectMapper.writeValueAsString(event)
-        kafkaTemplate.send(runFailedTopic, key, payload)
-            .whenComplete { _, ex ->
-                if (ex != null) {
-                    log.warn("[Event] failed to publish run-failed: runId={}: {}", event.runId, ex.message)
-                } else {
-                    log.info("[Event] published run-failed: runId={} endpoint={}", event.runId, event.endpoint)
-                }
-            }
+        kafkaTemplate.send(runFailedTopic, key, payload).get(30, TimeUnit.SECONDS)
+        log.info("[Event] published run-failed: runId={} endpoint={}", event.runId, event.endpoint)
     }
 }


### PR DESCRIPTION
## Summary

Code review에서 발견된 P1/P2 이슈 수정.

### P1 (Critical)
- **Kafka publish 동기화**: `KafkaSnapshotChunkEventPublisher`를 fire-and-forget에서 `.get(30s)` 동기식으로 변경. chunk 파일은 있지만 이벤트 누락으로 calculator가 못 받는 현상 방지
- **Calculator consumer ack 타이밍**: `scope.launch` 비동기 ack → `runBlocking` 동기 처리. listener thread에서 처리 완료 후 ack하여 rebalance 시 offset 꼬임 방지
- **WebClient timeout 적용**: `NexonExternalApiClientAdapter`에서 HttpClient에 timeout 설정했지만 `ReactorClientHttpConnector`로 주입하지 않아 dead code였던 것 수정

### P2 (Important)
- **ChunkedSnapshotSink blocking timeout**: `queue.put()` → `queue.offer(30s)`, `writerThread.join()` → `join(60s)`. 무기한 블로킹 방지
- **CompletionException unwrapping**: `ExternalApiIngestionService.fetchSingle()`에서 `.join()` 예외 시 원인 추출

### Deferred
- `ExternalApiIngestionService.fetchSingle()` async 변환 → #812

## Test plan
- [x] `./gradlew :module-external-api:compileKotlin :module-calculator:compileKotlin --continue` 통과
- [ ] E2E: external-api → Kafka → calculator 파이프라인 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)