### PR TITLE
fix(rest-controller): prevent batch-urgent pipeline overlap

### DIFF
--- a/.claude/rules/workflow-rules.md
+++ b/.claude/rules/workflow-rules.md
@@ -28,7 +28,20 @@
    - 202만 보고 성공 판단 금지 — 비동기 파이프라인 전체 완료까지 로그로 추적
 4. **컴파일 + 테스트 통과 ≠ 런타임 정상 동작 보장** — 반드시 실제 서버에서 검증
 
-## 11. 검증 명령어
+## 11. 테스트용 userIGN 우선순위
+
+userIGN이 필요한 테스트 및 런타임 검증 시 다음 순서로 선택:
+
+1. **1순위 (고정 캐릭터):** `진격캐넌`, `아델`, `강은호`
+2. **2순위 (CSV 랜덤 추출):** `module-app/src/main/resources/data/userIgn_List.csv`에서 추출
+   ```bash
+   # 1개 추출
+   shuf -n 1 module-app/src/main/resources/data/userIgn_List.csv
+   # 여러개 추출 (필요 시)
+   shuf -n 3 module-app/src/main/resources/data/userIgn_List.csv
+   ```
+
+## 12. 검증 명령어
 
 ```bash
 ./gradlew compileKotlin compileJava --continue  # 컴파일 확인
@@ -37,13 +50,13 @@
 - 컴파일검증시 --continue 반드시 사용할것.
 - 컴파일, 테스트 검증시 처음부터 실패하는경우, 에러나는경우만 메시지 나타나도록 할것. 없으면 성공.
 
-## 12. Flaky Test Prevention
+## 13. Flaky Test Prevention
 - kotlin `delay()` 사용금지
 - `Thread.sleep()` 금지 → `Awaitility` 사용
 - 테스트 간 상태 공유 금지
 - `@DirtiesContext` 남용 금지
 
-## 13. 부하테스트 (Load Test)
+## 14. 부하테스트 (Load Test)
 
 **기본 명령어:**
 ```bash

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/config/V6ReadProperties.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/config/V6ReadProperties.kt
@@ -11,4 +11,5 @@ class V6ReadProperties {
     var queueCapacity: Int = 5000
     var shutdownDrainTimeoutSeconds: Long = 5
     var cacheTtlSeconds: Long = 300
+    var urgentPendingTtlSeconds: Long = 30
 }

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/read/BatchReadScheduler.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/read/BatchReadScheduler.kt
@@ -92,9 +92,17 @@ class BatchReadScheduler(
             resolved++
         }
 
-        // 3. DB batch query for cache misses only
+        // 3. DB batch query for cache misses only (skip characters with urgent pending)
         if (cacheMisses.isNotEmpty()) {
-            val dbResults = queryService.batchQuery(cacheMisses)
+            val dbLookupCandidates = cacheMisses.filterKeys { userIgn ->
+                !cacheService.isUrgentPending(userIgn)
+            }
+
+            val dbResults = if (dbLookupCandidates.isNotEmpty()) {
+                queryService.batchQuery(dbLookupCandidates)
+            } else {
+                emptyMap()
+            }
 
             // 4. Write DB results to Redis cache
             cacheService.multiPut(dbResults)

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelCacheService.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelCacheService.kt
@@ -68,6 +68,7 @@ class ReadModelCacheService(
             val key = cacheKey(userIgn, response.presetNo)
             val json = objectMapper.writeValueAsString(response)
             redisTemplate.opsForValue().set(key, json, ttl)
+            clearUrgentPending(userIgn)
         }
 
         log.debug("Redis cache write: {} entries, TTL={}s", results.size, ttl.seconds)
@@ -90,9 +91,16 @@ class ReadModelCacheService(
 
     fun urgentPendingKey(userIgn: String): String = "$URGENT_PENDING_PREFIX:$userIgn"
 
-    fun tryMarkUrgentPending(userIgn: String, ttlSeconds: Long = 30): Boolean {
+    fun tryMarkUrgentPending(userIgn: String): Boolean {
         val result = redisTemplate.opsForValue()
-            .setIfAbsent(urgentPendingKey(userIgn), "1", Duration.ofSeconds(ttlSeconds))
+            .setIfAbsent(urgentPendingKey(userIgn), "1", Duration.ofSeconds(properties.urgentPendingTtlSeconds))
         return result == true
+    }
+
+    fun isUrgentPending(userIgn: String): Boolean =
+        redisTemplate.hasKey(urgentPendingKey(userIgn))
+
+    fun clearUrgentPending(userIgn: String) {
+        redisTemplate.delete(urgentPendingKey(userIgn))
     }
 }

--- a/module-rest-controller/src/main/resources/application.yml
+++ b/module-rest-controller/src/main/resources/application.yml
@@ -48,3 +48,4 @@ expectation:
       request-topic: urgent-character-request
       not-found-topic: urgent-character-not-found
       negative-cache-ttl-seconds: 3600            # 1 hour
+      pending-ttl-seconds: 30                     # urgent dedup TTL


### PR DESCRIPTION
## Summary
- Skip DB lookup for characters with urgent-pending key (avoids wasted query while urgent pipeline is in-flight)
- Clear urgent-pending Redis key on cache population (`multiPut`) so subsequent requests get cache hit immediately
- Externalize urgent-pending TTL from hardcoded 30s to YAML config (`pending-ttl-seconds`)
- Add test IGN priority rules to workflow-rules.md (1순위: 진격캐넌/아델/강은호, 2순위: CSV random)

## Test plan
- [x] `./gradlew :module-rest-controller:compileKotlin` passes
- [x] `./gradlew :module-rest-controller:test` passes (all tests green)
- [ ] Runtime verification with urgent pipeline enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)