### PR TITLE
feat(synchronizer): CHARACTER_BASIC snapshot pipeline

### DIFF
--- a/docs/superpowers/specs/2026-05-16-character-basic-sync-design.md
+++ b/docs/superpowers/specs/2026-05-16-character-basic-sync-design.md
@@ -1,0 +1,40 @@
+# CHARACTER_BASIC Synchronizer Pipeline Design
+
+## Goal
+CHARACTER_BASIC snapshot chunks를 Kafka → Synchronizer → DB 파이프라인으로 저장.
+
+## Architecture
+```
+External API (CHARACTER_BASIC chunk ready)
+  → Kafka "external-api.snapshot.chunk-ready" (endpoint=character-basic)
+  → Synchronizer BasicSnapshotChunkConsumer
+  → Read gzip JSONL chunk file
+  → Parse: ocid (key), character_name/level/class/world (body)
+  → gzip compress body
+  → Bulk upsert to character_basic_read_model
+```
+
+## Table: character_basic_read_model
+```sql
+CREATE TABLE character_basic_read_model (
+    user_ign        TEXT PRIMARY KEY,
+    ocid            TEXT NOT NULL,
+    world_name      TEXT,
+    character_class  TEXT,
+    character_level  INT,
+    guild_name      TEXT,
+    basic_data      BYTEA NOT NULL,
+    document_hash   TEXT,
+    source_run_id   TEXT NOT NULL,
+    source_chunk_id TEXT NOT NULL,
+    created_at      TIMESTAMPTZ DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ DEFAULT NOW(),
+    CONSTRAINT uq_basic_ocid UNIQUE (ocid)
+);
+```
+
+## Changes
+- DB: V126 migration
+- External API: characterBasicSnapshotPublisher Kafka 활성화
+- Synchronizer: BasicSnapshotChunkConsumer + BasicChunkFileReader + CharacterBasicRepository
+- Config: application.yml 양쪽 모두

--- a/module-external-api/src/main/kotlin/maple/externalapi/ExternalApiApplication.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/ExternalApiApplication.kt
@@ -4,9 +4,11 @@ import maple.externalapi.snapshot.SnapshotChunkingProperties
 import maple.externalapi.snapshot.event.SnapshotEventProperties
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Import
 import org.springframework.scheduling.annotation.EnableScheduling
 
-@SpringBootApplication
+@SpringBootApplication(scanBasePackages = ["maple.externalapi", "maple.expectation.infrastructure.executor"])
+@Import(maple.expectation.infrastructure.config.ExecutorConfig::class)
 @EnableScheduling
 @EnableConfigurationProperties(SnapshotChunkingProperties::class, SnapshotEventProperties::class)
 class ExternalApiApplication

--- a/module-external-api/src/main/kotlin/maple/externalapi/snapshot/event/SnapshotEventPublisherConfig.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/snapshot/event/SnapshotEventPublisherConfig.kt
@@ -44,6 +44,32 @@ class SnapshotEventPublisherConfig {
 
     @Bean
     @Qualifier("characterBasicSnapshotPublisher")
-    fun characterBasicSnapshotPublisher(): SnapshotChunkEventPublisher =
+    @ConditionalOnProperty(
+        prefix = "external-api.snapshot.events.kafka",
+        name = ["enabled"],
+        havingValue = "false",
+        matchIfMissing = true,
+    )
+    fun noOpCharacterBasicSnapshotPublisher(): SnapshotChunkEventPublisher =
         NoOpSnapshotChunkEventPublisher()
+
+    @Bean
+    @Qualifier("characterBasicSnapshotPublisher")
+    @ConditionalOnProperty(
+        prefix = "external-api.snapshot.events.kafka",
+        name = ["enabled"],
+        havingValue = "true",
+    )
+    fun kafkaCharacterBasicSnapshotPublisher(
+        kafkaTemplate: KafkaTemplate<String, String>,
+        objectMapper: ObjectMapper,
+        properties: SnapshotEventProperties,
+    ): SnapshotChunkEventPublisher =
+        KafkaSnapshotChunkEventPublisher(
+            kafkaTemplate = kafkaTemplate,
+            objectMapper = objectMapper,
+            chunkReadyTopic = properties.kafka.chunkReadyTopic,
+            runCompletedTopic = properties.kafka.runCompletedTopic,
+            runFailedTopic = properties.kafka.runFailedTopic,
+        )
 }

