### PR TITLE
feat: V6 urgent Kafka pipeline for cache-miss character data

### DIFF
--- a/docs/01_ADR/ADR-026_v6-urgent-kafka-pipeline.md
+++ b/docs/01_ADR/ADR-026_v6-urgent-kafka-pipeline.md
@@ -1,0 +1,105 @@
+# ADR-026: V6 Urgent Kafka Pipeline
+
+- Status: Proposed
+- Date: 2026-05-16
+- Owner: zbnerd
+
+---
+
+## 1. Background / Problem
+
+### Background
+
+- V6 read endpoint (`module-rest-controller`) serves character expectation data via Redis → DB → OCID lookup fallback chain.
+- When all three layers miss (cold character), the user receives a 202 but must poll or wait for the batch pipeline to eventually process the character.
+- Batch pipeline operates on scheduled chunks; latency from request to result can be minutes to hours.
+
+### Problem
+
+- No mechanism exists to trigger urgent (on-demand) data fetch for a single character outside the batch cycle.
+- Cold-character users experience unacceptable latency with no feedback until the next batch run picks them up.
+
+### Goal
+
+- Add an urgent pipeline that fetches data for a single character on-demand when the V6 read path finds no data, returning results within seconds rather than waiting for the next batch cycle.
+
+---
+
+## 2. Decision
+
+> Urgent pipeline uses dedicated Kafka topics separate from batch, triggered by `module-rest-controller` on cache miss.
+
+```text
+rest-controller (read miss)
+  → SETNX dedup check (Redis)
+  → Kafka: urgent-character-request
+  → external-api: resolve OCID + fetch basic/item
+     → Nexon 400 → Kafka: urgent-character-not-found → rest-controller → 404 + Redis negative cache
+     → Success → Kafka: external-api.urgent.snapshot.chunk-ready
+        → calculator (urgent consumer group)
+        → synchronizer/basic (urgent consumer group)
+  → calculator → Kafka: calculator.result.chunk-ready (existing shared topic)
+  → synchronizer/result → DB write → Redis write
+  → rest-controller reads result on next poll
+```
+
+Topic architecture:
+
+| Topic | Publisher | Consumer |
+|-------|-----------|----------|
+| `urgent-character-request` | rest-controller | external-api |
+| `urgent-character-not-found` | external-api | rest-controller |
+| `external-api.urgent.snapshot.chunk-ready` | external-api | calculator (urgent group), synchronizer/basic (urgent group) |
+| `calculator.result.chunk-ready` (existing) | calculator | synchronizer/result (existing, shared) |
+
+---
+
+## 3. Trade-offs
+
+### Sensitivity
+
+* Nexon API rate limit — urgent requests bypass batch pacing, can exhaust quota
+* Kafka topic partition count — single-partition urgent topics serialize per-character; too few partitions limit parallelism
+* Redis negative cache TTL — too short causes repeated Nexon 400 calls; too long delays valid retries
+* Feature flag `expectation.v6.urgent.enabled` — controls entire urgent path; misconfiguration silently disables
+
+### Trade-off
+
+| 선택 | 얻는 것 | 포기한 것 |
+| -- | ---- | ----- |
+| Dedicated urgent Kafka topics | Isolation from batch backlog; independent consumer group sizing | More topics to monitor and manage |
+| Calculator publishes to shared result topic | No new result pipeline; existing synchronizer/result handles both urgent and batch | Urgent results compete with batch for consumer capacity |
+| Redis SETNX dedup for trigger | Prevents duplicate urgent requests for same IGN | Additional Redis round-trip on every miss |
+| Redis negative cache for Nexon 400 | Fast 404 response; protects Nexon API quota | Stale negative cache if character becomes valid (mitigated by TTL) |
+
+### Risk
+
+* Urgent requests could starve batch consumers if not properly throttled
+* Calculator shared result topic becomes a coupling point — urgent SLA depends on batch not saturating consumers
+
+### Non-Risk
+
+* Urgent pipeline does not modify batch pipeline code paths — dedicated topics provide clean isolation
+* Calculator and synchronizer processing speed is not the bottleneck; urgency bottleneck is rest-controller → external-api (OCID + API fetch)
+
+---
+
+## 4. Result / Evidence
+
+### Metrics
+
+| Metric | Target | Notes |
+| ------ | ----: | ----- |
+| Urgent pipeline end-to-end latency | < 5s (p99) | From trigger to result available in Redis |
+| Nexon 400 → 404 response | < 100ms | Redis negative cache hit path |
+| Urgent trigger dedup hit rate | > 90% | SETNX prevents redundant triggers |
+
+### Observed Result
+
+* To be measured after implementation.
+
+---
+
+## 5. Summary
+
+> Urgent pipeline uses dedicated Kafka topics for request/snapshot stages while sharing the calculator result topic, trading topic sprawl for batch isolation with minimal operational overhead.

--- a/module-calculator/src/main/kotlin/maple/calculator/consumer/KafkaSnapshotChunkReadyConsumer.kt
+++ b/module-calculator/src/main/kotlin/maple/calculator/consumer/KafkaSnapshotChunkReadyConsumer.kt
@@ -29,4 +29,18 @@ class KafkaSnapshotChunkReadyConsumer(
         runBlocking { coordinator.handle(event) }
         acknowledgment.acknowledge()
     }
+
+    @KafkaListener(
+        topics = ["\${calculator.kafka.urgent-snapshot-chunk-ready-topic}"],
+        groupId = "\${calculator.kafka.urgent-consumer-group-id}",
+    )
+    fun consumeUrgent(message: String, acknowledgment: Acknowledgment) {
+        val event = objectMapper.readValue(message, SnapshotChunkReadyEvent::class.java)
+        log.info(
+            "[Consumer] received URGENT chunk-ready: runId={} endpoint={} chunkId={} objectKey={} recordCount={}",
+            event.runId, event.endpoint, event.chunkId, event.objectKey, event.recordCount,
+        )
+        runBlocking { coordinator.handle(event) }
+        acknowledgment.acknowledge()
+    }
 }

