### PR TITLE
feat(rest-controller): add V6 urgent status polling

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -91,6 +91,8 @@ spring-boot-starter-validation = { module = "org.springframework.boot:spring-boo
 spring-boot-starter-security = { module = "org.springframework.boot:spring-boot-starter-security" }
 spring-boot-starter-actuator = { module = "org.springframework.boot:spring-boot-starter-actuator" }
 spring-boot-starter-data-jpa = { module = "org.springframework.boot:spring-boot-starter-data-jpa" }
+spring-boot-starter-data-redis = { module = "org.springframework.boot:spring-boot-starter-data-redis" }
+spring-boot-starter-jdbc = { module = "org.springframework.boot:spring-boot-starter-jdbc" }
 spring-boot-starter-cache = { module = "org.springframework.boot:spring-boot-starter-cache" }
 spring-boot-starter-batch = { module = "org.springframework.boot:spring-boot-starter-batch" }
 spring-boot-starter-aop = { module = "org.springframework.boot:spring-boot-starter-aop" }
@@ -99,6 +101,7 @@ spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-star
 
 # Spring Boot Core
 spring-boot = { module = "org.springframework.boot:spring-boot" }
+spring-kafka = { module = "org.springframework.kafka:spring-kafka" }
 
 # Databases
 h2 = { module = "com.h2database:h2", version.ref = "h2" }

--- a/module-common/src/main/kotlin/maple/expectation/util/StringMaskingUtils.kt
+++ b/module-common/src/main/kotlin/maple/expectation/util/StringMaskingUtils.kt
@@ -17,6 +17,15 @@ object StringMaskingUtils {
     private const val CACHE_KEY_REPLACEMENT = "$1***"
 
     /**
+     * IGN 마스킹: 앞 1자리 + "***"
+     */
+    @JvmStatic
+    fun maskIgn(value: String?): String {
+        if (value.isNullOrBlank()) return "***"
+        return value.take(1) + "***"
+    }
+
+    /**
      * OCID 마스킹: 앞 4자리 + "***"
      *
      * @param value OCID 문자열

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/RestControllerApplication.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/RestControllerApplication.kt
@@ -1,0 +1,11 @@
+package maple.restcontroller
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+@SpringBootApplication
+class RestControllerApplication
+
+fun main(args: Array<String>) {
+    runApplication<RestControllerApplication>(*args)
+}

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/advice/RestControllerExceptionHandler.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/advice/RestControllerExceptionHandler.kt
@@ -1,0 +1,23 @@
+package maple.restcontroller.advice
+
+import maple.expectation.error.dto.ErrorResponse
+import maple.expectation.error.exception.base.BaseException
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class RestControllerExceptionHandler {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @ExceptionHandler(BaseException::class)
+    fun handleBaseException(ex: BaseException): ResponseEntity<ErrorResponse> =
+        ResponseEntity.status(ex.errorCode.statusCode).body(ErrorResponse.from(ex.errorCode))
+
+    @ExceptionHandler(Exception::class)
+    fun handleUnexpected(ex: Exception): ResponseEntity<ErrorResponse> {
+        log.error("Unexpected REST controller error", ex)
+        return ResponseEntity.status(500).body(ErrorResponse.from(500, "S999", "Unexpected server error"))
+    }
+}

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/config/V6ReadConfig.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/config/V6ReadConfig.kt
@@ -2,8 +2,6 @@ package maple.restcontroller.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.micrometer.core.instrument.MeterRegistry
-import maple.restcontroller.advice.RestControllerExceptionHandler
-import maple.restcontroller.controller.ExpectationV6Controller
 import maple.restcontroller.metrics.V6ReadMetrics
 import maple.restcontroller.read.*
 import maple.restcontroller.urgent.UrgentTriggerPublisher
@@ -57,8 +55,9 @@ class V6ReadConfig(
     fun expectationReadFacade(
         registry: InflightRequestRegistry,
         buffer: LocalRequestBuffer,
-        metrics: V6ReadMetrics
-    ): ExpectationReadFacade = ExpectationReadFacade(registry, buffer, metrics)
+        metrics: V6ReadMetrics,
+        cacheService: ReadModelCacheService
+    ): ExpectationReadFacade = ExpectationReadFacade(registry, buffer, metrics, cacheService, properties)
 
     @Bean
     fun batchReadScheduler(
@@ -73,15 +72,6 @@ class V6ReadConfig(
         urgentPublisherProvider.ifAvailable,
         v6ReadMetrics, properties
     )
-
-    @Bean
-    fun expectationV6Controller(
-        facade: ExpectationReadFacade
-    ): ExpectationV6Controller = ExpectationV6Controller(facade, properties)
-
-    @Bean
-    fun restControllerExceptionHandler(): RestControllerExceptionHandler =
-        RestControllerExceptionHandler()
 
     @Bean
     @ConditionalOnProperty(name = ["expectation.v6.urgent.enabled"], havingValue = "true")

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/config/V6ReadProperties.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/config/V6ReadProperties.kt
@@ -12,4 +12,6 @@ class V6ReadProperties {
     var shutdownDrainTimeoutSeconds: Long = 5
     var cacheTtlSeconds: Long = 300
     var urgentPendingTtlSeconds: Long = 30
+    var statusRetryAfterSeconds: Long = 3
+    var statusEstimatedThroughputPerSecond: Double = 5.0
 }

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/controller/ExpectationV6Controller.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/controller/ExpectationV6Controller.kt
@@ -1,0 +1,65 @@
+package maple.restcontroller.controller
+
+import maple.expectation.util.StringMaskingUtils.maskIgn
+import maple.restcontroller.config.V6ReadProperties
+import maple.restcontroller.read.ExpectationReadFacade
+import maple.restcontroller.read.ReadModelCacheService
+import maple.restcontroller.read.ReadModelQueryService
+import maple.restcontroller.read.UrgentReadState
+import maple.restcontroller.validation.ValidUserIgn
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.http.ResponseEntity
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.context.request.async.DeferredResult
+
+@RestController
+@RequestMapping("/api/v6/characters")
+@Validated
+@ConditionalOnProperty(name = ["expectation.v6.enabled"], havingValue = "true")
+class ExpectationV6Controller(
+    private val facade: ExpectationReadFacade,
+    private val properties: V6ReadProperties,
+    private val cacheService: ReadModelCacheService,
+    private val queryService: ReadModelQueryService,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @GetMapping("/{userIgn}/expectation")
+    fun getExpectation(
+        @PathVariable @ValidUserIgn userIgn: String,
+        @RequestParam(defaultValue = "1") presetNo: Int,
+    ): DeferredResult<ResponseEntity<*>> {
+        log.debug("V6 read request userIgn={} presetNo={}", maskIgn(userIgn), presetNo)
+        val deferred = DeferredResult<ResponseEntity<*>>(properties.requestTimeoutMs)
+        facade.enqueue(userIgn, presetNo, deferred)
+        return deferred
+    }
+
+    @GetMapping("/{userIgn}/status")
+    fun getStatus(
+        @PathVariable @ValidUserIgn userIgn: String,
+        @RequestParam(defaultValue = "1") presetNo: Int,
+    ): ResponseEntity<*> {
+        val current = cacheService.status(userIgn, presetNo)
+        val status = if (current.state == UrgentReadState.PENDING || current.state == UrgentReadState.UNKNOWN) {
+            val dbResult = queryService.batchQuery(mapOf(userIgn to presetNo))
+            if (dbResult.isNotEmpty()) {
+                cacheService.multiPut(dbResult)
+                cacheService.status(userIgn, presetNo)
+            } else {
+                current
+            }
+        } else {
+            current
+        }
+        return ResponseEntity.ok()
+            .header("Retry-After", status.retryAfterSeconds.toString())
+            .body(status)
+    }
+}

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/controller/HealthController.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/controller/HealthController.kt
@@ -1,0 +1,10 @@
+package maple.restcontroller.controller
+
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class HealthController {
+    @GetMapping("/health")
+    fun health(): Map<String, String> = mapOf("status" to "UP")
+}

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/read/ExpectationReadFacade.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/read/ExpectationReadFacade.kt
@@ -1,0 +1,54 @@
+package maple.restcontroller.read
+
+import maple.expectation.util.StringMaskingUtils.maskIgn
+import maple.restcontroller.config.V6ReadProperties
+import maple.restcontroller.metrics.V6ReadMetrics
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.web.context.request.async.DeferredResult
+
+class ExpectationReadFacade(
+    private val registry: InflightRequestRegistry,
+    private val buffer: RequestBuffer,
+    private val metrics: V6ReadMetrics,
+    private val cacheService: ReadModelCacheService,
+    private val properties: V6ReadProperties,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun enqueue(userIgn: String, presetNo: Int, deferred: DeferredResult<ResponseEntity<*>>) {
+        metrics.requestTotal.increment()
+        val firstRequest = registry.register(userIgn, deferred)
+        if (firstRequest) {
+            metrics.dedupMissTotal.increment()
+            if (!buffer.offer(ReadRequest(userIgn = userIgn, presetNo = presetNo))) {
+                metrics.bufferRejectedTotal.increment()
+                registry.cleanup(userIgn, deferred)
+                log.warn("Buffer full, rejecting request userIgn={}", maskIgn(userIgn))
+                deferred.setErrorResult(
+                    ResponseEntity.status(503)
+                        .header("Retry-After", "1")
+                        .build<Any>(),
+                )
+                return
+            }
+            log.debug("Buffered read request userIgn={}", maskIgn(userIgn))
+        } else {
+            metrics.dedupHitTotal.increment()
+            log.debug("Dedup hit for userIgn={}", maskIgn(userIgn))
+        }
+
+        deferred.onTimeout {
+            metrics.timeoutTotal.increment()
+            deferred.setErrorResult(
+                ResponseEntity.accepted()
+                    .header("Location", cacheService.statusUrl(userIgn, presetNo))
+                    .header("Retry-After", properties.statusRetryAfterSeconds.toString())
+                    .body(cacheService.status(userIgn, presetNo)),
+            )
+        }
+        deferred.onCompletion {
+            registry.cleanup(userIgn, deferred)
+        }
+    }
+}

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/read/InflightRequestRegistry.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/read/InflightRequestRegistry.kt
@@ -1,0 +1,33 @@
+package maple.restcontroller.read
+
+import org.springframework.http.ResponseEntity
+import org.springframework.web.context.request.async.DeferredResult
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArrayList
+
+class InflightRequestRegistry {
+    private val registry = ConcurrentHashMap<String, CopyOnWriteArrayList<DeferredResult<ResponseEntity<*>>>>()
+
+    fun register(userIgn: String, deferred: DeferredResult<ResponseEntity<*>>): Boolean {
+        val list = registry.computeIfAbsent(userIgn) { CopyOnWriteArrayList() }
+        list.add(deferred)
+        return list.size == 1
+    }
+
+    fun getAndRemove(userIgn: String): List<DeferredResult<ResponseEntity<*>>> =
+        registry.remove(userIgn)?.toList() ?: emptyList()
+
+    fun cleanup(userIgn: String, deferred: DeferredResult<ResponseEntity<*>>) {
+        registry.computeIfPresent(userIgn) { _, list ->
+            list.remove(deferred)
+            if (list.isEmpty()) null else list
+        }
+    }
+
+    fun size(): Int = registry.size
+
+    fun failAll(response: ResponseEntity<*>) {
+        registry.values.flatten().forEach { it.setErrorResult(response) }
+        registry.clear()
+    }
+}

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/read/LocalRequestBuffer.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/read/LocalRequestBuffer.kt
@@ -1,0 +1,49 @@
+package maple.restcontroller.read
+
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+
+class LocalRequestBuffer(
+    private val maxCapacity: Int,
+) : RequestBuffer {
+    private val queue = ConcurrentLinkedQueue<ReadRequest>()
+    private val counter = AtomicInteger(0)
+    private val accepting = AtomicBoolean(true)
+
+    override fun offer(request: ReadRequest): Boolean {
+        if (!accepting.get()) return false
+        if (counter.incrementAndGet() > maxCapacity) {
+            counter.decrementAndGet()
+            return false
+        }
+        if (!queue.offer(request)) {
+            counter.decrementAndGet()
+            return false
+        }
+        return true
+    }
+
+    override fun drain(maxItems: Int): List<ReadRequest> {
+        val batch = ArrayList<ReadRequest>(maxItems)
+        repeat(maxItems) {
+            val request = queue.poll() ?: return@repeat
+            counter.decrementAndGet()
+            batch.add(request)
+        }
+        return batch
+    }
+
+    override fun size(): Int = counter.get()
+
+    override fun isEmpty(): Boolean = queue.isEmpty()
+
+    override fun stopAccepting() {
+        accepting.set(false)
+    }
+
+    override fun failAllPending() {
+        queue.clear()
+        counter.set(0)
+    }
+}

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelCacheService.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelCacheService.kt
@@ -18,6 +18,7 @@ class ReadModelCacheService(
         private const val KEY_PREFIX = "v6:read"
         private const val NEGATIVE_KEY_PREFIX = "v6:not-found"
         private const val URGENT_PENDING_PREFIX = "v6:urgent-pending"
+        private const val URGENT_STATUS_QUEUE_KEY = "v6:urgent:status-queue"
     }
 
     fun cacheKey(userIgn: String, presetNo: Int): String =
@@ -69,6 +70,7 @@ class ReadModelCacheService(
             val json = objectMapper.writeValueAsString(response)
             redisTemplate.opsForValue().set(key, json, ttl)
             clearUrgentPending(userIgn)
+            removeUrgentStatus(userIgn)
         }
 
         log.debug("Redis cache write: {} entries, TTL={}s", results.size, ttl.seconds)
@@ -84,6 +86,8 @@ class ReadModelCacheService(
 
     fun setNegativeCache(userIgn: String, ttlSeconds: Long) {
         redisTemplate.opsForValue().set(negativeCacheKey(userIgn), "NOT_FOUND", Duration.ofSeconds(ttlSeconds))
+        clearUrgentPending(userIgn)
+        removeUrgentStatus(userIgn)
         log.info("Set negative cache: userIgn={}", maskIgn(userIgn))
     }
 
@@ -93,7 +97,12 @@ class ReadModelCacheService(
 
     fun tryMarkUrgentPending(userIgn: String): Boolean {
         val result = redisTemplate.opsForValue()
-            .setIfAbsent(urgentPendingKey(userIgn), "1", Duration.ofSeconds(properties.urgentPendingTtlSeconds))
+            .setIfAbsent(urgentPendingKey(userIgn), System.currentTimeMillis().toString(), Duration.ofSeconds(properties.urgentPendingTtlSeconds))
+        if (result == true) {
+            redisTemplate.opsForZSet().add(URGENT_STATUS_QUEUE_KEY, userIgn, System.currentTimeMillis().toDouble())
+        } else if (isUrgentPending(userIgn) && redisTemplate.opsForZSet().rank(URGENT_STATUS_QUEUE_KEY, userIgn) == null) {
+            redisTemplate.opsForZSet().add(URGENT_STATUS_QUEUE_KEY, userIgn, System.currentTimeMillis().toDouble())
+        }
         return result == true
     }
 
@@ -102,5 +111,40 @@ class ReadModelCacheService(
 
     fun clearUrgentPending(userIgn: String) {
         redisTemplate.delete(urgentPendingKey(userIgn))
+    }
+
+    fun statusUrl(userIgn: String, presetNo: Int): String = "/api/v6/characters/$userIgn/status?presetNo=$presetNo"
+
+    fun status(userIgn: String, presetNo: Int): UrgentReadStatusResponse {
+        val state = when {
+            hasReadyCache(userIgn, presetNo) -> UrgentReadState.READY
+            getNegativeCache(userIgn) -> UrgentReadState.NOT_FOUND
+            isUrgentPending(userIgn) -> UrgentReadState.PENDING
+            else -> UrgentReadState.UNKNOWN
+        }
+        val position = if (state == UrgentReadState.PENDING) queuePosition(userIgn) else null
+        return UrgentReadStatusResponse(
+            state = state,
+            userIgn = userIgn,
+            statusUrl = statusUrl(userIgn, presetNo),
+            queuePositionApprox = position,
+            estimatedWaitSeconds = position?.let(::estimateWaitSeconds),
+            retryAfterSeconds = if (state == UrgentReadState.READY || state == UrgentReadState.NOT_FOUND) 0 else properties.statusRetryAfterSeconds,
+        )
+    }
+
+    private fun hasReadyCache(userIgn: String, presetNo: Int): Boolean =
+        redisTemplate.hasKey(cacheKey(userIgn, presetNo))
+
+    private fun queuePosition(userIgn: String): Long? =
+        redisTemplate.opsForZSet().rank(URGENT_STATUS_QUEUE_KEY, userIgn)?.plus(1)
+
+    private fun estimateWaitSeconds(queuePosition: Long): Long {
+        val throughput = properties.statusEstimatedThroughputPerSecond.takeIf { it > 0.0 } ?: 1.0
+        return kotlin.math.ceil(queuePosition / throughput).toLong().coerceAtLeast(1)
+    }
+
+    private fun removeUrgentStatus(userIgn: String) {
+        redisTemplate.opsForZSet().remove(URGENT_STATUS_QUEUE_KEY, userIgn)
     }
 }

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelQueryService.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelQueryService.kt
@@ -1,0 +1,61 @@
+package maple.restcontroller.read
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import maple.expectation.util.GzipUtils
+import org.slf4j.LoggerFactory
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import java.math.BigDecimal
+import java.time.Instant
+
+class ReadModelQueryService(
+    private val jdbc: NamedParameterJdbcTemplate,
+    private val objectMapper: ObjectMapper,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun batchQuery(requests: Map<String, Int>): Map<String, V6ExpectationResponse> {
+        if (requests.isEmpty()) return emptyMap()
+
+        val sql = """
+            SELECT user_ign, preset_no, document, total_cost, equipment_count, calculated_at
+            FROM character_equipment_read_model
+            WHERE user_ign IN (:userIgns)
+              AND preset_no IN (:presetNos)
+              AND user_ign IS NOT NULL
+        """.trimIndent()
+        val params = MapSqlParameterSource()
+            .addValue("userIgns", requests.keys.toList())
+            .addValue("presetNos", requests.values.distinct())
+
+        val rows = jdbc.queryForList(sql, params)
+        val result = LinkedHashMap<String, V6ExpectationResponse>()
+        rows.forEach { row ->
+            val userIgn = row["user_ign"].toString()
+            val document = row["document"] as ByteArray
+            val node = objectMapper.readTree(GzipUtils.decompress(document))
+            val summary = node["summary"]
+            val equipmentNode = node["equipment"]
+            val equipment = if (equipmentNode != null && !equipmentNode.isNull) {
+                objectMapper.readValue(
+                    equipmentNode.toString(),
+                    objectMapper.typeFactory.constructCollectionType(List::class.java, Map::class.java),
+                ) as List<Map<String, Any>>
+            } else {
+                emptyList()
+            }
+            result[userIgn] = V6ExpectationResponse(
+                userIgn = userIgn,
+                presetNo = node["presetNo"]?.asInt() ?: (row["preset_no"] as Number).toInt(),
+                totalCost = summary?.get("totalCost")?.decimalValue() ?: (row["total_cost"] as? BigDecimal ?: BigDecimal.ZERO),
+                equipmentCount = summary?.get("equipmentCount")?.asInt() ?: (row["equipment_count"] as? Number)?.toInt() ?: 0,
+                equipment = equipment,
+                calculatedAt = node["metadata"]?.get("calculatedAt")?.asText()?.let(Instant::parse)
+                    ?: (row["calculated_at"] as? java.sql.Timestamp)?.toInstant()
+                    ?: Instant.now(),
+            )
+        }
+        log.debug("Read model query: requested={}, hits={}", requests.size, result.size)
+        return result
+    }
+}

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadRequest.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadRequest.kt
@@ -1,0 +1,9 @@
+package maple.restcontroller.read
+
+import java.util.UUID
+
+data class ReadRequest(
+    val requestId: UUID = UUID.randomUUID(),
+    val userIgn: String,
+    val presetNo: Int,
+)

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/read/RequestBuffer.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/read/RequestBuffer.kt
@@ -1,0 +1,10 @@
+package maple.restcontroller.read
+
+interface RequestBuffer {
+    fun offer(request: ReadRequest): Boolean
+    fun drain(maxItems: Int): List<ReadRequest>
+    fun size(): Int
+    fun isEmpty(): Boolean
+    fun stopAccepting()
+    fun failAllPending()
+}

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/read/UrgentReadStatus.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/read/UrgentReadStatus.kt
@@ -1,0 +1,17 @@
+package maple.restcontroller.read
+
+enum class UrgentReadState {
+    PENDING,
+    READY,
+    NOT_FOUND,
+    UNKNOWN,
+}
+
+data class UrgentReadStatusResponse(
+    val state: UrgentReadState,
+    val userIgn: String,
+    val statusUrl: String,
+    val queuePositionApprox: Long?,
+    val estimatedWaitSeconds: Long?,
+    val retryAfterSeconds: Long,
+)

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/read/V6ExpectationResponse.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/read/V6ExpectationResponse.kt
@@ -1,0 +1,13 @@
+package maple.restcontroller.read
+
+import java.math.BigDecimal
+import java.time.Instant
+
+data class V6ExpectationResponse(
+    val userIgn: String,
+    val presetNo: Int,
+    val totalCost: BigDecimal,
+    val equipmentCount: Int,
+    val equipment: List<Map<String, Any>>,
+    val calculatedAt: Instant,
+)

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/validation/UserIgnValidator.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/validation/UserIgnValidator.kt
@@ -1,0 +1,15 @@
+package maple.restcontroller.validation
+
+import jakarta.validation.ConstraintValidator
+import jakarta.validation.ConstraintValidatorContext
+
+class UserIgnValidator : ConstraintValidator<ValidUserIgn, String> {
+    override fun isValid(value: String?, context: ConstraintValidatorContext): Boolean {
+        if (value.isNullOrBlank()) return false
+        return IGN_PATTERN.matches(value)
+    }
+
+    companion object {
+        private val IGN_PATTERN = Regex("^[가-힣a-zA-Z0-9]{2,12}$")
+    }
+}

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/validation/ValidUserIgn.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/validation/ValidUserIgn.kt
@@ -1,0 +1,14 @@
+package maple.restcontroller.validation
+
+import jakarta.validation.Constraint
+import jakarta.validation.Payload
+import kotlin.reflect.KClass
+
+@Target(AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.FIELD)
+@Retention(AnnotationRetention.RUNTIME)
+@Constraint(validatedBy = [UserIgnValidator::class])
+annotation class ValidUserIgn(
+    val message: String = "invalid userIgn",
+    val groups: Array<KClass<*>> = [],
+    val payload: Array<KClass<out Payload>> = [],
+)

--- a/module-rest-controller/src/main/resources/application.yml
+++ b/module-rest-controller/src/main/resources/application.yml
@@ -43,6 +43,8 @@ expectation:
     max-batch-size: 200               # scheduler batch size (Phase 2)
     queue-capacity: 5000              # RequestBuffer max capacity
     shutdown-drain-timeout-seconds: 5 # graceful shutdown deadline
+    status-retry-after-seconds: 3     # frontend polling hint after 202/status
+    status-estimated-throughput-per-second: 5.0 # approximate urgent pipeline throughput
     urgent:
       enabled: false                              # feature flag
       request-topic: urgent-character-request

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,3 +16,6 @@ include 'module-chaos-test'
 
 // ADR-017: Web layer (GlobalExceptionHandler, Filter)
 include 'module-web'
+
+// Standalone V6 REST read controller
+include 'module-rest-controller'


### PR DESCRIPTION
## Summary
- Add V6 urgent status polling response for 202 Accepted (`Location`, `Retry-After`, status body)
- Add `/api/v6/characters/{userIgn}/status` endpoint backed by Redis status projection
- Track approximate urgent queue position in Redis ZSET while keeping Kafka as the work pipeline
- Re-include and restore standalone `module-rest-controller` source so the module compiles cleanly from source

## Test plan
- [x] `./gradlew :module-rest-controller:compileKotlin`
- [x] `./gradlew :module-rest-controller:test`