### PR TITLE
feat: add module-synchronizer with Kafka result chunk consumer

### DIFF
--- a/module-synchronizer/build.gradle
+++ b/module-synchronizer/build.gradle
@@ -1,0 +1,45 @@
+// ========================================
+// Module-Synchronizer: Calculator result files → DB sync
+// ========================================
+
+plugins {
+	alias(libs.plugins.kotlin.jvm)
+	alias(libs.plugins.kotlin.spring)
+	alias(libs.plugins.spring.boot)
+}
+
+dependencies {
+	implementation project(':module-common')
+	implementation project(':module-core')
+	implementation project(':module-infra')
+
+	implementation(libs.kotlin.stdlib)
+	implementation(libs.kotlin.reflect)
+	implementation(libs.kotlin.logging.jvm)
+
+	// Spring
+	implementation(libs.spring.boot)
+	implementation(libs.spring.boot.starter.web)
+
+	// Kafka
+	implementation(libs.spring.kafka)
+
+	// Jackson
+	implementation(libs.jackson.databind)
+	implementation(libs.jackson.module.kotlin)
+
+	// Testing
+	testImplementation(libs.spring.boot.starter.test)
+	testImplementation(libs.assertj.core)
+}
+
+bootJar {
+	enabled = true
+	archiveClassifier = ""
+	mainClass.set("maple.synchronizer.SynchronizerApplication")
+}
+
+tasks.named("jar") {
+	enabled = true
+	archiveClassifier = "plain"
+}

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/SynchronizerApplication.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/SynchronizerApplication.kt
@@ -1,0 +1,11 @@
+package maple.synchronizer
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+@SpringBootApplication
+class SynchronizerApplication
+
+fun main(args: Array<String>) {
+    runApplication<SynchronizerApplication>(*args)
+}

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/KafkaResultChunkConsumer.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/KafkaResultChunkConsumer.kt
@@ -1,0 +1,35 @@
+package maple.synchronizer.consumer
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import maple.synchronizer.event.CalculatorResultChunkReadyEvent
+import org.slf4j.LoggerFactory
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.kafka.support.Acknowledgment
+import org.springframework.stereotype.Component
+
+@Component
+class KafkaResultChunkConsumer(
+    private val objectMapper: ObjectMapper,
+) {
+    private val log = LoggerFactory.getLogger(KafkaResultChunkConsumer::class.java)
+
+    @KafkaListener(
+        topics = ["\${synchronizer.kafka.result-chunk-ready-topic}"],
+        groupId = "\${synchronizer.kafka.consumer-group-id}",
+    )
+    fun consume(message: String, acknowledgment: Acknowledgment) {
+        val event = objectMapper.readValue(message, CalculatorResultChunkReadyEvent::class.java)
+        log.info(
+            "[Synchronizer] received result chunk-ready: runId={} endpoint={} chunkId={} objectKey={} results={}",
+            event.sourceRunId,
+            event.sourceEndpoint,
+            event.sourceChunkId,
+            event.objectKey,
+            event.resultCount,
+        )
+
+        // TODO: read result file from objectKey, parse, bulk insert to DB
+
+        acknowledgment.acknowledge()
+    }
+}

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/event/CalculatorResultChunkReadyEvent.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/event/CalculatorResultChunkReadyEvent.kt
@@ -1,0 +1,19 @@
+package maple.synchronizer.event
+
+import java.time.Instant
+
+data class CalculatorResultChunkReadyEvent(
+    val eventId: String,
+    val eventType: String,
+    val schemaVersion: Int,
+    val sourceRunId: String,
+    val sourceEndpoint: String,
+    val sourceChunkId: String,
+    val objectKey: String,
+    val sourceRecordCount: Int,
+    val resultCount: Int,
+    val errorCount: Int,
+    val uncompressedBytes: Long,
+    val compressedBytes: Long,
+    val createdAt: Instant,
+)

--- a/module-synchronizer/src/main/resources/application.yml
+++ b/module-synchronizer/src/main/resources/application.yml
@@ -1,0 +1,29 @@
+server:
+  port: 8083
+
+spring:
+  application:
+    name: synchronizer
+  main:
+    banner-mode: off
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    consumer:
+      group-id: synchronizer-result-chunk-consumer
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      auto-offset-reset: earliest
+      enable-auto-commit: false
+    listener:
+      ack-mode: manual
+
+synchronizer:
+  kafka:
+    result-chunk-ready-topic: calculator.result.chunk-ready
+    consumer-group-id: synchronizer-result-chunk-consumer
+
+logging:
+  level:
+    maple.synchronizer: INFO
+  pattern:
+    console: "%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"

--- a/settings.gradle
+++ b/settings.gradle
@@ -22,3 +22,6 @@ include 'module-external-api'
 
 // Calculator module (Kafka-driven chunk processing)
 include 'module-calculator'
+
+// Synchronizer module (Calculator result files → DB sync)
+include 'module-synchronizer'


### PR DESCRIPTION
## Summary
- New `module-synchronizer` Spring Boot module (port 8083)
- Kafka consumer subscribing to `calculator.result.chunk-ready` topic
- `CalculatorResultChunkReadyEvent` DTO mapping
- DB sync logic (result file → bulk insert) is TODO

## Architecture
```
module-calculator ──[CALCULATOR_RESULT_CHUNK_READY]──→ module-synchronizer
  (계산 완료 후 이벤트 발행)          Kafka topic           (결과 → DB)
```

## Test plan
- [x] `./gradlew :module-synchronizer:compileKotlin` 컴파일 성공
- [x] `bootRun` 부팅 성공 (port 8083)
- [x] Kafka consumer `calculator.result.chunk-ready` 3파티션 정상 할당 확인
- [ ] 결과 파일 읽기 → DB bulk insert (후속 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)