--- a/module-calculator/src/main/resources/application.yml
+++ b/module-calculator/src/main/resources/application.yml
@@ -22,6 +22,8 @@ calculator:
     snapshot-chunk-ready-topic: external-api.snapshot.chunk-ready
     result-chunk-ready-topic: calculator.result.chunk-ready
     consumer-group-id: calculator-snapshot-chunk-processor
+    urgent-snapshot-chunk-ready-topic: external-api.urgent.snapshot.chunk-ready
+    urgent-consumer-group-id: calculator-urgent-chunk-processor
   store:
     input-base-path: ../module-external-api/external-api-data
   cleanup:

--- a/module-external-api/src/main/kotlin/maple/externalapi/urgent/UrgentCharacterRequestConsumer.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/urgent/UrgentCharacterRequestConsumer.kt
@@ -1,0 +1,178 @@
+package maple.externalapi.urgent
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import maple.externalapi.domain.ExternalApiEndpoint
+import maple.externalapi.domain.ExternalApiProvider
+import maple.externalapi.port.out.ExternalApiClientPort
+import maple.externalapi.snapshot.GzipJsonlChunkWriter
+import maple.externalapi.snapshot.SnapshotChunkRecord
+import maple.externalapi.snapshot.event.SnapshotChunkReadyEvent
+import maple.expectation.util.StringMaskingUtils.maskIgn
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.support.Acknowledgment
+import org.springframework.stereotype.Component
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Instant
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+
+@Component
+@ConditionalOnProperty(
+    name = ["external-api.urgent.enabled"],
+    havingValue = "true",
+    matchIfMissing = false,
+)
+class UrgentCharacterRequestConsumer(
+    private val clientPort: ExternalApiClientPort,
+    private val objectMapper: ObjectMapper,
+    private val kafkaTemplate: KafkaTemplate<String, String>,
+    @Value("\${external-api.urgent.not-found-topic}")
+    private val notFoundTopic: String,
+    @Value("\${external-api.urgent.chunk-ready-topic}")
+    private val urgentChunkReadyTopic: String,
+    @Value("\${external-api.store.base-path}")
+    private val storeBasePath: String,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @KafkaListener(
+        topics = ["\${external-api.urgent.request-topic}"],
+        groupId = "\${external-api.urgent.consumer-group-id}",
+    )
+    fun consume(message: String, acknowledgment: Acknowledgment) {
+        val request = objectMapper.readValue(message, UrgentCharacterRequest::class.java)
+        log.info("[Urgent] received: userIgn={}", maskIgn(request.userIgn))
+
+        processUrgentCharacter(request)
+
+        acknowledgment.acknowledge()
+        log.info("[Urgent] completed: userIgn={}", maskIgn(request.userIgn))
+    }
+
+    private fun processUrgentCharacter(request: UrgentCharacterRequest) {
+        val ocidData = clientPort.fetch(
+            ExternalApiProvider.NEXON,
+            ExternalApiEndpoint.OCID_LOOKUP,
+            request.userIgn,
+        ).join()
+
+        val ocidNode = objectMapper.readTree(ocidData).get("ocid")
+        if (ocidNode == null || ocidNode.isNull) {
+            log.info("[Urgent] OCID not found: userIgn={}", maskIgn(request.userIgn))
+            publishNotFound(request.userIgn)
+            return
+        }
+
+        val ocid = ocidNode.asText()
+        log.info("[Urgent] OCID resolved: userIgn={}", maskIgn(request.userIgn))
+
+        val basicFuture = clientPort.fetch(
+            ExternalApiProvider.NEXON,
+            ExternalApiEndpoint.CHARACTER_BASIC,
+            ocid,
+        )
+        val equipmentFuture = clientPort.fetch(
+            ExternalApiProvider.NEXON,
+            ExternalApiEndpoint.ITEM_EQUIPMENT,
+            ocid,
+        )
+
+        val basicData = basicFuture.join()
+        val equipmentData = equipmentFuture.join()
+
+        val runId = "urgent-${UUID.randomUUID()}"
+
+        publishUrgentChunk(
+            runId = runId,
+            endpoint = ExternalApiEndpoint.CHARACTER_BASIC,
+            userIgn = request.userIgn,
+            data = basicData,
+            keyType = "OCID",
+        )
+        publishUrgentChunk(
+            runId = runId,
+            endpoint = ExternalApiEndpoint.ITEM_EQUIPMENT,
+            userIgn = request.userIgn,
+            data = equipmentData,
+            keyType = "OCID",
+        )
+
+        log.info(
+            "[Urgent] data fetch complete: userIgn={}, runId={}",
+            maskIgn(request.userIgn),
+            runId,
+        )
+    }
+
+    private fun publishUrgentChunk(
+        runId: String,
+        endpoint: ExternalApiEndpoint,
+        userIgn: String,
+        data: ByteArray,
+        keyType: String,
+    ) {
+        val endpointDir = endpoint.storageSubDir()
+        val chunksDir = Path.of(storeBasePath, "runs", runId, endpointDir, "chunks")
+        Files.createDirectories(chunksDir)
+
+        val writer = GzipJsonlChunkWriter(chunksDir, 1, 1, Long.MAX_VALUE, objectMapper)
+        writer.append(
+            SnapshotChunkRecord.Success(
+                key = userIgn,
+                endpoint = endpointDir,
+                keyType = keyType,
+                httpStatus = 200,
+                fetchedAt = Instant.now(),
+                bodyBytes = data,
+            ),
+        )
+        val stats = writer.close()
+
+        val objectKey = "runs/$runId/$endpointDir/${stats.path}"
+        val event = SnapshotChunkReadyEvent(
+            eventId = UUID.randomUUID().toString(),
+            runId = runId,
+            endpoint = endpointDir,
+            chunkId = "part-000001",
+            objectKey = objectKey,
+            recordCount = stats.recordCount,
+            uncompressedBytes = stats.uncompressedBytes,
+            compressedBytes = stats.compressedBytes,
+            createdAt = Instant.now(),
+        )
+
+        val eventJson = objectMapper.writeValueAsString(event)
+        val key = "${event.runId}:${event.endpoint}:${event.chunkId}"
+        kafkaTemplate.send(urgentChunkReadyTopic, key, eventJson).get(30, TimeUnit.SECONDS)
+
+        log.info(
+            "[Urgent] published chunk: endpoint={}, userIgn={}, objectKey={}",
+            endpointDir,
+            maskIgn(userIgn),
+            objectKey,
+        )
+    }
+
+    private fun publishNotFound(userIgn: String) {
+        val event = mapOf(
+            "userIgn" to userIgn,
+            "reason" to "OCID_NOT_FOUND",
+            "occurredAt" to Instant.now().toString(),
+        )
+        val json = objectMapper.writeValueAsString(event)
+        kafkaTemplate.send(notFoundTopic, userIgn, json)
+        log.info("[Urgent] published not-found: userIgn={}", maskIgn(userIgn))
+    }
+}
+
+data class UrgentCharacterRequest(
+    val eventId: String,
+    val userIgn: String,
+    val presetNo: Int = 1,
+    val requestedAt: Instant,
+)