--- a/module-infra/src/main/resources/db/migration/V126__character_basic_read_model.sql
+++ b/module-infra/src/main/resources/db/migration/V126__character_basic_read_model.sql
@@ -1,0 +1,19 @@
+-- CHARACTER_BASIC read model for V6 read path
+CREATE TABLE IF NOT EXISTS character_basic_read_model (
+    user_ign        TEXT PRIMARY KEY,
+    ocid            TEXT NOT NULL,
+    world_name      TEXT,
+    character_class  TEXT,
+    character_level  INT,
+    guild_name      TEXT,
+    basic_data      BYTEA NOT NULL,
+    document_hash   TEXT,
+    source_run_id   TEXT NOT NULL,
+    source_chunk_id TEXT NOT NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT uq_basic_read_model_ocid UNIQUE (ocid)
+);
+
+CREATE INDEX idx_basic_read_model_ocid ON character_basic_read_model (ocid);

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/SynchronizerApplication.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/SynchronizerApplication.kt
@@ -2,8 +2,10 @@ package maple.synchronizer
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.context.annotation.Import
 
-@SpringBootApplication(scanBasePackages = ["maple.synchronizer"])
+@SpringBootApplication(scanBasePackages = ["maple.synchronizer", "maple.expectation.infrastructure.executor"])
+@Import(maple.expectation.infrastructure.config.ExecutorConfig::class)
 class SynchronizerApplication
 
 fun main(args: Array<String>) {

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/BasicSnapshotChunkConsumer.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/BasicSnapshotChunkConsumer.kt
@@ -1,0 +1,111 @@
+package maple.synchronizer.consumer
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import jakarta.annotation.PreDestroy
+import maple.expectation.infrastructure.executor.LogicExecutor
+import maple.expectation.infrastructure.executor.TaskContext
+import maple.synchronizer.repository.CharacterBasicRepository
+import maple.synchronizer.repository.SynchronizerChunkStatusRepository
+import maple.synchronizer.storage.BasicChunkFileReader
+import org.slf4j.LoggerFactory
+import org.slf4j.MDC
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.kafka.support.Acknowledgment
+import org.springframework.stereotype.Component
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executors
+import java.util.concurrent.Semaphore
+
+@Component
+class BasicSnapshotChunkConsumer(
+    private val objectMapper: ObjectMapper,
+    private val fileReader: BasicChunkFileReader,
+    private val repository: CharacterBasicRepository,
+    private val chunkStatusRepository: SynchronizerChunkStatusRepository,
+    private val logicExecutor: LogicExecutor,
+    @Value("\${synchronizer.store.base-path:../module-external-api/external-api-data}")
+    private val basePath: String,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+    private val vtExecutor = Executors.newVirtualThreadPerTaskExecutor()
+    private val processingPermit = Semaphore(2)
+
+    @KafkaListener(
+        topics = ["\${synchronizer.kafka.basic-chunk-ready-topic}"],
+        groupId = "\${synchronizer.kafka.basic-consumer-group-id}",
+    )
+    fun consume(message: String, acknowledgment: Acknowledgment) {
+        val event = objectMapper.readValue(message, SnapshotChunkReadyEvent::class.java)
+
+        if (event.endpoint != "character-basic") return
+
+        val runId = event.runId
+        val chunkId = event.chunkId
+
+        log.info("[BasicSync] received: runId={} chunkId={} objectKey={} records={}",
+            runId, chunkId, event.objectKey, event.recordCount)
+
+        if (chunkStatusRepository.isAlreadySuccess(runId, chunkId)) {
+            log.info("[BasicSync] skip already-successful chunk: runId={} chunkId={}", runId, chunkId)
+            acknowledgment.acknowledge()
+            return
+        }
+
+        if (!chunkStatusRepository.claimChunk(runId, chunkId, event.objectKey)) {
+            log.info("[BasicSync] skip - chunk already claimed: runId={} chunkId={}", runId, chunkId)
+            acknowledgment.acknowledge()
+            return
+        }
+
+        if (!processingPermit.tryAcquire()) {
+            log.info("[BasicSync] processing permit busy, will retry: runId={} chunkId={}", runId, chunkId)
+            return
+        }
+
+        MDC.put("runId", runId)
+        MDC.put("chunkId", chunkId)
+
+        CompletableFuture.runAsync({
+            logicExecutor.executeWithFinally(
+                task = {
+                    logicExecutor.executeOrCatch(
+                        task = {
+                            val records = fileReader.read(event.objectKey)
+                            repository.bulkUpsert(runId, chunkId, records)
+                            chunkStatusRepository.markSuccess(runId, chunkId)
+                            log.info("[BasicSync] chunk processed: runId={} chunkId={} records={}",
+                                runId, chunkId, records.size)
+                            acknowledgment.acknowledge()
+                        },
+                        recovery = { ex ->
+                            chunkStatusRepository.markFailed(runId, chunkId, ex.message ?: "unknown")
+                            log.error("[BasicSync] chunk processing failed: runId={} chunkId={}",
+                                runId, chunkId, ex)
+                            null
+                        },
+                        context = TaskContext.of("BasicSync", "ChunkProcess", chunkId),
+                    )
+                },
+                finallyBlock = {
+                    processingPermit.release()
+                    MDC.clear()
+                },
+                context = TaskContext.of("BasicSync", "ChunkLifecycle", chunkId),
+            )
+        }, vtExecutor)
+    }
+
+    @PreDestroy
+    fun close() {
+        vtExecutor.close()
+    }
+}
+
+private data class SnapshotChunkReadyEvent(
+    val runId: String,
+    val endpoint: String,
+    val chunkId: String,
+    val objectKey: String,
+    val recordCount: Int,
+)

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/repository/CharacterBasicRepository.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/repository/CharacterBasicRepository.kt
@@ -1,0 +1,74 @@
+package maple.synchronizer.repository
+
+import maple.synchronizer.storage.BasicRecord
+import org.slf4j.LoggerFactory
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.stereotype.Repository
+
+@Repository
+class CharacterBasicRepository(
+    private val jdbc: NamedParameterJdbcTemplate,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    companion object {
+        private const val SUB_BATCH_SIZE = 100
+    }
+
+    fun bulkUpsert(runId: String, chunkId: String, records: List<BasicRecord>) {
+        val batches = records.chunked(SUB_BATCH_SIZE)
+        log.info("[CharacterBasic] upsert start: records={} batches={}: runId={} chunkId={}",
+            records.size, batches.size, runId, chunkId)
+
+        var totalAffected = 0
+        batches.forEachIndexed { idx, batch ->
+            val affected = upsertBatch(runId, chunkId, batch)
+            totalAffected += affected
+            log.info("[CharacterBasic] upsert batch: batchNo={}/{} attempted={} affected={}",
+                idx + 1, batches.size, batch.size, affected)
+        }
+
+        log.info("[CharacterBasic] upsert done: records={} affected={}: runId={} chunkId={}",
+            records.size, totalAffected, runId, chunkId)
+    }
+
+    private fun upsertBatch(runId: String, chunkId: String, batch: List<BasicRecord>): Int {
+        val sql = """
+            INSERT INTO character_basic_read_model (
+                user_ign, ocid, world_name, character_class, character_level,
+                guild_name, basic_data, document_hash, source_run_id, source_chunk_id, updated_at
+            )
+            SELECT
+                unnest(:userIgns), unnest(:ocids), unnest(:worldNames),
+                unnest(:characterClasses), unnest(:characterLevels),
+                unnest(:guildNames), unnest(:basicData), unnest(:documentHashes),
+                :runId, :chunkId, now()
+            ON CONFLICT (user_ign) DO UPDATE SET
+                ocid = excluded.ocid,
+                world_name = excluded.world_name,
+                character_class = excluded.character_class,
+                character_level = excluded.character_level,
+                guild_name = excluded.guild_name,
+                basic_data = excluded.basic_data,
+                document_hash = excluded.document_hash,
+                source_run_id = excluded.source_run_id,
+                source_chunk_id = excluded.source_chunk_id,
+                updated_at = now()
+            WHERE character_basic_read_model.document_hash IS DISTINCT FROM excluded.document_hash
+        """.trimIndent()
+
+        return jdbc.update(sql, MapSqlParameterSource()
+            .addValue("runId", runId)
+            .addValue("chunkId", chunkId)
+            .addValue("userIgns", batch.map { it.userIgn }.toTypedArray())
+            .addValue("ocids", batch.map { it.ocid }.toTypedArray())
+            .addValue("worldNames", batch.map { it.worldName }.toTypedArray())
+            .addValue("characterClasses", batch.map { it.characterClass }.toTypedArray())
+            .addValue("characterLevels", batch.map { it.characterLevel }.toTypedArray())
+            .addValue("guildNames", batch.map { it.guildName }.toTypedArray())
+            .addValue("basicData", batch.map { it.compressedBody }.toTypedArray())
+            .addValue("documentHashes", batch.map { it.bodyHash }.toTypedArray())
+        )
+    }
+}

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/storage/BasicChunkFileReader.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/storage/BasicChunkFileReader.kt
@@ -1,0 +1,85 @@
+package maple.synchronizer.storage
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import maple.expectation.util.GzipUtils
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.security.MessageDigest
+import java.util.zip.GZIPInputStream
+
+data class BasicRecord(
+    val userIgn: String,
+    val ocid: String,
+    val worldName: String?,
+    val characterClass: String?,
+    val characterLevel: Int?,
+    val guildName: String?,
+    val compressedBody: ByteArray,
+    val bodyHash: String,
+) {
+    override fun equals(other: Any?): Boolean = this === other
+    override fun hashCode(): Int = System.identityHashCode(this)
+}
+
+@Component
+class BasicChunkFileReader(
+    @Value("\${synchronizer.store.base-path:../module-external-api/external-api-data}")
+    private val basePath: String,
+    private val objectMapper: ObjectMapper,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun read(objectKey: String): List<BasicRecord> {
+        val path = Paths.get(basePath, objectKey)
+        require(Files.exists(path)) { "Chunk file not found: $path" }
+
+        GZIPInputStream(Files.newInputStream(path)).bufferedReader().use { reader ->
+            val records = mutableListOf<BasicRecord>()
+            reader.lineSequence()
+                .filter { it.isNotBlank() }
+                .forEach { line -> parseRecord(line)?.let { records.add(it) } }
+            log.info("[BasicChunkFileReader] parsed {} records from {}", records.size, objectKey)
+            return records
+        }
+    }
+
+    private fun parseRecord(line: String): BasicRecord? {
+        return runCatching {
+            val node = objectMapper.readTree(line)
+            if (node.get("status")?.asText() != "SUCCESS") return null
+            if (node.get("endpoint")?.asText() != "character-basic") return null
+
+            val ocid = node.get("key")?.asText() ?: return null
+            val body = node.get("body") ?: return null
+
+            val userIgn = body.get("character_name")?.asText() ?: return null
+            val worldName = body.get("world_name")?.asText()
+            val characterClass = body.get("character_class")?.asText()
+            val characterLevel = body.get("character_level")?.asInt()
+            val guildName = body.get("guild_name")?.asText()
+
+            val bodyJson = objectMapper.writeValueAsString(body)
+            val compressed = GzipUtils.compress(bodyJson)
+            val hash = sha256Hex(bodyJson.toByteArray(Charsets.UTF_8))
+
+            BasicRecord(
+                userIgn = userIgn,
+                ocid = ocid,
+                worldName = worldName,
+                characterClass = characterClass,
+                characterLevel = characterLevel,
+                guildName = guildName,
+                compressedBody = compressed,
+                bodyHash = hash,
+            )
+        }.getOrNull()
+    }
+
+    private fun sha256Hex(input: ByteArray): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(input)
+        return digest.joinToString("") { "%02x".format(it) }
+    }
+}

