### PR TITLE
refactor(synchronizer): extract ChunkProcessor seam, replace try-catch with LogicExecutor

### DIFF
--- a/docs/01_ADR/ADR-716_synchronizer-extract-chunk-processor.md
+++ b/docs/01_ADR/ADR-716_synchronizer-extract-chunk-processor.md
@@ -1,0 +1,85 @@
+# ADR-716: Extract ChunkProcessor Seam from Synchronizer Consumer
+
+- Status: Accepted
+- Date: 2026-05-14
+- Owner: zbnerd
+
+---
+
+## 1. Background / Problem
+
+### Background
+
+- module-synchronizer의 KafkaResultChunkConsumer가 Kafka 수신, 동시성 제어, MDC, 메트릭 기록, 처리 파이프라인(file read → build → upsert)을 단일 클래스에서 모두 담당
+- Zero Try-Catch Policy를 위반: 직접 try-catch-finally 사용
+
+### Problem
+
+- 처리 파이프라인을 Kafka 없이 테스트 불가 (0개 테스트)
+- Consumer가 6개 의존성을 직접持有하여 변경 영향 범위가 넓음
+- 동일한 예외 처리 패턴이 Consumer에 하드코딩됨
+
+### Goal
+
+- 처리 로직을 별도 모듈로 추출하여 단위 테스트 가능하게 만들기
+- Consumer는 Kafka/인프라 관심사만 담당
+- try-catch를 LogicExecutor로 교체
+
+---
+
+## 2. Decision
+
+> ChunkProcessor 인터페이스를 seam으로 추출하고, Consumer는 인프라 관심사만 유지한다.
+
+```text
+KafkaResultChunkConsumer
+  ├─ Kafka 수신, idempotency guard, semaphore, virtual thread dispatch
+  ├─ LogicExecutor로 예외 처리 (executeWithFinally + executeOrCatch)
+  └─ ACK 정책 (성공 시에만 ACK)
+
+ChunkProcessor (interface)
+  └─ process(event): ChunkProcessResult
+
+DefaultChunkProcessor
+  ├─ file read → document build → bulk upsert
+  └─ pipeline metrics (duration, count, volume)
+```
+
+---
+
+## 3. Trade-offs
+
+### Sensitivity
+
+* 메트릭 기록 위치가 Consumer에서 ChunkProcessor로 이동 — 기존 대시보드 쿼리 영향 없음 (메트릭 이름 동일)
+
+### Trade-off
+
+| 선택 | 얻는 것 | 포기한 것 |
+| -- | ---- | ----- |
+| ChunkProcessor seam 추출 | Kafka 없는 단위 테스트, 관심사 분리 | interface + impl 클래스 2개 추가 |
+
+### Risk
+
+* ResultFileReader의 `runBlocking`은 이 PR에서 수정하지 않음 — PR 2에서 별도 처리
+
+### Non-Risk
+
+* 기능 변경 없음 — 동일한 처리 흐름, 동일한 메트릭, 동일한 ACK 정책
+* 기존 vtExecutor 누락된 @PreDestroy 추가 — shutdown 안전성 향상
+
+---
+
+## 4. Result / Evidence
+
+### Metrics
+
+| Metric | Value | Notes |
+| ------ | ----: | ----- |
+| | | PR 병합 후 업데이트 |
+
+---
+
+## 5. Summary
+
+> Consumer에서 처리 파이프라인을 ChunkProcessor seam으로 추출하여 테스트 가능하게 만들고, try-catch를 LogicExecutor로 교체했다.