--- a/module-external-api/src/main/resources/application.yml
+++ b/module-external-api/src/main/resources/application.yml
@@ -42,6 +42,12 @@ external-api:
     enabled: true
     run-on-startup: true
     skip-character-basic: false
+  urgent:
+    enabled: false                                    # feature flag for urgent pipeline
+    request-topic: urgent-character-request
+    not-found-topic: urgent-character-not-found
+    chunk-ready-topic: external-api.urgent.snapshot.chunk-ready
+    consumer-group-id: external-api-urgent-processor
   snapshot:
     chunk:
       character-basic:

--- a/module-external-api/src/test/kotlin/maple/externalapi/urgent/UrgentCharacterRequestConsumerTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/urgent/UrgentCharacterRequestConsumerTest.kt
@@ -1,0 +1,161 @@
+package maple.externalapi.urgent
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import maple.externalapi.domain.ExternalApiEndpoint
+import maple.externalapi.domain.ExternalApiProvider
+import maple.externalapi.port.out.ExternalApiClientPort
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.clients.producer.RecordMetadata
+import org.apache.kafka.common.TopicPartition
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.support.Acknowledgment
+import org.springframework.kafka.support.SendResult
+import java.nio.file.Path
+import java.time.Instant
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
+
+class UrgentCharacterRequestConsumerTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    private lateinit var clientPort: ExternalApiClientPort
+    private lateinit var objectMapper: ObjectMapper
+    private lateinit var kafkaTemplate: KafkaTemplate<String, String>
+    private lateinit var consumer: UrgentCharacterRequestConsumer
+
+    @BeforeEach
+    fun setUp() {
+        clientPort = mock()
+        objectMapper = ObjectMapper().registerKotlinModule().registerModule(JavaTimeModule())
+        kafkaTemplate = mock()
+
+        consumer = UrgentCharacterRequestConsumer(
+            clientPort = clientPort,
+            objectMapper = objectMapper,
+            kafkaTemplate = kafkaTemplate,
+            notFoundTopic = "urgent-character-not-found",
+            urgentChunkReadyTopic = "external-api.urgent.snapshot.chunk-ready",
+            storeBasePath = tempDir.toString(),
+        )
+    }
+
+    private fun stubSendResult(): CompletableFuture<SendResult<String, String>> {
+        val future = CompletableFuture<SendResult<String, String>>()
+        val record = ProducerRecord<String, String>("topic", "key", "value")
+        val metadata = RecordMetadata(TopicPartition("topic", 0), 0L, 0, 0L, 0, 0)
+        future.complete(SendResult(record, metadata))
+        return future
+    }
+
+    @Test
+    fun `successful path - resolves OCID, fetches basic and equipment, publishes 2 chunks`() {
+        // Given
+        val userIgn = "TestCharacter"
+        val ocid = "abc123ocid"
+        val request = UrgentCharacterRequest(
+            eventId = UUID.randomUUID().toString(),
+            userIgn = userIgn,
+            presetNo = 1,
+            requestedAt = Instant.now(),
+        )
+        val message = objectMapper.writeValueAsString(request)
+
+        val ocidResponse = """{"ocid":"$ocid"}""".toByteArray()
+        val basicResponse = """{"character_name":"TestCharacter","level":300}""".toByteArray()
+        val equipmentResponse = """{"item_equipment":[{"item_name":"sword"}]}""".toByteArray()
+
+        whenever(clientPort.fetch(ExternalApiProvider.NEXON, ExternalApiEndpoint.OCID_LOOKUP, userIgn))
+            .thenReturn(CompletableFuture.completedFuture(ocidResponse))
+        whenever(clientPort.fetch(ExternalApiProvider.NEXON, ExternalApiEndpoint.CHARACTER_BASIC, ocid))
+            .thenReturn(CompletableFuture.completedFuture(basicResponse))
+        whenever(clientPort.fetch(ExternalApiProvider.NEXON, ExternalApiEndpoint.ITEM_EQUIPMENT, ocid))
+            .thenReturn(CompletableFuture.completedFuture(equipmentResponse))
+        whenever(kafkaTemplate.send(any(), any(), any()))
+            .thenReturn(stubSendResult())
+
+        val acknowledgment = mock<Acknowledgment>()
+
+        // When
+        consumer.consume(message, acknowledgment)
+
+        // Then - verify 2 chunk-ready events published
+        val captor = argumentCaptor<String>()
+        verify(kafkaTemplate, times(2)).send(
+            eq("external-api.urgent.snapshot.chunk-ready"),
+            any(),
+            captor.capture(),
+        )
+
+        val chunkEvents = captor.allValues.map { objectMapper.readTree(it) }
+        assertThat(chunkEvents.all { it["eventType"].asText() == "SNAPSHOT_CHUNK_READY" }).isTrue()
+
+        val endpoints = chunkEvents.map { it["endpoint"].asText() }.toSet()
+        assertThat(endpoints).containsExactlyInAnyOrder("character-basic", "item-equipment")
+
+        // Verify chunk files exist on disk (consumer creates tempDir/runs/urgent-xxx/...)
+        val runsDir = tempDir.resolve("runs").toFile()
+        assertThat(runsDir.exists()).isTrue()
+        val urgentDirs = runsDir.listFiles()?.filter { it.isDirectory && it.name.startsWith("urgent-") }
+        assertThat(urgentDirs).isNotEmpty
+
+        val runDir = urgentDirs!!.first()
+        val chunksFiles = runDir.walkTopDown().filter { it.extension == "gz" }.toList()
+        assertThat(chunksFiles).hasSize(2)
+    }
+
+    @Test
+    fun `not-found path - OCID response missing ocid field publishes not-found event`() {
+        // Given
+        val userIgn = "NonExistent"
+        val request = UrgentCharacterRequest(
+            eventId = UUID.randomUUID().toString(),
+            userIgn = userIgn,
+            presetNo = 1,
+            requestedAt = Instant.now(),
+        )
+        val message = objectMapper.writeValueAsString(request)
+
+        val ocidResponse = """{"error":{"name":"OPENAPI00004","message":"Data not found"}}""".toByteArray()
+
+        whenever(clientPort.fetch(ExternalApiProvider.NEXON, ExternalApiEndpoint.OCID_LOOKUP, userIgn))
+            .thenReturn(CompletableFuture.completedFuture(ocidResponse))
+        whenever(kafkaTemplate.send(any(), any(), any()))
+            .thenReturn(stubSendResult())
+
+        val acknowledgment = mock<Acknowledgment>()
+
+        // When
+        consumer.consume(message, acknowledgment)
+
+        // Then
+        val captor = argumentCaptor<String>()
+        verify(kafkaTemplate).send(
+            eq("urgent-character-not-found"),
+            any(),
+            captor.capture(),
+        )
+
+        val notFoundEvent = objectMapper.readTree(captor.firstValue)
+        assertThat(notFoundEvent["userIgn"].asText()).isEqualTo(userIgn)
+        assertThat(notFoundEvent["reason"].asText()).isEqualTo("OCID_NOT_FOUND")
+
+        // No chunk files created
+        val runsDir = tempDir.resolve("runs").toFile()
+        assertThat(runsDir.exists()).isFalse()
+    }
+}

