### PR TITLE
fix(common): apply keepRecentCount in RunRetentionPolicy

### DIFF
--- a/module-common/src/main/kotlin/maple/common/cleanup/RunRetentionPolicy.kt
+++ b/module-common/src/main/kotlin/maple/common/cleanup/RunRetentionPolicy.kt
@@ -14,9 +14,13 @@ object RunRetentionPolicy {
         if (runs.isEmpty()) return emptyList()
 
         val cutoff = now.minus(Duration.ofHours(keepWithinHours))
+        val recentRunIds = runs.sortedByDescending { it.createdAt }
+            .take(keepRecentCount)
+            .map { it.runId }
+            .toSet()
 
         return runs.filter { run ->
-            !run.isRunning && run.createdAt.isBefore(cutoff)
+            !run.isRunning && run.createdAt.isBefore(cutoff) && run.runId !in recentRunIds
         }
     }
 }


### PR DESCRIPTION
## Summary
- `RunRetentionPolicy.selectForDeletion`이 `keepRecentCount` 파라미터를 무시하고 시간 조건만으로 삭제 대상 판별
- 최근 N개 run을 삭제 대상에서 제외하는 필터 추가

## Test plan
- [x] `./gradlew :module-common:test` — 7/7 pass (기존 2개 실패 테스트 포함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)