--- a/module-synchronizer/src/main/resources/application.yml
+++ b/module-synchronizer/src/main/resources/application.yml
@@ -41,7 +41,9 @@ spring:
 synchronizer:
   kafka:
     result-chunk-ready-topic: calculator.result.chunk-ready
+    basic-chunk-ready-topic: external-api.snapshot.chunk-ready
     consumer-group-id: synchronizer-result-chunk-consumer
+    basic-consumer-group-id: synchronizer-basic-chunk-consumer
   store:
     base-path: ../module-external-api/external-api-data
   chunk:


### PR DESCRIPTION
## Summary
- CHARACTER_BASIC snapshot chunk → Kafka → Synchronizer → DB bulk upsert 파이프라인 구현
- External API: character-basic Kafka publisher 활성화 (기존 NoOp → conditional Kafka)
- Synchronizer: BasicSnapshotChunkConsumer, BasicChunkFileReader, CharacterBasicRepository
- V126 migration: character_basic_read_model 테이블
- standalone 실행을 위한 ExecutorConfig import 추가 (external-api, synchronizer)

## Test plan
- [x] 컴파일 통과 (`./gradlew compileKotlin --continue`)
- [x] 테스트 통과 (`./gradlew :module-external-api:test :module-synchronizer:test`)
- [x] external-api + synchronizer 기동 확인 (8081, 8083 health 200)
- [x] E2E 파이프라인 검증: 42,000건 upsert 성공, ~200 users/sec

🤖 Generated with [Claude Code](https://claude.com/claude-code)