--- a/module-rest-controller/build.gradle
+++ b/module-rest-controller/build.gradle
@@ -30,6 +30,9 @@ dependencies {
 	// Redis for V6 read model cache
 	implementation(libs.spring.boot.starter.data.redis)
 
+	// Kafka for urgent pipeline trigger
+	implementation(libs.spring.kafka)
+
 	// Jackson
 	implementation(libs.jackson.module.kotlin)
 

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/config/V6ReadConfig.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/config/V6ReadConfig.kt
@@ -6,12 +6,15 @@ import maple.restcontroller.advice.RestControllerExceptionHandler
 import maple.restcontroller.controller.ExpectationV6Controller
 import maple.restcontroller.metrics.V6ReadMetrics
 import maple.restcontroller.read.*
+import maple.restcontroller.urgent.UrgentTriggerPublisher
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.scheduling.annotation.EnableScheduling
 
 @Configuration
@@ -73,4 +76,12 @@ class V6ReadConfig(
     @Bean
     fun restControllerExceptionHandler(): RestControllerExceptionHandler =
         RestControllerExceptionHandler()
+
+    @Bean
+    @ConditionalOnProperty(name = ["expectation.v6.urgent.enabled"], havingValue = "true")
+    fun urgentTriggerPublisher(
+        kafkaTemplate: KafkaTemplate<String, String>,
+        objectMapper: ObjectMapper,
+        @Value("\${expectation.v6.urgent.request-topic}") topic: String
+    ): UrgentTriggerPublisher = UrgentTriggerPublisher(kafkaTemplate, objectMapper, topic)
 }

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/config/V6ReadConfig.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/config/V6ReadConfig.kt
@@ -7,6 +7,7 @@ import maple.restcontroller.controller.ExpectationV6Controller
 import maple.restcontroller.metrics.V6ReadMetrics
 import maple.restcontroller.read.*
 import maple.restcontroller.urgent.UrgentTriggerPublisher
+import org.springframework.beans.factory.ObjectProvider
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
@@ -65,8 +66,13 @@ class V6ReadConfig(
         registry: InflightRequestRegistry,
         queryService: ReadModelQueryService,
         cacheService: ReadModelCacheService,
-        v6ReadMetrics: V6ReadMetrics
-    ): BatchReadScheduler = BatchReadScheduler(buffer, registry, queryService, cacheService, v6ReadMetrics, properties)
+        v6ReadMetrics: V6ReadMetrics,
+        urgentPublisherProvider: ObjectProvider<UrgentTriggerPublisher>
+    ): BatchReadScheduler = BatchReadScheduler(
+        buffer, registry, queryService, cacheService,
+        urgentPublisherProvider.ifAvailable,
+        v6ReadMetrics, properties
+    )
 
     @Bean
     fun expectationV6Controller(

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/metrics/V6ReadMetrics.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/metrics/V6ReadMetrics.kt
@@ -32,6 +32,10 @@ class V6ReadMetrics(
         .description("Buffer full to 503 rejection count")
         .register(meterRegistry)
 
+    val urgentTriggerTotal: Counter = Counter.builder("v6_urgent_trigger_total")
+        .description("Total urgent pipeline triggers")
+        .register(meterRegistry)
+
     private val hitCounter: Counter = Counter.builder("v6_read_hit_total")
         .description("V6 read model cache hits")
         .register(meterRegistry)

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/read/BatchReadScheduler.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/read/BatchReadScheduler.kt
@@ -1,7 +1,10 @@
 package maple.restcontroller.read
 
+import maple.expectation.util.StringMaskingUtils.maskIgn
 import maple.restcontroller.config.V6ReadProperties
 import maple.restcontroller.metrics.V6ReadMetrics
+import maple.restcontroller.urgent.UrgentCharacterRequest
+import maple.restcontroller.urgent.UrgentTriggerPublisher
 import org.slf4j.LoggerFactory
 import org.springframework.context.SmartLifecycle
 import org.springframework.http.ResponseEntity
@@ -13,6 +16,7 @@ class BatchReadScheduler(
     private val registry: InflightRequestRegistry,
     private val queryService: ReadModelQueryService,
     private val cacheService: ReadModelCacheService,
+    private val urgentPublisher: UrgentTriggerPublisher?,
     private val metrics: V6ReadMetrics,
     private val properties: V6ReadProperties
 ) : SmartLifecycle {
@@ -107,6 +111,26 @@ class BatchReadScheduler(
                     resolved++
                 } else {
                     metrics.recordMiss("read_model_empty")
+
+                    // Check negative cache first (character previously confirmed not found by Nexon)
+                    if (cacheService.getNegativeCache(userIgn)) {
+                        val notFoundResponse = ResponseEntity.status(404)
+                            .header("X-Error-Reason", "character-not-found")
+                            .build<Any>()
+                        deferreds.forEach { it.setResult(notFoundResponse) }
+                        resolved++
+                        return@forEach
+                    }
+
+                    // Trigger urgent pipeline (with dedup via Redis SETNX)
+                    if (urgentPublisher != null && cacheService.tryMarkUrgentPending(userIgn)) {
+                        val presetNo = cacheMisses[userIgn] ?: 1
+                        urgentPublisher.publish(UrgentCharacterRequest(userIgn = userIgn, presetNo = presetNo))
+                        metrics.urgentTriggerTotal.increment()
+                        log.info("Triggered urgent pipeline: userIgn={}", maskIgn(userIgn))
+                    }
+
+                    // Otherwise DeferredResult will time out → 202 Accepted
                 }
             }
         }

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelCacheService.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelCacheService.kt
@@ -15,6 +15,8 @@ class ReadModelCacheService(
 
     companion object {
         private const val KEY_PREFIX = "v6:read"
+        private const val NEGATIVE_KEY_PREFIX = "v6:not-found"
+        private const val URGENT_PENDING_PREFIX = "v6:urgent-pending"
     }
 
     fun cacheKey(userIgn: String, presetNo: Int): String =
@@ -68,5 +70,28 @@ class ReadModelCacheService(
         }
 
         log.debug("Redis cache write: {} entries, TTL={}s", results.size, ttl.seconds)
+    }
+
+    // --- Negative cache (non-existent characters) ---
+
+    fun negativeCacheKey(userIgn: String): String = "$NEGATIVE_KEY_PREFIX:$userIgn"
+
+    fun getNegativeCache(userIgn: String): Boolean {
+        return redisTemplate.hasKey(negativeCacheKey(userIgn))
+    }
+
+    fun setNegativeCache(userIgn: String, ttlSeconds: Long) {
+        redisTemplate.opsForValue().set(negativeCacheKey(userIgn), "NOT_FOUND", Duration.ofSeconds(ttlSeconds))
+        log.info("Set negative cache: userIgn={}", userIgn)
+    }
+
+    // --- Urgent dedup (prevent duplicate triggers) ---
+
+    fun urgentPendingKey(userIgn: String): String = "$URGENT_PENDING_PREFIX:$userIgn"
+
+    fun tryMarkUrgentPending(userIgn: String, ttlSeconds: Long = 30): Boolean {
+        val result = redisTemplate.opsForValue()
+            .setIfAbsent(urgentPendingKey(userIgn), "1", Duration.ofSeconds(ttlSeconds))
+        return result == true
     }
 }

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelCacheService.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelCacheService.kt
@@ -1,6 +1,7 @@
 package maple.restcontroller.read
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import maple.expectation.util.StringMaskingUtils.maskIgn
 import maple.restcontroller.config.V6ReadProperties
 import org.slf4j.LoggerFactory
 import org.springframework.data.redis.core.StringRedisTemplate