--- a/module-synchronizer/build.gradle
+++ b/module-synchronizer/build.gradle
@@ -41,6 +41,7 @@ dependencies {
 	// Testing
 	testImplementation(libs.spring.boot.starter.test)
 	testImplementation(libs.assertj.core)
+	testImplementation(libs.mockito.kotlin)
 }
 
 bootJar {

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/KafkaResultChunkConsumer.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/KafkaResultChunkConsumer.kt
@@ -2,12 +2,13 @@ package maple.synchronizer.consumer
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.micrometer.core.instrument.Timer
-import maple.synchronizer.builder.EquipmentDocumentBuilder
+import jakarta.annotation.PreDestroy
+import maple.expectation.infrastructure.executor.LogicExecutor
+import maple.expectation.infrastructure.executor.TaskContext
 import maple.synchronizer.event.CalculatorResultChunkReadyEvent
 import maple.synchronizer.metrics.SynchronizerMetrics
-import maple.synchronizer.repository.EquipmentReadModelRepository
+import maple.synchronizer.processor.ChunkProcessor
 import maple.synchronizer.repository.SynchronizerChunkStatusRepository
-import maple.synchronizer.storage.ResultFileReader
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC
 import org.springframework.kafka.annotation.KafkaListener
@@ -20,16 +21,13 @@ import java.util.concurrent.Semaphore
 @Component
 class KafkaResultChunkConsumer(
     private val objectMapper: ObjectMapper,
-    private val resultFileReader: ResultFileReader,
-    private val documentBuilder: EquipmentDocumentBuilder,
-    private val readModelRepository: EquipmentReadModelRepository,
+    private val chunkProcessor: ChunkProcessor,
     private val chunkStatusRepository: SynchronizerChunkStatusRepository,
     private val metrics: SynchronizerMetrics,
+    private val logicExecutor: LogicExecutor,
 ) {
     private val log = LoggerFactory.getLogger(KafkaResultChunkConsumer::class.java)
     private val vtExecutor = Executors.newVirtualThreadPerTaskExecutor()
-
-    // Permit covers entire chunk processing: file read → parse → build → upsert
     private val processingPermit = Semaphore(2)
 
     @KafkaListener(
@@ -44,98 +42,64 @@ class KafkaResultChunkConsumer(
         log.info("[Synchronizer] received: runId={} chunkId={} objectKey={} results={}",
             runId, chunkId, event.objectKey, event.resultCount)
 
-        // 1. Idempotency: skip already-successful chunks
         if (chunkStatusRepository.isAlreadySuccess(runId, chunkId)) {
             log.info("[Synchronizer] skip already-successful chunk: runId={} chunkId={}", runId, chunkId)
             acknowledgment.acknowledge()
             return
         }
 
-        // 2. Atomic claim: only this worker proceeds if claim succeeds
         if (!chunkStatusRepository.claimChunk(runId, chunkId, event.objectKey)) {
             log.info("[Synchronizer] skip - chunk already claimed by another worker: runId={} chunkId={}", runId, chunkId)
             acknowledgment.acknowledge()
             return
         }
 
-        // 3. Try acquire processing permit — covers entire chunk lifecycle
         if (!processingPermit.tryAcquire()) {
             log.info("[Synchronizer] processing permit busy, will retry: runId={} chunkId={}", runId, chunkId)
-            // DON'T ACK — message will be redelivered after poll timeout
             return
         }
 
-        // 4. Dispatch full processing to virtual thread — only event metadata is passed
         metrics.incrementReceived()
         metrics.incrementProcessing()
-
-        CompletableFuture.runAsync({
-            processChunk(event, acknowledgment)
-        }, vtExecutor)
-    }
-
-    private fun processChunk(event: CalculatorResultChunkReadyEvent, acknowledgment: Acknowledgment) {
-        val runId = event.sourceRunId
-        val chunkId = event.sourceChunkId
-        val chunkSample = Timer.start()
-
         MDC.put("runId", runId)
         MDC.put("chunkId", chunkId)
         MDC.put("kafkaTopic", "calculator.result.chunk-ready")
-        try {
-            // All heavy work happens here — inside the processing permit
-            val grouped = timed(metrics.fileReadTimer()) {
-                resultFileReader.readAndGroupByCompositeKey(event.objectKey)
-            }
-            val documents = timed(metrics.documentBuildTimer()) {
-                grouped.map { documentBuilder.build(runId, chunkId, it) }
-            }
-            val itemsCount = grouped.sumOf { it.items.size.toLong() }
 
-            log.info("[Synchronizer] grouped {} results into {} documents", event.resultCount, documents.size)
-
-            metrics.incrementDocuments(documents.size)
-            metrics.incrementItems(itemsCount)
-            metrics.recordChunkSize(documents.size, itemsCount, event.compressedBytes)
-            documents.forEach { metrics.recordDocumentEquipment(it.summary.equipmentCount) }
-
-            metrics.recordPreUpsertVolume(event.compressedBytes, event.uncompressedBytes, event.resultCount.toLong())
-            val ratio = if (event.compressedBytes > 0) "%.2f".format(event.uncompressedBytes.toDouble() / event.compressedBytes.toDouble()) else "N/A"
-            log.info(
-                "[preUpsertVolume] runId={} chunkId={} compressedBytes={} uncompressedBytes={} jsonRows={} documents={} compressionRatio={}",
-                runId, chunkId, event.compressedBytes, event.uncompressedBytes, event.resultCount, documents.size, ratio,
+        CompletableFuture.runAsync({
+            val chunkSample = Timer.start()
+            logicExecutor.executeWithFinally(
+                task = {
+                    logicExecutor.executeOrCatch(
+                        task = {
+                            chunkProcessor.process(event)
+                            chunkStatusRepository.markSuccess(runId, chunkId)
+                            metrics.incrementProcessed()
+                            metrics.recordStatusTransition("SUCCESS")
+                            chunkSample.stop(metrics.chunkTimer())
+                            acknowledgment.acknowledge()
+                        },
+                        recovery = { ex ->
+                            chunkStatusRepository.markFailed(runId, chunkId, ex.message ?: "unknown")
+                            metrics.incrementFailed()
+                            metrics.recordStatusTransition("FAILED")
+                            log.error("[Synchronizer] chunk processing failed: runId={} chunkId={}", runId, chunkId, ex)
+                            null
+                        },
+                        context = TaskContext.of("Synchronizer", "ChunkProcess", chunkId),
+                    )
+                },
+                finallyBlock = {
+                    metrics.decrementProcessing()
+                    processingPermit.release()
+                    MDC.clear()
+                },
+                context = TaskContext.of("Synchronizer", "ChunkLifecycle", chunkId),
             )
-
-            // DB upsert — still inside same permit
-            metrics.mainUpsertTimer().record(Runnable {
-                readModelRepository.bulkUpsert(runId, chunkId, documents)
-            })
-
-            chunkStatusRepository.markSuccess(runId, chunkId)
-            metrics.incrementProcessed()
-            metrics.recordStatusTransition("SUCCESS")
-            chunkSample.stop(metrics.chunkTimer())
-            acknowledgment.acknowledge()
-        } catch (e: Exception) {
-            chunkStatusRepository.markFailed(runId, chunkId, e.message ?: "unknown")
-            metrics.incrementFailed()
-            metrics.recordStatusTransition("FAILED")
-            log.error("[Synchronizer] chunk processing failed: runId={} chunkId={}", runId, chunkId, e)
-            // DON'T ACK — message will be redelivered
-        } finally {
-            metrics.decrementProcessing()
-            processingPermit.release()
-            MDC.clear()
-        }
+        }, vtExecutor)
     }
 
-    private fun unwrapCompletionException(ex: Throwable): Throwable {
-        val cause = ex.cause
-        return if (cause != null && ex is java.util.concurrent.CompletionException) cause else ex
-    }
-
-    private inline fun <T> timed(timer: Timer, block: () -> T): T {
-        val sample = Timer.start()
-        return block().also { sample.stop(timer) }
+    @PreDestroy
+    fun close() {
+        vtExecutor.close()
     }
 }

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/processor/ChunkProcessResult.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/processor/ChunkProcessResult.kt
@@ -1,0 +1,9 @@
+package maple.synchronizer.processor
+
+data class ChunkProcessResult(
+    val documentCount: Int,
+    val itemCount: Long,
+    val compressedBytes: Long,
+    val uncompressedBytes: Long,
+    val jsonRowCount: Long,
+)

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/processor/ChunkProcessor.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/processor/ChunkProcessor.kt
@@ -1,0 +1,7 @@
+package maple.synchronizer.processor
+
+import maple.synchronizer.event.CalculatorResultChunkReadyEvent
+
+interface ChunkProcessor {
+    fun process(event: CalculatorResultChunkReadyEvent): ChunkProcessResult
+}

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/processor/DefaultChunkProcessor.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/processor/DefaultChunkProcessor.kt
@@ -1,0 +1,67 @@
+package maple.synchronizer.processor
+
+import io.micrometer.core.instrument.Timer
+import maple.synchronizer.builder.EquipmentDocumentBuilder
+import maple.synchronizer.event.CalculatorResultChunkReadyEvent
+import maple.synchronizer.metrics.SynchronizerMetrics
+import maple.synchronizer.repository.EquipmentReadModelRepository
+import maple.synchronizer.storage.ResultFileReader
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+@Component
+class DefaultChunkProcessor(
+    private val resultFileReader: ResultFileReader,
+    private val documentBuilder: EquipmentDocumentBuilder,
+    private val readModelRepository: EquipmentReadModelRepository,
+    private val metrics: SynchronizerMetrics,
+) : ChunkProcessor {
+
+    private val log = LoggerFactory.getLogger(DefaultChunkProcessor::class.java)
+
+    override fun process(event: CalculatorResultChunkReadyEvent): ChunkProcessResult {
+        val grouped = timed(metrics.fileReadTimer()) {
+            resultFileReader.readAndGroupByCompositeKey(event.objectKey)
+        }
+
+        val documents = timed(metrics.documentBuildTimer()) {
+            grouped.map { documentBuilder.build(event.sourceRunId, event.sourceChunkId, it) }
+        }
+
+        val itemsCount = grouped.sumOf { it.items.size.toLong() }
+
+        log.info("[Synchronizer] grouped {} results into {} documents", event.resultCount, documents.size)
+
+        metrics.incrementDocuments(documents.size)
+        metrics.incrementItems(itemsCount)
+        metrics.recordChunkSize(documents.size, itemsCount, event.compressedBytes)
+        documents.forEach { metrics.recordDocumentEquipment(it.summary.equipmentCount) }
+
+        metrics.recordPreUpsertVolume(event.compressedBytes, event.uncompressedBytes, event.resultCount.toLong())
+        val ratio = if (event.compressedBytes > 0)
+            "%.2f".format(event.uncompressedBytes.toDouble() / event.compressedBytes.toDouble())
+        else "N/A"
+        log.info(
+            "[preUpsertVolume] runId={} chunkId={} compressedBytes={} uncompressedBytes={} jsonRows={} documents={} compressionRatio={}",
+            event.sourceRunId, event.sourceChunkId, event.compressedBytes, event.uncompressedBytes,
+            event.resultCount, documents.size, ratio,
+        )
+
+        metrics.mainUpsertTimer().record(Runnable {
+            readModelRepository.bulkUpsert(event.sourceRunId, event.sourceChunkId, documents)
+        })
+
+        return ChunkProcessResult(
+            documentCount = documents.size,
+            itemCount = itemsCount,
+            compressedBytes = event.compressedBytes,
+            uncompressedBytes = event.uncompressedBytes,
+            jsonRowCount = event.resultCount.toLong(),
+        )
+    }
+
+    private inline fun <T> timed(timer: Timer, block: () -> T): T {
+        val sample = Timer.start()
+        return block().also { sample.stop(timer) }
+    }
+}

--- a/module-synchronizer/src/test/kotlin/maple/synchronizer/processor/DefaultChunkProcessorTest.kt
+++ b/module-synchronizer/src/test/kotlin/maple/synchronizer/processor/DefaultChunkProcessorTest.kt
@@ -1,0 +1,166 @@
+package maple.synchronizer.processor
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import maple.synchronizer.builder.EquipmentDocumentBuilder
+import maple.synchronizer.domain.CalculatedEquipmentItem
+import maple.synchronizer.domain.EquipmentReadDocument
+import maple.synchronizer.domain.EquipmentReadMetadata
+import maple.synchronizer.domain.EquipmentSummary
+import maple.synchronizer.domain.GroupedEquipmentResult
+import maple.synchronizer.metrics.SynchronizerMetrics
+import maple.synchronizer.repository.EquipmentReadModelRepository
+import maple.synchronizer.storage.ResultFileReader
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+import java.time.Instant
+
+class DefaultChunkProcessorTest {
+
+    private val resultFileReader: ResultFileReader = mock()
+    private val documentBuilder: EquipmentDocumentBuilder = mock()
+    private val readModelRepository: EquipmentReadModelRepository = mock()
+    private val metrics = SynchronizerMetrics(SimpleMeterRegistry())
+
+    private lateinit var chunkProcessor: DefaultChunkProcessor
+
+    @BeforeEach
+    fun setUp() {
+        chunkProcessor = DefaultChunkProcessor(resultFileReader, documentBuilder, readModelRepository, metrics)
+    }
+
+    @Test
+    fun `process - happy path returns result with correct counts`() {
+        val event = testEvent()
+        val items = listOf(testItem())
+        val grouped = listOf(GroupedEquipmentResult(readKey = "oc1:1", ocid = "oc1", presetNo = 1, items = items))
+        val document = testDocument()
+
+        whenever(resultFileReader.readAndGroupByCompositeKey(any())).thenReturn(grouped)
+        whenever(documentBuilder.build(any(), any(), any())).thenReturn(document)
+
+        val result = chunkProcessor.process(event)
+
+        assertThat(result.documentCount).isEqualTo(1)
+        assertThat(result.itemCount).isEqualTo(1)
+        assertThat(result.compressedBytes).isEqualTo(event.compressedBytes)
+        assertThat(result.uncompressedBytes).isEqualTo(event.uncompressedBytes)
+        assertThat(result.jsonRowCount).isEqualTo(event.resultCount.toLong())
+    }
+
+    @Test
+    fun `process - calls repository bulkUpsert`() {
+        val event = testEvent()
+        val grouped = listOf(GroupedEquipmentResult(readKey = "oc1:1", ocid = "oc1", presetNo = 1, items = listOf(testItem())))
+
+        whenever(resultFileReader.readAndGroupByCompositeKey(any())).thenReturn(grouped)
+        whenever(documentBuilder.build(any(), any(), any())).thenReturn(testDocument())
+
+        chunkProcessor.process(event)
+
+        verify(readModelRepository).bulkUpsert(eq(event.sourceRunId), eq(event.sourceChunkId), any())
+    }
+
+    @Test
+    fun `process - file not found propagates exception`() {
+        val event = testEvent()
+        whenever(resultFileReader.readAndGroupByCompositeKey(any()))
+            .thenThrow(IllegalStateException("Result file not found"))
+
+        assertThatThrownBy { chunkProcessor.process(event) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("Result file not found")
+    }
+
+    @Test
+    fun `process - upsert failure propagates exception`() {
+        val event = testEvent()
+        val grouped = listOf(GroupedEquipmentResult(readKey = "oc1:1", ocid = "oc1", presetNo = 1, items = listOf(testItem())))
+
+        whenever(resultFileReader.readAndGroupByCompositeKey(any())).thenReturn(grouped)
+        whenever(documentBuilder.build(any(), any(), any())).thenReturn(testDocument())
+        whenever(readModelRepository.bulkUpsert(any(), any(), any()))
+            .thenThrow(RuntimeException("DB connection failed"))
+
+        assertThatThrownBy { chunkProcessor.process(event) }
+            .isInstanceOf(RuntimeException::class.java)
+            .hasMessageContaining("DB connection failed")
+    }
+
+    @Test
+    fun `process - multiple groups produce multiple documents`() {
+        val event = testEvent(objectKey = "multi.jsonl.gz", resultCount = 3)
+        val grouped = listOf(
+            GroupedEquipmentResult(readKey = "oc1:1", ocid = "oc1", presetNo = 1, items = listOf(testItem(ocid = "oc1"))),
+            GroupedEquipmentResult(readKey = "oc2:1", ocid = "oc2", presetNo = 1, items = listOf(testItem(ocid = "oc2"), testItem(ocid = "oc2"))),
+        )
+
+        whenever(resultFileReader.readAndGroupByCompositeKey(any())).thenReturn(grouped)
+        whenever(documentBuilder.build(any(), any(), any())).thenReturn(testDocument())
+
+        val result = chunkProcessor.process(event)
+
+        assertThat(result.documentCount).isEqualTo(2)
+        assertThat(result.itemCount).isEqualTo(3)
+    }
+
+    private fun testEvent(
+        objectKey: String = "run1/chunk001.jsonl.gz",
+        resultCount: Int = 1,
+    ) = maple.synchronizer.event.CalculatorResultChunkReadyEvent(
+        eventId = "evt-1",
+        eventType = "CALCULATOR_RESULT_CHUNK_READY",
+        schemaVersion = 1,
+        sourceRunId = "run-1",
+        sourceEndpoint = "ITEM_EQUIPMENT",
+        sourceChunkId = "chunk-001",
+        objectKey = objectKey,
+        sourceRecordCount = resultCount,
+        resultCount = resultCount,
+        errorCount = 0,
+        uncompressedBytes = 2048L,
+        compressedBytes = 512L,
+        createdAt = Instant.now(),
+    )
+
+    private fun testItem(
+        ocid: String = "oc1",
+        presetNo: Int = 1,
+    ) = CalculatedEquipmentItem(
+        ocid = ocid,
+        presetNo = presetNo,
+        itemName = "Test Sword",
+        itemLevel = 160,
+        itemPart = "Weapon",
+        itemEquipmentPart = "무기",
+        potentialGrade = "레전드리",
+        potentialOptions = listOf("공격력 +12%"),
+        additionalGrade = "에픽",
+        additionalOptions = listOf("STR +9%"),
+        currentStar = 17,
+        targetStar = 22,
+        status = "SUCCESS",
+        totalCost = BigDecimal("150000000000"),
+        blackCubeCost = BigDecimal("50000000000"),
+        additionalCubeCost = BigDecimal("30000000000"),
+        starforceCost = BigDecimal("70000000000"),
+        errorMessage = null,
+    )
+
+    private fun testDocument(
+        ocid: String = "oc1",
+    ) = EquipmentReadDocument(
+        ocid = ocid,
+        presetNo = 1,
+        summary = EquipmentSummary(totalCost = BigDecimal("150000000000"), equipmentCount = 1),
+        equipment = listOf(mapOf("itemName" to "Test Sword")),
+        metadata = EquipmentReadMetadata(sourceRunId = "run-1", sourceChunkId = "chunk-001", calculatedAt = Instant.now()),
+    )
+}


### PR DESCRIPTION
## Summary

- Extract `ChunkProcessor` interface + `DefaultChunkProcessor` from `KafkaResultChunkConsumer`
- Consumer now only handles Kafka/infra concerns (idempotency, semaphore, dispatch, ACK)
- `DefaultChunkProcessor` owns the processing pipeline (file read → build → upsert + pipeline metrics)
- Replace direct try-catch-finally with `LogicExecutor.executeWithFinally` + `executeOrCatch`
- Add `@PreDestroy` for vtExecutor (was missing — potential resource leak on shutdown)
- Add 5 unit tests for `DefaultChunkProcessor` (0 → 5 test coverage)

### Metric responsibility split

| Consumer | ChunkProcessor |
|----------|---------------|
| received, processing gauge | file read duration |
| processed/failed counters | document build duration |
| status transitions | upsert duration |
| | document/item/bytes counts |

## Test plan

- [x] `./gradlew :module-synchronizer:test` — 5/5 tests pass
- [x] `./gradlew compileKotlin compileJava --continue` — BUILD SUCCESSFUL
- [ ] 서버 구동 후 Synchronizer Kafka consume 정상 동작 확인

ADR-716

🤖 Generated with [Claude Code](https://claude.com/claude-code)