### PR TITLE
feat: Prometheus metrics, Grafana dashboard, metric reference rules

### DIFF
--- a/.claude/rules/prometheus-metrics.md
+++ b/.claude/rules/prometheus-metrics.md
@@ -1,0 +1,119 @@
+# Prometheus Metrics 참조
+
+모듈별 Prometheus 메트릭 엔드포인트:
+- External API: `http://localhost:8081/actuator/prometheus`
+- Calculator: `http://localhost:8082/actuator/prometheus`
+
+## External API 메트릭
+
+### Counter (누적)
+| 메트릭명 | 설명 |
+|----------|------|
+| `external_api_users_fetched_total` | 전체 유저 fetch 수 |
+| `external_api_users_failed_total` | 전체 유저 실패 수 |
+| `external_api_character_basic_fetched_total` | CHARACTER_BASIC 성공 수 |
+| `external_api_character_basic_failed_total` | CHARACTER_BASIC 실패 수 |
+| `external_api_item_equipment_fetched_total` | ITEM_EQUIPMENT 성공 수 |
+| `external_api_item_equipment_failed_total` | ITEM_EQUIPMENT 실패 수 |
+| `external_api_chunks_total` | 생성된 chunk 수 |
+
+### Timer (시간)
+| 메트릭명 | 설명 |
+|----------|------|
+| `external_api_character_basic_duration_seconds` | CHARACTER_BASIC 전체 소요 시간 |
+| `external_api_item_equipment_duration_seconds` | ITEM_EQUIPMENT 전체 소요 시간 |
+| `external_api_lookup_duration_seconds` | Lookup 전체 소요 시간 |
+
+### 초당 처리율 쿼리
+```bash
+# 초당 fetch 수
+curl -s http://localhost:8081/actuator/prometheus | grep "external_api_item_equipment_fetched_total" | grep -v "^#"
+
+# Prometheus rate 쿼리
+rate(external_api_item_equipment_fetched_total{application="external-api"}[1m])
+```
+
+## Calculator 메트릭
+
+### Counter (누적)
+| 메트릭명 | 설명 |
+|----------|------|
+| `calculator_chunks_processed_total` | 처리 완료 chunk 수 |
+| `calculator_chunks_failed_total` | 실패 chunk 수 |
+| `calculator_chunks_skipped_total` | 스킵 chunk 수 (reason 태그: endpoint_mismatch, source_not_found, result_exists) |
+| `calculator_users_processed_total` | 처리 유저 수 |
+| `calculator_items_processed_total` | 처리 아이템 수 |
+| `calculator_items_calculated_total` | 계산 완료 아이템 수 |
+| `calculator_items_errored_total` | 계산 에러 아이템 수 |
+
+### Timer (시간)
+| 메트릭명 | 설명 |
+|----------|------|
+| `calculator_chunk_duration_seconds` | chunk 처리 시간 (avg, max, count) |
+
+### Gauge (실시간)
+| 메트릭명 | 설명 |
+|----------|------|
+| `calculator_chunk_users_per_second` | 마지막 완료 chunk의 초당 유저 처리율 |
+| `calculator_chunk_items_per_second` | 마지막 완료 chunk의 초당 아이템 처리율 |
+
+### 초당 처리율 쿼리
+```bash
+# 실시간 처리율
+curl -s http://localhost:8082/actuator/prometheus | grep -E "calculator_chunk_(users|items)_per_second" | grep -v "^#"
+
+# Prometheus rate 쿼리
+rate(calculator_items_calculated_total{application="calculator"}[1m])
+rate(calculator_users_processed_total{application="calculator"}[1m])
+```
+
+## JVM & System 메트릭 (Spring Boot Actuator 자동 수집)
+
+### Memory
+| 메트릭명 | 설명 |
+|----------|------|
+| `jvm_memory_used_bytes` | JVM 메모리 사용량 (area 태그: heap, non_heap) |
+| `jvm_memory_max_bytes` | JVM 메모리 최대치 |
+| `jvm_memory_committed_bytes` | JVM 메모리 커밋량 |
+
+### GC
+| 메트릭명 | 설명 |
+|----------|------|
+| `jvm_gc_pause_seconds` | GC pause 시간 (action 태그: major/minor) |
+| `jvm_gc_memory_promoted_bytes_total` | GC로 old generation 승격 바이트 |
+| `jvm_gc_max_data_size_bytes` | Old generation 최대 크기 |
+
+### CPU & Threads
+| 메트릭명 | 설명 |
+|----------|------|
+| `process_cpu_usage` | 프로세스 CPU 사용률 (0~1) |
+| `system_cpu_usage` | 시스템 전체 CPU 사용률 (0~1) |
+| `system_cpu_count` | CPU 코어 수 |
+| `jvm_threads_live_threads` | 활성 스레드 수 |
+| `jvm_threads_states_threads` | 스레드 상태별 수 (state 태그) |
+
+### Process & Disk
+| 메트릭명 | 설명 |
+|----------|------|
+| `process_uptime_seconds` | 프로세스 가동 시간 |
+| `disk_free_bytes` | 디스크 여유 공간 |
+| `disk_total_bytes` | 디스크 전체 공간 |
+
+### 쿼리 예시
+```bash
+# Heap 메모리 사용량
+curl -s http://localhost:8082/actuator/prometheus | grep 'jvm_memory_used_bytes.*area="heap"' | grep -v "^#"
+
+# GC pause
+curl -s http://localhost:8082/actuator/prometheus | grep "jvm_gc_pause_seconds_count" | grep -v "^#"
+
+# CPU 사용률
+curl -s http://localhost:8082/actuator/prometheus | grep "process_cpu_usage" | grep -v "^#"
+
+# 스레드 수
+curl -s http://localhost:8082/actuator/prometheus | grep "jvm_threads_live_threads" | grep -v "^#"
+```
+
+## Grafana 대시보드
+
+`grafana/dashboard-pipeline.json` — 위 메트릭 전체를 포함한 대시보드. Import → Upload JSON으로 가져가기.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,7 @@ Claude Code가 이 프로젝트에서 작업할 때 따라야 할 규칙은 `.cl
 | `db-migration.md` | Migration 완전성, Forward compatibility | `**/migration/**`, `**/*.sql` |
 | `skill-routing.md` | Skill 라우팅 규칙 | 항상 |
 | `load-test.md` | 부하테스트 명령어, 파괴적 플래그, 병목 분석 체크리스트 | 부하테스트 시 |
+| `prometheus-metrics.md` | External API / Calculator Prometheus 메트릭 이름, 쿼리, 엔드포인트 | 메트릭 확인 시 |
 
 ## 상세 문서 (참조)
 

--- a/grafana/dashboard-pipeline.json
+++ b/grafana/dashboard-pipeline.json
@@ -1,0 +1,359 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "title": "Pipeline Overview",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "collapsed": false
+    },
+    {
+      "title": "Users Fetched / sec",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "expr": "rate(external_api_users_fetched_total{application=\"external-api\"}[1m])", "legendFormat": "total", "refId": "A" },
+        { "expr": "rate(external_api_character_basic_fetched_total{application=\"external-api\"}[1m])", "legendFormat": "character_basic", "refId": "B" },
+        { "expr": "rate(external_api_item_equipment_fetched_total{application=\"external-api\"}[1m])", "legendFormat": "item_equipment", "refId": "C" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "ops", "custom": { "fillOpacity": 10 } } }
+    },
+    {
+      "title": "Users Failed / sec",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "expr": "rate(external_api_users_failed_total{application=\"external-api\"}[1m])", "legendFormat": "total", "refId": "A" },
+        { "expr": "rate(external_api_character_basic_failed_total{application=\"external-api\"}[1m])", "legendFormat": "character_basic", "refId": "B" },
+        { "expr": "rate(external_api_item_equipment_failed_total{application=\"external-api\"}[1m])", "legendFormat": "item_equipment", "refId": "C" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "ops", "custom": { "fillOpacity": 10 } } }
+    },
+    {
+      "title": "Calculator: Users / sec",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "expr": "rate(calculator_users_processed_total{application=\"calculator\"}[1m])", "legendFormat": "users/s", "refId": "A" },
+        { "expr": "calculator_chunk_users_per_second{application=\"calculator\"}", "legendFormat": "last chunk rate", "refId": "B" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "ops", "custom": { "fillOpacity": 10 } } }
+    },
+    {
+      "title": "Calculator: Items / sec",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "expr": "rate(calculator_items_calculated_total{application=\"calculator\"}[1m])", "legendFormat": "items/s", "refId": "A" },
+        { "expr": "calculator_chunk_items_per_second{application=\"calculator\"}", "legendFormat": "last chunk rate", "refId": "B" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "ops", "custom": { "fillOpacity": 10 } } }
+    },
+
+    {
+      "title": "Cumulative Totals",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 9 },
+      "collapsed": false
+    },
+    {
+      "title": "External API: Total Fetched",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 10 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [{ "expr": "external_api_users_fetched_total{application=\"external-api\"}", "refId": "A" }],
+      "fieldConfig": { "defaults": { "unit": "none", "color": { "mode": "thresholds" }, "thresholds": { "steps": [{ "value": null, "color": "blue" }] } } }
+    },
+    {
+      "title": "External API: Total Failed",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 10 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [{ "expr": "external_api_users_failed_total{application=\"external-api\"}", "refId": "A" }],
+      "fieldConfig": { "defaults": { "unit": "none", "color": { "mode": "thresholds" }, "thresholds": { "steps": [{ "value": null, "color": "green" }, { "value": 10, "color": "yellow" }, { "value": 100, "color": "red" }] } } }
+    },
+    {
+      "title": "Calculator: Chunks Processed",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 10 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [{ "expr": "calculator_chunks_processed_total{application=\"calculator\"}", "refId": "A" }],
+      "fieldConfig": { "defaults": { "unit": "none", "color": { "mode": "thresholds" }, "thresholds": { "steps": [{ "value": null, "color": "blue" }] } } }
+    },
+    {
+      "title": "Calculator: Items Calculated",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 10 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [{ "expr": "calculator_items_calculated_total{application=\"calculator\"}", "refId": "A" }],
+      "fieldConfig": { "defaults": { "unit": "none", "color": { "mode": "thresholds" }, "thresholds": { "steps": [{ "value": null, "color": "blue" }] } } }
+    },
+    {
+      "title": "Calculator: Errors",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 10 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "expr": "calculator_items_errored_total{application=\"calculator\"}", "refId": "A" },
+        { "expr": "calculator_chunks_failed_total{application=\"calculator\"}", "refId": "B" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "none", "color": { "mode": "thresholds" }, "thresholds": { "steps": [{ "value": null, "color": "green" }, { "value": 1, "color": "red" }] } } }
+    },
+    {
+      "title": "Calculator: Users Processed",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 10 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [{ "expr": "calculator_users_processed_total{application=\"calculator\"}", "refId": "A" }],
+      "fieldConfig": { "defaults": { "unit": "none", "color": { "mode": "thresholds" }, "thresholds": { "steps": [{ "value": null, "color": "blue" }] } } }
+    },
+
+    {
+      "title": "External API: Endpoint Metrics",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 14 },
+      "collapsed": false
+    },
+    {
+      "title": "CHARACTER_BASIC: Fetched",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 15 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [{ "expr": "external_api_character_basic_fetched_total{application=\"external-api\"}", "refId": "A" }],
+      "fieldConfig": { "defaults": { "unit": "none", "color": { "mode": "thresholds" }, "thresholds": { "steps": [{ "value": null, "color": "green" }] } } }
+    },
+    {
+      "title": "CHARACTER_BASIC: Failed",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 15 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [{ "expr": "external_api_character_basic_failed_total{application=\"external-api\"}", "refId": "A" }],
+      "fieldConfig": { "defaults": { "unit": "none", "color": { "mode": "thresholds" }, "thresholds": { "steps": [{ "value": null, "color": "green" }, { "value": 1, "color": "yellow" }, { "value": 10, "color": "red" }] } } }
+    },
+    {
+      "title": "ITEM_EQUIPMENT: Fetched",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 15 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [{ "expr": "external_api_item_equipment_fetched_total{application=\"external-api\"}", "refId": "A" }],
+      "fieldConfig": { "defaults": { "unit": "none", "color": { "mode": "thresholds" }, "thresholds": { "steps": [{ "value": null, "color": "green" }] } } }
+    },
+    {
+      "title": "ITEM_EQUIPMENT: Failed",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 15 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [{ "expr": "external_api_item_equipment_failed_total{application=\"external-api\"}", "refId": "A" }],
+      "fieldConfig": { "defaults": { "unit": "none", "color": { "mode": "thresholds" }, "thresholds": { "steps": [{ "value": null, "color": "green" }, { "value": 1, "color": "yellow" }, { "value": 10, "color": "red" }] } } }
+    },
+    {
+      "title": "Success Rate",
+      "type": "gauge",
+      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 15 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [{ "expr": "external_api_users_fetched_total{application=\"external-api\"} / (external_api_users_fetched_total{application=\"external-api\"} + external_api_users_failed_total{application=\"external-api\"}) * 100", "refId": "A" }],
+      "fieldConfig": { "defaults": { "unit": "percent", "min": 99, "max": 100, "thresholds": { "steps": [{ "value": null, "color": "red" }, { "value": 99.5, "color": "yellow" }, { "value": 99.9, "color": "green" }] } } }
+    },
+    {
+      "title": "Failure Rate",
+      "type": "gauge",
+      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 15 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [{ "expr": "external_api_users_failed_total{application=\"external-api\"} / (external_api_users_fetched_total{application=\"external-api\"} + external_api_users_failed_total{application=\"external-api\"}) * 100", "refId": "A" }],
+      "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 1, "thresholds": { "steps": [{ "value": null, "color": "green" }, { "value": 0.1, "color": "yellow" }, { "value": 0.5, "color": "red" }] } } }
+    },
+
+    {
+      "title": "Durations",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 19 },
+      "collapsed": false
+    },
+    {
+      "title": "External API: Lookup Duration",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 20 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "expr": "external_api_character_basic_duration_seconds_sum{application=\"external-api\"} / external_api_character_basic_duration_seconds_count{application=\"external-api\"}", "legendFormat": "character_basic avg", "refId": "A" },
+        { "expr": "external_api_item_equipment_duration_seconds_sum{application=\"external-api\"} / external_api_item_equipment_duration_seconds_count{application=\"external-api\"}", "legendFormat": "item_equipment avg", "refId": "B" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s", "custom": { "fillOpacity": 10 } } }
+    },
+    {
+      "title": "Calculator: Chunk Duration",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 20 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "expr": "calculator_chunk_duration_seconds_sum{application=\"calculator\"} / calculator_chunk_duration_seconds_count{application=\"calculator\"}", "legendFormat": "avg duration", "refId": "A" },
+        { "expr": "calculator_chunk_duration_seconds_max{application=\"calculator\"}", "legendFormat": "max duration", "refId": "B" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s", "custom": { "fillOpacity": 10 } } }
+    },
+    {
+      "title": "Calculator: Chunk Rates (Gauge)",
+      "type": "gauge",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 20 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "expr": "calculator_chunk_users_per_second{application=\"calculator\"}", "legendFormat": "users/s", "refId": "A" },
+        { "expr": "calculator_chunk_items_per_second{application=\"calculator\"} / 1000", "legendFormat": "items/s (K)", "refId": "B" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "ops", "thresholds": { "steps": [{ "value": null, "color": "blue" }] } } }
+    },
+
+    {
+      "title": "JVM & System Metrics",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 28 },
+      "collapsed": false
+    },
+    {
+      "title": "JVM Heap Memory",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 29 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "expr": "jvm_memory_used_bytes{application=~\"external-api|calculator\", area=\"heap\"}", "legendFormat": "{{application}} used", "refId": "A" },
+        { "expr": "jvm_memory_max_bytes{application=~\"external-api|calculator\", area=\"heap\"}", "legendFormat": "{{application}} max", "refId": "B" },
+        { "expr": "jvm_memory_committed_bytes{application=~\"external-api|calculator\", area=\"heap\"}", "legendFormat": "{{application}} committed", "refId": "C" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "bytes", "custom": { "fillOpacity": 10 } } }
+    },
+    {
+      "title": "JVM Non-Heap Memory",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 29 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "expr": "jvm_memory_used_bytes{application=~\"external-api|calculator\", area=\"nonheap\"}", "legendFormat": "{{application}} used", "refId": "A" },
+        { "expr": "jvm_memory_max_bytes{application=~\"external-api|calculator\", area=\"nonheap\"}", "legendFormat": "{{application}} max", "refId": "B" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "bytes", "custom": { "fillOpacity": 10 } } }
+    },
+    {
+      "title": "GC Pause",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 29 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "expr": "rate(jvm_gc_pause_seconds_sum{application=~\"external-api|calculator\"}[1m])", "legendFormat": "{{application}} {{action}} {{cause}}", "refId": "A" },
+        { "expr": "jvm_gc_max_data_size_bytes{application=~\"external-api|calculator\"}", "legendFormat": "{{application}} gc max data", "refId": "B" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s", "custom": { "fillOpacity": 10 } } }
+    },
+
+    {
+      "title": "CPU Usage",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 37 },
+      "collapsed": false
+    },
+    {
+      "title": "Process CPU Usage",
+      "type": "gauge",
+      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 38 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "expr": "process_cpu_usage{application=\"external-api\"}", "legendFormat": "external-api", "refId": "A" },
+        { "expr": "process_cpu_usage{application=\"calculator\"}", "legendFormat": "calculator", "refId": "B" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "max": 1, "thresholds": { "steps": [{ "value": null, "color": "green" }, { "value": 0.7, "color": "yellow" }, { "value": 0.9, "color": "red" }] } } }
+    },
+    {
+      "title": "System CPU Usage",
+      "type": "gauge",
+      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 38 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "expr": "system_cpu_usage{application=~\"external-api|calculator\"}", "legendFormat": "{{application}}", "refId": "A" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "max": 1, "thresholds": { "steps": [{ "value": null, "color": "green" }, { "value": 0.7, "color": "yellow" }, { "value": 0.9, "color": "red" }] } } }
+    },
+    {
+      "title": "JVM Threads",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 38 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "expr": "jvm_threads_live_threads{application=~\"external-api|calculator\"}", "legendFormat": "{{application}} live", "refId": "A" },
+        { "expr": "jvm_threads_states_threads{application=~\"external-api|calculator\", state=\"runnable\"}", "legendFormat": "{{application}} runnable", "refId": "B" },
+        { "expr": "jvm_threads_states_threads{application=~\"external-api|calculator\", state=\"blocked\"}", "legendFormat": "{{application}} blocked", "refId": "C" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short", "custom": { "fillOpacity": 10 } } }
+    },
+    {
+      "title": "GC Count / sec",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 38 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "expr": "rate(jvm_gc_pause_seconds_count{application=~\"external-api|calculator\"}[1m])", "legendFormat": "{{application}} {{action}}", "refId": "A" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "ops", "custom": { "fillOpacity": 10 } } }
+    },
+
+    {
+      "title": "Process Uptime",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 46 },
+      "collapsed": false
+    },
+    {
+      "title": "External API Uptime",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 47 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [{ "expr": "process_uptime_seconds{application=\"external-api\"}", "refId": "A" }],
+      "fieldConfig": { "defaults": { "unit": "s", "color": { "mode": "thresholds" }, "thresholds": { "steps": [{ "value": null, "color": "green" }] } } }
+    },
+    {
+      "title": "Calculator Uptime",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 47 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [{ "expr": "process_uptime_seconds{application=\"calculator\"}", "refId": "A" }],
+      "fieldConfig": { "defaults": { "unit": "s", "color": { "mode": "thresholds" }, "thresholds": { "steps": [{ "value": null, "color": "green" }] } } }
+    },
+    {
+      "title": "Disk Free (External API)",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 47 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [{ "expr": "disk_free_bytes{application=\"external-api\"}", "refId": "A" }],
+      "fieldConfig": { "defaults": { "unit": "bytes", "color": { "mode": "thresholds" }, "thresholds": { "steps": [{ "value": null, "color": "green" }, { "value": 10737418240, "color": "yellow" }, { "value": 1073741824, "color": "red" }] } } }
+    },
+    {
+      "title": "Disk Free (Calculator)",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 47 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [{ "expr": "disk_free_bytes{application=\"calculator\"}", "refId": "A" }],
+      "fieldConfig": { "defaults": { "unit": "bytes", "color": { "mode": "thresholds" }, "thresholds": { "steps": [{ "value": null, "color": "green" }, { "value": 10737418240, "color": "yellow" }, { "value": 1073741824, "color": "red" }] } } }
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": ["maple", "pipeline", "external-api", "calculator"],
+  "templating": {
+    "list": [
+      {
+        "name": "DS_PROMETHEUS",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": { "selected": true, "text": "Prometheus", "value": "Prometheus" }
+      }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "title": "Maple Pipeline - External API & Calculator",
+  "uid": "maple-pipeline"
+}

--- a/module-calculator/src/main/kotlin/maple/calculator/CalculatorApplication.kt
+++ b/module-calculator/src/main/kotlin/maple/calculator/CalculatorApplication.kt
@@ -16,16 +16,17 @@ import maple.expectation.config.TableMassConfig
 import maple.expectation.infrastructure.adapter.policy.PolicyAdapter
 import maple.expectation.infrastructure.config.CalculationPortConfig
 import maple.expectation.infrastructure.config.ExecutorConfig
-import maple.expectation.infrastructure.security.config.SecurityConfig
 import maple.expectation.infrastructure.executor.DefaultLogicExecutor
 import maple.expectation.infrastructure.executor.classifier.DefaultExceptionClassifier
 import maple.expectation.infrastructure.persistence.repository.CubeProbabilityRepositoryImpl
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
+import org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.runApplication
 import org.springframework.context.annotation.Import
 
-@SpringBootApplication
+@SpringBootApplication(exclude = [SecurityAutoConfiguration::class, ManagementWebSecurityAutoConfiguration::class])
 @EnableConfigurationProperties(PipelineProperties::class)
 @Import(
     EquipmentExpectationCalculatorFactory::class,
@@ -46,7 +47,6 @@ import org.springframework.context.annotation.Import
     TableMassConfig::class,
     CalculationPortConfig::class,
     ExecutorConfig::class,
-    SecurityConfig::class,
 )
 class CalculatorApplication
 

--- a/module-calculator/src/main/kotlin/maple/calculator/consumer/KafkaSnapshotChunkReadyConsumer.kt
+++ b/module-calculator/src/main/kotlin/maple/calculator/consumer/KafkaSnapshotChunkReadyConsumer.kt
@@ -82,8 +82,8 @@ class KafkaSnapshotChunkReadyConsumer(
 
         runBlocking {
             concurrency.withPermit {
+                val start = System.nanoTime()
                 runCatching {
-                    val start = System.nanoTime()
                     val result = chunkProcessor.process(event)
                     metrics.timer().record(Duration.ofNanos(System.nanoTime() - start))
                     resultEventPublisher.publishChunkReady(
@@ -116,6 +116,8 @@ class KafkaSnapshotChunkReadyConsumer(
                     metrics.recordItems(result.totalItems)
                     metrics.recordCalculated(result.resultCount)
                     metrics.recordErrors(result.errorCount)
+                    val durationSec = (System.nanoTime() - start) / 1_000_000_000.0
+                    metrics.recordChunkRates(result.recordCount, result.totalItems, durationSec)
                     acknowledgment.acknowledge()
                 }.onFailure { ex ->
                     log.error("[Consumer] chunk processing failed, skipping: runId={} chunkId={}: {}", event.runId, event.chunkId, ex.message, ex)

--- a/module-calculator/src/main/kotlin/maple/calculator/metrics/CalculatorMetrics.kt
+++ b/module-calculator/src/main/kotlin/maple/calculator/metrics/CalculatorMetrics.kt
@@ -1,6 +1,7 @@
 package maple.calculator.metrics
 
 import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.Gauge
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Timer
 import org.springframework.stereotype.Component
@@ -22,6 +23,18 @@ class CalculatorMetrics(registry: MeterRegistry) {
         .description("Time to process a single snapshot chunk")
         .register(registry)
 
+    @Volatile private var lastChunkUsersPerSec = 0.0
+    @Volatile private var lastChunkItemsPerSec = 0.0
+
+    init {
+        Gauge.builder("calculator_chunk_users_per_second") { lastChunkUsersPerSec }
+            .description("Users processed per second in the last completed chunk")
+            .register(registry)
+        Gauge.builder("calculator_chunk_items_per_second") { lastChunkItemsPerSec }
+            .description("Items processed per second in the last completed chunk")
+            .register(registry)
+    }
+
     fun recordChunkProcessed() = chunksProcessed.increment()
     fun recordChunkSkippedEndpoint() = chunksSkipped.increment()
     fun recordChunkSkippedNotFound() = chunksNotFound.increment()
@@ -32,6 +45,13 @@ class CalculatorMetrics(registry: MeterRegistry) {
     fun recordItems(count: Int) = itemsProcessed.increment(count.toDouble())
     fun recordCalculated(count: Int) = itemsCalculated.increment(count.toDouble())
     fun recordErrors(count: Int) = itemsErrored.increment(count.toDouble())
+
+    fun recordChunkRates(users: Int, items: Int, durationSec: Double) {
+        if (durationSec > 0) {
+            lastChunkUsersPerSec = users / durationSec
+            lastChunkItemsPerSec = items / durationSec
+        }
+    }
 
     fun timer(): Timer = chunkTimer
 }

--- a/module-external-api/src/main/kotlin/maple/externalapi/metrics/ExternalApiMetrics.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/metrics/ExternalApiMetrics.kt
@@ -7,18 +7,53 @@ import org.springframework.stereotype.Component
 
 @Component
 class ExternalApiMetrics(registry: MeterRegistry) {
-    private val usersFetched = registry.counter("external_users_fetched_total")
-    private val usersFailed = registry.counter("external_users_failed_total")
 
-    private val chunksCreated = registry.counter("external_chunks_created_total")
+    private val usersFetched = registry.counter("external_api_users_fetched_total")
+    private val usersFailed = registry.counter("external_api_users_failed_total")
+    private val characterBasicFetched = registry.counter("external_api_character_basic_fetched_total")
+    private val characterBasicFailed = registry.counter("external_api_character_basic_failed_total")
+    private val itemEquipmentFetched = registry.counter("external_api_item_equipment_fetched_total")
+    private val itemEquipmentFailed = registry.counter("external_api_item_equipment_failed_total")
+    private val chunksCreated = registry.counter("external_api_chunks_created_total")
 
-    private val lookupTimer = Timer.builder("external_lookup_duration_seconds")
+    private val lookupTimer = Timer.builder("external_api_lookup_duration_seconds")
         .description("Time for a full endpoint lookup run")
+        .register(registry)
+
+    private val characterBasicTimer = Timer.builder("external_api_character_basic_duration_seconds")
+        .description("Time for CHARACTER_BASIC lookup run")
+        .register(registry)
+
+    private val itemEquipmentTimer = Timer.builder("external_api_item_equipment_duration_seconds")
+        .description("Time for ITEM_EQUIPMENT lookup run")
         .register(registry)
 
     fun recordFetched(count: Int = 1) = usersFetched.increment(count.toDouble())
     fun recordFailed(count: Int = 1) = usersFailed.increment(count.toDouble())
-    fun recordChunkCreated() = chunksCreated.increment()
 
-    fun timer(): Timer = lookupTimer
+    fun recordCharacterBasicFetched(count: Int = 1) {
+        characterBasicFetched.increment(count.toDouble())
+        usersFetched.increment(count.toDouble())
+    }
+
+    fun recordCharacterBasicFailed(count: Int = 1) {
+        characterBasicFailed.increment(count.toDouble())
+        usersFailed.increment(count.toDouble())
+    }
+
+    fun recordItemEquipmentFetched(count: Int = 1) {
+        itemEquipmentFetched.increment(count.toDouble())
+        usersFetched.increment(count.toDouble())
+    }
+
+    fun recordItemEquipmentFailed(count: Int = 1) {
+        itemEquipmentFailed.increment(count.toDouble())
+        usersFailed.increment(count.toDouble())
+    }
+
+    fun recordChunkCreated(count: Int = 1) = chunksCreated.increment(count.toDouble())
+
+    fun lookupTimer(): Timer = lookupTimer
+    fun characterBasicTimer(): Timer = characterBasicTimer
+    fun itemEquipmentTimer(): Timer = itemEquipmentTimer
 }

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/ExternalApiScheduler.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/ExternalApiScheduler.kt
@@ -260,6 +260,7 @@ class ExternalApiScheduler(
                                     ),
                                 )
                                 successCount.incrementAndGet()
+                                metrics.recordCharacterBasicFetched()
                             } catch (ex: Exception) {
                                 val httpStatus = extractHttpStatus(ex)
                                 sink.submit(
@@ -273,6 +274,7 @@ class ExternalApiScheduler(
                                     ),
                                 )
                                 failCount.incrementAndGet()
+                                metrics.recordCharacterBasicFailed()
                             }
                         },
                     )
@@ -290,6 +292,7 @@ class ExternalApiScheduler(
             sink.close()
         }
 
+        metrics.characterBasicTimer().record(Duration.between(start, Instant.now()))
         logSummary("CHARACTER_BASIC", entries.size, successCount.get(), successCount.get(), failCount.get(), start)
     }
 
@@ -350,7 +353,7 @@ class ExternalApiScheduler(
                                     ),
                                 )
                                 successCount.incrementAndGet()
-                                metrics.recordFetched()
+                                metrics.recordItemEquipmentFetched()
                             } catch (ex: Exception) {
                                 val httpStatus = extractHttpStatus(ex)
                                 sink.submit(
@@ -364,7 +367,7 @@ class ExternalApiScheduler(
                                     ),
                                 )
                                 failCount.incrementAndGet()
-                                metrics.recordFailed()
+                                metrics.recordItemEquipmentFailed()
                             }
                         },
                     )
@@ -382,6 +385,7 @@ class ExternalApiScheduler(
             sink.close()
         }
 
+        metrics.itemEquipmentTimer().record(Duration.between(start, Instant.now()))
         logSummary("ITEM_EQUIPMENT", entries.size, successCount.get(), successCount.get(), failCount.get(), start)
     }
 


### PR DESCRIPTION
## Summary
- ExternalApiMetrics에 per-endpoint 카운터/타이머 추가 (CHARACTER_BASIC, ITEM_EQUIPMENT)
- CalculatorMetrics에 per-chunk rate gauge 추가 (users/s, items/s)
- Calculator SecurityConfig 의존성 제거 (SecurityAutoConfiguration exclude)
- Grafana 대시보드 JSON 추가 (pipeline, endpoint success/failure, JVM/CPU/Memory 패널)
- `.claude/rules/prometheus-metrics.md` 추가 (커스텀 + JVM/OS 메트릭 전체 참조)

## Test plan
- [x] external-api 8081 `/actuator/prometheus`에서 커스텀 메트릭 노출 확인
- [x] calculator 8082 `/actuator/prometheus`에서 per-chunk rate gauge 확인
- [x] `grafana/dashboard-pipeline.json` JSON 유효성 검증 통과
- [x] `.claude/rules/prometheus-metrics.md`에 JVM/OS 메트릭 쿼리 예시 포함

🤖 Generated with [Claude Code](https://claude.com/claude-code)