@@ -82,7 +83,7 @@ class ReadModelCacheService(
 
     fun setNegativeCache(userIgn: String, ttlSeconds: Long) {
         redisTemplate.opsForValue().set(negativeCacheKey(userIgn), "NOT_FOUND", Duration.ofSeconds(ttlSeconds))
-        log.info("Set negative cache: userIgn={}", userIgn)
+        log.info("Set negative cache: userIgn={}", maskIgn(userIgn))
     }
 
     // --- Urgent dedup (prevent duplicate triggers) ---

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/urgent/UrgentCharacterNotFoundConsumer.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/urgent/UrgentCharacterNotFoundConsumer.kt
@@ -1,0 +1,31 @@
+package maple.restcontroller.urgent
+
+import maple.restcontroller.read.ReadModelCacheService
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.kafka.support.Acknowledgment
+import org.springframework.stereotype.Component
+
+@Component
+@ConditionalOnProperty(name = ["expectation.v6.urgent.enabled"], havingValue = "true")
+class UrgentCharacterNotFoundConsumer(
+    private val cacheService: ReadModelCacheService,
+    private val objectMapper: ObjectMapper,
+    @Value("\${expectation.v6.urgent.negative-cache-ttl-seconds}") private val negativeCacheTtlSeconds: Long
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @KafkaListener(
+        topics = ["\${expectation.v6.urgent.not-found-topic}"],
+        groupId = "\${spring.kafka.consumer.group-id}"
+    )
+    fun consume(message: String, acknowledgment: Acknowledgment) {
+        val userIgn = objectMapper.readTree(message).get("userIgn").asText()
+        log.info("Received character-not-found event: userIgn={}", userIgn)
+        cacheService.setNegativeCache(userIgn, negativeCacheTtlSeconds)
+        acknowledgment.acknowledge()
+    }
+}

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/urgent/UrgentCharacterNotFoundConsumer.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/urgent/UrgentCharacterNotFoundConsumer.kt
@@ -1,5 +1,6 @@
 package maple.restcontroller.urgent
 
+import maple.expectation.util.StringMaskingUtils.maskIgn
 import maple.restcontroller.read.ReadModelCacheService
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.slf4j.LoggerFactory
@@ -23,8 +24,13 @@ class UrgentCharacterNotFoundConsumer(
         groupId = "\${spring.kafka.consumer.group-id}"
     )
     fun consume(message: String, acknowledgment: Acknowledgment) {
-        val userIgn = objectMapper.readTree(message).get("userIgn").asText()
-        log.info("Received character-not-found event: userIgn={}", userIgn)
+        val userIgn = objectMapper.readTree(message).get("userIgn")?.asText()
+        if (userIgn == null) {
+            log.warn("Missing userIgn in not-found message, acknowledging to skip")
+            acknowledgment.acknowledge()
+            return
+        }
+        log.info("Received character-not-found event: userIgn={}", maskIgn(userIgn))
         cacheService.setNegativeCache(userIgn, negativeCacheTtlSeconds)
         acknowledgment.acknowledge()
     }

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/urgent/UrgentCharacterRequest.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/urgent/UrgentCharacterRequest.kt
@@ -1,0 +1,11 @@
+package maple.restcontroller.urgent
+
+import java.time.Instant
+import java.util.UUID
+
+data class UrgentCharacterRequest(
+    val eventId: String = UUID.randomUUID().toString(),
+    val userIgn: String,
+    val presetNo: Int = 1,
+    val requestedAt: Instant = Instant.now()
+)

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/urgent/UrgentTriggerPublisher.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/urgent/UrgentTriggerPublisher.kt
@@ -1,0 +1,26 @@
+package maple.restcontroller.urgent
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.slf4j.LoggerFactory
+import org.springframework.kafka.core.KafkaTemplate
+
+class UrgentTriggerPublisher(
+    private val kafkaTemplate: KafkaTemplate<String, String>,
+    private val objectMapper: ObjectMapper,
+    private val topic: String
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun publish(request: UrgentCharacterRequest) {
+        val json = objectMapper.writeValueAsString(request)
+        kafkaTemplate.send(topic, request.userIgn, json)
+            .whenComplete { result, ex ->
+                if (ex != null) {
+                    log.error("Failed to publish urgent request: userIgn={}, topic={}", request.userIgn, topic, ex)
+                } else {
+                    log.info("Published urgent request: userIgn={}, topic={}, partition={}, offset={}",
+                        request.userIgn, topic, result.recordMetadata.partition(), result.recordMetadata.offset())
+                }
+            }
+    }
+}

--- a/module-rest-controller/src/main/resources/application.yml
+++ b/module-rest-controller/src/main/resources/application.yml
@@ -13,6 +13,21 @@ spring:
     hikari:
       maximum-pool-size: 5
       minimum-idle: 2
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+      acks: all
+      retries: 3
+    consumer:
+      group-id: rest-controller-urgent-feedback
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      auto-offset-reset: earliest
+      enable-auto-commit: false
+    listener:
+      ack-mode: manual_immediate
 
 management:
   endpoints:
@@ -28,3 +43,8 @@ expectation:
     max-batch-size: 200               # scheduler batch size (Phase 2)
     queue-capacity: 5000              # RequestBuffer max capacity
     shutdown-drain-timeout-seconds: 5 # graceful shutdown deadline
+    urgent:
+      enabled: false                              # feature flag
+      request-topic: urgent-character-request
+      not-found-topic: urgent-character-not-found
+      negative-cache-ttl-seconds: 3600            # 1 hour

--- a/module-rest-controller/src/test/kotlin/maple/restcontroller/urgent/UrgentCharacterNotFoundConsumerTest.kt
+++ b/module-rest-controller/src/test/kotlin/maple/restcontroller/urgent/UrgentCharacterNotFoundConsumerTest.kt
@@ -23,4 +23,14 @@ class UrgentCharacterNotFoundConsumerTest {
         verify(cacheService).setNegativeCache("unknownChar", 3600L)
         verify(acknowledgment).acknowledge()
     }
+
+    @Test
+    fun `consume with missing userIgn acknowledges without setting negative cache`() {
+        val message = """{"reason":"OPENAPI00004"}"""
+
+        consumer.consume(message, acknowledgment)
+
+        verify(cacheService, never()).setNegativeCache(any(), any())
+        verify(acknowledgment).acknowledge()
+    }
 }

