### PR TITLE
feat(rest-controller): V6 read path Redis caching with partial hit/miss support

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -95,6 +95,7 @@ spring-boot-starter-actuator = { module = "org.springframework.boot:spring-boot-
 spring-boot-starter-data-jpa = { module = "org.springframework.boot:spring-boot-starter-data-jpa" }
 spring-boot-starter-jdbc = { module = "org.springframework.boot:spring-boot-starter-jdbc" }
 spring-boot-starter-cache = { module = "org.springframework.boot:spring-boot-starter-cache" }
+spring-boot-starter-data-redis = { module = "org.springframework.boot:spring-boot-starter-data-redis" }
 spring-boot-starter-batch = { module = "org.springframework.boot:spring-boot-starter-batch" }
 spring-boot-starter-aop = { module = "org.springframework.boot:spring-boot-starter-aop" }
 spring-kafka = { module = "org.springframework.kafka:spring-kafka" }

--- a/module-rest-controller/build.gradle
+++ b/module-rest-controller/build.gradle
@@ -27,6 +27,9 @@ dependencies {
 	implementation(libs.spring.boot.starter.jdbc)
 	runtimeOnly(libs.postgresql)
 
+	// Redis for V6 read model cache
+	implementation(libs.spring.boot.starter.data.redis)
+
 	// Jackson
 	implementation(libs.jackson.module.kotlin)
 

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/config/V6ReadConfig.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/config/V6ReadConfig.kt
@@ -10,6 +10,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.scheduling.annotation.EnableScheduling
 
@@ -43,6 +44,12 @@ class V6ReadConfig(
     ): ReadModelQueryService = ReadModelQueryService(jdbc, objectMapper)
 
     @Bean
+    fun readModelCacheService(
+        redisTemplate: StringRedisTemplate,
+        objectMapper: ObjectMapper
+    ): ReadModelCacheService = ReadModelCacheService(redisTemplate, objectMapper, properties)
+
+    @Bean
     fun expectationReadFacade(
         registry: InflightRequestRegistry,
         buffer: LocalRequestBuffer,
@@ -54,8 +61,9 @@ class V6ReadConfig(
         buffer: LocalRequestBuffer,
         registry: InflightRequestRegistry,
         queryService: ReadModelQueryService,
+        cacheService: ReadModelCacheService,
         v6ReadMetrics: V6ReadMetrics
-    ): BatchReadScheduler = BatchReadScheduler(buffer, registry, queryService, v6ReadMetrics, properties)
+    ): BatchReadScheduler = BatchReadScheduler(buffer, registry, queryService, cacheService, v6ReadMetrics, properties)
 
     @Bean
     fun expectationV6Controller(

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/config/V6ReadProperties.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/config/V6ReadProperties.kt
@@ -10,4 +10,5 @@ class V6ReadProperties {
     var maxBatchSize: Int = 200
     var queueCapacity: Int = 5000
     var shutdownDrainTimeoutSeconds: Long = 5
+    var cacheTtlSeconds: Long = 300
 }

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/metrics/V6ReadMetrics.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/metrics/V6ReadMetrics.kt
@@ -36,6 +36,14 @@ class V6ReadMetrics(
         .description("V6 read model cache hits")
         .register(meterRegistry)
 
+    private val redisHitCounter: Counter = Counter.builder("v6_redis_hit_total")
+        .description("V6 Redis cache hits")
+        .register(meterRegistry)
+
+    private val dbHitCounter: Counter = Counter.builder("v6_db_hit_total")
+        .description("V6 DB query hits (cache miss -> DB fallback)")
+        .register(meterRegistry)
+
     private val missCounters = mutableMapOf<String, Counter>()
     private val meterRegistry = meterRegistry
 
@@ -44,6 +52,10 @@ class V6ReadMetrics(
         .register(meterRegistry)
 
     fun recordHit() = hitCounter.increment()
+
+    fun recordRedisHit() = redisHitCounter.increment()
+
+    fun recordDbHit() = dbHitCounter.increment()
 
     fun recordMiss(reason: String) {
         val counter = missCounters.getOrPut(reason) {

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/read/BatchReadScheduler.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/read/BatchReadScheduler.kt
@@ -12,6 +12,7 @@ class BatchReadScheduler(
     private val buffer: LocalRequestBuffer,
     private val registry: InflightRequestRegistry,
     private val queryService: ReadModelQueryService,
+    private val cacheService: ReadModelCacheService,
     private val metrics: V6ReadMetrics,
     private val properties: V6ReadProperties
 ) : SmartLifecycle {
@@ -73,21 +74,43 @@ class BatchReadScheduler(
         if (batch.isEmpty()) return 0
 
         val requests = batch.associate { it.userIgn to it.presetNo }
-        val results = queryService.batchQuery(requests)
         var resolved = 0
 
-        batch.forEach { request ->
-            val deferreds = registry.getAndRemove(request.userIgn)
-            val response = results[request.userIgn]
+        // 1. Redis cache lookup — split hits / misses
+        val (cacheHits, cacheMisses) = cacheService.multiGet(requests)
 
-            if (response != null) {
-                metrics.recordHit()
-                deferreds.forEach { it.setResult(ResponseEntity.ok(response)) }
-                resolved++
-            } else {
-                metrics.recordMiss("read_model_empty")
+        // 2. Resolve cache hits directly
+        cacheHits.forEach { (userIgn, response) ->
+            val deferreds = registry.getAndRemove(userIgn)
+            metrics.recordHit()
+            metrics.recordRedisHit()
+            deferreds.forEach { it.setResult(ResponseEntity.ok(response)) }
+            resolved++
+        }
+
+        // 3. DB batch query for cache misses only
+        if (cacheMisses.isNotEmpty()) {
+            val dbResults = queryService.batchQuery(cacheMisses)
+
+            // 4. Write DB results to Redis cache
+            cacheService.multiPut(dbResults)
+
+            // 5. Resolve miss deferreds
+            cacheMisses.keys.forEach { userIgn ->
+                val deferreds = registry.getAndRemove(userIgn)
+                val response = dbResults[userIgn]
+
+                if (response != null) {
+                    metrics.recordHit()
+                    metrics.recordDbHit()
+                    deferreds.forEach { it.setResult(ResponseEntity.ok(response)) }
+                    resolved++
+                } else {
+                    metrics.recordMiss("read_model_empty")
+                }
             }
         }
+
         return resolved
     }
 

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelCacheService.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelCacheService.kt
@@ -1,0 +1,72 @@
+package maple.restcontroller.read
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import maple.restcontroller.config.V6ReadProperties
+import org.slf4j.LoggerFactory
+import org.springframework.data.redis.core.StringRedisTemplate
+import java.time.Duration
+
+class ReadModelCacheService(
+    private val redisTemplate: StringRedisTemplate,
+    private val objectMapper: ObjectMapper,
+    private val properties: V6ReadProperties
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    companion object {
+        private const val KEY_PREFIX = "v6:read"
+    }
+
+    fun cacheKey(userIgn: String, presetNo: Int): String =
+        "$KEY_PREFIX:$userIgn:$presetNo"
+
+    /**
+     * Redis multiGet for partial cache lookup.
+     * @return Pair of (cacheHits: userIgn -> V6ExpectationResponse, cacheMissKeys: userIgn -> presetNo)
+     */
+    fun multiGet(
+        requests: Map<String, Int>
+    ): Pair<Map<String, V6ExpectationResponse>, Map<String, Int>> {
+        if (requests.isEmpty()) return emptyMap<String, V6ExpectationResponse>() to emptyMap()
+
+        val keys = requests.entries.associate { (userIgn, presetNo) ->
+            cacheKey(userIgn, presetNo) to (userIgn to presetNo)
+        }
+
+        val values = redisTemplate.opsForValue().multiGet(keys.keys.toList())
+
+        val hits = mutableMapOf<String, V6ExpectationResponse>()
+        val misses = mutableMapOf<String, Int>()
+
+        keys.entries.forEachIndexed { index, (key, userIgnAndPresetNo) ->
+            val (userIgn, presetNo) = userIgnAndPresetNo
+            val value = values?.get(index)
+
+            if (value != null) {
+                val response = objectMapper.readValue(value, V6ExpectationResponse::class.java)
+                hits[userIgn] = response
+            } else {
+                misses[userIgn] = presetNo
+            }
+        }
+
+        log.debug("Redis cache lookup: hits={}, misses={}", hits.size, misses.size)
+        return hits to misses
+    }
+
+    /**
+     * Write DB results to Redis cache with TTL.
+     */
+    fun multiPut(results: Map<String, V6ExpectationResponse>) {
+        if (results.isEmpty()) return
+
+        val ttl = Duration.ofSeconds(properties.cacheTtlSeconds)
+        results.forEach { (userIgn, response) ->
+            val key = cacheKey(userIgn, response.presetNo)
+            val json = objectMapper.writeValueAsString(response)
+            redisTemplate.opsForValue().set(key, json, ttl)
+        }
+
+        log.debug("Redis cache write: {} entries, TTL={}s", results.size, ttl.seconds)
+    }
+}

--- a/module-rest-controller/src/main/resources/application-local.yml
+++ b/module-rest-controller/src/main/resources/application-local.yml
@@ -5,8 +5,13 @@ spring:
     url: ${DB_URL}
     username: ${DB_USER}
     password: ${DB_PASSWORD}
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
 
 expectation:
   v6:
     enabled: true
     request-timeout-ms: 5000
+    cache-ttl-seconds: 300  # Redis cache TTL for read model entries


### PR DESCRIPTION
## Summary
- BatchReadScheduler에서 Redis multiGet → cache hit/miss 분리 → miss만 DB batch query → Redis write
- Partial cache hit 지원 (일부 Redis hit, 나머지 DB fallback)
- Prometheus metrics: `v6_redis_hit_total`, `v6_db_hit_total`

## Test plan
- [x] 첫 호출: cache miss → DB → Redis write (v6_db_hit_total=1)
- [x] 두 번째 호출: Redis cache hit (v6_redis_hit_total=1)
- [x] 부분 cache hit: 진격캐넌(Redis) + 아델(DB) 동시 → 둘 다 200 OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)