--- a/module-rest-controller/src/test/kotlin/maple/restcontroller/urgent/UrgentCharacterNotFoundConsumerTest.kt
+++ b/module-rest-controller/src/test/kotlin/maple/restcontroller/urgent/UrgentCharacterNotFoundConsumerTest.kt
@@ -1,0 +1,26 @@
+package maple.restcontroller.urgent
+
+import maple.restcontroller.read.ReadModelCacheService
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.*
+import org.springframework.kafka.support.Acknowledgment
+
+class UrgentCharacterNotFoundConsumerTest {
+
+    private val cacheService: ReadModelCacheService = mock()
+    private val objectMapper = ObjectMapper().registerKotlinModule()
+    private val acknowledgment: Acknowledgment = mock()
+    private val consumer = UrgentCharacterNotFoundConsumer(cacheService, objectMapper, 3600L)
+
+    @Test
+    fun `consume sets negative cache and acknowledges`() {
+        val message = """{"userIgn":"unknownChar","reason":"OPENAPI00004"}"""
+
+        consumer.consume(message, acknowledgment)
+
+        verify(cacheService).setNegativeCache("unknownChar", 3600L)
+        verify(acknowledgment).acknowledge()
+    }
+}

--- a/module-rest-controller/src/test/kotlin/maple/restcontroller/urgent/UrgentTriggerPublisherTest.kt
+++ b/module-rest-controller/src/test/kotlin/maple/restcontroller/urgent/UrgentTriggerPublisherTest.kt
@@ -1,0 +1,37 @@
+package maple.restcontroller.urgent
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.clients.producer.RecordMetadata
+import org.apache.kafka.common.TopicPartition
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.*
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.support.SendResult
+import java.util.concurrent.CompletableFuture
+
+class UrgentTriggerPublisherTest {
+
+    private val kafkaTemplate: KafkaTemplate<String, String> = mock()
+    private val objectMapper = ObjectMapper().registerKotlinModule().registerModule(JavaTimeModule())
+    private val topic = "urgent-character-request"
+    private val publisher = UrgentTriggerPublisher(kafkaTemplate, objectMapper, topic)
+
+    @Test
+    fun `publish sends message with userIgn as key`() {
+        val request = UrgentCharacterRequest(userIgn = "testCharacter")
+        val producerRecord = ProducerRecord(topic, "testCharacter", "{}")
+        val recordMetadata = RecordMetadata(TopicPartition(topic, 0), 0L, 0L, 0L, 0L.toLong(), 0, 0)
+        val sendResult = CompletableFuture.completedFuture(
+            SendResult<String, String>(producerRecord, recordMetadata)
+        )
+
+        whenever(kafkaTemplate.send(eq(topic), eq("testCharacter"), any())).thenReturn(sendResult)
+
+        publisher.publish(request)
+
+        verify(kafkaTemplate).send(eq(topic), eq("testCharacter"), argThat { contains("testCharacter") })
+    }
+}

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/BasicSnapshotChunkConsumer.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/BasicSnapshotChunkConsumer.kt
@@ -7,9 +7,12 @@ import maple.expectation.infrastructure.executor.TaskContext
 import maple.synchronizer.repository.CharacterBasicRepository
 import maple.synchronizer.repository.SynchronizerChunkStatusRepository
 import maple.synchronizer.storage.BasicChunkFileReader
+import maple.synchronizer.storage.BasicRecord
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.kafka.annotation.KafkaListener
 import org.springframework.kafka.support.Acknowledgment
 import org.springframework.stereotype.Component
@@ -24,6 +27,7 @@ class BasicSnapshotChunkConsumer(
     private val repository: CharacterBasicRepository,
     private val chunkStatusRepository: SynchronizerChunkStatusRepository,
     private val logicExecutor: LogicExecutor,
+    private val jdbc: NamedParameterJdbcTemplate,
     @Value("\${synchronizer.store.base-path:../module-external-api/external-api-data}")
     private val basePath: String,
 ) {
@@ -94,6 +98,91 @@ class BasicSnapshotChunkConsumer(
                 context = TaskContext.of("BasicSync", "ChunkLifecycle", chunkId),
             )
         }, vtExecutor)
+    }
+
+    @KafkaListener(
+        topics = ["\${synchronizer.kafka.urgent-basic-chunk-ready-topic}"],
+        groupId = "\${synchronizer.kafka.urgent-basic-consumer-group-id}",
+    )
+    fun consumeUrgentBasic(message: String, acknowledgment: Acknowledgment) {
+        val event = objectMapper.readValue(message, SnapshotChunkReadyEvent::class.java)
+
+        if (event.endpoint != "character-basic") {
+            acknowledgment.acknowledge()
+            return
+        }
+
+        val runId = event.runId
+        val chunkId = event.chunkId
+
+        log.info("[BasicSync] received URGENT: runId={} chunkId={} objectKey={} records={}",
+            runId, chunkId, event.objectKey, event.recordCount)
+
+        if (chunkStatusRepository.isAlreadySuccess(runId, chunkId)) {
+            log.info("[BasicSync] skip already-successful urgent chunk: runId={} chunkId={}", runId, chunkId)
+            acknowledgment.acknowledge()
+            return
+        }
+
+        if (!chunkStatusRepository.claimChunk(runId, chunkId, event.objectKey)) {
+            log.info("[BasicSync] skip - urgent chunk already claimed: runId={} chunkId={}", runId, chunkId)
+            acknowledgment.acknowledge()
+            return
+        }
+
+        if (!processingPermit.tryAcquire()) {
+            log.info("[BasicSync] processing permit busy, urgent will retry: runId={} chunkId={}", runId, chunkId)
+            return
+        }
+
+        MDC.put("runId", runId)
+        MDC.put("chunkId", chunkId)
+
+        CompletableFuture.runAsync({
+            logicExecutor.executeWithFinally(
+                task = {
+                    logicExecutor.executeOrCatch(
+                        task = {
+                            val records = fileReader.read(event.objectKey)
+                            repository.bulkUpsert(runId, chunkId, records)
+                            chunkStatusRepository.markSuccess(runId, chunkId)
+
+                            upsertOcidFromBasicRecords(records)
+
+                            log.info("[BasicSync] urgent chunk processed: runId={} chunkId={} records={}",
+                                runId, chunkId, records.size)
+                            acknowledgment.acknowledge()
+                        },
+                        recovery = { ex ->
+                            chunkStatusRepository.markFailed(runId, chunkId, ex.message ?: "unknown")
+                            log.error("[BasicSync] urgent chunk processing failed: runId={} chunkId={}",
+                                runId, chunkId, ex)
+                            null
+                        },
+                        context = TaskContext.of("BasicSync", "UrgentChunkProcess", chunkId),
+                    )
+                },
+                finallyBlock = {
+                    processingPermit.release()
+                    MDC.clear()
+                },
+                context = TaskContext.of("BasicSync", "UrgentChunkLifecycle", chunkId),
+            )
+        }, vtExecutor)
+    }
+
+    private fun upsertOcidFromBasicRecords(records: List<BasicRecord>) {
+        records.forEach { record ->
+            jdbc.update(
+                """INSERT INTO game_character (user_ign, ocid, created_at, updated_at)
+                   VALUES (:userIgn, :ocid, NOW(), NOW())
+                   ON CONFLICT (user_ign) DO UPDATE SET ocid = EXCLUDED.ocid, updated_at = NOW()""",
+                MapSqlParameterSource()
+                    .addValue("userIgn", record.userIgn)
+                    .addValue("ocid", record.ocid)
+            )
+            log.info("[BasicSync] upserted OCID to game_character: userIgn={}", record.userIgn)
+        }
     }
 
     @PreDestroy

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/BasicSnapshotChunkConsumer.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/BasicSnapshotChunkConsumer.kt
@@ -8,6 +8,7 @@ import maple.synchronizer.repository.CharacterBasicRepository
 import maple.synchronizer.repository.SynchronizerChunkStatusRepository
 import maple.synchronizer.storage.BasicChunkFileReader
 import maple.synchronizer.storage.BasicRecord
+import maple.expectation.util.StringMaskingUtils.maskIgn
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC
 import org.springframework.beans.factory.annotation.Value
@@ -181,7 +182,7 @@ class BasicSnapshotChunkConsumer(
                     .addValue("userIgn", record.userIgn)
                     .addValue("ocid", record.ocid)
             )
-            log.info("[BasicSync] upserted OCID to game_character: userIgn={}", record.userIgn)
+            log.info("[BasicSync] upserted OCID to game_character: userIgn={}", maskIgn(record.userIgn))
         }
     }
 

--- a/module-synchronizer/src/main/resources/application.yml
+++ b/module-synchronizer/src/main/resources/application.yml
@@ -44,6 +44,8 @@ synchronizer:
     basic-chunk-ready-topic: external-api.snapshot.chunk-ready
     consumer-group-id: synchronizer-result-chunk-consumer
     basic-consumer-group-id: synchronizer-basic-chunk-consumer
+    urgent-basic-chunk-ready-topic: external-api.urgent.snapshot.chunk-ready
+    urgent-basic-consumer-group-id: synchronizer-urgent-basic-chunk-consumer
   store:
     base-path: ../module-external-api/external-api-data
   chunk:


### PR DESCRIPTION
## Summary

- V6 read endpoint에서 Redis + DB miss 시 urgent Kafka pipeline 트리거
- module-rest-controller → module-external-api → module-calculator → module-synchronizer 흐름
- Nexon 400 (존재하지 않는 캐릭터) → Redis negative cache → 404 응답
- OCID를 game_character 테이블에 upsert → 향후 scheduler batch pipeline 포함

## Architecture

```
V6 miss → 202 → Kafka "urgent-character-request"
                         ↓
external-api: OCID lookup + basic + equipment → urgent chunk
                         ↓
calculator: urgent chunk processing
                         ↓
synchronizer: read model upsert + game_character OCID save
                         ↓
next V6 request → cache hit → 200
```

## Key Design Decisions (ADR-026)

- **Dedicated urgent topics**: `urgent-character-request`, `urgent-character-not-found`, `external-api.urgent.snapshot.chunk-ready`
- **Shared result topic**: calculator publishes to normal `calculator.result.chunk-ready` (urgency bottleneck is external-api, not calculator/synchronizer)
- **Redis SETNX dedup**: `v6:urgent-pending:{userIgn}` TTL 30s prevents duplicate triggers
- **Redis negative cache**: `v6:not-found:{userIgn}` TTL 3600s for Nexon 400 responses
- **Feature flag**: `expectation.v6.urgent.enabled` controls activation per environment

## Commits (9)

1. `docs` ADR-026 for V6 urgent Kafka pipeline
2. `feat(rest-controller)` Kafka infrastructure (spring-kafka, config, UrgentTriggerPublisher)
3. `feat(rest-controller)` Negative cache + not-found consumer + dedup (SETNX)
4. `feat(rest-controller)` BatchReadScheduler urgent trigger on total miss
5. `feat(external-api)` Urgent character request consumer (OCID + fetch + chunk publish)
6. `feat(calculator)` Urgent snapshot chunk consumer
7. `feat(synchronizer)` Urgent basic chunk consumer + OCID upsert to game_character
8. `fix(rest-controller)` Null-safe userIgn parsing + IGN masking
9. `fix(synchronizer)` IGN masking in OCID upsert log

## Test plan

- [x] `./gradlew compileKotlin compileJava --continue` BUILD SUCCESSFUL
- [x] `./gradlew test` 전체 통과
- [x] 서버 런타임: V6 hit (진격캐넌, 아델) → 200 응답 확인
- [x] 서버 런타임: V6 miss (류쫑) → 202 Accepted + Kafka 메시지 publish 확인
- [x] Kafka topic `urgent-character-request`에 올바른 JSON 형식 확인
- [x] Redis SETNX dedup 동작 확인 (30s 내 중복 트리거 차단)
- [x] 기존 V6 read hit 경로 정상 동작 확인 (regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)