### PR TITLE
fix(pipeline): restore urgent worker modules

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,6 +57,7 @@ springdoc = "2.8.13"
 
 # Logging
 loki-logback = "1.4.2"
+logstash-logback = "8.0"
 
 # Spring Dotenv
 spring-dotenv = "4.0.0"
@@ -80,6 +81,7 @@ kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref =
 kotlin-logging-jvm = { module = "io.github.oshai:kotlin-logging-jvm", version.ref = "kotlin-logging" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-jdk8 = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-slf4j = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-slf4j", version.ref = "kotlinx-coroutines" }
 
 # Lombok
 lombok = { module = "org.projectlombok:lombok", version.ref = "lombok" }
@@ -160,6 +162,7 @@ springdoc-openapi-starter-webmvc-ui = { module = "org.springdoc:springdoc-openap
 
 # Logging
 loki-logback-appender = { module = "com.github.loki4j:loki-logback-appender", version.ref = "loki-logback" }
+logstash-logback-encoder = { module = "net.logstash.logback:logstash-logback-encoder", version.ref = "logstash-logback" }
 
 # Spring Dotenv
 spring-dotenv = { module = "me.paulschwarz:spring-dotenv", version.ref = "spring-dotenv" }

--- a/module-calculator/build.gradle
+++ b/module-calculator/build.gradle
@@ -1,0 +1,60 @@
+// ========================================
+// Module-Calculator: Kafka-driven chunk processing
+// SNAPSHOT_CHUNK_READY event consume → calculate → result publish
+// ========================================
+
+plugins {
+	alias(libs.plugins.kotlin.jvm)
+	alias(libs.plugins.kotlin.spring)
+	alias(libs.plugins.spring.boot)
+}
+
+dependencies {
+	implementation project(':module-common')
+	implementation project(':module-core')
+	implementation project(':module-infra')
+
+	implementation(libs.kotlin.stdlib)
+	implementation(libs.kotlin.reflect)
+	implementation(libs.kotlin.logging.jvm)
+	implementation(libs.kotlinx.coroutines.core)
+	implementation(libs.kotlinx.coroutines.jdk8)
+	implementation(libs.kotlinx.coroutines.slf4j)
+
+	// Spring
+	implementation(libs.spring.boot)
+	implementation(libs.spring.boot.starter.web)
+
+	// Kafka
+	implementation(libs.spring.kafka)
+
+	// Jackson
+	implementation(libs.jackson.databind)
+	implementation(libs.jackson.module.kotlin)
+
+	// Cache
+	implementation(libs.caffeine)
+
+	// Metrics
+	implementation(libs.spring.boot.starter.actuator)
+	implementation(libs.micrometer.registry.prometheus)
+
+	// Structured JSON logging
+	implementation(libs.logstash.logback.encoder)
+
+	// Testing
+	testImplementation(libs.spring.boot.starter.test)
+	testImplementation(libs.assertj.core)
+	testImplementation(libs.mockito.kotlin)
+}
+
+bootJar {
+	enabled = true
+	archiveClassifier = ""
+	mainClass.set("maple.calculator.CalculatorApplication")
+}
+
+tasks.named("jar") {
+	enabled = true
+	archiveClassifier = "plain"
+}

--- a/module-calculator/src/main/kotlin/maple/calculator/CalculatorApplication.kt
+++ b/module-calculator/src/main/kotlin/maple/calculator/CalculatorApplication.kt
@@ -1,0 +1,57 @@
+package maple.calculator
+
+import maple.calculator.config.PipelineProperties
+import maple.expectation.application.service.calculator.v4.EquipmentExpectationCalculatorFactory
+import maple.expectation.application.service.cube.CubeServiceImpl
+import maple.expectation.application.service.cube.component.CubeComputeBuffer
+import maple.expectation.application.service.cube.component.CubeDpCalculator
+import maple.expectation.application.service.cube.component.CubeSlotCountResolver
+import maple.expectation.application.service.cube.component.DpModeInferrer
+import maple.expectation.application.service.cube.component.SlotDistributionBuilder
+import maple.expectation.application.service.cube.component.StatValueExtractor
+import maple.expectation.application.service.cube.policy.CubeCostPolicy
+import maple.expectation.application.service.starforce.StarforceLookupAdapter
+import maple.expectation.config.CubeEngineFeatureFlag
+import maple.expectation.config.TableMassConfig
+import maple.expectation.infrastructure.adapter.policy.PolicyAdapter
+import maple.expectation.infrastructure.config.CalculationPortConfig
+import maple.expectation.infrastructure.config.ExecutorConfig
+import maple.expectation.infrastructure.executor.DefaultLogicExecutor
+import maple.expectation.infrastructure.executor.classifier.DefaultExceptionClassifier
+import maple.expectation.infrastructure.persistence.repository.CubeProbabilityRepositoryImpl
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
+import org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.boot.runApplication
+import org.springframework.context.annotation.Import
+import org.springframework.scheduling.annotation.EnableScheduling
+
+@SpringBootApplication(exclude = [SecurityAutoConfiguration::class, ManagementWebSecurityAutoConfiguration::class])
+@EnableScheduling
+@EnableConfigurationProperties(PipelineProperties::class)
+@Import(
+    EquipmentExpectationCalculatorFactory::class,
+    CubeServiceImpl::class,
+    CubeDpCalculator::class,
+    CubeComputeBuffer::class,
+    CubeSlotCountResolver::class,
+    DpModeInferrer::class,
+    SlotDistributionBuilder::class,
+    StatValueExtractor::class,
+    CubeCostPolicy::class,
+    StarforceLookupAdapter::class,
+    PolicyAdapter::class,
+    DefaultLogicExecutor::class,
+    DefaultExceptionClassifier::class,
+    CubeProbabilityRepositoryImpl::class,
+    CubeEngineFeatureFlag::class,
+    TableMassConfig::class,
+    CalculationPortConfig::class,
+    ExecutorConfig::class,
+)
+class CalculatorApplication
+
+fun main(args: Array<String>) {
+    runApplication<CalculatorApplication>(*args)
+}

--- a/module-calculator/src/main/kotlin/maple/calculator/CalculatorChunkProcessingCoordinator.kt
+++ b/module-calculator/src/main/kotlin/maple/calculator/CalculatorChunkProcessingCoordinator.kt
@@ -1,0 +1,135 @@
+package maple.calculator
+
+import kotlinx.coroutines.slf4j.MDCContext
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+import kotlinx.coroutines.withContext
+import maple.expectation.common.event.CalculatorResultChunkReadyEvent
+import maple.calculator.event.KafkaResultEventPublisher
+import maple.calculator.event.SnapshotChunkReadyEvent
+import maple.calculator.metrics.CalculatorMetrics
+import maple.calculator.model.ChunkResult
+import maple.calculator.metrics.CalculatorVolumeMetrics
+import maple.calculator.processor.SnapshotChunkProcessor
+import maple.calculator.storage.ObjectStorage
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import java.time.Duration
+
+@Component
+class CalculatorChunkProcessingCoordinator(
+    private val chunkProcessor: SnapshotChunkProcessor,
+    private val resultEventPublisher: KafkaResultEventPublisher,
+    private val objectStorage: ObjectStorage,
+    private val metrics: CalculatorMetrics,
+    private val volumeMetrics: CalculatorVolumeMetrics,
+) {
+    private val log = LoggerFactory.getLogger(CalculatorChunkProcessingCoordinator::class.java)
+    private val concurrency = Semaphore(2)
+
+    suspend fun handle(event: SnapshotChunkReadyEvent) {
+        if (event.endpoint != "item-equipment") {
+            log.info("[Coordinator] skipping non-item-equipment endpoint: {}", event.endpoint)
+            metrics.recordChunkSkippedEndpoint()
+            return
+        }
+
+        if (!objectStorage.exists(event.objectKey)) {
+            log.error("[Coordinator] source chunk not found: runId={} chunkId={} objectKey={}", event.runId, event.chunkId, event.objectKey)
+            metrics.recordChunkSkippedNotFound()
+            return
+        }
+
+        val resultObjectKey = resultObjectKeyFor(event)
+        if (objectStorage.exists(resultObjectKey)) {
+            republishExistingResult(event, resultObjectKey)
+            return
+        }
+
+        withMdc(event) {
+            concurrency.withPermit {
+                executeChunk(event, resultObjectKey)
+            }
+        }
+    }
+
+    fun resultObjectKeyFor(event: SnapshotChunkReadyEvent): String =
+        "data/calculator/runs/${event.runId}/${event.endpoint}/chunks/result-${event.chunkId}.jsonl.gz"
+
+    private suspend fun republishExistingResult(event: SnapshotChunkReadyEvent, resultObjectKey: String) {
+        log.info("[Coordinator] result already exists, republishing: runId={} chunkId={} objectKey={}", event.runId, event.chunkId, resultObjectKey)
+        metrics.recordChunkSkippedIdempotent()
+        resultEventPublisher.publishChunkReady(
+            CalculatorResultChunkReadyEvent(
+                sourceRunId = event.runId,
+                sourceEndpoint = event.endpoint,
+                sourceChunkId = event.chunkId,
+                objectKey = resultObjectKey,
+                sourceRecordCount = event.recordCount,
+                resultCount = 0,
+                errorCount = 0,
+                uncompressedBytes = 0,
+                compressedBytes = 0,
+            ),
+        )
+    }
+
+    private suspend fun executeChunk(event: SnapshotChunkReadyEvent, resultObjectKey: String) {
+        val start = System.nanoTime()
+        runCatching {
+            val result = chunkProcessor.process(event, resultObjectKey)
+            metrics.timer().record(Duration.ofNanos(System.nanoTime() - start))
+            onChunkProcessed(event, result, start)
+        }.onFailure { ex ->
+            log.error("[Coordinator] chunk processing failed: runId={} chunkId={}: {}", event.runId, event.chunkId, ex.message, ex)
+            metrics.recordChunkFailed()
+        }
+    }
+
+    private suspend fun onChunkProcessed(
+        event: SnapshotChunkReadyEvent,
+        result: ChunkResult,
+        startNanos: Long,
+    ) {
+        resultEventPublisher.publishChunkReady(
+            CalculatorResultChunkReadyEvent(
+                sourceRunId = event.runId,
+                sourceEndpoint = event.endpoint,
+                sourceChunkId = event.chunkId,
+                objectKey = result.resultObjectKey,
+                sourceRecordCount = event.recordCount,
+                resultCount = result.resultCount,
+                errorCount = result.errorCount,
+                uncompressedBytes = result.resultUncompressedBytes,
+                compressedBytes = result.resultCompressedBytes,
+            ),
+        )
+        log.info(
+            "[Coordinator] processed chunk: runId={} chunkId={} records={} success={} items={} results={} errors={}",
+            event.runId, event.chunkId,
+            result.recordCount, result.successCount, result.totalItems, result.resultCount, result.errorCount,
+        )
+        volumeMetrics.recordInput(event.compressedBytes, event.uncompressedBytes)
+        volumeMetrics.recordResult(result.resultCompressedBytes, result.resultUncompressedBytes, result.resultCount.toLong())
+        val ratio = if (result.resultCompressedBytes > 0) "%.2f".format(result.resultUncompressedBytes.toDouble() / result.resultCompressedBytes.toDouble()) else "N/A"
+        log.info(
+            "[calculatorArtifactVolume] runId={} chunkId={} inputCompressedBytes={} inputUncompressedBytes={} resultCompressedBytes={} resultUncompressedBytes={} resultJsonRows={} resultCompressionRatio={}",
+            event.runId, event.chunkId, event.compressedBytes, event.uncompressedBytes,
+            result.resultCompressedBytes, result.resultUncompressedBytes, result.resultCount, ratio,
+        )
+        metrics.recordChunkProcessed()
+        metrics.recordUsers(result.recordCount)
+        metrics.recordItems(result.totalItems)
+        metrics.recordCalculated(result.resultCount)
+        metrics.recordErrors(result.errorCount)
+        val durationSec = (System.nanoTime() - startNanos) / 1_000_000_000.0
+        metrics.recordChunkRates(result.recordCount, result.totalItems, durationSec)
+    }
+
+    private suspend fun <T> withMdc(event: SnapshotChunkReadyEvent, block: suspend () -> T): T =
+        withContext(MDCContext(mapOf(
+            "runId" to event.runId,
+            "chunkId" to event.chunkId,
+            "kafkaTopic" to "external-api.snapshot.chunk-ready",
+        ))) { block() }
+}

--- a/module-calculator/src/main/kotlin/maple/calculator/cleanup/CalculatorResultCleanupScheduler.kt
+++ b/module-calculator/src/main/kotlin/maple/calculator/cleanup/CalculatorResultCleanupScheduler.kt
@@ -1,0 +1,178 @@
+package maple.calculator.cleanup
+
+import maple.calculator.storage.ObjectStorage
+import maple.common.cleanup.RunInfo
+import maple.common.cleanup.RunRetentionPolicy
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.nio.file.attribute.BasicFileAttributes
+import java.time.Instant
+
+@Component
+@ConditionalOnProperty(name = ["calculator.cleanup.enabled"], havingValue = "true")
+class CalculatorResultCleanupScheduler(
+    private val objectStorage: ObjectStorage,
+    @Value("\${calculator.cleanup.dry-run:true}")
+    private val dryRun: Boolean,
+    @Value("\${calculator.cleanup.runs.keep-recent:5}")
+    private val keepRecent: Int,
+    @Value("\${calculator.cleanup.runs.keep-within-hours:48}")
+    private val keepWithinHours: Long,
+    @Value("\${calculator.cleanup.max-delete-runs-per-cycle:10}")
+    private val maxDeleteRunsPerCycle: Int,
+    @Value("\${calculator.cleanup.max-delete-bytes-per-cycle:5368709120}")
+    private val maxDeleteBytesPerCycle: Long,
+    @Value("\${calculator.cleanup.max-runtime-seconds:60}")
+    private val maxRuntimeSeconds: Long,
+    @Value("\${calculator.store.input-base-path:./external-api-data}")
+    private val basePath: String,
+) {
+    private val log = LoggerFactory.getLogger(CalculatorResultCleanupScheduler::class.java)
+
+    @Scheduled(fixedDelayString = "\${calculator.cleanup.interval-ms:21600000}")
+    fun cleanup() {
+        Thread.ofVirtual().name("cleanup-calc").start {
+            val start = Instant.now()
+            log.info("[CalculatorCleanup] started: dryRun={}", dryRun)
+
+            // Pipeline isolation: catch everything, never propagate
+            val result = runCatching { cleanupRuns(start) }
+
+            val durationMs = Instant.now().toEpochMilli() - start.toEpochMilli()
+
+            result.onSuccess { res ->
+                log.info(
+                    "[CalculatorCleanup] completed: dryRun={}, deleted={}, bytes={}, " +
+                        "errors={}, throttled={}, durationMs={}",
+                    dryRun, res.deleted, res.bytes, res.errors, res.throttled, durationMs,
+                )
+            }.onFailure { ex ->
+                log.error("[CalculatorCleanup] failed (pipeline NOT affected): {}", ex.message, ex)
+            }
+        }
+    }
+
+    private fun cleanupRuns(startedAt: Instant): CleanupResult {
+        val prefix = "data/calculator/runs"
+        val runDirs = objectStorage.listDirectories(prefix)
+        if (runDirs.isEmpty()) {
+            log.info("[CalculatorCleanup] no calculator runs found")
+            return CleanupResult.ZERO
+        }
+
+        val runInfos = runDirs.mapNotNull { parseRunInfo(prefix, it) }
+
+        val toDelete = RunRetentionPolicy.selectForDeletion(
+            runs = runInfos,
+            keepRecentCount = keepRecent,
+            keepWithinHours = keepWithinHours,
+            now = Instant.now(),
+        )
+
+        if (toDelete.isEmpty()) {
+            log.info("[CalculatorCleanup] no runs to delete")
+            return CleanupResult.ZERO
+        }
+
+        // Apply throttling limits
+        val throttled = maxOf(0, toDelete.size - maxDeleteRunsPerCycle)
+        val limited = if (toDelete.size > maxDeleteRunsPerCycle) {
+            log.info("[CalculatorCleanup] throttling: {} candidates, limit {}", toDelete.size, maxDeleteRunsPerCycle)
+            toDelete.take(maxDeleteRunsPerCycle)
+        } else {
+            toDelete
+        }
+
+        log.info(
+            "[CalculatorCleanup] candidates: {} of {} (throttled={}, dryRun={})",
+            limited.size, runInfos.size, throttled, dryRun,
+        )
+
+        if (dryRun) {
+            limited.forEach { run ->
+                log.info(
+                    "[CalculatorCleanup] would delete: runId={}, size={}MB",
+                    run.runId, run.sizeBytes / (1024 * 1024),
+                )
+            }
+            return CleanupResult(limited.size, limited.sumOf { it.sizeBytes }, 0, throttled)
+        }
+
+        return deleteRunWithLimits(limited, startedAt)
+    }
+
+    private fun deleteRunWithLimits(runs: List<RunInfo>, startedAt: Instant): CleanupResult {
+        var deleted = 0
+        var bytes = 0L
+        var errors = 0
+
+        for (run in runs) {
+            // Check runtime limit
+            val elapsed = Instant.now().toEpochMilli() - startedAt.toEpochMilli()
+            if (elapsed > maxRuntimeSeconds * 1000) {
+                log.info("[CalculatorCleanup] runtime limit reached: {}ms, stopping", elapsed)
+                break
+            }
+            // Check byte limit
+            if (bytes >= maxDeleteBytesPerCycle) {
+                log.info("[CalculatorCleanup] byte limit reached: {} bytes, stopping", bytes)
+                break
+            }
+
+            val deletedBytes = objectStorage.deleteDirectory("data/calculator/runs/${run.runId}")
+            if (deletedBytes >= 0) {
+                deleted++
+                bytes += deletedBytes
+            } else {
+                errors++
+                log.warn("[CalculatorCleanup] failed to delete: {} (pipeline NOT affected)", run.runId)
+            }
+        }
+
+        return CleanupResult(deleted, bytes, errors, 0)
+    }
+
+    private fun parseRunInfo(prefix: String, runId: String): RunInfo? {
+        val fullPath = "$prefix/$runId"
+        val sizeBytes = objectStorage.calculateDirectorySize(fullPath)
+        val createdAt = readDirectoryCreatedTime(fullPath) ?: return null
+        val isRunning = isRecentlyModified(fullPath)
+        return RunInfo(
+            runId = runId,
+            createdAt = createdAt,
+            isRunning = isRunning,
+            sizeBytes = sizeBytes,
+        )
+    }
+
+    private fun readDirectoryCreatedTime(prefix: String): Instant? {
+        val path = Paths.get(basePath, prefix)
+        if (!Files.exists(path)) return null
+        val attrs = Files.readAttributes(path, BasicFileAttributes::class.java)
+        return Instant.ofEpochMilli(attrs.creationTime().toMillis())
+    }
+
+    private fun isRecentlyModified(prefix: String): Boolean {
+        val path = Paths.get(basePath, prefix)
+        if (!Files.exists(path)) return false
+        val attrs = Files.readAttributes(path, BasicFileAttributes::class.java)
+        val modifiedAt = Instant.ofEpochMilli(attrs.lastModifiedTime().toMillis())
+        return modifiedAt.isAfter(Instant.now().minusSeconds(1800))
+    }
+
+    private data class CleanupResult(
+        val deleted: Int,
+        val bytes: Long,
+        val errors: Int,
+        val throttled: Int,
+    ) {
+        companion object {
+            val ZERO = CleanupResult(0, 0L, 0, 0)
+        }
+    }
+}

--- a/module-calculator/src/main/kotlin/maple/calculator/config/PipelineProperties.kt
+++ b/module-calculator/src/main/kotlin/maple/calculator/config/PipelineProperties.kt
@@ -1,0 +1,9 @@
+package maple.calculator.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties("calculator.pipeline")
+data class PipelineProperties(
+    val workerCount: Int = 4,
+    val channelCapacity: Int = 500,
+)

--- a/module-calculator/src/main/kotlin/maple/calculator/event/KafkaResultEventPublisher.kt
+++ b/module-calculator/src/main/kotlin/maple/calculator/event/KafkaResultEventPublisher.kt
@@ -1,0 +1,33 @@
+package maple.calculator.event
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import maple.expectation.common.event.CalculatorResultChunkReadyEvent
+import kotlinx.coroutines.future.await
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.stereotype.Component
+
+@Component
+class KafkaResultEventPublisher(
+    private val kafkaTemplate: KafkaTemplate<String, String>,
+    private val objectMapper: ObjectMapper,
+    @Value("\${calculator.kafka.result-chunk-ready-topic}")
+    private val resultChunkReadyTopic: String,
+) {
+    private val log = LoggerFactory.getLogger(KafkaResultEventPublisher::class.java)
+
+    suspend fun publishChunkReady(event: CalculatorResultChunkReadyEvent) {
+        val key = "${event.sourceRunId}:${event.sourceEndpoint}:${event.sourceChunkId}"
+        val payload = objectMapper.writeValueAsString(event)
+        kafkaTemplate.send(resultChunkReadyTopic, key, payload).await()
+        log.info(
+            "[Event] published calculator result chunk-ready: sourceRunId={} sourceEndpoint={} sourceChunkId={} objectKey={} results={}",
+            event.sourceRunId,
+            event.sourceEndpoint,
+            event.sourceChunkId,
+            event.objectKey,
+            event.resultCount,
+        )
+    }
+}

--- a/module-calculator/src/main/kotlin/maple/calculator/event/SnapshotChunkReadyEvent.kt
+++ b/module-calculator/src/main/kotlin/maple/calculator/event/SnapshotChunkReadyEvent.kt
@@ -1,0 +1,18 @@
+package maple.calculator.event
+
+import java.time.Instant
+
+data class SnapshotChunkReadyEvent(
+    val eventId: String,
+    val eventType: String = "SNAPSHOT_CHUNK_READY",
+    val schemaVersion: Int = 1,
+    val runId: String,
+    val endpoint: String,
+    val chunkId: String,
+    val objectKey: String,
+    val recordCount: Int,
+    val uncompressedBytes: Long,
+    val compressedBytes: Long,
+    val sha256: String? = null,
+    val createdAt: Instant,
+)

--- a/module-calculator/src/main/kotlin/maple/calculator/metrics/CalculatorMetrics.kt
+++ b/module-calculator/src/main/kotlin/maple/calculator/metrics/CalculatorMetrics.kt
@@ -1,0 +1,57 @@
+package maple.calculator.metrics
+
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.Gauge
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Timer
+import org.springframework.stereotype.Component
+
+@Component
+class CalculatorMetrics(registry: MeterRegistry) {
+    private val chunksProcessed = registry.counter("calculator_chunks_processed_total")
+    private val chunksSkipped = registry.counter("calculator_chunks_skipped_total", "reason", "endpoint_mismatch")
+    private val chunksNotFound = registry.counter("calculator_chunks_skipped_total", "reason", "source_not_found")
+    private val chunksIdempotent = registry.counter("calculator_chunks_skipped_total", "reason", "result_exists")
+    private val chunksFailed = registry.counter("calculator_chunks_failed_total")
+
+    private val usersProcessed = registry.counter("calculator_users_processed_total")
+    private val itemsProcessed = registry.counter("calculator_items_processed_total")
+    private val itemsCalculated = registry.counter("calculator_items_calculated_total")
+    private val itemsErrored = registry.counter("calculator_items_errored_total")
+
+    private val chunkTimer = Timer.builder("calculator_chunk_duration_seconds")
+        .description("Time to process a single snapshot chunk")
+        .register(registry)
+
+    @Volatile private var lastChunkUsersPerSec = 0.0
+    @Volatile private var lastChunkItemsPerSec = 0.0
+
+    init {
+        Gauge.builder("calculator_chunk_users_per_second") { lastChunkUsersPerSec }
+            .description("Users processed per second in the last completed chunk")
+            .register(registry)
+        Gauge.builder("calculator_chunk_items_per_second") { lastChunkItemsPerSec }
+            .description("Items processed per second in the last completed chunk")
+            .register(registry)
+    }
+
+    fun recordChunkProcessed() = chunksProcessed.increment()
+    fun recordChunkSkippedEndpoint() = chunksSkipped.increment()
+    fun recordChunkSkippedNotFound() = chunksNotFound.increment()
+    fun recordChunkSkippedIdempotent() = chunksIdempotent.increment()
+    fun recordChunkFailed() = chunksFailed.increment()
+
+    fun recordUsers(count: Int) = usersProcessed.increment(count.toDouble())
+    fun recordItems(count: Int) = itemsProcessed.increment(count.toDouble())
+    fun recordCalculated(count: Int) = itemsCalculated.increment(count.toDouble())
+    fun recordErrors(count: Int) = itemsErrored.increment(count.toDouble())
+
+    fun recordChunkRates(users: Int, items: Int, durationSec: Double) {
+        if (durationSec > 0) {
+            lastChunkUsersPerSec = users / durationSec
+            lastChunkItemsPerSec = items / durationSec
+        }
+    }
+
+    fun timer(): Timer = chunkTimer
+}

--- a/module-calculator/src/main/kotlin/maple/calculator/metrics/CalculatorVolumeMetrics.kt
+++ b/module-calculator/src/main/kotlin/maple/calculator/metrics/CalculatorVolumeMetrics.kt
@@ -1,0 +1,57 @@
+package maple.calculator.metrics
+
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.DistributionSummary
+import io.micrometer.core.instrument.MeterRegistry
+import org.springframework.stereotype.Component
+
+@Component
+class CalculatorVolumeMetrics(registry: MeterRegistry) {
+
+    // Input (snapshot artifact read)
+    private val inputCompressedBytesTotal = registry.counter("calculator_input_compressed_bytes_total")
+    private val inputUncompressedBytesTotal = registry.counter("calculator_input_uncompressed_bytes_total")
+
+    private val inputCompressedSummary = DistributionSummary.builder("calculator_input_compressed_bytes")
+        .description("Compressed input bytes per chunk")
+        .register(registry)
+
+    private val inputUncompressedSummary = DistributionSummary.builder("calculator_input_uncompressed_bytes")
+        .description("Uncompressed input bytes per chunk")
+        .register(registry)
+
+    // Result (calculator output artifact)
+    private val resultCompressedBytesTotal = registry.counter("calculator_result_compressed_bytes_total")
+    private val resultUncompressedBytesTotal = registry.counter("calculator_result_uncompressed_bytes_total")
+    private val resultJsonRowsTotal = registry.counter("calculator_result_json_rows_total")
+
+    private val resultCompressedSummary = DistributionSummary.builder("calculator_result_compressed_bytes")
+        .description("Compressed result bytes per chunk")
+        .register(registry)
+
+    private val resultUncompressedSummary = DistributionSummary.builder("calculator_result_uncompressed_bytes")
+        .description("Uncompressed result bytes per chunk")
+        .register(registry)
+
+    private val resultCompressionRatio = DistributionSummary.builder("calculator_result_compression_ratio")
+        .description("Compression ratio (uncompressed/compressed) per result chunk")
+        .register(registry)
+
+    fun recordInput(compressedBytes: Long, uncompressedBytes: Long) {
+        inputCompressedBytesTotal.increment(compressedBytes.toDouble())
+        inputUncompressedBytesTotal.increment(uncompressedBytes.toDouble())
+        inputCompressedSummary.record(compressedBytes.toDouble())
+        inputUncompressedSummary.record(uncompressedBytes.toDouble())
+    }
+
+    fun recordResult(compressedBytes: Long, uncompressedBytes: Long, jsonRows: Long) {
+        resultCompressedBytesTotal.increment(compressedBytes.toDouble())
+        resultUncompressedBytesTotal.increment(uncompressedBytes.toDouble())
+        resultJsonRowsTotal.increment(jsonRows.toDouble())
+        resultCompressedSummary.record(compressedBytes.toDouble())
+        resultUncompressedSummary.record(uncompressedBytes.toDouble())
+        if (compressedBytes > 0) {
+            resultCompressionRatio.record(uncompressedBytes.toDouble() / compressedBytes.toDouble())
+        }
+    }
+}

--- a/module-calculator/src/main/kotlin/maple/calculator/model/CalculationResult.kt
+++ b/module-calculator/src/main/kotlin/maple/calculator/model/CalculationResult.kt
@@ -1,0 +1,22 @@
+package maple.calculator.model
+
+data class CalculationResult(
+    val ocid: String,
+    val presetNo: Int,
+    val itemName: String,
+    val itemLevel: Int,
+    val itemPart: String?,
+    val itemEquipmentPart: String?,
+    val potentialGrade: String?,
+    val potentialOptions: List<String?>,
+    val additionalGrade: String?,
+    val additionalOptions: List<String>,
+    val currentStar: Int,
+    val targetStar: Int,
+    val status: String,
+    val totalCost: Double?,
+    val blackCubeCost: Double?,
+    val additionalCubeCost: Double?,
+    val starforceCost: Double?,
+    val errorMessage: String? = null,
+)

--- a/module-calculator/src/main/kotlin/maple/calculator/model/ChunkResult.kt
+++ b/module-calculator/src/main/kotlin/maple/calculator/model/ChunkResult.kt
@@ -1,0 +1,13 @@
+package maple.calculator.model
+
+data class ChunkResult(
+    val recordCount: Int,
+    val successCount: Int,
+    val totalItems: Int,
+    val calculatedCount: Int,
+    val errorCount: Int,
+    val resultObjectKey: String,
+    val resultCount: Int,
+    val resultUncompressedBytes: Long,
+    val resultCompressedBytes: Long,
+)

--- a/module-calculator/src/main/kotlin/maple/calculator/parser/SnapshotEquipmentParser.kt
+++ b/module-calculator/src/main/kotlin/maple/calculator/parser/SnapshotEquipmentParser.kt
@@ -1,0 +1,64 @@
+package maple.calculator.parser
+
+import com.fasterxml.jackson.databind.JsonNode
+import maple.expectation.core.domain.model.PotentialGrade
+import maple.expectation.core.dto.v4.*
+import org.springframework.stereotype.Component
+
+@Component
+class SnapshotEquipmentParser {
+
+    fun parseAllPresets(body: JsonNode): Map<Int, List<EquipmentItem>> {
+        val result = mutableMapOf<Int, List<EquipmentItem>>()
+        for (presetNo in 1..3) {
+            val preset = body.path("item_equipment_preset_$presetNo")
+            if (preset.isArray) {
+                result[presetNo] = preset.map { convertItem(it) }
+            }
+        }
+        return result
+    }
+
+    private fun convertItem(item: JsonNode): EquipmentItem {
+        val baseOption = item.path("item_base_option")
+        val addOption = item.path("item_add_option")
+
+        return EquipmentItem(
+            part = EquipmentSlot.fromKorean(item.path("item_equipment_slot").asText("")),
+            equipmentPart = EquipmentPart.fromKorean(item.path("item_equipment_part").asText("")),
+            itemName = item.path("item_name").asText(""),
+            level = intStr(baseOption.path("base_equipment_level")),
+            potential = buildPotentialLines(item, "potential_option_grade", "potential_option_"),
+            additionalPotential = buildPotentialLines(item, "additional_potential_option_grade", "additional_potential_option_"),
+            starforce = intStr(item.path("starforce")),
+            starforceScrollFlag = StarforceScrollFlag.fromKorean(item.path("starforce_scroll_flag").asText(null)),
+            addOption = AddOption(
+                str = intStr(addOption.path("str")),
+                dex = intStr(addOption.path("dex")),
+                int = intStr(addOption.path("int")),
+                luk = intStr(addOption.path("luk")),
+                maxHp = intStr(addOption.path("max_hp")),
+                allStat = intStr(addOption.path("all_stat")),
+                attackPower = intStr(addOption.path("attack_power")),
+                magicPower = intStr(addOption.path("magic_power")),
+                bossDamage = intStr(addOption.path("boss_damage")),
+                damage = intStr(addOption.path("damage")),
+            ),
+            baseAttackPower = intStr(baseOption.path("attack_power")),
+            baseMagicPower = intStr(baseOption.path("magic_power")),
+        )
+    }
+
+    private fun intStr(node: JsonNode): Int = node.asText().toIntOrNull() ?: 0
+
+    private fun buildPotentialLines(item: JsonNode, gradeKey: String, optionPrefix: String): PotentialLines? {
+        val gradeStr = item.path(gradeKey).asText(null) ?: return null
+        val grade = PotentialGrade.entries.find { it.koreanName == gradeStr } ?: return null
+        return PotentialLines(
+            grade = grade,
+            line1 = item.path("${optionPrefix}1").asText(null),
+            line2 = item.path("${optionPrefix}2").asText(null),
+            line3 = item.path("${optionPrefix}3").asText(null),
+        )
+    }
+}

--- a/module-calculator/src/main/kotlin/maple/calculator/processor/CalculationCache.kt
+++ b/module-calculator/src/main/kotlin/maple/calculator/processor/CalculationCache.kt
@@ -1,0 +1,78 @@
+package maple.calculator.processor
+
+import com.github.benmanes.caffeine.cache.Cache
+import com.github.benmanes.caffeine.cache.Caffeine
+import maple.expectation.application.service.calculator.v4.EquipmentExpectationCalculatorFactory
+import maple.expectation.core.dto.v4.EquipmentCalculationInput
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+@Component
+class CalculationCache(
+    private val factory: EquipmentExpectationCalculatorFactory,
+) {
+    private val log = LoggerFactory.getLogger(CalculationCache::class.java)
+
+    data class CacheKey(
+        val itemName: String,
+        val itemPart: String,
+        val itemLevel: Int,
+        val potentialGrade: String?,
+        val potentialOptions: List<String?>?,
+        val additionalPotentialGrade: String?,
+        val additionalPotentialOptions: List<String?>?,
+        val targetStar: Int,
+        val isNoljang: Boolean,
+    )
+
+    data class ComponentCosts(
+        val blackCubeCost: Double?,
+        val additionalCubeCost: Double?,
+        val starforceCost: Double?,
+    ) {
+        val hasAnyCost: Boolean = blackCubeCost != null || additionalCubeCost != null || starforceCost != null
+        val totalCost: Double?
+            get() = if (hasAnyCost) {
+                (blackCubeCost ?: 0.0) + (additionalCubeCost ?: 0.0) + (starforceCost ?: 0.0)
+            } else {
+                null
+            }
+
+        companion object {
+            fun empty(): ComponentCosts = ComponentCosts(null, null, null)
+        }
+    }
+
+    private val cache: Cache<CacheKey, ComponentCosts> = Caffeine.newBuilder()
+        .maximumSize(100_000)
+        .recordStats()
+        .build()
+
+    fun calculate(input: EquipmentCalculationInput): ComponentCosts {
+        val key = CacheKey(
+            itemName = input.itemName,
+            itemPart = input.itemPart,
+            itemLevel = input.itemLevel,
+            potentialGrade = input.potentialGrade,
+            potentialOptions = input.potentialOptions,
+            additionalPotentialGrade = input.additionalPotentialGrade,
+            additionalPotentialOptions = input.additionalPotentialOptions,
+            targetStar = input.targetStar,
+            isNoljang = input.isNoljang,
+        )
+        return cache.get(key) {
+            val calculator = factory.createFullCalculator(input)
+            val details = calculator.detailedCosts
+            ComponentCosts(
+                blackCubeCost = details.blackCubeCost,
+                additionalCubeCost = details.additionalCubeCost,
+                starforceCost = details.starforceCost,
+            )
+        }
+    }
+
+    fun stats(): String {
+        val s = cache.stats()
+        return "size=${cache.estimatedSize()} hits=${s.hitCount()} misses=${s.missCount()} hitRate=${"%.1f%%".format(s.hitRate() * 100)}"
+    }
+}

--- a/module-calculator/src/main/kotlin/maple/calculator/processor/EquipmentCalculationInputConverter.kt
+++ b/module-calculator/src/main/kotlin/maple/calculator/processor/EquipmentCalculationInputConverter.kt
@@ -1,0 +1,71 @@
+package maple.calculator.processor
+
+import maple.calculator.model.CalculationResult
+import maple.expectation.application.service.starforce.NoljangProbabilityTable
+import maple.expectation.core.domain.equipment.SecondaryWeaponCategory
+import maple.expectation.core.dto.cube.CubeCalculationInput
+import maple.expectation.core.dto.v4.EquipmentCalculationInput
+
+object EquipmentCalculationInputConverter {
+
+    fun toCalculationInput(
+        cubeInput: CubeCalculationInput,
+        presetNo: Int,
+    ): EquipmentCalculationInput {
+        val potentialPart = SecondaryWeaponCategory.resolvePotentialPart(
+            cubeInput.part, cubeInput.itemEquipmentPart,
+        )
+        return EquipmentCalculationInput.builder()
+            .itemName(cubeInput.itemName ?: "")
+            .itemPart(potentialPart)
+            .itemEquipmentPart(cubeInput.itemEquipmentPart ?: "")
+            .itemIcon(cubeInput.itemIcon ?: "")
+            .itemLevel(cubeInput.level)
+            .presetNo(presetNo)
+            .isNoljang(cubeInput.isNoljangEquipment())
+            .potentialGrade(cubeInput.grade)
+            .potentialOptions(cubeInput.options?.filterNotNull())
+            .additionalPotentialGrade(cubeInput.additionalGrade)
+            .additionalPotentialOptions(cubeInput.additionalOptions?.filterNotNull())
+            .currentStar(0)
+            .targetStar(targetStar(cubeInput))
+            .build()
+    }
+
+    fun toCalculationResult(
+        ocid: String,
+        presetNo: Int,
+        cubeInput: CubeCalculationInput,
+        componentCosts: CalculationCache.ComponentCosts,
+        status: String,
+        errorMessage: String?,
+    ): CalculationResult = CalculationResult(
+        ocid = ocid,
+        presetNo = presetNo,
+        itemName = cubeInput.itemName ?: "",
+        itemLevel = cubeInput.level,
+        itemPart = cubeInput.part,
+        itemEquipmentPart = cubeInput.itemEquipmentPart,
+        potentialGrade = cubeInput.grade,
+        potentialOptions = cubeInput.options,
+        additionalGrade = cubeInput.additionalGrade,
+        additionalOptions = cubeInput.additionalOptions,
+        currentStar = 0,
+        targetStar = targetStar(cubeInput),
+        status = status,
+        totalCost = componentCosts.totalCost,
+        blackCubeCost = componentCosts.blackCubeCost,
+        additionalCubeCost = componentCosts.additionalCubeCost,
+        starforceCost = componentCosts.starforceCost,
+        errorMessage = errorMessage,
+    )
+
+    fun targetStar(cubeInput: CubeCalculationInput): Int {
+        if (cubeInput.starforce <= 0 || cubeInput.itemName.isNullOrBlank() || cubeInput.level <= 0) return 0
+        return if (cubeInput.isNoljangEquipment()) {
+            minOf(cubeInput.starforce, NoljangProbabilityTable.MAX_NOLJANG_STAR)
+        } else {
+            cubeInput.starforce
+        }
+    }
+}

--- a/module-calculator/src/main/kotlin/maple/calculator/processor/SnapshotChunkProcessor.kt
+++ b/module-calculator/src/main/kotlin/maple/calculator/processor/SnapshotChunkProcessor.kt
@@ -1,0 +1,172 @@
+package maple.calculator.processor
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import maple.calculator.config.PipelineProperties
+import maple.calculator.event.SnapshotChunkReadyEvent
+import maple.calculator.model.CalculationResult
+import maple.calculator.model.ChunkResult
+import maple.calculator.parser.SnapshotEquipmentParser
+import maple.calculator.reader.GzipJsonlSnapshotRecordReader
+import maple.calculator.storage.ObjectStorage
+import maple.calculator.writer.CalculationResultWriter
+import maple.expectation.core.dto.cube.CubeCalculationInput
+import maple.expectation.core.dto.v4.EquipmentItem
+import maple.expectation.core.dto.v4.EquipmentItemConverter
+import maple.expectation.util.StringMaskingUtils
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+@Component
+class SnapshotChunkProcessor(
+    private val objectStorage: ObjectStorage,
+    private val jsonlReader: GzipJsonlSnapshotRecordReader,
+    private val equipmentParser: SnapshotEquipmentParser,
+    private val calculationCache: CalculationCache,
+    private val objectMapper: ObjectMapper,
+    private val properties: PipelineProperties,
+    private val resultWriter: CalculationResultWriter,
+) {
+    private val log = LoggerFactory.getLogger(SnapshotChunkProcessor::class.java)
+    private val sampleCount = AtomicInteger(0)
+
+    data class FlatItem(
+        val ocid: String,
+        val presetNo: Int,
+        val item: EquipmentItem,
+    )
+
+    suspend fun process(event: SnapshotChunkReadyEvent, resultObjectKey: String): ChunkResult = coroutineScope {
+        val lineChannel = Channel<String>(properties.channelCapacity)
+        val itemChannel = Channel<FlatItem>(properties.channelCapacity)
+        val resultChannel = Channel<CalculationResult>(properties.channelCapacity)
+        val recordCount = AtomicInteger(0)
+        val successCount = AtomicInteger(0)
+        val totalItems = AtomicInteger(0)
+        val calculatedCount = AtomicInteger(0)
+        val errorCount = AtomicInteger(0)
+
+        launch(Dispatchers.IO) { readLines(event.objectKey, lineChannel) }
+
+        launch {
+            coroutineScope {
+                repeat(properties.workerCount) {
+                    launch(Dispatchers.Default) {
+                        parseLines(lineChannel, itemChannel, recordCount, successCount, totalItems)
+                    }
+                }
+            }
+            itemChannel.close()
+        }
+
+        launch {
+            coroutineScope {
+                repeat(properties.workerCount) {
+                    launch(Dispatchers.Default) {
+                        processItems(itemChannel, resultChannel, calculatedCount, errorCount)
+                    }
+                }
+            }
+            resultChannel.close()
+        }
+
+        val writeResult = async(Dispatchers.IO) {
+            resultWriter.write(resultObjectKey, resultChannel)
+        }.await()
+
+        ChunkResult(
+            recordCount = recordCount.get(),
+            successCount = successCount.get(),
+            totalItems = totalItems.get(),
+            calculatedCount = calculatedCount.get(),
+            errorCount = errorCount.get(),
+            resultObjectKey = writeResult.objectKey,
+            resultCount = writeResult.resultCount,
+            resultUncompressedBytes = writeResult.uncompressedBytes,
+            resultCompressedBytes = writeResult.compressedBytes,
+        )
+    }
+
+    private suspend fun readLines(
+        objectKey: String,
+        channel: Channel<String>,
+    ) {
+        objectStorage.openInputStream(objectKey).use { stream ->
+            jsonlReader.readLines(stream).collect { line ->
+                channel.send(line)
+            }
+        }
+        channel.close()
+    }
+
+    private suspend fun parseLines(
+        lineChannel: Channel<String>,
+        itemChannel: Channel<FlatItem>,
+        recordCount: AtomicInteger,
+        successCount: AtomicInteger,
+        totalItems: AtomicInteger,
+    ) {
+        for (line in lineChannel) {
+            recordCount.incrementAndGet()
+            val node = objectMapper.readTree(line)
+            if (node.path("status").asText() != "SUCCESS") continue
+            val body = node.path("body").takeIf { !it.isMissingNode && !it.isNull } ?: continue
+            val ocid = node.path("key").asText("")
+            successCount.incrementAndGet()
+
+            for ((presetNo, items) in equipmentParser.parseAllPresets(body)) {
+                for (item in items) {
+                    totalItems.incrementAndGet()
+                    itemChannel.send(FlatItem(ocid, presetNo, item))
+                }
+            }
+        }
+    }
+
+    private suspend fun processItems(
+        itemChannel: Channel<FlatItem>,
+        resultChannel: Channel<CalculationResult>,
+        calculatedCount: AtomicInteger,
+        errorCount: AtomicInteger,
+    ) {
+        for (flatItem in itemChannel) {
+            val result = calculateItem(flatItem)
+            if (result.status == "ERROR") {
+                errorCount.incrementAndGet()
+            } else {
+                calculatedCount.incrementAndGet()
+            }
+            resultChannel.send(result)
+        }
+    }
+
+    private fun calculateItem(flatItem: FlatItem): CalculationResult = runCatching {
+        val cubeInput = EquipmentItemConverter.toCubeInput(flatItem.item)
+        val componentCosts = calculateComponentCosts(cubeInput, flatItem.presetNo)
+        val status = if (componentCosts.hasAnyCost) "SUCCESS" else "SKIPPED"
+        val result = EquipmentCalculationInputConverter.toCalculationResult(flatItem.ocid, flatItem.presetNo, cubeInput, componentCosts, status, null)
+        logSample(result)
+        result
+    }.getOrElse { ex ->
+        val cubeInput = EquipmentItemConverter.toCubeInput(flatItem.item)
+        log.warn("Calculation error: ocid={} preset={}: {}", StringMaskingUtils.maskOcid(flatItem.ocid), flatItem.presetNo, ex.message)
+        EquipmentCalculationInputConverter.toCalculationResult(flatItem.ocid, flatItem.presetNo, cubeInput, CalculationCache.ComponentCosts.empty(), "ERROR", ex.message)
+    }
+
+    private fun calculateComponentCosts(cubeInput: CubeCalculationInput, presetNo: Int): CalculationCache.ComponentCosts {
+        if (!cubeInput.isReady()) return CalculationCache.ComponentCosts.empty()
+        val input = EquipmentCalculationInputConverter.toCalculationInput(cubeInput, presetNo)
+        return calculationCache.calculate(input)
+    }
+
+    private fun logSample(result: CalculationResult) {
+        if (sampleCount.incrementAndGet() <= 10) {
+            log.debug("[SAMPLE] {}", objectMapper.writeValueAsString(result))
+        }
+    }
+}

--- a/module-calculator/src/main/kotlin/maple/calculator/reader/GzipJsonlSnapshotRecordReader.kt
+++ b/module-calculator/src/main/kotlin/maple/calculator/reader/GzipJsonlSnapshotRecordReader.kt
@@ -1,0 +1,21 @@
+package maple.calculator.reader
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import org.springframework.stereotype.Component
+import java.io.BufferedInputStream
+import java.io.InputStream
+import java.util.zip.GZIPInputStream
+
+@Component
+class GzipJsonlSnapshotRecordReader {
+    fun readLines(inputStream: InputStream): Flow<String> = flow {
+        GZIPInputStream(BufferedInputStream(inputStream)).bufferedReader().use { reader ->
+            var line = reader.readLine()
+            while (line != null) {
+                if (line.isNotBlank()) emit(line)
+                line = reader.readLine()
+            }
+        }
+    }
+}

--- a/module-calculator/src/main/kotlin/maple/calculator/storage/LocalObjectStorageAdapter.kt
+++ b/module-calculator/src/main/kotlin/maple/calculator/storage/LocalObjectStorageAdapter.kt
@@ -1,0 +1,71 @@
+package maple.calculator.storage
+
+import java.io.InputStream
+import java.io.OutputStream
+import java.nio.file.FileVisitOption
+import java.nio.file.FileVisitResult
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.attribute.BasicFileAttributes
+import java.util.stream.Collectors
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+
+@Component
+class LocalObjectStorageAdapter(
+    @Value("\${calculator.store.input-base-path:./external-api-data}")
+    private val basePath: String,
+) : ObjectStorage {
+
+    override fun openInputStream(objectKey: String): InputStream {
+        val path = Paths.get(basePath, objectKey)
+        return Files.newInputStream(path)
+    }
+
+    override fun openOutputStream(objectKey: String): OutputStream {
+        val path = Paths.get(basePath, objectKey)
+        path.parent?.let { Files.createDirectories(it) }
+        return Files.newOutputStream(path)
+    }
+
+    override fun exists(objectKey: String): Boolean = Files.exists(Paths.get(basePath, objectKey))
+
+    override fun listDirectories(prefix: String): List<String> {
+        val dir = Paths.get(basePath, prefix)
+        if (!Files.exists(dir)) return emptyList()
+        return Files.list(dir).use { stream ->
+            stream
+                .filter { Files.isDirectory(it) }
+                .map { it.fileName.toString() }
+                .collect(Collectors.toList())
+        }
+    }
+
+    override fun deleteDirectory(prefix: String): Long {
+        val dir = Paths.get(basePath, prefix)
+        if (!Files.exists(dir)) return 0L
+        var deletedBytes = 0L
+        Files.walkFileTree(dir, object : SimpleFileVisitor<Path>() {
+            override fun visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult {
+                deletedBytes += attrs.size()
+                Files.delete(file)
+                return FileVisitResult.CONTINUE
+            }
+            override fun postVisitDirectory(dir: Path, exc: java.io.IOException?): FileVisitResult {
+                Files.delete(dir)
+                return FileVisitResult.CONTINUE
+            }
+        })
+        return deletedBytes
+    }
+
+    override fun calculateDirectorySize(prefix: String): Long {
+        val dir = Paths.get(basePath, prefix)
+        if (!Files.exists(dir)) return 0L
+        return Files.walk(dir, FileVisitOption.FOLLOW_LINKS).use { stream ->
+            stream.filter { Files.isRegularFile(it) }.mapToLong { Files.size(it) }.sum()
+        }
+    }
+}

--- a/module-calculator/src/main/kotlin/maple/calculator/storage/ObjectStorage.kt
+++ b/module-calculator/src/main/kotlin/maple/calculator/storage/ObjectStorage.kt
@@ -1,0 +1,16 @@
+package maple.calculator.storage
+
+import java.io.InputStream
+import java.io.OutputStream
+
+interface ObjectStorage {
+    fun openInputStream(objectKey: String): InputStream
+    fun openOutputStream(objectKey: String): OutputStream
+    fun exists(objectKey: String): Boolean
+
+    fun listDirectories(prefix: String): List<String>
+
+    fun deleteDirectory(prefix: String): Long
+
+    fun calculateDirectorySize(prefix: String): Long
+}

--- a/module-calculator/src/main/kotlin/maple/calculator/writer/CalculationResultWriter.kt
+++ b/module-calculator/src/main/kotlin/maple/calculator/writer/CalculationResultWriter.kt
@@ -1,0 +1,77 @@
+package maple.calculator.writer
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import java.io.OutputStream
+import java.util.zip.GZIPOutputStream
+import kotlinx.coroutines.channels.ReceiveChannel
+import maple.calculator.model.CalculationResult
+import maple.calculator.storage.ObjectStorage
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+@Component
+class CalculationResultWriter(
+    private val objectStorage: ObjectStorage,
+    private val objectMapper: ObjectMapper,
+) {
+    private val log = LoggerFactory.getLogger(CalculationResultWriter::class.java)
+
+    data class WriteResult(
+        val objectKey: String,
+        val resultCount: Int,
+        val uncompressedBytes: Long,
+        val compressedBytes: Long,
+    )
+
+    suspend fun write(
+        objectKey: String,
+        results: ReceiveChannel<CalculationResult>,
+    ): WriteResult {
+        val compressedCounter = CountingOutputStream(objectStorage.openOutputStream(objectKey))
+        val gzipStream = GZIPOutputStream(compressedCounter)
+        val uncompressedCounter = CountingOutputStream(gzipStream)
+        var resultCount = 0
+
+        objectMapper.factory.createGenerator(uncompressedCounter).use { generator ->
+            for (result in results) {
+                generator.writeObject(result)
+                generator.writeRaw('\n')
+                resultCount += 1
+            }
+        }
+
+        log.info(
+            "[Writer] wrote calculator result chunk: objectKey={} results={} uncompressedBytes={} compressedBytes={}",
+            objectKey,
+            resultCount,
+            uncompressedCounter.bytesWritten,
+            compressedCounter.bytesWritten,
+        )
+        return WriteResult(objectKey, resultCount, uncompressedCounter.bytesWritten, compressedCounter.bytesWritten)
+    }
+
+    private class CountingOutputStream(
+        private val delegate: OutputStream,
+    ) : OutputStream() {
+        var bytesWritten: Long = 0
+            private set
+
+        override fun write(b: Int) {
+            delegate.write(b)
+            bytesWritten += 1
+        }
+
+        override fun write(b: ByteArray, off: Int, len: Int) {
+            delegate.write(b, off, len)
+            bytesWritten += len
+        }
+
+        override fun flush() {
+            delegate.flush()
+        }
+
+        override fun close() {
+            delegate.close()
+        }
+    }
+}

--- a/module-calculator/src/main/resources/logback-spring.xml
+++ b/module-calculator/src/main/resources/logback-spring.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <springProperty scope="context" name="APP_NAME" source="spring.application.name" defaultValue="calculator"/>
+    <springProperty scope="context" name="SERVER_PORT" source="server.port" defaultValue="8082"/>
+    <property name="HOST" value="${HOSTNAME:-${HOST:-unknown}}"/>
+
+    <appender name="JSON_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <customFields>{
+                "service":"${APP_NAME}",
+                "port":"${SERVER_PORT}",
+                "host":"${HOST}"
+            }</customFields>
+            <includeMdc>true</includeMdc>
+            <includeContext>true</includeContext>
+            <fieldNames>
+                <timestamp>timestamp</timestamp>
+                <version>[ignore]</version>
+                <levelValue>[ignore]</levelValue>
+            </fieldNames>
+        </encoder>
+    </appender>
+
+    <appender name="JSON_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/${APP_NAME}.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>logs/${APP_NAME}.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+            <maxFileSize>100MB</maxFileSize>
+            <maxHistory>3</maxHistory>
+            <totalSizeCap>500MB</totalSizeCap>
+        </rollingPolicy>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <customFields>{
+                "service":"${APP_NAME}",
+                "port":"${SERVER_PORT}",
+                "host":"${HOST}"
+            }</customFields>
+            <includeMdc>true</includeMdc>
+            <includeContext>true</includeContext>
+            <fieldNames>
+                <timestamp>timestamp</timestamp>
+                <version>[ignore]</version>
+                <levelValue>[ignore]</levelValue>
+            </fieldNames>
+        </encoder>
+    </appender>
+
+    <springProfile name="local">
+        <appender name="PLAIN_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            </encoder>
+        </appender>
+        <root level="INFO">
+            <appender-ref ref="PLAIN_CONSOLE"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="!local">
+        <root level="INFO">
+            <appender-ref ref="JSON_CONSOLE"/>
+            <appender-ref ref="JSON_FILE"/>
+        </root>
+    </springProfile>
+
+    <logger name="maple.calculator" level="INFO"/>
+</configuration>

--- a/module-calculator/src/test/kotlin/maple/calculator/CalculatorChunkProcessingCoordinatorTest.kt
+++ b/module-calculator/src/test/kotlin/maple/calculator/CalculatorChunkProcessingCoordinatorTest.kt
@@ -1,0 +1,240 @@
+package maple.calculator
+
+import io.micrometer.core.instrument.Timer
+import kotlinx.coroutines.runBlocking
+import maple.expectation.common.event.CalculatorResultChunkReadyEvent
+import maple.calculator.event.KafkaResultEventPublisher
+import maple.calculator.event.SnapshotChunkReadyEvent
+import maple.calculator.metrics.CalculatorMetrics
+import maple.calculator.metrics.CalculatorVolumeMetrics
+import maple.calculator.model.ChunkResult
+import maple.calculator.processor.SnapshotChunkProcessor
+import maple.calculator.storage.ObjectStorage
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.check
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.time.Duration
+import java.time.Instant
+
+@ExtendWith(MockitoExtension::class)
+class CalculatorChunkProcessingCoordinatorTest {
+
+    @Mock
+    private lateinit var chunkProcessor: SnapshotChunkProcessor
+
+    @Mock
+    private lateinit var resultEventPublisher: KafkaResultEventPublisher
+
+    @Mock
+    private lateinit var objectStorage: ObjectStorage
+
+    @Mock
+    private lateinit var metrics: CalculatorMetrics
+
+    @Mock
+    private lateinit var volumeMetrics: CalculatorVolumeMetrics
+
+    @Mock
+    private lateinit var chunkTimer: Timer
+
+    private lateinit var coordinator: CalculatorChunkProcessingCoordinator
+
+    @BeforeEach
+    fun setUp() {
+        coordinator = CalculatorChunkProcessingCoordinator(
+            chunkProcessor, resultEventPublisher, objectStorage, metrics, volumeMetrics,
+        )
+    }
+
+    private fun testEvent(
+        endpoint: String = "item-equipment",
+        runId: String = "run-1",
+        chunkId: String = "chunk-1",
+    ) = SnapshotChunkReadyEvent(
+        eventId = "evt-1",
+        runId = runId,
+        endpoint = endpoint,
+        chunkId = chunkId,
+        objectKey = "data/snapshots/$runId/$endpoint/chunks/$chunkId.jsonl.gz",
+        recordCount = 100,
+        uncompressedBytes = 5000,
+        compressedBytes = 1000,
+        createdAt = Instant.parse("2026-01-01T00:00:00Z"),
+    )
+
+    private fun chunkResult() = ChunkResult(
+        recordCount = 100,
+        successCount = 95,
+        totalItems = 500,
+        calculatedCount = 480,
+        errorCount = 20,
+        resultObjectKey = "data/calculator/runs/run-1/item-equipment/chunks/result-chunk-1.jsonl.gz",
+        resultCount = 480,
+        resultUncompressedBytes = 10000,
+        resultCompressedBytes = 2000,
+    )
+
+    private suspend fun setupHappyPath(event: SnapshotChunkReadyEvent = testEvent()) {
+        whenever(objectStorage.exists(event.objectKey)).thenReturn(true)
+        whenever(objectStorage.exists(coordinator.resultObjectKeyFor(event))).thenReturn(false)
+        whenever(chunkProcessor.process(any(), any())).thenReturn(chunkResult())
+        whenever(metrics.timer()).thenReturn(chunkTimer)
+    }
+
+    @Test
+    fun `skips non-item-equipment endpoint without calling processor`() = runBlocking {
+        val event = testEvent(endpoint = "character-basic")
+
+        coordinator.handle(event)
+
+        verify(chunkProcessor, never()).process(any(), any())
+        verify(metrics).recordChunkSkippedEndpoint()
+    }
+
+    @Test
+    fun `skips when source artifact does not exist`() = runBlocking {
+        val event = testEvent()
+        whenever(objectStorage.exists(event.objectKey)).thenReturn(false)
+
+        coordinator.handle(event)
+
+        verify(chunkProcessor, never()).process(any(), any())
+        verify(metrics).recordChunkSkippedNotFound()
+    }
+
+    @Test
+    fun `republishes event when result already exists without calling processor`() = runBlocking {
+        val event = testEvent()
+        whenever(objectStorage.exists(event.objectKey)).thenReturn(true)
+        whenever(objectStorage.exists(coordinator.resultObjectKeyFor(event))).thenReturn(true)
+
+        coordinator.handle(event)
+
+        verify(chunkProcessor, never()).process(any(), any())
+        verify(metrics).recordChunkSkippedIdempotent()
+        verify(resultEventPublisher).publishChunkReady(any())
+    }
+
+    @Test
+    fun `processes chunk and publishes result on success`() = runBlocking {
+        val event = testEvent()
+        setupHappyPath(event)
+
+        coordinator.handle(event)
+
+        verify(chunkProcessor).process(any(), any())
+        verify(resultEventPublisher).publishChunkReady(any())
+        verify(metrics).recordChunkProcessed()
+        verify(chunkTimer).record(any<Duration>())
+    }
+
+    @Test
+    fun `records volume metrics on success`() = runBlocking {
+        val event = testEvent()
+        val result = chunkResult()
+        setupHappyPath(event)
+
+        coordinator.handle(event)
+
+        verify(volumeMetrics).recordInput(event.compressedBytes, event.uncompressedBytes)
+        verify(volumeMetrics).recordResult(result.resultCompressedBytes, result.resultUncompressedBytes, result.resultCount.toLong())
+    }
+
+    @Test
+    fun `records chunk-level metrics on success`() = runBlocking {
+        val event = testEvent()
+        setupHappyPath(event)
+
+        coordinator.handle(event)
+
+        verify(metrics).recordChunkProcessed()
+        verify(metrics).recordUsers(100)
+        verify(metrics).recordItems(500)
+        verify(metrics).recordCalculated(480)
+        verify(metrics).recordErrors(20)
+        verify(metrics).recordChunkRates(any(), any(), any())
+    }
+
+    @Test
+    fun `records failure metric when processor throws`() = runBlocking {
+        val event = testEvent()
+        whenever(objectStorage.exists(event.objectKey)).thenReturn(true)
+        whenever(objectStorage.exists(coordinator.resultObjectKeyFor(event))).thenReturn(false)
+        whenever(chunkProcessor.process(any(), any())).thenThrow(RuntimeException("boom"))
+
+        coordinator.handle(event)
+
+        verify(metrics).recordChunkFailed()
+        verify(resultEventPublisher, never()).publishChunkReady(any())
+        verify(metrics, never()).recordChunkProcessed()
+    }
+
+    @Test
+    fun `generates correct resultObjectKey format`() {
+        val event = testEvent(runId = "run-42", chunkId = "chunk-7")
+
+        assertThat(coordinator.resultObjectKeyFor(event))
+            .isEqualTo("data/calculator/runs/run-42/item-equipment/chunks/result-chunk-7.jsonl.gz")
+    }
+
+    @Test
+    fun `handles sequential calls without deadlock`() = runBlocking {
+        val event = testEvent()
+        setupHappyPath(event)
+
+        coordinator.handle(event)
+        coordinator.handle(event)
+
+        verify(chunkProcessor, times(2)).process(any(), any())
+    }
+
+    @Test
+    fun `republished event has zero counts and correct key`() = runBlocking {
+        val event = testEvent(runId = "run-abc", chunkId = "chunk-xyz")
+        whenever(objectStorage.exists(event.objectKey)).thenReturn(true)
+        whenever(objectStorage.exists(coordinator.resultObjectKeyFor(event))).thenReturn(true)
+
+        coordinator.handle(event)
+
+        verify(resultEventPublisher).publishChunkReady(check { published ->
+            assertThat(published.sourceRunId).isEqualTo("run-abc")
+            assertThat(published.sourceChunkId).isEqualTo("chunk-xyz")
+            assertThat(published.objectKey)
+                .isEqualTo("data/calculator/runs/run-abc/item-equipment/chunks/result-chunk-xyz.jsonl.gz")
+            assertThat(published.resultCount).isEqualTo(0)
+            assertThat(published.errorCount).isEqualTo(0)
+            assertThat(published.uncompressedBytes).isEqualTo(0)
+            assertThat(published.compressedBytes).isEqualTo(0)
+        })
+    }
+
+    @Test
+    fun `published event on success contains processing results`() = runBlocking {
+        val event = testEvent()
+        val result = chunkResult()
+        setupHappyPath(event)
+
+        coordinator.handle(event)
+
+        verify(resultEventPublisher).publishChunkReady(check { published ->
+            assertThat(published.sourceRunId).isEqualTo("run-1")
+            assertThat(published.sourceEndpoint).isEqualTo("item-equipment")
+            assertThat(published.sourceChunkId).isEqualTo("chunk-1")
+            assertThat(published.objectKey).isEqualTo(result.resultObjectKey)
+            assertThat(published.sourceRecordCount).isEqualTo(100)
+            assertThat(published.resultCount).isEqualTo(480)
+            assertThat(published.errorCount).isEqualTo(20)
+            assertThat(published.uncompressedBytes).isEqualTo(10000)
+            assertThat(published.compressedBytes).isEqualTo(2000)
+        })
+    }
+}

--- a/module-calculator/src/test/kotlin/maple/calculator/processor/EquipmentCalculationInputConverterTest.kt
+++ b/module-calculator/src/test/kotlin/maple/calculator/processor/EquipmentCalculationInputConverterTest.kt
@@ -1,0 +1,228 @@
+package maple.calculator.processor
+
+import maple.calculator.model.CalculationResult
+import maple.expectation.core.dto.cube.CubeCalculationInput
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.data.Offset.offset
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class EquipmentCalculationInputConverterTest {
+
+    private val converter = EquipmentCalculationInputConverter
+
+    private fun cubeInput(block: CubeCalculationInput.() -> Unit): CubeCalculationInput =
+        CubeCalculationInput().apply(block)
+
+    @Nested
+    inner class TargetStarTest {
+
+        @Test
+        fun `returns 0 when starforce is 0`() {
+            val input = cubeInput { starforce = 0; itemName = "소드"; level = 150 }
+            assertThat(converter.targetStar(input)).isEqualTo(0)
+        }
+
+        @Test
+        fun `returns 0 when starforce is negative`() {
+            val input = cubeInput { starforce = -1; itemName = "소드"; level = 150 }
+            assertThat(converter.targetStar(input)).isEqualTo(0)
+        }
+
+        @Test
+        fun `returns 0 when itemName is null`() {
+            val input = cubeInput { starforce = 17; itemName = null; level = 150 }
+            assertThat(converter.targetStar(input)).isEqualTo(0)
+        }
+
+        @Test
+        fun `returns 0 when itemName is blank`() {
+            val input = cubeInput { starforce = 17; itemName = "  "; level = 150 }
+            assertThat(converter.targetStar(input)).isEqualTo(0)
+        }
+
+        @Test
+        fun `returns 0 when level is 0`() {
+            val input = cubeInput { starforce = 17; itemName = "소드"; level = 0 }
+            assertThat(converter.targetStar(input)).isEqualTo(0)
+        }
+
+        @Test
+        fun `returns starforce for normal equipment`() {
+            val input = cubeInput { starforce = 17; itemName = "소드"; level = 150 }
+            assertThat(converter.targetStar(input)).isEqualTo(17)
+        }
+
+        @Test
+        fun `caps at MAX_NOLJANG_STAR for noljang equipment`() {
+            val input = cubeInput {
+                starforce = 25; itemName = "소드"; level = 150; starforceScrollFlag = "사용"
+            }
+            assertThat(converter.targetStar(input)).isEqualTo(15)
+        }
+
+        @Test
+        fun `returns starforce for noljang equipment below cap`() {
+            val input = cubeInput {
+                starforce = 10; itemName = "소드"; level = 150; starforceScrollFlag = "사용"
+            }
+            assertThat(converter.targetStar(input)).isEqualTo(10)
+        }
+    }
+
+    @Nested
+    inner class ToCalculationInputTest {
+
+        @Test
+        fun `maps all fields for normal equipment`() {
+            val cubeInput = cubeInput {
+                itemName = "아케인소드"; level = 200; part = "무기"
+                itemEquipmentPart = "한손검"; itemIcon = "https://icon.url"
+                grade = "유니크"; options = mutableListOf("공격력 +6%", "보스 공격력 +30%", null)
+                additionalGrade = "에픽"; additionalOptions = mutableListOf("올스탯 +3%")
+                starforce = 17; starforceScrollFlag = "미사용"
+            }
+
+            val result = converter.toCalculationInput(cubeInput, presetNo = 2)
+
+            assertThat(result.itemName).isEqualTo("아케인소드")
+            assertThat(result.itemLevel).isEqualTo(200)
+            assertThat(result.itemPart).isEqualTo("무기")
+            assertThat(result.itemEquipmentPart).isEqualTo("한손검")
+            assertThat(result.itemIcon).isEqualTo("https://icon.url")
+            assertThat(result.presetNo).isEqualTo(2)
+            assertThat(result.isNoljang).isFalse()
+            assertThat(result.potentialGrade).isEqualTo("유니크")
+            assertThat(result.potentialOptions).containsExactly("공격력 +6%", "보스 공격력 +30%")
+            assertThat(result.additionalPotentialGrade).isEqualTo("에픽")
+            assertThat(result.additionalPotentialOptions).containsExactly("올스탯 +3%")
+            assertThat(result.currentStar).isEqualTo(0)
+            assertThat(result.targetStar).isEqualTo(17)
+        }
+
+        @Test
+        fun `resolves potentialPart for force shield`() {
+            val cubeInput = cubeInput { part = "보조무기"; itemEquipmentPart = "포스실드" }
+            assertThat(converter.toCalculationInput(cubeInput, 1).itemPart).isEqualTo("포스실드")
+        }
+
+        @Test
+        fun `resolves potentialPart for soul ring`() {
+            val cubeInput = cubeInput { part = "보조무기"; itemEquipmentPart = "소울링" }
+            assertThat(converter.toCalculationInput(cubeInput, 1).itemPart).isEqualTo("포스실드")
+        }
+
+        @Test
+        fun `resolves potentialPart for standard secondary weapon`() {
+            val cubeInput = cubeInput { part = "보조무기"; itemEquipmentPart = "블레이드" }
+            assertThat(converter.toCalculationInput(cubeInput, 1).itemPart).isEqualTo("보조무기")
+        }
+
+        @Test
+        fun `leaves part unchanged for non-secondary weapon`() {
+            val cubeInput = cubeInput { part = "모자"; itemEquipmentPart = "모자" }
+            assertThat(converter.toCalculationInput(cubeInput, 1).itemPart).isEqualTo("모자")
+        }
+
+        @Test
+        fun `sets isNoljang true when starforceScrollFlag is 사용`() {
+            val cubeInput = cubeInput { starforceScrollFlag = "사용" }
+            assertThat(converter.toCalculationInput(cubeInput, 1).isNoljang).isTrue()
+        }
+
+        @Test
+        fun `filters null options from potential options`() {
+            val cubeInput = cubeInput { options = mutableListOf(null, "공격력 +6%", null) }
+            assertThat(converter.toCalculationInput(cubeInput, 1).potentialOptions).containsExactly("공격력 +6%")
+        }
+
+        @Test
+        fun `handles all null fields`() {
+            val cubeInput = cubeInput {
+                itemName = null; part = null; itemEquipmentPart = null; itemIcon = null
+                grade = null; options = mutableListOf(); additionalGrade = null; additionalOptions = mutableListOf()
+            }
+
+            val result = converter.toCalculationInput(cubeInput, 1)
+
+            assertThat(result.itemName).isEqualTo("")
+            assertThat(result.itemPart).isEmpty()
+            assertThat(result.itemEquipmentPart).isEmpty()
+            assertThat(result.itemIcon).isEmpty()
+        }
+    }
+
+    @Nested
+    inner class ToCalculationResultTest {
+
+        @Test
+        fun `maps all fields with SUCCESS status and costs`() {
+            val cubeInput = cubeInput {
+                itemName = "아케인소드"; level = 200; part = "무기"; itemEquipmentPart = "한손검"
+                grade = "유니크"; options = mutableListOf("공격력 +6%", "보스 공격력 +30%", "공격력 +9%")
+                additionalGrade = "에픽"; additionalOptions = mutableListOf("올스탯 +3%", "올스탯 +3%", "올스탯 +3%")
+                starforce = 17; starforceScrollFlag = "미사용"
+            }
+            val costs = CalculationCache.ComponentCosts(
+                blackCubeCost = 1.23, additionalCubeCost = 4.56, starforceCost = 7.89,
+            )
+
+            val result = converter.toCalculationResult("abc123", 3, cubeInput, costs, "SUCCESS", null)
+
+            assertThat(result.ocid).isEqualTo("abc123")
+            assertThat(result.presetNo).isEqualTo(3)
+            assertThat(result.itemName).isEqualTo("아케인소드")
+            assertThat(result.itemLevel).isEqualTo(200)
+            assertThat(result.itemPart).isEqualTo("무기")
+            assertThat(result.itemEquipmentPart).isEqualTo("한손검")
+            assertThat(result.potentialGrade).isEqualTo("유니크")
+            assertThat(result.potentialOptions).containsExactly("공격력 +6%", "보스 공격력 +30%", "공격력 +9%")
+            assertThat(result.additionalGrade).isEqualTo("에픽")
+            assertThat(result.additionalOptions).containsExactly("올스탯 +3%", "올스탯 +3%", "올스탯 +3%")
+            assertThat(result.currentStar).isEqualTo(0)
+            assertThat(result.targetStar).isEqualTo(17)
+            assertThat(result.status).isEqualTo("SUCCESS")
+            assertThat(result.totalCost).isCloseTo(13.68, offset(0.01))
+            assertThat(result.blackCubeCost).isEqualTo(1.23)
+            assertThat(result.additionalCubeCost).isEqualTo(4.56)
+            assertThat(result.starforceCost).isEqualTo(7.89)
+            assertThat(result.errorMessage).isNull()
+        }
+
+        @Test
+        fun `maps ERROR status with message and empty costs`() {
+            val cubeInput = cubeInput { itemName = "소드"; level = 150; part = "무기" }
+
+            val result = converter.toCalculationResult("abc", 1, cubeInput, CalculationCache.ComponentCosts.empty(), "ERROR", "calculation failed")
+
+            assertThat(result.status).isEqualTo("ERROR")
+            assertThat(result.errorMessage).isEqualTo("calculation failed")
+            assertThat(result.totalCost).isNull()
+        }
+
+        @Test
+        fun `maps SKIPPED status with empty costs`() {
+            val cubeInput = cubeInput { itemName = "소드"; level = 150; part = "모자"; starforce = 0 }
+
+            val result = converter.toCalculationResult("xyz", 1, cubeInput, CalculationCache.ComponentCosts.empty(), "SKIPPED", null)
+
+            assertThat(result.status).isEqualTo("SKIPPED")
+            assertThat(result.totalCost).isNull()
+        }
+
+        @Test
+        fun `handles null cubeInput fields`() {
+            val cubeInput = cubeInput {
+                itemName = null; part = null; grade = null
+                options = mutableListOf(); additionalGrade = null; additionalOptions = mutableListOf()
+            }
+
+            val result = converter.toCalculationResult("abc", 1, cubeInput, CalculationCache.ComponentCosts.empty(), "SKIPPED", null)
+
+            assertThat(result.itemName).isEqualTo("")
+            assertThat(result.itemPart).isNull()
+            assertThat(result.potentialGrade).isNull()
+            assertThat(result.additionalGrade).isNull()
+        }
+    }
+}

--- a/module-common/src/main/kotlin/maple/common/cleanup/RunInfo.kt
+++ b/module-common/src/main/kotlin/maple/common/cleanup/RunInfo.kt
@@ -1,0 +1,10 @@
+package maple.common.cleanup
+
+import java.time.Instant
+
+data class RunInfo(
+    val runId: String,
+    val createdAt: Instant,
+    val isRunning: Boolean,
+    val sizeBytes: Long,
+)

--- a/module-common/src/main/kotlin/maple/common/cleanup/RunRetentionPolicy.kt
+++ b/module-common/src/main/kotlin/maple/common/cleanup/RunRetentionPolicy.kt
@@ -1,0 +1,26 @@
+package maple.common.cleanup
+
+import java.time.Duration
+import java.time.Instant
+
+object RunRetentionPolicy {
+
+    fun selectForDeletion(
+        runs: List<RunInfo>,
+        keepRecentCount: Int,
+        keepWithinHours: Long,
+        now: Instant,
+    ): List<RunInfo> {
+        if (runs.isEmpty()) return emptyList()
+
+        val cutoff = now.minus(Duration.ofHours(keepWithinHours))
+        val recentRunIds = runs.sortedByDescending { it.createdAt }
+            .take(keepRecentCount)
+            .map { it.runId }
+            .toSet()
+
+        return runs.filter { run ->
+            !run.isRunning && run.createdAt.isBefore(cutoff) && run.runId !in recentRunIds
+        }
+    }
+}

--- a/module-common/src/main/kotlin/maple/expectation/common/event/CalculatorResultChunkReadyEvent.kt
+++ b/module-common/src/main/kotlin/maple/expectation/common/event/CalculatorResultChunkReadyEvent.kt
@@ -1,0 +1,20 @@
+package maple.expectation.common.event
+
+import java.time.Instant
+import java.util.UUID
+
+data class CalculatorResultChunkReadyEvent(
+    val eventId: String = UUID.randomUUID().toString(),
+    val eventType: String = "CALCULATOR_RESULT_CHUNK_READY",
+    val schemaVersion: Int = 1,
+    val sourceRunId: String,
+    val sourceEndpoint: String,
+    val sourceChunkId: String,
+    val objectKey: String,
+    val sourceRecordCount: Int,
+    val resultCount: Int,
+    val errorCount: Int,
+    val uncompressedBytes: Long,
+    val compressedBytes: Long,
+    val createdAt: Instant = Instant.now(),
+)

--- a/module-common/src/test/kotlin/maple/common/cleanup/RunRetentionPolicyTest.kt
+++ b/module-common/src/test/kotlin/maple/common/cleanup/RunRetentionPolicyTest.kt
@@ -1,0 +1,106 @@
+package maple.common.cleanup
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+class RunRetentionPolicyTest {
+
+    @Test
+    fun `should delete run when not active, not recent 5, and older than 48h`() {
+        val now = Instant.now()
+        val runs = (0..9).map { i ->
+            RunInfo(
+                runId = "run-${i}",
+                createdAt = now.minus(49, ChronoUnit.HOURS).plusSeconds(i.toLong()),
+                isRunning = false,
+                sizeBytes = 1024L,
+            )
+        }
+        val toDelete = RunRetentionPolicy.selectForDeletion(
+            runs = runs,
+            keepRecentCount = 5,
+            keepWithinHours = 48,
+            now = now,
+        )
+        assertThat(toDelete.map { it.runId }).containsExactly(
+            "run-0", "run-1", "run-2", "run-3", "run-4",
+        )
+    }
+
+    @Test
+    fun `should keep active run even if not recent 5 and older than 48h`() {
+        val now = Instant.now()
+        val oldActive = RunInfo(
+            runId = "active-old",
+            createdAt = now.minus(72, ChronoUnit.HOURS),
+            isRunning = true,
+            sizeBytes = 1024L,
+        )
+        val toDelete = RunRetentionPolicy.selectForDeletion(
+            runs = listOf(oldActive),
+            keepRecentCount = 5,
+            keepWithinHours = 48,
+            now = now,
+        )
+        assertThat(toDelete).isEmpty()
+    }
+
+    @Test
+    fun `should keep run within 48h even if not recent 5`() {
+        val now = Instant.now()
+        val recentButOld = RunInfo(
+            runId = "recent-24h",
+            createdAt = now.minus(24, ChronoUnit.HOURS),
+            isRunning = false,
+            sizeBytes = 1024L,
+        )
+        val newer = (0..5).map { i ->
+            RunInfo(
+                runId = "newer-$i",
+                createdAt = now.minus(1, ChronoUnit.HOURS).plusSeconds(i.toLong()),
+                isRunning = false,
+                sizeBytes = 1024L,
+            )
+        }
+        val toDelete = RunRetentionPolicy.selectForDeletion(
+            runs = newer + recentButOld,
+            keepRecentCount = 5,
+            keepWithinHours = 48,
+            now = now,
+        )
+        assertThat(toDelete.map { it.runId }).doesNotContain("recent-24h")
+    }
+
+    @Test
+    fun `should return empty when no runs`() {
+        val toDelete = RunRetentionPolicy.selectForDeletion(
+            runs = emptyList(),
+            keepRecentCount = 5,
+            keepWithinHours = 48,
+            now = Instant.now(),
+        )
+        assertThat(toDelete).isEmpty()
+    }
+
+    @Test
+    fun `should handle exactly keepRecentCount runs`() {
+        val now = Instant.now()
+        val runs = (0..4).map { i ->
+            RunInfo(
+                runId = "run-$i",
+                createdAt = now.minus(49, ChronoUnit.HOURS).plusSeconds(i.toLong()),
+                isRunning = false,
+                sizeBytes = 1024L,
+            )
+        }
+        val toDelete = RunRetentionPolicy.selectForDeletion(
+            runs = runs,
+            keepRecentCount = 5,
+            keepWithinHours = 48,
+            now = now,
+        )
+        assertThat(toDelete).isEmpty()
+    }
+}

--- a/module-core/src/main/kotlin/maple/expectation/core/calculator/port/CubeTrialsPort.kt
+++ b/module-core/src/main/kotlin/maple/expectation/core/calculator/port/CubeTrialsPort.kt
@@ -1,0 +1,14 @@
+package maple.expectation.core.calculator.port
+
+import maple.expectation.core.domain.model.CubeType
+import maple.expectation.core.dto.cube.CubeCalculationInput
+
+/**
+ * Port: 큐브 기대 시도 횟수 계산
+ *
+ * module-app의 CubeTrialsProvider와 동일한 계약을 core CubeType으로 정의.
+ * module-app, module-calculator 모두 이 port에 의존.
+ */
+interface CubeTrialsPort {
+    fun calculateExpectedTrials(input: CubeCalculationInput, type: CubeType): Double
+}

--- a/module-external-api/.gitignore
+++ b/module-external-api/.gitignore
@@ -1,0 +1,1 @@
+external-api-data/

--- a/module-external-api/build.gradle
+++ b/module-external-api/build.gradle
@@ -1,0 +1,62 @@
+// ========================================
+// Module-External-Api: External API Data Collection
+// Nexon API 호출 + Local Storage 저장 전용 모듈
+// Calculator, DB write path, ReadPath, PGMQ 의존 없음
+// ========================================
+
+plugins {
+	alias(libs.plugins.kotlin.jvm)
+	alias(libs.plugins.kotlin.spring)
+	alias(libs.plugins.spring.boot)
+}
+
+dependencies {
+	implementation project(':module-common')
+	implementation project(':module-infra')
+
+	implementation(libs.kotlin.stdlib)
+	implementation(libs.kotlin.reflect)
+	implementation(libs.kotlin.logging.jvm)
+	implementation(libs.kotlinx.coroutines.core)
+	implementation(libs.kotlinx.coroutines.jdk8)
+
+	// Spring (scheduler, @Service, @Value)
+	implementation(libs.spring.boot)
+	implementation(libs.spring.boot.starter.web)
+	implementation(libs.spring.boot.starter.webflux)
+
+	// Kafka (chunk-ready event publishing)
+	implementation(libs.spring.kafka)
+
+	// Rate limiting
+	implementation(libs.bucket4j.core)
+
+	// Metrics
+	implementation(libs.spring.boot.starter.actuator)
+	implementation(libs.micrometer.registry.prometheus)
+
+	// Structured JSON logging
+	implementation(libs.logstash.logback.encoder)
+
+	// Jackson (JSON serialization + CSV)
+	implementation(libs.jackson.databind)
+	implementation(libs.jackson.dataformat.csv)
+	implementation(libs.jackson.module.kotlin)
+
+	// Testing
+	testImplementation(libs.spring.boot.starter.test)
+	testImplementation(libs.mockito.kotlin)
+	testImplementation(libs.assertj.core)
+}
+
+// bootJar enabled — standalone executable application
+bootJar {
+	enabled = true
+	archiveClassifier = ""
+	mainClass.set("maple.externalapi.ExternalApiApplication")
+}
+
+tasks.named("jar") {
+	enabled = true
+	archiveClassifier = "plain"
+}

--- a/module-external-api/src/main/kotlin/maple/externalapi/cache/OcidCacheProvider.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/cache/OcidCacheProvider.kt
@@ -1,0 +1,60 @@
+package maple.externalapi.cache
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import maple.expectation.infrastructure.executor.LogicExecutor
+import maple.expectation.infrastructure.executor.TaskContext
+import maple.externalapi.domain.ExternalApiEndpoint
+import maple.externalapi.port.out.ExternalApiArtifactStorePort
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import java.util.concurrent.atomic.AtomicReference
+
+@Component
+class OcidCacheProvider(
+    private val artifactStore: ExternalApiArtifactStorePort,
+    private val objectMapper: ObjectMapper,
+    private val executor: LogicExecutor,
+) {
+    private val log = LoggerFactory.getLogger(OcidCacheProvider::class.java)
+    private val cacheRef = AtomicReference<Map<String, String>>(emptyMap())
+
+    fun refresh(): Map<String, String> {
+        val loaded = loadFromArtifacts()
+        cacheRef.set(loaded)
+        return loaded
+    }
+
+    fun current(): Map<String, String> = cacheRef.get()
+
+    fun isEmpty(): Boolean = cacheRef.get().isEmpty()
+
+    private fun loadFromArtifacts(): Map<String, String> {
+        val keys = artifactStore.listStoredKeys(ExternalApiEndpoint.OCID_LOOKUP)
+        if (keys.isEmpty()) {
+            log.info("[OcidCache] no stored OCIDs found, cache empty")
+            return emptyMap()
+        }
+
+        val cache = mutableMapOf<String, String>()
+        for (key in keys) {
+            val ocid = parseOcidFromArtifact(key)
+            if (ocid != null) {
+                cache[key] = ocid
+            }
+        }
+        log.info("[OcidCache] loaded: {} entries", cache.size)
+        return cache
+    }
+
+    private fun parseOcidFromArtifact(key: String): String? {
+        val bytes = artifactStore.read(ExternalApiEndpoint.OCID_LOOKUP, key) ?: return null
+        return parseOcidField(bytes, key)
+    }
+
+    private fun parseOcidField(bytes: ByteArray, key: String): String? =
+        executor.executeOrDefault(
+            { objectMapper.readTree(bytes).get("ocid")?.asText() },
+            null,
+            TaskContext.of("OcidCache", "ParseField", key),
+        )
+}

--- a/module-external-api/src/main/kotlin/maple/externalapi/cleanup/ArtifactCleanupScheduler.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/cleanup/ArtifactCleanupScheduler.kt
@@ -1,0 +1,182 @@
+package maple.externalapi.cleanup
+
+import maple.common.cleanup.RunInfo
+import maple.common.cleanup.RunRetentionPolicy
+import maple.externalapi.metrics.CleanupMetrics
+import maple.externalapi.port.out.ExternalApiArtifactStorePort
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+@Component
+@ConditionalOnProperty(name = ["external-api.cleanup.enabled"], havingValue = "true")
+class ArtifactCleanupScheduler(
+    private val artifactStore: ExternalApiArtifactStorePort,
+    private val metrics: CleanupMetrics,
+    @Value("\${external-api.cleanup.dry-run:true}")
+    private val dryRun: Boolean,
+    @Value("\${external-api.cleanup.runs.keep-recent:5}")
+    private val keepRecent: Int,
+    @Value("\${external-api.cleanup.runs.keep-within-hours:48}")
+    private val keepWithinHours: Long,
+    @Value("\${external-api.cleanup.max-delete-runs-per-cycle:10}")
+    private val maxDeleteRunsPerCycle: Int,
+    @Value("\${external-api.cleanup.max-delete-bytes-per-cycle:5368709120}")
+    private val maxDeleteBytesPerCycle: Long,
+    @Value("\${external-api.cleanup.max-runtime-seconds:60}")
+    private val maxRuntimeSeconds: Long,
+) {
+    private val log = LoggerFactory.getLogger(ArtifactCleanupScheduler::class.java)
+
+    private val runIdPattern = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss")
+        .withZone(ZoneId.systemDefault())
+
+    @Scheduled(fixedDelayString = "\${external-api.cleanup.interval-ms:21600000}")
+    fun cleanup() {
+        Thread.ofVirtual().name("cleanup-ext").start {
+            val sample = io.micrometer.core.instrument.Timer.start()
+            val start = Instant.now()
+            log.info("[Cleanup] started: dryRun={}", dryRun)
+
+            updateStorageMetrics()
+
+            val result = runCatching { cleanupRuns(start) }
+
+            val durationMs = Instant.now().toEpochMilli() - start.toEpochMilli()
+            sample.stop(metrics.timer())
+
+            result.onSuccess { res ->
+                log.info(
+                    "[Cleanup] completed: dryRun={}, runsDeleted={}, bytesDeleted={}, " +
+                        "throttled={}, errors={}, durationMs={}",
+                    dryRun, res.runsDeleted, res.bytesDeleted, res.throttled, res.errors, durationMs,
+                )
+            }.onFailure { ex ->
+                metrics.recordError()
+                log.error("[Cleanup] failed (pipeline NOT affected): {}", ex.message, ex)
+            }
+        }
+    }
+
+    private fun cleanupRuns(startedAt: Instant): CleanupResult {
+        val runIds = artifactStore.listRuns()
+        if (runIds.isEmpty()) {
+            log.info("[Cleanup] no runs found")
+            return CleanupResult.ZERO
+        }
+
+        var skippedActive = 0
+        val runInfos = runIds.mapNotNull { runId ->
+            val isRunning = artifactStore.fileExists("runs/$runId/_RUNNING")
+            if (isRunning) {
+                skippedActive++
+                metrics.recordSkippedActive()
+                return@mapNotNull null
+            }
+            val createdAt = parseRunIdTimestamp(runId) ?: return@mapNotNull null
+            RunInfo(
+                runId = runId,
+                createdAt = createdAt,
+                isRunning = false,
+                sizeBytes = artifactStore.calculateDirectorySize("runs/$runId"),
+            )
+        }
+
+        log.info("[Cleanup] scanned {} runs, skipped {} active, {} parseable", runIds.size, skippedActive, runInfos.size)
+
+        val toDelete = RunRetentionPolicy.selectForDeletion(
+            runs = runInfos,
+            keepRecentCount = keepRecent,
+            keepWithinHours = keepWithinHours,
+            now = Instant.now(),
+        )
+
+        if (toDelete.isEmpty()) {
+            log.info("[Cleanup] no runs to delete")
+            return CleanupResult.ZERO
+        }
+
+        val throttled = maxOf(0, toDelete.size - maxDeleteRunsPerCycle)
+        val limited = if (toDelete.size > maxDeleteRunsPerCycle) {
+            log.info("[Cleanup] throttling: {} candidates, limit {}", toDelete.size, maxDeleteRunsPerCycle)
+            metrics.recordThrottled(throttled)
+            toDelete.take(maxDeleteRunsPerCycle)
+        } else {
+            toDelete
+        }
+
+        log.info(
+            "[Cleanup] candidates: {} of {} scanned (throttled={}, dryRun={})",
+            limited.size, runInfos.size, maxOf(0, throttled), dryRun,
+        )
+
+        if (dryRun) {
+            limited.forEach { run ->
+                log.info(
+                    "[Cleanup] would delete: runId={}, size={}MB, createdAt={}",
+                    run.runId, run.sizeBytes / (1024 * 1024), run.createdAt,
+                )
+            }
+            return CleanupResult(limited.size, limited.sumOf { it.sizeBytes }, 0, maxOf(0, throttled))
+        }
+
+        return deleteRunWithLimits(limited, startedAt)
+    }
+
+    private fun deleteRunWithLimits(runs: List<RunInfo>, startedAt: Instant): CleanupResult {
+        var deletedRuns = 0
+        var deletedBytes = 0L
+        var errors = 0
+
+        for (run in runs) {
+            val elapsed = Instant.now().toEpochMilli() - startedAt.toEpochMilli()
+            if (elapsed > maxRuntimeSeconds * 1000) {
+                log.info("[Cleanup] runtime limit reached: {}ms > {}ms, stopping", elapsed, maxRuntimeSeconds * 1000)
+                break
+            }
+            if (deletedBytes >= maxDeleteBytesPerCycle) {
+                log.info("[Cleanup] byte limit reached: {} >= {}, stopping", deletedBytes, maxDeleteBytesPerCycle)
+                break
+            }
+
+            val bytes = artifactStore.deleteRun(run.runId)
+            if (bytes >= 0) {
+                deletedRuns++
+                deletedBytes += bytes
+                metrics.recordDeletedBytes(bytes)
+            } else {
+                errors++
+                metrics.recordError()
+                log.warn("[Cleanup] failed to delete run: {} (pipeline NOT affected)", run.runId)
+            }
+        }
+
+        metrics.recordDeletedRuns(deletedRuns)
+        return CleanupResult(deletedRuns, deletedBytes, errors, 0)
+    }
+
+    private fun parseRunIdTimestamp(runId: String): Instant? {
+        return runIdPattern.parse(runId) { Instant.from(it) }
+    }
+
+    private fun updateStorageMetrics() {
+        val runsSize = artifactStore.calculateDirectorySize("runs")
+        metrics.updateStorageUsed(runsSize)
+    }
+
+    private data class CleanupResult(
+        val runsDeleted: Int,
+        val bytesDeleted: Long,
+        val errors: Int,
+        val throttled: Int,
+    ) {
+        companion object {
+            val ZERO = CleanupResult(0, 0L, 0, 0)
+        }
+    }
+}

--- a/module-external-api/src/main/kotlin/maple/externalapi/domain/ExternalApiFetchCommand.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/domain/ExternalApiFetchCommand.kt
@@ -1,0 +1,27 @@
+package maple.externalapi.domain
+
+data class ExternalApiFetchCommand(
+    val jobId: String,
+    val provider: ExternalApiProvider,
+    val endpoint: ExternalApiEndpoint,
+    val requestKey: String,
+    val characterName: String? = null,
+    val ocid: String? = null,
+)
+
+enum class ExternalApiEndpoint(
+    val path: String,
+    val keyType: KeyType,
+) {
+    OCID_LOOKUP("/maplestory/v1/id", KeyType.USER_IGN),
+    CHARACTER_BASIC("/maplestory/v1/character/basic", KeyType.OCID),
+    ITEM_EQUIPMENT("/maplestory/v1/character/item-equipment", KeyType.OCID),
+    ;
+
+    fun storageSubDir(): String = name.lowercase().replace('_', '-')
+}
+
+enum class KeyType {
+    USER_IGN,
+    OCID,
+}

--- a/module-external-api/src/main/kotlin/maple/externalapi/domain/ExternalApiPayloadRef.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/domain/ExternalApiPayloadRef.kt
@@ -1,0 +1,9 @@
+package maple.externalapi.domain
+
+data class ExternalApiPayloadRef(
+    val artifactUri: String,
+    val sha256: String,
+    val sizeBytes: Long,
+    val contentType: String = "application/json",
+    val schemaVersion: String = "v1",
+)

--- a/module-external-api/src/main/kotlin/maple/externalapi/domain/ExternalApiProvider.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/domain/ExternalApiProvider.kt
@@ -1,0 +1,7 @@
+package maple.externalapi.domain
+
+enum class ExternalApiProvider(
+    val baseUrl: String,
+) {
+    NEXON("https://open.api.nexon.com"),
+}

--- a/module-external-api/src/main/kotlin/maple/externalapi/infra/nexon/NexonExternalApiClientAdapter.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/infra/nexon/NexonExternalApiClientAdapter.kt
@@ -1,0 +1,74 @@
+package maple.externalapi.infra.nexon
+
+import io.netty.channel.ChannelOption
+import java.time.Duration
+import java.util.concurrent.CompletableFuture
+import maple.externalapi.domain.ExternalApiEndpoint
+import maple.externalapi.domain.ExternalApiProvider
+import maple.externalapi.domain.KeyType
+import maple.externalapi.port.out.ExternalApiClientPort
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.http.client.reactive.ReactorClientHttpConnector
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import org.springframework.web.util.DefaultUriBuilderFactory
+import reactor.netty.http.client.HttpClient
+
+@Component
+class NexonExternalApiClientAdapter(
+    @Value("\${nexon.api.key}")
+    private val apiKey: String,
+) : ExternalApiClientPort {
+
+    private val log = LoggerFactory.getLogger(NexonExternalApiClientAdapter::class.java)
+
+    private val webClient: WebClient by lazy {
+        val factory = DefaultUriBuilderFactory("https://open.api.nexon.com")
+        factory.encodingMode = DefaultUriBuilderFactory.EncodingMode.VALUES_ONLY
+
+        val httpClient = HttpClient.create()
+            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 3000)
+            .responseTimeout(Duration.ofSeconds(5))
+
+        WebClient.builder()
+            .uriBuilderFactory(factory)
+            .baseUrl("https://open.api.nexon.com")
+            .clientConnector(ReactorClientHttpConnector(httpClient))
+            .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+            .codecs { it.defaultCodecs().maxInMemorySize(2 * 1024 * 1024) }
+            .build()
+    }
+
+    override fun fetch(
+        provider: ExternalApiProvider,
+        endpoint: ExternalApiEndpoint,
+        requestKey: String,
+    ): CompletableFuture<ByteArray> {
+        val queryParam = when (endpoint.keyType) {
+            KeyType.USER_IGN -> "character_name"
+            KeyType.OCID -> "ocid"
+        }
+
+        return webClient.get()
+            .uri { builder ->
+                builder
+                    .path(endpoint.path)
+                    .queryParam(queryParam, requestKey)
+                    .build()
+            }
+            .header("x-nxopen-api-key", apiKey)
+            .retrieve()
+            .bodyToMono(ByteArray::class.java)
+            .doOnNext { log.debug("[NexonAdapter] fetch OK: endpoint={}, key={}", endpoint.name, requestKey) }
+            .onErrorResume(WebClientResponseException::class.java) { ex ->
+                log.warn("[NexonAdapter] fetch failed: endpoint={}, key={}, status={}, body={}", endpoint.name, requestKey, ex.statusCode, ex.responseBodyAsString)
+                throw ex
+            }
+            .timeout(Duration.ofSeconds(10))
+            .toFuture()
+    }
+}

--- a/module-external-api/src/main/kotlin/maple/externalapi/infra/storage/LocalExternalApiArtifactStoreAdapter.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/infra/storage/LocalExternalApiArtifactStoreAdapter.kt
@@ -1,0 +1,129 @@
+package maple.externalapi.infra.storage
+
+import java.nio.file.FileVisitOption
+import java.nio.file.FileVisitResult
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.StandardCopyOption
+import java.nio.file.attribute.BasicFileAttributes
+import java.security.MessageDigest
+import java.util.stream.Collectors
+import java.util.zip.GZIPInputStream
+import java.util.zip.GZIPOutputStream
+import maple.externalapi.domain.ExternalApiEndpoint
+import maple.externalapi.domain.ExternalApiPayloadRef
+import maple.externalapi.port.out.ExternalApiArtifactStorePort
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+
+@Component
+class LocalExternalApiArtifactStoreAdapter(
+    @Value("\${external-api.store.base-path:/data/external-api}")
+    private val basePath: String,
+) : ExternalApiArtifactStorePort {
+
+    private val log = LoggerFactory.getLogger(LocalExternalApiArtifactStoreAdapter::class.java)
+
+    override fun store(
+        endpoint: ExternalApiEndpoint,
+        key: String,
+        data: ByteArray,
+    ): ExternalApiPayloadRef {
+        val compressed = gzipCompress(data)
+        val hash = sha256(compressed)
+        val filePath = resolvePath(endpoint, key)
+
+        filePath.parent.toFile().mkdirs()
+        val tempFile = filePath.resolveSibling(filePath.fileName.toString() + ".tmp")
+        Files.write(tempFile, compressed)
+        Files.move(tempFile, filePath, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
+
+        log.info("[ArtifactStore] stored: endpoint={}, key={}, size={}bytes, hash={}", endpoint, key, compressed.size, hash.take(16))
+
+        return ExternalApiPayloadRef(
+            artifactUri = filePath.toString(),
+            sha256 = hash,
+            sizeBytes = compressed.size.toLong(),
+        )
+    }
+
+    override fun read(
+        endpoint: ExternalApiEndpoint,
+        key: String,
+    ): ByteArray? {
+        val filePath = resolvePath(endpoint, key)
+        if (!Files.exists(filePath)) return null
+        return GZIPInputStream(Files.readAllBytes(filePath).inputStream()).use { it.readAllBytes() }
+    }
+
+    override fun listStoredKeys(endpoint: ExternalApiEndpoint): List<String> {
+        val dir = Paths.get(basePath, endpoint.storageSubDir())
+        if (!Files.exists(dir)) return emptyList()
+        return Files.walk(dir).use { stream ->
+            stream
+                .filter { it.fileName.toString().endsWith(".json.gz") }
+                .map { it.fileName.toString().removeSuffix(".json.gz") }
+                .toList()
+        }
+    }
+
+    override fun listRuns(): List<String> {
+        val runsDir = Paths.get(basePath, "runs")
+        if (!Files.exists(runsDir)) return emptyList()
+        return Files.list(runsDir).use { stream ->
+            stream
+                .filter { Files.isDirectory(it) }
+                .map { it.fileName.toString() }
+                .collect(Collectors.toList())
+        }
+    }
+
+    override fun deleteRun(runId: String): Long {
+        val runDir = Paths.get(basePath, "runs", runId)
+        if (!Files.exists(runDir)) return 0L
+        var deletedBytes = 0L
+        Files.walkFileTree(runDir, object : SimpleFileVisitor<Path>() {
+            override fun visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult {
+                deletedBytes += attrs.size()
+                Files.delete(file)
+                return FileVisitResult.CONTINUE
+            }
+            override fun postVisitDirectory(dir: Path, exc: java.io.IOException?): FileVisitResult {
+                Files.delete(dir)
+                return FileVisitResult.CONTINUE
+            }
+        })
+        return deletedBytes
+    }
+
+    override fun fileExists(relativePath: String): Boolean =
+        Files.exists(Paths.get(basePath, relativePath))
+
+    override fun calculateDirectorySize(relativePath: String): Long {
+        val dir = Paths.get(basePath, relativePath)
+        if (!Files.exists(dir)) return 0L
+        return Files.walk(dir, FileVisitOption.FOLLOW_LINKS).use { stream ->
+            stream.filter { Files.isRegularFile(it) }.mapToLong { Files.size(it) }.sum()
+        }
+    }
+
+    private fun resolvePath(endpoint: ExternalApiEndpoint, key: String): Path {
+        val sanitized = key.replace("/", "_").replace("\\", "_")
+        val shard = sanitized.take(2)
+        return Paths.get(basePath, endpoint.storageSubDir(), shard, "$sanitized.json.gz")
+    }
+
+    private fun gzipCompress(data: ByteArray): ByteArray {
+        val bos = java.io.ByteArrayOutputStream()
+        GZIPOutputStream(bos).use { it.write(data) }
+        return bos.toByteArray()
+    }
+
+    private fun sha256(data: ByteArray): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        return digest.digest(data).joinToString("") { "%02x".format(it) }
+    }
+}

--- a/module-external-api/src/main/kotlin/maple/externalapi/metrics/CleanupMetrics.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/metrics/CleanupMetrics.kt
@@ -1,0 +1,39 @@
+package maple.externalapi.metrics
+
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.Gauge
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Timer
+import org.springframework.stereotype.Component
+
+@Component
+class CleanupMetrics(registry: MeterRegistry) {
+
+    private val deletedRuns = registry.counter("artifact_cleanup_deleted_runs_total", "module", "external-api")
+    private val deletedBytes = registry.counter("artifact_cleanup_deleted_bytes_total", "module", "external-api")
+    private val errors = registry.counter("artifact_cleanup_errors_total", "module", "external-api")
+    private val skippedActive = registry.counter("artifact_cleanup_skipped_active_runs_total", "module", "external-api")
+    private val throttledRuns = registry.counter("artifact_cleanup_throttled_runs_total", "module", "external-api")
+
+    private val durationTimer = Timer.builder("artifact_cleanup_duration_seconds")
+        .description("Time spent on cleanup cycle")
+        .tag("module", "external-api")
+        .register(registry)
+
+    @Volatile private var storageUsedBytes = 0L
+
+    init {
+        Gauge.builder("artifact_storage_used_bytes") { storageUsedBytes }
+            .description("Current storage usage in bytes for external-api artifacts")
+            .tag("module", "external-api")
+            .register(registry)
+    }
+
+    fun recordDeletedRuns(count: Int) = deletedRuns.increment(count.toDouble())
+    fun recordDeletedBytes(bytes: Long) = deletedBytes.increment(bytes.toDouble())
+    fun recordError() = errors.increment()
+    fun recordSkippedActive() = skippedActive.increment()
+    fun recordThrottled(count: Int) = throttledRuns.increment(count.toDouble())
+    fun timer(): Timer = durationTimer
+    fun updateStorageUsed(bytes: Long) { storageUsedBytes = bytes }
+}

--- a/module-external-api/src/main/kotlin/maple/externalapi/metrics/ExternalApiMetrics.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/metrics/ExternalApiMetrics.kt
@@ -1,0 +1,59 @@
+package maple.externalapi.metrics
+
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Timer
+import org.springframework.stereotype.Component
+
+@Component
+class ExternalApiMetrics(registry: MeterRegistry) {
+
+    private val usersFetched = registry.counter("external_api_users_fetched_total")
+    private val usersFailed = registry.counter("external_api_users_failed_total")
+    private val characterBasicFetched = registry.counter("external_api_character_basic_fetched_total")
+    private val characterBasicFailed = registry.counter("external_api_character_basic_failed_total")
+    private val itemEquipmentFetched = registry.counter("external_api_item_equipment_fetched_total")
+    private val itemEquipmentFailed = registry.counter("external_api_item_equipment_failed_total")
+    private val chunksCreated = registry.counter("external_api_chunks_created_total")
+
+    private val lookupTimer = Timer.builder("external_api_lookup_duration_seconds")
+        .description("Time for a full endpoint lookup run")
+        .register(registry)
+
+    private val characterBasicTimer = Timer.builder("external_api_character_basic_duration_seconds")
+        .description("Time for CHARACTER_BASIC lookup run")
+        .register(registry)
+
+    private val itemEquipmentTimer = Timer.builder("external_api_item_equipment_duration_seconds")
+        .description("Time for ITEM_EQUIPMENT lookup run")
+        .register(registry)
+
+    fun recordFetched(count: Int = 1) = usersFetched.increment(count.toDouble())
+    fun recordFailed(count: Int = 1) = usersFailed.increment(count.toDouble())
+
+    fun recordCharacterBasicFetched(count: Int = 1) {
+        characterBasicFetched.increment(count.toDouble())
+        usersFetched.increment(count.toDouble())
+    }
+
+    fun recordCharacterBasicFailed(count: Int = 1) {
+        characterBasicFailed.increment(count.toDouble())
+        usersFailed.increment(count.toDouble())
+    }
+
+    fun recordItemEquipmentFetched(count: Int = 1) {
+        itemEquipmentFetched.increment(count.toDouble())
+        usersFetched.increment(count.toDouble())
+    }
+
+    fun recordItemEquipmentFailed(count: Int = 1) {
+        itemEquipmentFailed.increment(count.toDouble())
+        usersFailed.increment(count.toDouble())
+    }
+
+    fun recordChunkCreated(count: Int = 1) = chunksCreated.increment(count.toDouble())
+
+    fun lookupTimer(): Timer = lookupTimer
+    fun characterBasicTimer(): Timer = characterBasicTimer
+    fun itemEquipmentTimer(): Timer = itemEquipmentTimer
+}

--- a/module-external-api/src/main/kotlin/maple/externalapi/metrics/SnapshotVolumeMetrics.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/metrics/SnapshotVolumeMetrics.kt
@@ -1,0 +1,37 @@
+package maple.externalapi.metrics
+
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.DistributionSummary
+import io.micrometer.core.instrument.MeterRegistry
+import org.springframework.stereotype.Component
+
+@Component
+class SnapshotVolumeMetrics(registry: MeterRegistry) {
+
+    private val compressedBytesTotal = registry.counter("external_api_snapshot_compressed_bytes_total")
+    private val uncompressedBytesTotal = registry.counter("external_api_snapshot_uncompressed_bytes_total")
+    private val jsonRowsTotal = registry.counter("external_api_snapshot_json_rows_total")
+
+    private val compressedBytesSummary = DistributionSummary.builder("external_api_snapshot_compressed_bytes")
+        .description("Compressed bytes per snapshot chunk")
+        .register(registry)
+
+    private val uncompressedBytesSummary = DistributionSummary.builder("external_api_snapshot_uncompressed_bytes")
+        .description("Uncompressed bytes per snapshot chunk")
+        .register(registry)
+
+    private val compressionRatioSummary = DistributionSummary.builder("external_api_snapshot_compression_ratio")
+        .description("Compression ratio (uncompressed/compressed) per snapshot chunk")
+        .register(registry)
+
+    fun recordChunk(compressedBytes: Long, uncompressedBytes: Long, jsonRows: Long) {
+        compressedBytesTotal.increment(compressedBytes.toDouble())
+        uncompressedBytesTotal.increment(uncompressedBytes.toDouble())
+        jsonRowsTotal.increment(jsonRows.toDouble())
+        compressedBytesSummary.record(compressedBytes.toDouble())
+        uncompressedBytesSummary.record(uncompressedBytes.toDouble())
+        if (compressedBytes > 0) {
+            compressionRatioSummary.record(uncompressedBytes.toDouble() / compressedBytes.toDouble())
+        }
+    }
+}

--- a/module-external-api/src/main/kotlin/maple/externalapi/port/out/ExternalApiArtifactStorePort.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/port/out/ExternalApiArtifactStorePort.kt
@@ -1,0 +1,28 @@
+package maple.externalapi.port.out
+
+import maple.externalapi.domain.ExternalApiEndpoint
+import maple.externalapi.domain.ExternalApiPayloadRef
+
+interface ExternalApiArtifactStorePort {
+
+    fun store(
+        endpoint: ExternalApiEndpoint,
+        key: String,
+        data: ByteArray,
+    ): ExternalApiPayloadRef
+
+    fun read(
+        endpoint: ExternalApiEndpoint,
+        key: String,
+    ): ByteArray?
+
+    fun listStoredKeys(endpoint: ExternalApiEndpoint): List<String>
+
+    fun listRuns(): List<String>
+
+    fun deleteRun(runId: String): Long
+
+    fun fileExists(relativePath: String): Boolean
+
+    fun calculateDirectorySize(relativePath: String): Long
+}

--- a/module-external-api/src/main/kotlin/maple/externalapi/port/out/ExternalApiClientPort.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/port/out/ExternalApiClientPort.kt
@@ -1,0 +1,14 @@
+package maple.externalapi.port.out
+
+import java.util.concurrent.CompletableFuture
+import maple.externalapi.domain.ExternalApiEndpoint
+import maple.externalapi.domain.ExternalApiProvider
+
+interface ExternalApiClientPort {
+
+    fun fetch(
+        provider: ExternalApiProvider,
+        endpoint: ExternalApiEndpoint,
+        requestKey: String,
+    ): CompletableFuture<ByteArray>
+}

--- a/module-external-api/src/main/kotlin/maple/externalapi/reader/UserIgnCsvReader.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/reader/UserIgnCsvReader.kt
@@ -1,0 +1,35 @@
+package maple.externalapi.reader
+
+import java.nio.file.Files
+import java.nio.file.Paths
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+
+@Component
+class UserIgnCsvReader(
+    @Value("\${external-api.csv.path:module-app/src/main/resources/data/userIgn_List.csv}")
+    private val csvPath: String,
+) {
+    private val log = LoggerFactory.getLogger(UserIgnCsvReader::class.java)
+
+    fun readAll(): List<String> {
+        val path = Paths.get(csvPath)
+        if (!Files.exists(path)) {
+            log.warn("[CsvReader] file not found: {}", path.toAbsolutePath())
+            return emptyList()
+        }
+        val igns = Files.readAllLines(path)
+            .map { it.trim() }
+            .filter { it.isNotBlank() }
+        log.info("[CsvReader] loaded {} IGNs from {}", igns.size, csvPath)
+        return igns
+    }
+
+    fun readBatch(offset: Int, limit: Int): List<String> {
+        val all = readAll()
+        if (offset >= all.size) return emptyList()
+        val end = minOf(offset + limit, all.size)
+        return all.subList(offset, end)
+    }
+}

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/ExternalApiScheduler.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/ExternalApiScheduler.kt
@@ -1,0 +1,106 @@
+package maple.externalapi.scheduler
+
+import jakarta.annotation.PreDestroy
+import maple.externalapi.cache.OcidCacheProvider
+import maple.externalapi.scheduler.phase.OcidLookupPhase
+import maple.externalapi.scheduler.phase.SnapshotFetchPhase
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.event.EventListener
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import java.time.Duration
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
+
+@Component
+@ConditionalOnProperty(name = ["external-api.schedule.enabled"], havingValue = "true")
+class ExternalApiScheduler(
+    private val ocidLookupPhase: OcidLookupPhase,
+    private val snapshotFetchPhase: SnapshotFetchPhase,
+    private val ocidCacheProvider: OcidCacheProvider,
+    @Value("\${external-api.schedule.run-on-startup:false}")
+    private val runOnStartup: Boolean,
+    @Value("\${external-api.schedule.skip-character-basic:false}")
+    private val skipCharacterBasic: Boolean,
+) {
+    private val log = LoggerFactory.getLogger(ExternalApiScheduler::class.java)
+    private val running = AtomicBoolean(false)
+    private val shutdown = AtomicBoolean(false)
+    private val executor = Executors.newVirtualThreadPerTaskExecutor()
+
+    @EventListener(ApplicationReadyEvent::class)
+    fun onStartup() {
+        ocidCacheProvider.refresh()
+        if (runOnStartup) {
+            log.info("[Scheduler] run-on-startup enabled, triggering daily refresh")
+            triggerDailyRefresh()
+        }
+        executor.submit { runItemEquipmentLoop() }
+    }
+
+    @Scheduled(cron = "\${external-api.schedule.daily-cron:0 0 3 * * *}")
+    fun scheduledDailyRefresh() {
+        triggerDailyRefresh()
+    }
+
+    fun triggerDailyRefresh() {
+        if (!acquireLock(120_000)) {
+            log.warn("[Scheduler] could not acquire lock for daily refresh, skipping")
+            return
+        }
+        try {
+            if (skipCharacterBasic) {
+                log.info("[Scheduler] skip-character-basic enabled, loading OCID cache from existing data")
+                ocidCacheProvider.refresh()
+            } else {
+                ocidLookupPhase.execute(executor)
+                val cache = ocidCacheProvider.refresh()
+                snapshotFetchPhase.executeCharacterBasic(executor, cache)
+            }
+        } finally {
+            running.set(false)
+        }
+    }
+
+    private fun runItemEquipmentLoop() {
+        log.info("[Scheduler] ITEM_EQUIPMENT continuous loop started")
+        while (!shutdown.get()) {
+            val entries = ocidCacheProvider.current().entries.toList()
+            if (entries.isEmpty()) {
+                log.warn("[Scheduler] OCID cache empty, waiting 30s")
+                Thread.sleep(Duration.ofSeconds(30))
+                ocidCacheProvider.refresh()
+                continue
+            }
+            if (!acquireLock(120_000)) {
+                Thread.sleep(Duration.ofSeconds(5))
+                continue
+            }
+            try {
+                snapshotFetchPhase.executeItemEquipment(executor, entries)
+            } finally {
+                running.set(false)
+            }
+        }
+        log.info("[Scheduler] ITEM_EQUIPMENT continuous loop stopped")
+    }
+
+    private fun acquireLock(timeoutMs: Long): Boolean {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            if (running.compareAndSet(false, true)) return true
+            Thread.sleep(Duration.ofMillis(500))
+        }
+        return false
+    }
+
+    @PreDestroy
+    fun onDestroy() {
+        log.info("[Scheduler] shutdown requested")
+        shutdown.set(true)
+        executor.close()
+    }
+}

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/OcidLookupPhase.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/OcidLookupPhase.kt
@@ -1,0 +1,112 @@
+package maple.externalapi.scheduler.phase
+
+import maple.externalapi.domain.ExternalApiEndpoint
+import maple.externalapi.domain.ExternalApiProvider
+import maple.expectation.infrastructure.executor.LogicExecutor
+import maple.expectation.infrastructure.executor.TaskContext
+import maple.externalapi.port.out.ExternalApiClientPort
+import maple.externalapi.port.out.ExternalApiArtifactStorePort
+import maple.externalapi.reader.UserIgnCsvReader
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+import java.time.Instant
+import java.util.concurrent.Callable
+import java.util.concurrent.ExecutorService
+
+@Component
+@ConditionalOnProperty(name = ["external-api.schedule.enabled"], havingValue = "true")
+class OcidLookupPhase(
+    private val clientPort: ExternalApiClientPort,
+    private val csvReader: UserIgnCsvReader,
+    private val artifactStore: ExternalApiArtifactStorePort,
+    private val executor: LogicExecutor,
+    @Value("\${external-api.rate-limit.ocid-lookup-permits-per-second:400}")
+    private val ocidLookupPermitsPerSecond: Int,
+    @Value("\${external-api.batch-size:1000}")
+    private val batchSize: Int,
+    @Value("\${external-api.store.base-path:/data/external-api}")
+    private val storeBasePath: String,
+) {
+    private val log = LoggerFactory.getLogger(OcidLookupPhase::class.java)
+
+    fun execute(executor: ExecutorService) {
+        val existingOcids = artifactStore.listStoredKeys(ExternalApiEndpoint.OCID_LOOKUP)
+        if (existingOcids.isNotEmpty()) {
+            log.info("[Scheduler] OCID lookup already done ({} files), skipping", existingOcids.size)
+            return
+        }
+
+        val rateLimiter = SchedulerPhaseUtils.newRateLimiter(ocidLookupPermitsPerSecond)
+
+        val igns = csvReader.readAll()
+        if (igns.isEmpty()) {
+            log.warn("[Scheduler] no IGNs to process")
+            return
+        }
+
+        log.info("[Scheduler] ========== OCID lookup start ==========")
+        log.info(
+            "[Scheduler] config: total={}, rate={}/s, batchSize={}, store={}",
+            igns.size, ocidLookupPermitsPerSecond, batchSize, storeBasePath,
+        )
+
+        val start = Instant.now()
+        val successCount = java.util.concurrent.atomic.AtomicInteger(0)
+        val failCount = java.util.concurrent.atomic.AtomicInteger(0)
+        val storedCount = java.util.concurrent.atomic.AtomicInteger(0)
+        var processed = 0
+        var lastProgressLog = 0
+
+        while (processed < igns.size) {
+            val permits = SchedulerPhaseUtils.acquirePermits(rateLimiter, batchSize, igns.size - processed)
+            if (permits == 0) continue
+
+            val chunk = igns.subList(processed, processed + permits)
+            processed += permits
+
+            val futures = chunk.map { ign ->
+                executor.submit(Callable { fetchAndStoreOcid(ign, successCount, failCount, storedCount) })
+            }
+
+            futures.forEach { it.get() }
+
+            val progress = successCount.get() + failCount.get()
+            if (progress - lastProgressLog >= 5000) {
+                lastProgressLog = progress
+                SchedulerPhaseUtils.logProgress("OCID lookup", progress, igns.size, storedCount.get(), failCount.get(), start)
+            }
+        }
+
+        SchedulerPhaseUtils.logSummary("OCID lookup", igns.size, successCount.get(), storedCount.get(), failCount.get(), start)
+    }
+
+    private fun fetchAndStoreOcid(
+        ign: String,
+        successCount: java.util.concurrent.atomic.AtomicInteger,
+        failCount: java.util.concurrent.atomic.AtomicInteger,
+        storedCount: java.util.concurrent.atomic.AtomicInteger,
+    ) {
+        executor.executeWithFallback(
+            { performOcidFetch(ign, successCount, storedCount) },
+            { failCount.incrementAndGet() },
+            TaskContext.of("OcidLookup", "FetchStore", ign),
+        )
+    }
+
+    private fun performOcidFetch(
+        ign: String,
+        successCount: java.util.concurrent.atomic.AtomicInteger,
+        storedCount: java.util.concurrent.atomic.AtomicInteger,
+    ) {
+        val data = clientPort.fetch(
+            ExternalApiProvider.NEXON,
+            ExternalApiEndpoint.OCID_LOOKUP,
+            ign,
+        ).join()
+        val payloadRef = artifactStore.store(ExternalApiEndpoint.OCID_LOOKUP, ign, data)
+        successCount.incrementAndGet()
+        if (payloadRef != null) storedCount.incrementAndGet()
+    }
+}

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/SchedulerPhaseUtils.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/SchedulerPhaseUtils.kt
@@ -1,0 +1,70 @@
+package maple.externalapi.scheduler.phase
+
+import io.github.bucket4j.Bandwidth
+import io.github.bucket4j.Bucket
+import org.slf4j.LoggerFactory
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+internal object SchedulerPhaseUtils {
+    private val log = LoggerFactory.getLogger(SchedulerPhaseUtils::class.java)
+
+    fun newRateLimiter(permits: Int): Bucket = Bucket.builder()
+        .addLimit(
+            Bandwidth.builder()
+                .capacity(permits.toLong())
+                .refillIntervally(permits.toLong(), Duration.ofSeconds(1))
+                .build(),
+        )
+        .build()
+
+    fun acquirePermits(rateLimiter: Bucket, batchSize: Int, remaining: Int): Int {
+        val maxBatch = minOf(batchSize, remaining)
+        return rateLimiter.tryConsumeAsMuchAsPossible(maxBatch.toLong()).toInt().also {
+            if (it == 0) Thread.sleep(Duration.ofMillis(100))
+        }
+    }
+
+    fun newRunId(): String {
+        val formatter = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss").withZone(ZoneId.systemDefault())
+        return formatter.format(Instant.now())
+    }
+
+    fun writeRunningMarker(runDir: Path) {
+        val marker = runDir.resolve("_RUNNING")
+        Files.createDirectories(runDir)
+        Files.writeString(marker, Instant.now().toString())
+        log.info("[Scheduler] wrote _RUNNING marker: {}", marker)
+    }
+
+    fun extractHttpStatus(ex: Throwable): Int {
+        val cause = if (ex is java.util.concurrent.CompletionException) ex.cause else ex
+        return when (cause) {
+            is org.springframework.web.reactive.function.client.WebClientResponseException -> cause.statusCode.value()
+            else -> 0
+        }
+    }
+
+    fun logProgress(phase: String, progress: Int, total: Int, stored: Int, fails: Int, start: Instant) {
+        val elapsedSec = Duration.between(start, Instant.now()).toMillis() / 1000.0
+        val rate = if (elapsedSec > 0) "%.0f".format(progress / elapsedSec) else "?"
+        log.info(
+            "[Scheduler] {}: {}/{} (success={}, fail={}, rate={}files/s, elapsed={}s)",
+            phase, progress, total, stored, fails, rate, elapsedSec.toLong(),
+        )
+    }
+
+    fun logSummary(phase: String, total: Int, success: Int, stored: Int, fails: Int, start: Instant) {
+        val elapsedSec = Duration.between(start, Instant.now()).toMillis() / 1000.0
+        val rate = if (elapsedSec > 0) "%.0f".format(total / elapsedSec) else "?"
+        log.info("[Scheduler] ========== {} complete ==========", phase)
+        log.info(
+            "[Scheduler] result: total={}, success={}, fail={}, elapsed={}s, avgRate={}files/s",
+            total, success, fails, elapsedSec.toLong(), rate,
+        )
+    }
+}

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/SnapshotFetchPhase.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/SnapshotFetchPhase.kt
@@ -1,0 +1,227 @@
+package maple.externalapi.scheduler.phase
+
+import maple.externalapi.domain.ExternalApiEndpoint
+import maple.externalapi.domain.ExternalApiProvider
+import maple.expectation.infrastructure.executor.LogicExecutor
+import maple.expectation.infrastructure.executor.TaskContext
+import maple.externalapi.metrics.ExternalApiMetrics
+import maple.externalapi.metrics.SnapshotVolumeMetrics
+import maple.externalapi.port.out.ExternalApiArtifactStorePort
+import maple.externalapi.port.out.ExternalApiClientPort
+import maple.externalapi.snapshot.ChunkedSnapshotSink
+import maple.externalapi.snapshot.SnapshotChunkRecord
+import maple.externalapi.snapshot.SnapshotChunkingProperties
+import maple.externalapi.snapshot.event.SnapshotChunkEventPublisher
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+import java.nio.file.Paths
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.Callable
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.atomic.AtomicInteger
+
+data class SnapshotFetchConfig(
+    val endpoint: String,
+    val apiEndpoint: ExternalApiEndpoint,
+    val eventPublisher: SnapshotChunkEventPublisher,
+    val onFetched: () -> Unit,
+    val onFailed: () -> Unit,
+    val recordDuration: (Duration) -> Unit,
+    val skipIfExisting: Boolean = false,
+)
+
+@Component
+@ConditionalOnProperty(name = ["external-api.schedule.enabled"], havingValue = "true")
+class SnapshotFetchPhase(
+    private val clientPort: ExternalApiClientPort,
+    private val artifactStore: ExternalApiArtifactStorePort,
+    private val objectMapper: ObjectMapper,
+    private val chunkingProperties: SnapshotChunkingProperties,
+    private val volumeMetrics: SnapshotVolumeMetrics,
+    private val metrics: ExternalApiMetrics,
+    private val executor: LogicExecutor,
+    @Qualifier("characterBasicSnapshotPublisher")
+    private val characterBasicPublisher: SnapshotChunkEventPublisher,
+    private val itemEquipmentPublisher: SnapshotChunkEventPublisher,
+    @Value("\${external-api.rate-limit.permits-per-second:200}")
+    private val permitsPerSecond: Int,
+    @Value("\${external-api.batch-size:1000}")
+    private val batchSize: Int,
+    @Value("\${external-api.store.base-path:/data/external-api}")
+    private val storeBasePath: String,
+) {
+    private val log = LoggerFactory.getLogger(SnapshotFetchPhase::class.java)
+
+    fun executeCharacterBasic(executor: ExecutorService, ocidCache: Map<String, String>) {
+        execute(
+            executor,
+            ocidCache.entries.toList(),
+            SnapshotFetchConfig(
+                endpoint = "character-basic",
+                apiEndpoint = ExternalApiEndpoint.CHARACTER_BASIC,
+                eventPublisher = characterBasicPublisher,
+                onFetched = { metrics.recordCharacterBasicFetched() },
+                onFailed = { metrics.recordCharacterBasicFailed() },
+                recordDuration = { metrics.characterBasicTimer().record(it) },
+                skipIfExisting = true,
+            ),
+        )
+    }
+
+    fun executeItemEquipment(executor: ExecutorService, entries: List<Map.Entry<String, String>>) {
+        execute(
+            executor,
+            entries,
+            SnapshotFetchConfig(
+                endpoint = "item-equipment",
+                apiEndpoint = ExternalApiEndpoint.ITEM_EQUIPMENT,
+                eventPublisher = itemEquipmentPublisher,
+                onFetched = { metrics.recordItemEquipmentFetched() },
+                onFailed = { metrics.recordItemEquipmentFailed() },
+                recordDuration = { metrics.itemEquipmentTimer().record(it) },
+            ),
+        )
+    }
+
+    private fun execute(
+        executor: ExecutorService,
+        entries: List<Map.Entry<String, String>>,
+        config: SnapshotFetchConfig,
+    ) {
+        if (config.skipIfExisting) {
+            val existing = artifactStore.listStoredKeys(config.apiEndpoint)
+            if (existing.isNotEmpty()) {
+                log.info("[Scheduler] {} already done ({} files), skipping", config.endpoint, existing.size)
+                return
+            }
+        }
+
+        if (entries.isEmpty()) {
+            log.warn("[Scheduler] OCID cache empty, skipping {}", config.endpoint)
+            return
+        }
+
+        val runId = SchedulerPhaseUtils.newRunId()
+        val chunkConfig = chunkingProperties.configFor(config.endpoint)
+        val runDir = Paths.get(storeBasePath, "runs", runId)
+        SchedulerPhaseUtils.writeRunningMarker(runDir)
+        val sink = ChunkedSnapshotSink(
+            runDir = runDir,
+            endpoint = config.endpoint,
+            maxRecords = chunkConfig.maxRecords,
+            maxUncompressedBytes = chunkConfig.maxUncompressedBytes,
+            queueCapacity = chunkingProperties.queueCapacity,
+            objectMapper = objectMapper,
+            eventPublisher = config.eventPublisher,
+            volumeMetrics = volumeMetrics,
+        )
+
+        val rateLimiter = SchedulerPhaseUtils.newRateLimiter(permitsPerSecond)
+
+        log.info("[Scheduler] ========== {} lookup start ==========", config.endpoint)
+        log.info(
+            "[Scheduler] config: total={}, rate={}/s, batchSize={}, chunk={}records/{}bytes, runId={}",
+            entries.size, permitsPerSecond, batchSize,
+            chunkConfig.maxRecords, chunkConfig.maxUncompressedBytes, runId,
+        )
+
+        val start = Instant.now()
+        val successCount = AtomicInteger(0)
+        val failCount = AtomicInteger(0)
+        var processed = 0
+        var lastProgressLog = 0
+
+        try {
+            while (processed < entries.size) {
+                val permits = SchedulerPhaseUtils.acquirePermits(rateLimiter, batchSize, entries.size - processed)
+                if (permits == 0) continue
+
+                val chunk = entries.subList(processed, processed + permits)
+                processed += permits
+
+                val futures = chunk.map { (ign, ocid) ->
+                    executor.submit(Callable { fetchSingle(ocid, config, sink, successCount, failCount) })
+                }
+
+                futures.forEach { it.get() }
+
+                val progress = successCount.get() + failCount.get()
+                if (progress - lastProgressLog >= 5000) {
+                    lastProgressLog = progress
+                    SchedulerPhaseUtils.logProgress(config.endpoint, progress, entries.size, successCount.get(), failCount.get(), start)
+                }
+            }
+        } finally {
+            sink.close()
+        }
+
+        config.recordDuration(Duration.between(start, Instant.now()))
+        SchedulerPhaseUtils.logSummary(config.endpoint, entries.size, successCount.get(), successCount.get(), failCount.get(), start)
+    }
+
+    private fun fetchSingle(
+        ocid: String,
+        config: SnapshotFetchConfig,
+        sink: ChunkedSnapshotSink,
+        successCount: AtomicInteger,
+        failCount: AtomicInteger,
+    ) {
+        executor.executeWithFallback(
+            { performSnapshotFetch(ocid, config, sink, successCount) },
+            { ex -> handleSnapshotFailure(ocid, config, sink, failCount, ex) },
+            TaskContext.of("SnapshotFetch", "FetchSingle", ocid),
+        )
+    }
+
+    private fun performSnapshotFetch(
+        ocid: String,
+        config: SnapshotFetchConfig,
+        sink: ChunkedSnapshotSink,
+        successCount: AtomicInteger,
+    ) {
+        val bodyBytes = clientPort.fetch(
+            ExternalApiProvider.NEXON,
+            config.apiEndpoint,
+            ocid,
+        ).join()
+        sink.submit(
+            SnapshotChunkRecord.Success(
+                key = ocid,
+                endpoint = config.endpoint,
+                keyType = "OCID",
+                httpStatus = 200,
+                fetchedAt = Instant.now(),
+                bodyBytes = bodyBytes,
+            ),
+        )
+        successCount.incrementAndGet()
+        config.onFetched()
+    }
+
+    private fun handleSnapshotFailure(
+        ocid: String,
+        config: SnapshotFetchConfig,
+        sink: ChunkedSnapshotSink,
+        failCount: AtomicInteger,
+        ex: Throwable,
+    ) {
+        val httpStatus = SchedulerPhaseUtils.extractHttpStatus(ex)
+        sink.submit(
+            SnapshotChunkRecord.Failure(
+                key = ocid,
+                endpoint = config.endpoint,
+                keyType = "OCID",
+                httpStatus = httpStatus,
+                fetchedAt = Instant.now(),
+                errorMessage = ex.message ?: "unknown",
+            ),
+        )
+        failCount.incrementAndGet()
+        config.onFailed()
+    }
+}

--- a/module-external-api/src/main/kotlin/maple/externalapi/snapshot/ChunkedSnapshotSink.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/snapshot/ChunkedSnapshotSink.kt
@@ -1,0 +1,265 @@
+package maple.externalapi.snapshot
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import maple.externalapi.metrics.SnapshotVolumeMetrics
+import maple.externalapi.snapshot.event.SnapshotChunkEventPublisher
+import maple.externalapi.snapshot.event.SnapshotChunkReadyEvent
+import maple.externalapi.snapshot.event.SnapshotRunCompletedEvent
+import maple.externalapi.snapshot.event.SnapshotRunFailedEvent
+import org.slf4j.LoggerFactory
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Instant
+import java.util.UUID
+import java.util.concurrent.ArrayBlockingQueue
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+
+class ChunkedSnapshotSink(
+    private val runDir: Path,
+    private val endpoint: String,
+    private val maxRecords: Int,
+    private val maxUncompressedBytes: Long,
+    private val queueCapacity: Int,
+    private val objectMapper: ObjectMapper,
+    private val eventPublisher: SnapshotChunkEventPublisher,
+    private val volumeMetrics: SnapshotVolumeMetrics,
+) {
+    private val log = LoggerFactory.getLogger(ChunkedSnapshotSink::class.java)
+
+    private val chunksDir: Path = runDir.resolve(endpoint).resolve("chunks")
+    private val failedPath: Path = runDir.resolve(endpoint).resolve("failed.jsonl")
+    private val manifestPath: Path = runDir.resolve(endpoint).resolve("manifest.json")
+    private val successPath: Path = runDir.resolve(endpoint).resolve("_SUCCESS")
+
+    private val queue = ArrayBlockingQueue<SnapshotChunkRecord>(queueCapacity)
+    private val accepting = AtomicBoolean(true)
+    private val writerError = AtomicReference<Throwable?>(null)
+
+    private val manifest = SnapshotChunkManifest(
+        runId = runDir.fileName.toString(),
+        endpoint = endpoint,
+        startedAt = Instant.now(),
+    )
+
+    private val failedWriter = SnapshotFailedRecordWriter(failedPath, objectMapper)
+    private var currentWriter: GzipJsonlChunkWriter
+    private var nextPartIndex = 2
+
+    init {
+        Files.createDirectories(chunksDir)
+        Files.createDirectories(failedPath.parent)
+        currentWriter = newChunkWriter(1)
+    }
+
+    private val writerThread: Thread = Thread.ofPlatform().name("snapshot-writer-$endpoint").start {
+        runWriterLoop()
+    }
+
+    fun submit(record: SnapshotChunkRecord) {
+        if (!accepting.get()) {
+            val err = writerError.get()
+            if (err != null) {
+                throw IllegalStateException("sink closed due to writer error: ${err.message}", err)
+            }
+            throw IllegalStateException("sink is closed, cannot submit")
+        }
+        if (!queue.offer(record, 30, java.util.concurrent.TimeUnit.SECONDS)) {
+            throw IllegalStateException("sink queue full after 30s, likely writer thread stuck")
+        }
+    }
+
+    fun close() {
+        accepting.set(false)
+        if (!queue.offer(SnapshotChunkRecord.CloseSignal, 30, java.util.concurrent.TimeUnit.SECONDS)) {
+            throw IllegalStateException("failed to enqueue close signal after 30s")
+        }
+
+        writerThread.join(60_000)
+        if (writerThread.isAlive) {
+            log.warn("[Sink] writer thread did not terminate within 60s, interrupting")
+            writerThread.interrupt()
+        }
+
+        val err = writerError.get()
+        if (err != null) {
+            cleanupOnFailure()
+            publishRunFailed(err.message ?: "unknown")
+            throw RuntimeException("writer thread failed: ${err.message}", err)
+        }
+
+        // close current chunk
+        closeCurrentChunk()
+
+        // close failed writer
+        manifest.totalFailed = failedWriter.count()
+
+        // write manifest
+        manifest.finishedAt = Instant.now()
+        val manifestWriter = SnapshotChunkManifestWriter(manifestPath, objectMapper)
+        manifestWriter.write(manifest)
+
+        // create _SUCCESS
+        Files.writeString(successPath, "")
+
+        // Remove run-level _RUNNING marker (if exists)
+        val runningMarker = runDir.resolve("_RUNNING")
+        if (Files.exists(runningMarker)) {
+            Files.delete(runningMarker)
+        }
+
+        log.info(
+            "[Sink] closed: endpoint={}, chunks={}, records={}, failed={}",
+            endpoint, manifest.chunks.size, manifest.totalRecords, manifest.totalFailed,
+        )
+
+        // publish run completed (after _SUCCESS)
+        publishRunCompleted()
+    }
+
+    private fun runWriterLoop() {
+        try {
+            while (true) {
+                val record = queue.take()
+                when (record) {
+                    is SnapshotChunkRecord.Success -> handleSuccess(record)
+                    is SnapshotChunkRecord.Failure -> failedWriter.append(record)
+                    is SnapshotChunkRecord.CloseSignal -> return
+                }
+            }
+        } catch (ex: Exception) {
+            writerError.set(ex)
+            accepting.set(false)
+            log.error("[Sink] writer thread error: {}", ex.message, ex)
+        }
+    }
+
+    private fun handleSuccess(record: SnapshotChunkRecord.Success) {
+        try {
+            currentWriter.append(record)
+            manifest.totalRecords++
+
+            if (currentWriter.shouldRotate()) {
+                rotateChunk()
+            }
+        } catch (ex: Exception) {
+            log.warn("[Sink] invalid bodyBytes for key={}, treating as failure: {}", record.key, ex.message)
+            failedWriter.append(
+                SnapshotChunkRecord.Failure(
+                    key = record.key,
+                    endpoint = record.endpoint,
+                    keyType = record.keyType,
+                    httpStatus = record.httpStatus,
+                    fetchedAt = record.fetchedAt,
+                    errorMessage = "invalid body: ${ex.message}",
+                ),
+            )
+        }
+    }
+
+    private fun rotateChunk() {
+        val stats = currentWriter.close()
+        if (stats.recordCount > 0) {
+            val entry = ChunkEntry(
+                path = stats.path,
+                recordCount = stats.recordCount,
+                uncompressedBytes = stats.uncompressedBytes,
+                compressedBytes = stats.compressedBytes,
+                startedAt = stats.startedAt,
+                finishedAt = stats.finishedAt,
+            )
+            manifest.chunks.add(entry)
+            publishChunkReady(stats)
+        }
+        currentWriter = newChunkWriter(nextPartIndex++)
+    }
+
+    private fun closeCurrentChunk() {
+        val stats = currentWriter.close()
+        if (stats.recordCount > 0) {
+            val entry = ChunkEntry(
+                path = stats.path,
+                recordCount = stats.recordCount,
+                uncompressedBytes = stats.uncompressedBytes,
+                compressedBytes = stats.compressedBytes,
+                startedAt = stats.startedAt,
+                finishedAt = stats.finishedAt,
+            )
+            manifest.chunks.add(entry)
+            publishChunkReady(stats)
+        }
+    }
+
+    private fun cleanupOnFailure() {
+        currentWriter.deleteTmp()
+        log.warn("[Sink] cleaned up .tmp files after failure")
+    }
+
+    private fun newChunkWriter(partIndex: Int): GzipJsonlChunkWriter =
+        GzipJsonlChunkWriter(chunksDir, partIndex, maxRecords, maxUncompressedBytes, objectMapper)
+
+    private fun objectKeyFor(stats: ChunkStats): String =
+        "runs/${manifest.runId}/${endpoint}/${stats.path}"
+
+    private fun publishChunkReady(stats: ChunkStats) {
+        val chunkId = String.format("part-%06d", stats.partIndex)
+        val ratio = if (stats.compressedBytes > 0) "%.2f".format(stats.uncompressedBytes.toDouble() / stats.compressedBytes.toDouble()) else "N/A"
+        volumeMetrics.recordChunk(stats.compressedBytes, stats.uncompressedBytes, stats.recordCount.toLong())
+        log.info(
+            "[snapshotVolume] runId={} chunkId={} compressedBytes={} uncompressedBytes={} jsonRows={} compressionRatio={}",
+            manifest.runId, chunkId, stats.compressedBytes, stats.uncompressedBytes, stats.recordCount, ratio,
+        )
+
+        val event = SnapshotChunkReadyEvent(
+            eventId = UUID.randomUUID().toString(),
+            runId = manifest.runId,
+            endpoint = endpoint,
+            chunkId = chunkId,
+            objectKey = objectKeyFor(stats),
+            recordCount = stats.recordCount,
+            uncompressedBytes = stats.uncompressedBytes,
+            compressedBytes = stats.compressedBytes,
+            createdAt = Instant.now(),
+        )
+        try {
+            eventPublisher.publishChunkReady(event)
+        } catch (ex: Exception) {
+            log.warn("[Sink] failed to publish chunk-ready event for chunkId={}: {}", event.chunkId, ex.message)
+        }
+    }
+
+    private fun publishRunCompleted() {
+        val event = SnapshotRunCompletedEvent(
+            eventId = UUID.randomUUID().toString(),
+            runId = manifest.runId,
+            endpoint = endpoint,
+            manifestPath = "runs/${manifest.runId}/${endpoint}/manifest.json",
+            totalRecords = manifest.totalRecords,
+            totalFailed = manifest.totalFailed,
+            chunkCount = manifest.chunks.size,
+            startedAt = manifest.startedAt,
+            finishedAt = requireNotNull(manifest.finishedAt),
+            createdAt = Instant.now(),
+        )
+        try {
+            eventPublisher.publishRunCompleted(event)
+        } catch (ex: Exception) {
+            log.warn("[Sink] failed to publish run-completed event for runId={}: {}", manifest.runId, ex.message)
+        }
+    }
+
+    private fun publishRunFailed(errorMessage: String) {
+        val event = SnapshotRunFailedEvent(
+            eventId = UUID.randomUUID().toString(),
+            runId = manifest.runId,
+            endpoint = endpoint,
+            errorMessage = errorMessage,
+            createdAt = Instant.now(),
+        )
+        try {
+            eventPublisher.publishRunFailed(event)
+        } catch (ex: Exception) {
+            log.warn("[Sink] failed to publish run-failed event for runId={}: {}", manifest.runId, ex.message)
+        }
+    }
+}

--- a/module-external-api/src/main/kotlin/maple/externalapi/snapshot/GzipJsonlChunkWriter.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/snapshot/GzipJsonlChunkWriter.kt
@@ -1,0 +1,118 @@
+package maple.externalapi.snapshot
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import java.io.BufferedOutputStream
+import java.io.FileOutputStream
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.time.Instant
+
+data class ChunkStats(
+    val partIndex: Int,
+    val path: String,
+    val recordCount: Int,
+    val uncompressedBytes: Long,
+    val compressedBytes: Long,
+    val startedAt: Instant,
+    val finishedAt: Instant,
+)
+
+class GzipJsonlChunkWriter(
+    private val chunksDir: Path,
+    private val partIndex: Int,
+    private val maxRecords: Int,
+    private val maxUncompressedBytes: Long,
+    private val objectMapper: ObjectMapper,
+) {
+    private val startedAt = Instant.now()
+    private val tmpFile: Path = chunksDir.resolve(String.format("part-%06d.jsonl.gz.tmp", partIndex))
+    private val finalFile: Path = chunksDir.resolve(String.format("part-%06d.jsonl.gz", partIndex))
+
+    private val fos = FileOutputStream(tmpFile.toFile())
+    private val bos = BufferedOutputStream(fos)
+    private val gzip = java.util.zip.GZIPOutputStream(bos)
+
+    private var recordCount = 0
+    private var uncompressedBytes = 0L
+
+    fun append(record: SnapshotChunkRecord.Success) {
+        require(record.bodyBytes.isNotEmpty()) { "bodyBytes must not be empty for key=${record.key}" }
+
+        val line = buildRecordLine(record)
+        gzip.write(line)
+        gzip.flush()
+
+        recordCount++
+        uncompressedBytes += line.size
+    }
+
+    fun shouldRotate(): Boolean =
+        recordCount >= maxRecords || uncompressedBytes >= maxUncompressedBytes
+
+    fun close(): ChunkStats {
+        gzip.finish()
+        bos.flush()
+        fos.fd.sync()
+        fos.close()
+
+        if (recordCount == 0) {
+            Files.deleteIfExists(tmpFile)
+            return ChunkStats(
+                partIndex = partIndex,
+                path = "chunks/${finalFile.fileName}",
+                recordCount = 0,
+                uncompressedBytes = 0,
+                compressedBytes = 0,
+                startedAt = startedAt,
+                finishedAt = Instant.now(),
+            )
+        }
+
+        Files.move(tmpFile, finalFile, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
+        val compressedBytes = Files.size(finalFile)
+
+        return ChunkStats(
+            partIndex = partIndex,
+            path = "chunks/${finalFile.fileName}",
+            recordCount = recordCount,
+            uncompressedBytes = uncompressedBytes,
+            compressedBytes = compressedBytes,
+            startedAt = startedAt,
+            finishedAt = Instant.now(),
+        )
+    }
+
+    fun deleteTmp() {
+        try {
+            gzip.close()
+        } catch (_: Exception) {
+        }
+        Files.deleteIfExists(tmpFile)
+    }
+
+    private fun buildRecordLine(record: SnapshotChunkRecord.Success): ByteArray {
+        val buf = java.io.ByteArrayOutputStream()
+
+        // metadata prefix
+        buf.write("{\"endpoint\":".toByteArray())
+        buf.write(objectMapper.writeValueAsBytes(record.endpoint))
+        buf.write(",\"keyType\":".toByteArray())
+        buf.write(objectMapper.writeValueAsBytes(record.keyType))
+        buf.write(",\"key\":".toByteArray())
+        buf.write(objectMapper.writeValueAsBytes(record.key))
+        buf.write(",\"status\":\"SUCCESS\",\"httpStatus\":".toByteArray())
+        buf.write(record.httpStatus.toString().toByteArray())
+        buf.write(",\"fetchedAt\":".toByteArray())
+        buf.write(objectMapper.writeValueAsBytes(record.fetchedAt.toString()))
+        buf.write(",\"body\":".toByteArray())
+
+        // body: raw JSON bytes directly (no parse/re-serialize)
+        buf.write(record.bodyBytes)
+
+        // closing
+        buf.write("}\n".toByteArray())
+
+        return buf.toByteArray()
+    }
+}

--- a/module-external-api/src/main/kotlin/maple/externalapi/snapshot/SnapshotChunkManifest.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/snapshot/SnapshotChunkManifest.kt
@@ -1,0 +1,35 @@
+package maple.externalapi.snapshot
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Instant
+
+data class SnapshotChunkManifest(
+    val runId: String,
+    val endpoint: String,
+    val startedAt: Instant,
+    var finishedAt: Instant = Instant.EPOCH,
+    val chunks: MutableList<ChunkEntry> = mutableListOf(),
+    var totalRecords: Int = 0,
+    var totalFailed: Int = 0,
+)
+
+data class ChunkEntry(
+    val path: String,
+    val recordCount: Int,
+    val uncompressedBytes: Long,
+    val compressedBytes: Long,
+    val startedAt: Instant,
+    val finishedAt: Instant,
+)
+
+class SnapshotChunkManifestWriter(
+    private val manifestPath: Path,
+    private val objectMapper: ObjectMapper,
+) {
+    fun write(manifest: SnapshotChunkManifest) {
+        val json = objectMapper.writeValueAsBytes(manifest)
+        Files.write(manifestPath, json)
+    }
+}

--- a/module-external-api/src/main/kotlin/maple/externalapi/snapshot/SnapshotChunkRecord.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/snapshot/SnapshotChunkRecord.kt
@@ -1,0 +1,40 @@
+package maple.externalapi.snapshot
+
+import java.time.Instant
+
+sealed interface SnapshotChunkRecord {
+    val key: String
+    val endpoint: String
+    val keyType: String
+    val httpStatus: Int
+    val fetchedAt: Instant
+
+    data class Success(
+        override val key: String,
+        override val endpoint: String,
+        override val keyType: String,
+        override val httpStatus: Int,
+        override val fetchedAt: Instant,
+        val bodyBytes: ByteArray,
+    ) : SnapshotChunkRecord {
+        override fun equals(other: Any?): Boolean = this === other
+        override fun hashCode(): Int = System.identityHashCode(this)
+    }
+
+    data class Failure(
+        override val key: String,
+        override val endpoint: String,
+        override val keyType: String,
+        override val httpStatus: Int,
+        override val fetchedAt: Instant,
+        val errorMessage: String,
+    ) : SnapshotChunkRecord
+
+    data object CloseSignal : SnapshotChunkRecord {
+        override val key: String = ""
+        override val endpoint: String = ""
+        override val keyType: String = ""
+        override val httpStatus: Int = 0
+        override val fetchedAt: Instant = Instant.EPOCH
+    }
+}

--- a/module-external-api/src/main/kotlin/maple/externalapi/snapshot/SnapshotChunkingProperties.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/snapshot/SnapshotChunkingProperties.kt
@@ -1,0 +1,25 @@
+package maple.externalapi.snapshot
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "external-api.snapshot")
+data class SnapshotChunkingProperties(
+    val chunk: ChunkConfig = ChunkConfig(),
+    val queueCapacity: Int = 1000,
+) {
+    data class ChunkConfig(
+        val characterBasic: EndpointChunkConfig = EndpointChunkConfig(maxRecords = 2000),
+        val itemEquipment: EndpointChunkConfig = EndpointChunkConfig(maxRecords = 500),
+    )
+
+    data class EndpointChunkConfig(
+        val maxRecords: Int = 1000,
+        val maxUncompressedBytes: Long = 134217728L,
+    )
+
+    fun configFor(endpoint: String): EndpointChunkConfig = when (endpoint) {
+        "character-basic" -> chunk.characterBasic
+        "item-equipment" -> chunk.itemEquipment
+        else -> EndpointChunkConfig()
+    }
+}

--- a/module-external-api/src/main/kotlin/maple/externalapi/snapshot/SnapshotFailedRecordWriter.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/snapshot/SnapshotFailedRecordWriter.kt
@@ -1,0 +1,39 @@
+package maple.externalapi.snapshot
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+
+class SnapshotFailedRecordWriter(
+    private val filePath: Path,
+    private val objectMapper: ObjectMapper,
+) {
+    private var count = 0
+
+    fun append(record: SnapshotChunkRecord.Failure) {
+        val line = buildFailureLine(record)
+        Files.write(filePath, line, StandardOpenOption.CREATE, StandardOpenOption.APPEND)
+        count++
+    }
+
+    fun count(): Int = count
+
+    private fun buildFailureLine(record: SnapshotChunkRecord.Failure): ByteArray {
+        val buf = java.io.ByteArrayOutputStream()
+        buf.write("{\"endpoint\":".toByteArray())
+        buf.write(objectMapper.writeValueAsBytes(record.endpoint))
+        buf.write(",\"keyType\":".toByteArray())
+        buf.write(objectMapper.writeValueAsBytes(record.keyType))
+        buf.write(",\"key\":".toByteArray())
+        buf.write(objectMapper.writeValueAsBytes(record.key))
+        buf.write(",\"status\":\"FAILURE\",\"httpStatus\":".toByteArray())
+        buf.write(record.httpStatus.toString().toByteArray())
+        buf.write(",\"fetchedAt\":".toByteArray())
+        buf.write(objectMapper.writeValueAsBytes(record.fetchedAt.toString()))
+        buf.write(",\"error\":".toByteArray())
+        buf.write(objectMapper.writeValueAsBytes(record.errorMessage))
+        buf.write("}\n".toByteArray())
+        return buf.toByteArray()
+    }
+}

--- a/module-external-api/src/main/kotlin/maple/externalapi/snapshot/event/KafkaSnapshotChunkEventPublisher.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/snapshot/event/KafkaSnapshotChunkEventPublisher.kt
@@ -1,0 +1,37 @@
+package maple.externalapi.snapshot.event
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.slf4j.LoggerFactory
+import org.springframework.kafka.core.KafkaTemplate
+import java.util.concurrent.TimeUnit
+
+class KafkaSnapshotChunkEventPublisher(
+    private val kafkaTemplate: KafkaTemplate<String, String>,
+    private val objectMapper: ObjectMapper,
+    private val chunkReadyTopic: String,
+    private val runCompletedTopic: String,
+    private val runFailedTopic: String,
+) : SnapshotChunkEventPublisher {
+    private val log = LoggerFactory.getLogger(KafkaSnapshotChunkEventPublisher::class.java)
+
+    override fun publishChunkReady(event: SnapshotChunkReadyEvent) {
+        val key = "${event.runId}:${event.endpoint}:${event.chunkId}"
+        val payload = objectMapper.writeValueAsString(event)
+        kafkaTemplate.send(chunkReadyTopic, key, payload).get(30, TimeUnit.SECONDS)
+        log.info("[Event] published chunk-ready: runId={} endpoint={} chunkId={}", event.runId, event.endpoint, event.chunkId)
+    }
+
+    override fun publishRunCompleted(event: SnapshotRunCompletedEvent) {
+        val key = "${event.runId}:${event.endpoint}"
+        val payload = objectMapper.writeValueAsString(event)
+        kafkaTemplate.send(runCompletedTopic, key, payload).get(30, TimeUnit.SECONDS)
+        log.info("[Event] published run-completed: runId={} endpoint={} chunks={}", event.runId, event.endpoint, event.chunkCount)
+    }
+
+    override fun publishRunFailed(event: SnapshotRunFailedEvent) {
+        val key = "${event.runId}:${event.endpoint}"
+        val payload = objectMapper.writeValueAsString(event)
+        kafkaTemplate.send(runFailedTopic, key, payload).get(30, TimeUnit.SECONDS)
+        log.info("[Event] published run-failed: runId={} endpoint={}", event.runId, event.endpoint)
+    }
+}

--- a/module-external-api/src/main/kotlin/maple/externalapi/snapshot/event/NoOpSnapshotChunkEventPublisher.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/snapshot/event/NoOpSnapshotChunkEventPublisher.kt
@@ -1,0 +1,19 @@
+package maple.externalapi.snapshot.event
+
+import org.slf4j.LoggerFactory
+
+class NoOpSnapshotChunkEventPublisher : SnapshotChunkEventPublisher {
+    private val log = LoggerFactory.getLogger(NoOpSnapshotChunkEventPublisher::class.java)
+
+    override fun publishChunkReady(event: SnapshotChunkReadyEvent) {
+        log.debug("[Event] NoOp: chunk ready runId={} endpoint={} chunkId={}", event.runId, event.endpoint, event.chunkId)
+    }
+
+    override fun publishRunCompleted(event: SnapshotRunCompletedEvent) {
+        log.debug("[Event] NoOp: run completed runId={} endpoint={}", event.runId, event.endpoint)
+    }
+
+    override fun publishRunFailed(event: SnapshotRunFailedEvent) {
+        log.debug("[Event] NoOp: run failed runId={} endpoint={}", event.runId, event.endpoint)
+    }
+}

--- a/module-external-api/src/main/kotlin/maple/externalapi/snapshot/event/SnapshotChunkEventPublisher.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/snapshot/event/SnapshotChunkEventPublisher.kt
@@ -1,0 +1,7 @@
+package maple.externalapi.snapshot.event
+
+interface SnapshotChunkEventPublisher {
+    fun publishChunkReady(event: SnapshotChunkReadyEvent)
+    fun publishRunCompleted(event: SnapshotRunCompletedEvent)
+    fun publishRunFailed(event: SnapshotRunFailedEvent)
+}

--- a/module-external-api/src/main/kotlin/maple/externalapi/snapshot/event/SnapshotChunkReadyEvent.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/snapshot/event/SnapshotChunkReadyEvent.kt
@@ -1,0 +1,18 @@
+package maple.externalapi.snapshot.event
+
+import java.time.Instant
+
+data class SnapshotChunkReadyEvent(
+    val eventId: String,
+    val eventType: String = "SNAPSHOT_CHUNK_READY",
+    val schemaVersion: Int = 1,
+    val runId: String,
+    val endpoint: String,
+    val chunkId: String,
+    val objectKey: String,
+    val recordCount: Int,
+    val uncompressedBytes: Long,
+    val compressedBytes: Long,
+    val sha256: String? = null,
+    val createdAt: Instant,
+)

--- a/module-external-api/src/main/kotlin/maple/externalapi/snapshot/event/SnapshotEventProperties.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/snapshot/event/SnapshotEventProperties.kt
@@ -1,0 +1,16 @@
+package maple.externalapi.snapshot.event
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "external-api.snapshot.events")
+data class SnapshotEventProperties(
+    val enabled: Boolean = true,
+    val kafka: KafkaConfig = KafkaConfig(),
+) {
+    data class KafkaConfig(
+        val enabled: Boolean = false,
+        val chunkReadyTopic: String = "external-api.snapshot.chunk-ready",
+        val runCompletedTopic: String = "external-api.snapshot.run-completed",
+        val runFailedTopic: String = "external-api.snapshot.run-failed",
+    )
+}

--- a/module-external-api/src/main/kotlin/maple/externalapi/snapshot/event/SnapshotRunCompletedEvent.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/snapshot/event/SnapshotRunCompletedEvent.kt
@@ -1,0 +1,18 @@
+package maple.externalapi.snapshot.event
+
+import java.time.Instant
+
+data class SnapshotRunCompletedEvent(
+    val eventId: String,
+    val eventType: String = "SNAPSHOT_RUN_COMPLETED",
+    val schemaVersion: Int = 1,
+    val runId: String,
+    val endpoint: String,
+    val manifestPath: String,
+    val totalRecords: Int,
+    val totalFailed: Int,
+    val chunkCount: Int,
+    val startedAt: Instant,
+    val finishedAt: Instant,
+    val createdAt: Instant,
+)

--- a/module-external-api/src/main/kotlin/maple/externalapi/snapshot/event/SnapshotRunFailedEvent.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/snapshot/event/SnapshotRunFailedEvent.kt
@@ -1,0 +1,13 @@
+package maple.externalapi.snapshot.event
+
+import java.time.Instant
+
+data class SnapshotRunFailedEvent(
+    val eventId: String,
+    val eventType: String = "SNAPSHOT_RUN_FAILED",
+    val schemaVersion: Int = 1,
+    val runId: String,
+    val endpoint: String,
+    val errorMessage: String,
+    val createdAt: Instant,
+)

--- a/module-external-api/src/main/resources/logback-spring.xml
+++ b/module-external-api/src/main/resources/logback-spring.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <springProperty scope="context" name="APP_NAME" source="spring.application.name" defaultValue="external-api"/>
+    <springProperty scope="context" name="SERVER_PORT" source="server.port" defaultValue="8081"/>
+    <property name="HOST" value="${HOSTNAME:-${HOST:-unknown}}"/>
+
+    <appender name="JSON_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <customFields>{
+                "service":"${APP_NAME}",
+                "port":"${SERVER_PORT}",
+                "host":"${HOST}"
+            }</customFields>
+            <includeMdc>true</includeMdc>
+            <includeContext>true</includeContext>
+            <fieldNames>
+                <timestamp>timestamp</timestamp>
+                <version>[ignore]</version>
+                <levelValue>[ignore]</levelValue>
+            </fieldNames>
+        </encoder>
+    </appender>
+
+    <appender name="JSON_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/${APP_NAME}.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>logs/${APP_NAME}.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+            <maxFileSize>100MB</maxFileSize>
+            <maxHistory>3</maxHistory>
+            <totalSizeCap>500MB</totalSizeCap>
+        </rollingPolicy>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <customFields>{
+                "service":"${APP_NAME}",
+                "port":"${SERVER_PORT}",
+                "host":"${HOST}"
+            }</customFields>
+            <includeMdc>true</includeMdc>
+            <includeContext>true</includeContext>
+            <fieldNames>
+                <timestamp>timestamp</timestamp>
+                <version>[ignore]</version>
+                <levelValue>[ignore]</levelValue>
+            </fieldNames>
+        </encoder>
+    </appender>
+
+    <springProfile name="local">
+        <appender name="PLAIN_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            </encoder>
+        </appender>
+        <root level="INFO">
+            <appender-ref ref="PLAIN_CONSOLE"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="!local">
+        <root level="INFO">
+            <appender-ref ref="JSON_CONSOLE"/>
+            <appender-ref ref="JSON_FILE"/>
+        </root>
+    </springProfile>
+
+    <logger name="maple.externalapi" level="INFO"/>
+</configuration>

--- a/module-infra/src/main/java/maple/expectation/application/service/calculator/v4/EquipmentEnhanceDecorator.java
+++ b/module-infra/src/main/java/maple/expectation/application/service/calculator/v4/EquipmentEnhanceDecorator.java
@@ -1,0 +1,50 @@
+package maple.expectation.application.service.calculator.v4;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * V4 장비 강화 데코레이터 추상 클래스 (#240)
+ *
+ * <h3>Decorator Pattern (GoF)</h3>
+ *
+ * <p>기존 ExpectationCalculator를 감싸서 추가 강화 비용을 누적합니다.
+ *
+ * <h3>SOLID - OCP 준수</h3>
+ *
+ * <p>새로운 강화 타입 추가 시 이 클래스를 상속하여 확장
+ *
+ * <h3>성능 최적화 (2026-03-23)</h3>
+ *
+ * <ul>
+ *   <li>BigDecimal → Double로 변경하여 계산 비용 절감
+ *   <li>모든 반환 타입을 Double로 통일
+ * </ul>
+ *
+ * @see EquipmentExpectationCalculator 대상 인터페이스
+ */
+@RequiredArgsConstructor
+public abstract class EquipmentEnhanceDecorator implements EquipmentExpectationCalculator {
+
+  protected final EquipmentExpectationCalculator target;
+
+  @Override
+  public double calculateCost() {
+    return target.calculateCost();
+  }
+
+  @Override
+  public String getEnhancePath() {
+    return target.getEnhancePath();
+  }
+
+  @Override
+  public Optional<Double> getTrials() {
+    return target.getTrials();
+  }
+
+  @Override
+  public CostBreakdown getDetailedCosts() {
+    return target.getDetailedCosts();
+  }
+}

--- a/module-infra/src/main/java/maple/expectation/application/service/calculator/v4/EquipmentExpectationCalculator.java
+++ b/module-infra/src/main/java/maple/expectation/application/service/calculator/v4/EquipmentExpectationCalculator.java
@@ -1,0 +1,153 @@
+package maple.expectation.application.service.calculator.v4;
+
+import java.util.Optional;
+
+/**
+ * V4 장비 기대값 계산기 인터페이스 (#240)
+ *
+ * <h3>성능 최적화 (2026-03-23)</h3>
+ *
+ * <ul>
+ *   <li>BigDecimal → Double로 변경하여 계산 비용 절감
+ *   <li>내부 루프에서 Kahan Summation 사용으로 정확도 유지
+ *   <li>최종 결과만 BigDecimal로 변환 (경계 계층)
+ * </ul>
+ *
+ * <h3>기존 ExpectationCalculator와의 차이</h3>
+ *
+ * <ul>
+ *   <li>calculateCost() → Double (BigDecimal에서 변경)
+ *   <li>getTrials() → Double (정밀 기대값 계산)
+ *   <li>새로운 메서드: getDetailedCosts() - 비용 상세 분류
+ * </ul>
+ *
+ * @see maple.expectation.service.v2.calculator.ExpectationCalculator 기존 V2/V3 인터페이스
+ */
+public interface EquipmentExpectationCalculator {
+
+  /**
+   * 최종 소모 비용 합산 (Double)
+   *
+   * <p>성능 최적화: Double로 계산하여 BigDecimal 오버헤드 제거
+   *
+   * @return 기대 비용 (메소 단위)
+   */
+  double calculateCost();
+
+  /**
+   * 적용된 강화 경로 문자열 반환
+   *
+   * @return 강화 경로 (예: "무기 > 블랙큐브(윗잠) > 레드큐브(윗잠) > 에디셔널(아랫잠) > 스타포스")
+   */
+  String getEnhancePath();
+
+  /**
+   * 기대 시도 횟수 (기하분포 기반)
+   *
+   * @return 기대 시도 횟수 (없으면 Optional.empty())
+   */
+  Optional<Double> getTrials();
+
+  /**
+   * 비용 상세 분류
+   *
+   * <p>V4 API에서 항목별 비용 분류를 위해 사용
+   *
+   * @return 비용 상세 (블랙큐브, 레드큐브, 에디셔널, 스타포스 등)
+   */
+  CostBreakdown getDetailedCosts();
+
+  /**
+   * 비용 상세 분류 Record (#240 V4: trials 추가)
+   *
+   * <p>trials는 기대 시도 횟수로, Double로 변환하여 사용합니다.
+   */
+  record CostBreakdown(
+      double blackCubeCost,
+      double redCubeCost,
+      double additionalCubeCost,
+      double starforceCost,
+      double blackCubeTrials, // #240 V4: 블랙큐브 기대 시도 횟수
+      double redCubeTrials, // #240 V4: 레드큐브 기대 시도 횟수
+      double additionalCubeTrials // #240 V4: 에디셔널큐브 기대 시도 횟수
+      ) {
+    public static CostBreakdown empty() {
+      return new CostBreakdown(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+    }
+
+    public double total() {
+      return blackCubeCost + redCubeCost + additionalCubeCost + starforceCost;
+    }
+
+    public CostBreakdown withBlackCube(double cost) {
+      return new CostBreakdown(
+          cost,
+          redCubeCost,
+          additionalCubeCost,
+          starforceCost,
+          blackCubeTrials,
+          redCubeTrials,
+          additionalCubeTrials);
+    }
+
+    public CostBreakdown withBlackCube(double cost, double trials) {
+      return new CostBreakdown(
+          cost,
+          redCubeCost,
+          additionalCubeCost,
+          starforceCost,
+          trials,
+          redCubeTrials,
+          additionalCubeTrials);
+    }
+
+    public CostBreakdown withRedCube(double cost) {
+      return new CostBreakdown(
+          blackCubeCost,
+          cost,
+          additionalCubeCost,
+          starforceCost,
+          blackCubeTrials,
+          redCubeTrials,
+          additionalCubeTrials);
+    }
+
+    public CostBreakdown withRedCube(double cost, double trials) {
+      return new CostBreakdown(
+          blackCubeCost,
+          cost,
+          additionalCubeCost,
+          starforceCost,
+          blackCubeTrials,
+          trials,
+          additionalCubeTrials);
+    }
+
+    public CostBreakdown withAdditionalCube(double cost) {
+      return new CostBreakdown(
+          blackCubeCost,
+          redCubeCost,
+          cost,
+          starforceCost,
+          blackCubeTrials,
+          redCubeTrials,
+          additionalCubeTrials);
+    }
+
+    public CostBreakdown withAdditionalCube(double cost, double trials) {
+      return new CostBreakdown(
+          blackCubeCost, redCubeCost, cost, starforceCost, blackCubeTrials, redCubeTrials, trials);
+    }
+
+    public CostBreakdown withStarforce(double cost) {
+      return new CostBreakdown(
+          blackCubeCost,
+          redCubeCost,
+          additionalCubeCost,
+          cost,
+          blackCubeTrials,
+          redCubeTrials,
+          additionalCubeTrials);
+    }
+  }
+}

--- a/module-infra/src/main/java/maple/expectation/application/service/calculator/v4/EquipmentExpectationCalculatorFactory.java
+++ b/module-infra/src/main/java/maple/expectation/application/service/calculator/v4/EquipmentExpectationCalculatorFactory.java
@@ -1,0 +1,122 @@
+package maple.expectation.application.service.calculator.v4;
+
+import lombok.RequiredArgsConstructor;
+import maple.expectation.application.service.calculator.v4.impl.AdditionalCubeDecoratorV4;
+import maple.expectation.application.service.calculator.v4.impl.BaseEquipmentItem;
+import maple.expectation.application.service.calculator.v4.impl.BlackCubeDecoratorV4;
+import maple.expectation.application.service.calculator.v4.impl.StarforceDecoratorV4;
+import maple.expectation.application.service.cube.CubeTrialsProvider;
+import maple.expectation.application.service.cube.policy.CubeCostPolicy;
+import maple.expectation.core.calculator.port.StarforceLookupPort;
+import maple.expectation.core.dto.cube.CubeCalculationInput;
+import maple.expectation.core.dto.v4.EquipmentCalculationInput;
+import org.springframework.stereotype.Component;
+
+/**
+ * V4 장비 기대값 계산기 팩토리 (#240)
+ *
+ * <h3>역할</h3>
+ *
+ * <p>장비 입력을 기반으로 적절한 Decorator 체인을 구성합니다.
+ *
+ * <h3>Decorator 체인 예시</h3>
+ *
+ * <pre>
+ * BaseEquipmentItem
+ *   └→ BlackCubeDecoratorV4 (윗잠재)
+ *       └→ RedCubeDecoratorV4 (윗잠재 보조) [선택적]
+ *           └→ AdditionalCubeDecoratorV4 (아랫잠재)
+ *               └→ StarforceDecoratorV4 (스타포스)
+ * </pre>
+ *
+ * @see EquipmentExpectationCalculator 대상 인터페이스
+ */
+@Component
+@RequiredArgsConstructor
+public class EquipmentExpectationCalculatorFactory {
+
+  private final CubeTrialsProvider trialsProvider;
+  private final CubeCostPolicy costPolicy;
+  private final StarforceLookupPort starforceLookupPort;
+
+  /**
+   * 전체 강화 계산기 생성 (블랙큐브 + 에디셔널 + 스타포스)
+   *
+   * @param input 장비 계산 입력
+   * @return 전체 강화 계산기
+   */
+  public EquipmentExpectationCalculator createFullCalculator(EquipmentCalculationInput input) {
+    // 1. 기본 아이템
+    EquipmentExpectationCalculator calculator =
+        new BaseEquipmentItem(input.getItemName(), input.getItemLevel(), input.getCurrentStar());
+
+    // 2. 윗잠재 (블랙큐브) - 잠재능력이 있는 경우에만
+    if (input.hasPotential()) {
+      CubeCalculationInput potentialInput = input.toPotentialCubeInput();
+      calculator = new BlackCubeDecoratorV4(calculator, trialsProvider, costPolicy, potentialInput);
+    }
+
+    // 3. 아랫잠재 (에디셔널큐브) - 에디셔널 잠재능력이 있는 경우에만
+    if (input.hasAdditionalPotential()) {
+      CubeCalculationInput additionalInput = input.toAdditionalCubeInput();
+      calculator =
+          new AdditionalCubeDecoratorV4(calculator, trialsProvider, costPolicy, additionalInput);
+    }
+
+    // 4. 스타포스 - 스타포스 정보가 있는 경우에만
+    if (input.hasStarforce()) {
+      calculator =
+          new StarforceDecoratorV4(
+              calculator,
+              starforceLookupPort,
+              input.getCurrentStar(),
+              input.getTargetStar(),
+              input.getItemLevel());
+    }
+
+    return calculator;
+  }
+
+  /**
+   * 윗잠재(블랙큐브)만 계산하는 계산기 생성
+   *
+   * @param input 큐브 계산 입력
+   * @return 블랙큐브 계산기
+   */
+  public EquipmentExpectationCalculator createBlackCubeCalculator(CubeCalculationInput input) {
+    EquipmentExpectationCalculator calculator =
+        new BaseEquipmentItem(
+            input.getItemName(), input.getLevel(), 0 // 스타포스 정보 없음
+            );
+    return new BlackCubeDecoratorV4(calculator, trialsProvider, costPolicy, input);
+  }
+
+  /**
+   * 아랫잠재(에디셔널큐브)만 계산하는 계산기 생성
+   *
+   * @param input 큐브 계산 입력
+   * @return 에디셔널큐브 계산기
+   */
+  public EquipmentExpectationCalculator createAdditionalCubeCalculator(CubeCalculationInput input) {
+    EquipmentExpectationCalculator calculator =
+        new BaseEquipmentItem(input.getItemName(), input.getLevel(), 0);
+    return new AdditionalCubeDecoratorV4(calculator, trialsProvider, costPolicy, input);
+  }
+
+  /**
+   * 스타포스만 계산하는 계산기 생성
+   *
+   * @param itemName 아이템 이름
+   * @param itemLevel 아이템 레벨
+   * @param currentStar 현재 스타포스
+   * @param targetStar 목표 스타포스
+   * @return 스타포스 계산기
+   */
+  public EquipmentExpectationCalculator createStarforceCalculator(
+      String itemName, int itemLevel, int currentStar, int targetStar) {
+    EquipmentExpectationCalculator calculator =
+        new BaseEquipmentItem(itemName, itemLevel, currentStar);
+    return new StarforceDecoratorV4(
+        calculator, starforceLookupPort, currentStar, targetStar, itemLevel);
+  }
+}

--- a/module-infra/src/main/java/maple/expectation/application/service/calculator/v4/impl/BaseEquipmentItem.java
+++ b/module-infra/src/main/java/maple/expectation/application/service/calculator/v4/impl/BaseEquipmentItem.java
@@ -1,0 +1,57 @@
+package maple.expectation.application.service.calculator.v4.impl;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import maple.expectation.application.service.calculator.v4.EquipmentExpectationCalculator;
+
+/**
+ * V4 기본 장비 아이템 (Decorator Pattern - Concrete Component) (#240)
+ *
+ * <h3>역할</h3>
+ *
+ * <p>Decorator 체인의 시작점. 기본 아이템 자체의 비용은 0입니다.
+ *
+ * <h3>성능 최적화 (2026-03-23)</h3>
+ *
+ * <ul>
+ *   <li>BigDecimal → Double로 변경
+ *   <li>모든 반환 타입을 Double로 통일
+ * </ul>
+ *
+ * @see EquipmentExpectationCalculator 대상 인터페이스
+ */
+@RequiredArgsConstructor
+public class BaseEquipmentItem implements EquipmentExpectationCalculator {
+
+  private final String itemName;
+  private final int itemLevel;
+  private final int currentStar;
+
+  @Override
+  public double calculateCost() {
+    return 0.0; // 기본 아이템 자체의 비용은 0
+  }
+
+  @Override
+  public String getEnhancePath() {
+    return itemName;
+  }
+
+  @Override
+  public Optional<Double> getTrials() {
+    return Optional.of(0.0);
+  }
+
+  @Override
+  public CostBreakdown getDetailedCosts() {
+    return CostBreakdown.empty();
+  }
+
+  public int getItemLevel() {
+    return itemLevel;
+  }
+
+  public int getCurrentStar() {
+    return currentStar;
+  }
+}

--- a/module-infra/src/main/java/maple/expectation/application/service/calculator/v4/impl/StarforceDecoratorV4.java
+++ b/module-infra/src/main/java/maple/expectation/application/service/calculator/v4/impl/StarforceDecoratorV4.java
@@ -1,0 +1,124 @@
+package maple.expectation.application.service.calculator.v4.impl;
+
+import java.util.Optional;
+import maple.expectation.application.service.calculator.v4.EquipmentEnhanceDecorator;
+import maple.expectation.application.service.calculator.v4.EquipmentExpectationCalculator;
+import maple.expectation.core.calculator.port.StarforceLookupPort;
+
+/**
+ * V4 스타포스 데코레이터 (#240)
+ *
+ * <h3>스타포스 특성</h3>
+ *
+ * <ul>
+ *   <li>장비의 기본 스탯 강화 (0~25성)
+ *   <li>15성 이상부터 파괴 확률 존재
+ *   <li>세이프가드 옵션으로 파괴 방지 가능 (비용 2배)
+ * </ul>
+ *
+ * <h3>Lookup Table 사용</h3>
+ *
+ * <p>StarforceLookupTable에서 pre-computed 기대값 조회 (O(1))
+ *
+ * @see StarforceLookupPort 스타포스 기대값 조회
+ * @see EquipmentEnhanceDecorator 추상 데코레이터
+ */
+public class StarforceDecoratorV4 extends EquipmentEnhanceDecorator {
+
+  private static final int PRECISION_SCALE = 2;
+
+  private final StarforceLookupPort lookupPort;
+  private final int currentStar;
+  private final int targetStar;
+  private final int itemLevel;
+  private Double starforceCost;
+
+  /**
+   * 스타포스 데코레이터 생성
+   *
+   * @param target 이전 단계 계산기
+   * @param lookupPort 스타포스 기대값 조회 테이블
+   * @param currentStar 현재 스타포스 (0~25)
+   * @param targetStar 목표 스타포스 (currentStar ~ 25)
+   * @param itemLevel 아이템 레벨
+   */
+  public StarforceDecoratorV4(
+      EquipmentExpectationCalculator target,
+      StarforceLookupPort lookupPort,
+      int currentStar,
+      int targetStar,
+      int itemLevel) {
+    super(target);
+    this.lookupPort = lookupPort;
+    this.currentStar = currentStar;
+    this.targetStar = targetStar;
+    this.itemLevel = itemLevel;
+  }
+
+  /** 레벨별 최대 스타로 생성 (레벨에 따라 자동 결정) */
+  public StarforceDecoratorV4(
+      EquipmentExpectationCalculator target,
+      StarforceLookupPort lookupPort,
+      int currentStar,
+      int itemLevel) {
+    this(target, lookupPort, currentStar, lookupPort.getMaxStarForLevel(itemLevel), itemLevel);
+  }
+
+  @Override
+  public double calculateCost() {
+    double previousCost = super.calculateCost();
+    double sfCost = calculateStarforceCost();
+    return previousCost + sfCost;
+  }
+
+  /**
+   * 스타포스 기대 비용 계산
+   *
+   * <p>Lookup Table에서 pre-computed 값을 조회합니다.
+   *
+   * @return 스타포스 기대 비용
+   */
+  public double calculateStarforceCost() {
+    if (starforceCost == null) {
+      // 이미 목표 스타에 도달한 경우
+      if (currentStar >= targetStar) {
+        starforceCost = 0.0;
+      } else {
+        // Lookup Table에서 기대값 조회 (이미 Double 반환)
+        starforceCost = lookupPort.getExpectedCost(currentStar, targetStar, itemLevel);
+      }
+    }
+    return starforceCost;
+  }
+
+  @Override
+  public Optional<Double> getTrials() {
+    // 스타포스는 단순 시도 횟수로 표현하기 어려움 (성공/실패/파괴 복합 확률)
+    // 대신 calculateStarforceCost()를 사용하여 기대 비용 제공
+    return Optional.empty();
+  }
+
+  @Override
+  public CostBreakdown getDetailedCosts() {
+    CostBreakdown base = super.getDetailedCosts();
+    double sfCost = calculateStarforceCost();
+    return base.withStarforce(base.starforceCost() + sfCost);
+  }
+
+  @Override
+  public String getEnhancePath() {
+    return super.getEnhancePath() + String.format(" > 스타포스(%d→%d성)", currentStar, targetStar);
+  }
+
+  public int getCurrentStar() {
+    return currentStar;
+  }
+
+  public int getTargetStar() {
+    return targetStar;
+  }
+
+  public int getItemLevel() {
+    return itemLevel;
+  }
+}

--- a/module-infra/src/main/java/maple/expectation/application/service/cube/AbstractCubeDecorator.java
+++ b/module-infra/src/main/java/maple/expectation/application/service/cube/AbstractCubeDecorator.java
@@ -1,0 +1,243 @@
+package maple.expectation.application.service.cube;
+
+import java.math.RoundingMode;
+import java.util.Optional;
+import maple.expectation.application.service.cube.policy.CubeCostPolicy;
+import maple.expectation.core.dto.cube.CubeCalculationInput;
+import maple.expectation.domain.v2.CubeType;
+
+/**
+ * Abstract template for Cube decorators that eliminates duplication between V2 (long) and V4
+ * (BigDecimal).
+ *
+ * <h3>Generic Number Type Parameter</h3>
+ *
+ * <p>N extends Number allows this template to work with both:
+ *
+ * <ul>
+ *   <li>V2: Long (primitive long wrapper)
+ *   <li>V4: BigDecimal (precise decimal calculations)
+ * </ul>
+ *
+ * <h3>Template Method Pattern</h3>
+ *
+ * <p>Common cube calculation logic is provided in this abstract class. Subclasses only need to:
+ *
+ * <ul>
+ *   <li>Specify the cube type (BLACK, RED, ADDITIONAL)
+ *   <li>Provide number conversion utilities (long ↔ BigDecimal)
+ *   <li>Customize enhance path description
+ * </ul>
+ *
+ * <h3>Benefits</h3>
+ *
+ * <ul>
+ *   <li>Code reduction: ~15% less duplication
+ *   <li>Single source of truth for cube calculation logic
+ *   <li>Type-safe generic parameter ensures compile-time correctness
+ *   <li>Easy to add new cube types in the future
+ * </ul>
+ *
+ * @param <N> Number type (Long for V2, BigDecimal for V4)
+ * @param <T> Target calculator type (ExpectationCalculator for V2, EquipmentExpectationCalculator
+ *     for V4)
+ */
+public abstract class AbstractCubeDecorator<N extends Number, T> {
+
+  private static final int PRECISION_SCALE = 2;
+
+  protected final T target;
+  protected final CubeTrialsProvider trialsProvider;
+  protected final CubeCostPolicy costPolicy;
+  protected final CubeCalculationInput input;
+  protected N trials;
+
+  /**
+   * Protected constructor for subclass initialization.
+   *
+   * @param target The wrapped calculator (previous enhancement stage)
+   * @param trialsProvider Provider for calculating expected trials
+   * @param costPolicy Policy for cube cost calculation
+   * @param input Input parameters for cube calculation
+   */
+  protected AbstractCubeDecorator(
+      T target,
+      CubeTrialsProvider trialsProvider,
+      CubeCostPolicy costPolicy,
+      CubeCalculationInput input) {
+    this.target = target;
+    this.trialsProvider = trialsProvider;
+    this.costPolicy = costPolicy;
+    this.input = input;
+  }
+
+  /**
+   * Get the cube type for this decorator (Template Method hook).
+   *
+   * @return CubeType (BLACK, RED, or ADDITIONAL)
+   */
+  protected abstract CubeType getCubeType();
+
+  /**
+   * Calculate expected trials and cache result.
+   *
+   * <p>Uses geometric distribution expected value: E[X] = 1 / p
+   *
+   * <p>Handles edge cases:
+   *
+   * <ul>
+   *   <li>null trials → 0
+   *   <li>Infinity trials → 0 (impossible combination)
+   *   <li>Finite trials → converted to N type
+   * </ul>
+   *
+   * @return Expected number of trials
+   */
+  public N calculateTrials() {
+    if (trials == null) {
+      Double rawTrials = trialsProvider.calculateExpectedTrials(input, getCubeType());
+
+      // P0 Fix (#262): Infinity values cannot convert to BigDecimal → ZERO handling
+      // Infinity = impossible combination = cost calculation meaningless
+      if (rawTrials != null && Double.isFinite(rawTrials)) {
+        trials = convertFromDouble(rawTrials);
+      } else {
+        trials = getZero();
+      }
+    }
+    return trials;
+  }
+
+  /**
+   * Get cached trials value (Template Method hook for Optional return).
+   *
+   * @return Optional containing trials, or empty if not calculated
+   */
+  protected abstract Optional<N> getTrialsOptional();
+
+  /**
+   * Calculate cost per trial from policy (Template Method hook).
+   *
+   * @return Cost per trial as type N
+   */
+  protected abstract N getCostPerTrial();
+
+  /**
+   * Calculate total cost for this cube enhancement (Template Method).
+   *
+   * @return Total cost (previous cost + cube cost)
+   */
+  protected abstract N calculateTotalCost();
+
+  /**
+   * Get enhance path description (Template Method hook).
+   *
+   * @return Base enhance path from target
+   */
+  protected abstract String getBaseEnhancePath();
+
+  /**
+   * Get cube-specific path suffix (Template Method hook).
+   *
+   * @return Path suffix (e.g., " > 블랙큐브(윗잠)")
+   */
+  protected abstract String getCubePathSuffix();
+
+  /**
+   * Convert Double to N type (Template Method hook).
+   *
+   * @param value Double value to convert
+   * @return Converted value as N
+   */
+  protected abstract N convertFromDouble(Double value);
+
+  /**
+   * Convert long to N type (Template Method hook).
+   *
+   * @param value long value to convert
+   * @return Converted value as N
+   */
+  protected abstract N convertFromLong(long value);
+
+  /**
+   * Get zero value for type N (Template Method hook).
+   *
+   * @return Zero as N
+   */
+  protected abstract N getZero();
+
+  /**
+   * Add two N values (Template Method hook).
+   *
+   * @param a First value
+   * @param b Second value
+   * @return Sum as N
+   */
+  protected abstract N add(N a, N b);
+
+  /**
+   * Multiply two N values (Template Method hook).
+   *
+   * @param a First value
+   * @param b Second value
+   * @return Product as N
+   */
+  protected abstract N multiply(N a, N b);
+
+  /**
+   * Round BigDecimal to specified scale (V4 only hook).
+   *
+   * @param value Value to round
+   * @param scale Decimal places
+   * @return Rounded value as N
+   */
+  protected N roundBigDecimal(N value, int scale) {
+    // Default implementation: no rounding (for V2 Long)
+    return value;
+  }
+
+  /**
+   * Get final enhance path with cube suffix.
+   *
+   * @return Complete enhance path string
+   */
+  public final String getEnhancePath() {
+    return getBaseEnhancePath() + getCubePathSuffix();
+  }
+
+  /**
+   * Get raw long cost from policy (common helper).
+   *
+   * @return Cost per trial as long
+   */
+  protected final long getLongCostPerTrial() {
+    return costPolicy.getCubeCost(getCubeType(), input.getLevel(), input.getGrade());
+  }
+
+  /**
+   * Get precision scale for BigDecimal operations.
+   *
+   * @return Scale value (2 for V4)
+   */
+  protected final int getPrecisionScale() {
+    return PRECISION_SCALE;
+  }
+
+  /**
+   * Check if rounding should be applied (V4 specific).
+   *
+   * @return true if this is a V4 BigDecimal decorator
+   */
+  protected boolean shouldRoundTrials() {
+    return false; // Default: V2 doesn't round
+  }
+
+  /**
+   * Get rounding mode for V4 calculations.
+   *
+   * @return RoundingMode.HALF_UP
+   */
+  protected RoundingMode getRoundingMode() {
+    return RoundingMode.HALF_UP;
+  }
+}

--- a/module-infra/src/main/java/maple/expectation/application/service/cube/AbstractCubeDecoratorV4.java
+++ b/module-infra/src/main/java/maple/expectation/application/service/cube/AbstractCubeDecoratorV4.java
@@ -1,0 +1,247 @@
+package maple.expectation.application.service.cube;
+
+import java.util.Optional;
+import maple.expectation.application.service.calculator.v4.EquipmentEnhanceDecorator;
+import maple.expectation.application.service.calculator.v4.EquipmentExpectationCalculator;
+import maple.expectation.application.service.calculator.v4.EquipmentExpectationCalculator.CostBreakdown;
+import maple.expectation.application.service.cube.policy.CubeCostPolicy;
+import maple.expectation.core.dto.cube.CubeCalculationInput;
+import maple.expectation.domain.v2.CubeType;
+
+/**
+ * V4-specific abstract cube decorator using Double type for performance.
+ *
+ * <p>Extends AbstractCubeDecorator with V4-specific implementations:
+ *
+ * <ul>
+ *   <li>Type parameter: Double (performance optimization)
+ *   <li>Rounds trials to integer (HALF_UP) before cost calculation
+ *   <li>Extends EquipmentEnhanceDecorator for V4 calculator chain
+ *   <li>Supports CostBreakdown for detailed cost tracking
+ * </ul>
+ *
+ * <h3>V4 Improvements over V2</h3>
+ *
+ * <ul>
+ *   <li>Performance: Double prevents BigDecimal object allocation overhead
+ *   <li>Rounding: Trials rounded to integer before multiplication
+ *   <li>Detailed breakdown: Separate tracking of cube costs and trials
+ * </ul>
+ */
+public abstract class AbstractCubeDecoratorV4 extends EquipmentEnhanceDecorator {
+
+  private static final int PRECISION_SCALE = 2;
+
+  private final AbstractCubeDecorator<Double, EquipmentExpectationCalculator> delegate;
+
+  /**
+   * Constructor that initializes both the decorator chain and the generic delegate.
+   *
+   * @param target The wrapped calculator (previous enhancement stage)
+   * @param trialsProvider Provider for calculating expected trials
+   * @param costPolicy Policy for cube cost calculation
+   * @param input Input parameters for cube calculation
+   */
+  protected AbstractCubeDecoratorV4(
+      EquipmentExpectationCalculator target,
+      CubeTrialsProvider trialsProvider,
+      CubeCostPolicy costPolicy,
+      CubeCalculationInput input) {
+    super(target);
+
+    // Create delegate with V4-specific implementations
+    this.delegate =
+        new AbstractCubeDecorator<Double, EquipmentExpectationCalculator>(
+            target, trialsProvider, costPolicy, input) {
+
+          @Override
+          protected CubeType getCubeType() {
+            return AbstractCubeDecoratorV4.this.getCubeType();
+          }
+
+          @Override
+          protected Optional<Double> getTrialsOptional() {
+            return AbstractCubeDecoratorV4.this.getTrials();
+          }
+
+          @Override
+          protected Double getCostPerTrial() {
+            return (double)
+                costPolicy.getCubeCost(getCubeType(), input.getLevel(), input.getGrade());
+          }
+
+          @Override
+          protected Double calculateTotalCost() {
+            return AbstractCubeDecoratorV4.this.calculateCost();
+          }
+
+          @Override
+          protected String getBaseEnhancePath() {
+            return AbstractCubeDecoratorV4.this.getBaseEnhancePath();
+          }
+
+          @Override
+          protected String getCubePathSuffix() {
+            return AbstractCubeDecoratorV4.this.getCubePathSuffix();
+          }
+
+          @Override
+          protected Double convertFromDouble(Double value) {
+            return value;
+          }
+
+          @Override
+          protected Double convertFromLong(long value) {
+            return (double) value;
+          }
+
+          @Override
+          protected Double getZero() {
+            return 0.0;
+          }
+
+          @Override
+          protected Double add(Double a, Double b) {
+            return a + b;
+          }
+
+          @Override
+          protected Double multiply(Double a, Double b) {
+            return a * b;
+          }
+
+          @Override
+          protected boolean shouldRoundTrials() {
+            return true; // V4 always rounds trials
+          }
+        };
+  }
+
+  /**
+   * Get the cube type for this decorator (subclass must implement).
+   *
+   * @return CubeType (BLACK, RED, or ADDITIONAL)
+   */
+  protected abstract CubeType getCubeType();
+
+  /**
+   * Get cube-specific path suffix (subclass must implement).
+   *
+   * @return Path suffix (e.g., " > 블랙큐브(윗잠)")
+   */
+  protected abstract String getCubePathSuffix();
+
+  /**
+   * Calculate expected trials using delegate.
+   *
+   * @return Expected number of trials (Double)
+   */
+  public double calculateTrials() {
+    return delegate.calculateTrials();
+  }
+
+  /**
+   * Get trials as Optional.
+   *
+   * @return Optional containing trials
+   */
+  @Override
+  public Optional<Double> getTrials() {
+    return Optional.of(delegate.calculateTrials());
+  }
+
+  /**
+   * Calculate total cost: previous cost + (rounded trials × cost per trial).
+   *
+   * <p>V4 improvement: Trials are rounded to integer before cost calculation.
+   *
+   * @return Total cost (Double)
+   */
+  @Override
+  public double calculateCost() {
+    // 1. Previous stage cumulative cost
+    double previousCost = super.calculateCost();
+
+    // 2. Expected trials for cube
+    double expectedTrials = delegate.calculateTrials();
+
+    // 3. Round trials to integer (V4 improvement)
+    long roundedTrials = Math.round(expectedTrials);
+
+    // 4. Cost per trial from policy
+    double costPerTrial = delegate.getLongCostPerTrial();
+
+    // 5. Total cost = previous + (roundedTrials × costPerTrial)
+    double cubeCost = roundedTrials * costPerTrial;
+
+    return previousCost + cubeCost;
+  }
+
+  /**
+   * Get detailed cost breakdown with cube-specific costs.
+   *
+   * <p>Subclasses should override this to add cube-specific cost breakdown.
+   *
+   * @return CostBreakdown with cube costs added
+   */
+  @Override
+  public CostBreakdown getDetailedCosts() {
+    CostBreakdown base = super.getDetailedCosts();
+
+    // Calculate trials and cost
+    double expectedTrials = delegate.calculateTrials();
+    long roundedTrials = Math.round(expectedTrials);
+    double costPerTrial = delegate.getLongCostPerTrial();
+    double cubeCost = roundedTrials * costPerTrial;
+
+    // Delegate to subclass for specific CostBreakdown method
+    return updateCostBreakdown(base, cubeCost, roundedTrials);
+  }
+
+  /**
+   * Update CostBreakdown with cube-specific costs (Template Method hook).
+   *
+   * <p>Subclasses must implement this to call the appropriate CostBreakdown method:
+   *
+   * <ul>
+   *   <li>Black Cube: base.withBlackCube(cost, trials)
+   *   <li>Red Cube: base.withRedCube(cost, trials)
+   *   <li>Additional Cube: base.withAdditionalCube(cost, trials)
+   * </ul>
+   *
+   * @param base Base CostBreakdown from previous stage
+   * @param cubeCost Cost for this cube
+   * @param trials Rounded trials for this cube
+   * @return Updated CostBreakdown
+   */
+  protected abstract CostBreakdown updateCostBreakdown(
+      CostBreakdown base, double cubeCost, double trials);
+
+  /**
+   * Get base enhance path from target.
+   *
+   * @return Base enhance path
+   */
+  protected String getBaseEnhancePath() {
+    return super.getEnhancePath();
+  }
+
+  /**
+   * Get complete enhance path with cube suffix.
+   *
+   * @return Complete enhance path string
+   */
+  @Override
+  public String getEnhancePath() {
+    return delegate.getEnhancePath();
+  }
+
+  /**
+   * Get precision scale for operations.
+   *
+   * @return Scale value (2)
+   */
+  protected int getPrecisionScale() {
+    return PRECISION_SCALE;
+  }
+}

--- a/module-infra/src/main/java/maple/expectation/application/service/cube/CubeServiceImpl.java
+++ b/module-infra/src/main/java/maple/expectation/application/service/cube/CubeServiceImpl.java
@@ -1,0 +1,221 @@
+package maple.expectation.application.service.cube;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import maple.expectation.application.service.cube.component.CubeComputeBuffer;
+import maple.expectation.application.service.cube.component.CubeDpCalculator;
+import maple.expectation.application.service.cube.component.DpModeInferrer;
+import maple.expectation.config.CubeEngineFeatureFlag;
+import maple.expectation.core.calculator.CubeRateCalculator;
+import maple.expectation.core.domain.model.CubeRate;
+import maple.expectation.core.dto.cube.CubeCalculationInput;
+import maple.expectation.core.dto.cube.CubeComputeKey;
+import maple.expectation.domain.repository.CubeProbabilityRepository;
+import maple.expectation.domain.v2.CubeProbability;
+import maple.expectation.core.calculator.port.CubeTrialsPort;
+import maple.expectation.domain.v2.CubeType;
+import maple.expectation.error.exception.UnsupportedCalculationEngineException;
+import maple.expectation.infrastructure.executor.LogicExecutor;
+import maple.expectation.infrastructure.executor.TaskContext;
+import maple.expectation.infrastructure.util.PermutationUtil;
+import org.springframework.stereotype.Service;
+
+/**
+ * 큐브 기대값 계산 서비스
+ *
+ * <h3>두 가지 엔진 지원</h3>
+ *
+ * <ul>
+ *   <li><b>v1 (순열)</b>: 기존 PermutationUtil 기반 O(N!) 방식
+ *   <li><b>v2 (DP)</b>: 새로운 Convolution 기반 O(slots × target × K) 방식
+ * </ul>
+ *
+ * <h3>Feature Flag 전환</h3>
+ *
+ * <ul>
+ *   <li>dpEnabled=false: v1 결과 반환 (shadow=true면 v2 비교 로깅)
+ *   <li>dpEnabled=true: v2 결과 반환 (shadow=true면 v1 drift 모니터링)
+ * </ul>
+ */
+@Slf4j
+@Service("cubeServiceImpl")
+@RequiredArgsConstructor
+public class CubeServiceImpl implements CubeTrialsProvider, CubeTrialsPort {
+
+  private final CubeRateCalculator rateCalculator;
+  private final CubeDpCalculator dpCalculator;
+  private final CubeProbabilityRepository repository;
+  private final CubeEngineFeatureFlag featureFlag;
+  private final LogicExecutor executor;
+  private final DpModeInferrer dpModeInferrer;
+  private final CubeComputeBuffer computeBuffer;
+
+  @Override
+  public Double calculateExpectedTrials(CubeCalculationInput input, CubeType type) {
+    // 1. 이미 DP 모드가 명시적으로 설정된 경우 → Feature Flag에 따라 분기
+    if (input.isDpMode()) {
+      // P2 Fix (PR #159 Codex 지적): dpEnabled=false면 fail fast
+      // v1 엔진은 DP 입력(minTotal 등 누적 확률)을 처리할 수 없음
+      if (!featureFlag.isDpEnabled()) {
+        log.warn("[CubeService] DP 모드 요청이지만 dpEnabled=false. input={}", input);
+        throw new UnsupportedCalculationEngineException();
+      }
+      return calculateWithDpEngine(input, type);
+    }
+
+    // 2. DP 모드가 아닌 경우 → 자동 추론 시도
+    boolean inferred = dpModeInferrer.applyDpFields(input);
+
+    if (inferred) {
+      // 추론 성공: DP 엔진으로 누적 확률 계산 (Feature Flag 무시)
+      // 이유: 자동 추론의 목적 자체가 "X% 이상" 계산이므로 DP 필수
+      log.debug(
+          "[CubeService] DP 모드 자동 추론 성공: {} {}% 이상",
+          input.getTargetStatType(), input.getMinTotal());
+      return calculateWithDpEngine(input, type);
+    }
+
+    // 3. 추론 실패: 기존 v1 엔진으로 처리
+    return calculateWithV1Engine(input, type);
+  }
+
+  /** DP 엔진 활성 (flag ON) - v2 결과 반환 - shadow=true면 v1도 계산하여 drift 모니터링 */
+  private Double calculateWithDpEngine(CubeCalculationInput input, CubeType type) {
+    String tableVersion = repository.getCurrentTableVersion();
+
+    CubeComputeKey key = CubeComputeKey.from(input, type.name(), tableVersion);
+    Double v2Result =
+        computeBuffer.getOrCompute(
+            key,
+            () ->
+                executor.execute(
+                    () -> dpCalculator.calculateWithCache(input, type, tableVersion),
+                    TaskContext.of(
+                        "CubeService", "CalculateDP", input.getTargetStatType().name())));
+
+    if (featureFlag.isShadowEnabled()) {
+      Double v1Result = calculateWithV1Engine(input, type);
+      logDrift("V2_ACTIVE", v1Result, v2Result, input, tableVersion);
+    }
+
+    return v2Result;
+  }
+
+  /** v1 엔진 활성 (flag OFF) - v1 결과 반환 - shadow=true면 v2도 계산하여 비교 로깅 */
+  private Double calculateWithV1AndShadow(CubeCalculationInput input, CubeType type) {
+    Double v1Result = calculateWithV1Engine(input, type);
+
+    if (featureFlag.isShadowEnabled()) {
+      String tableVersion = repository.getCurrentTableVersion();
+      Double v2Result =
+          executor.executeOrDefault(
+              () -> dpCalculator.calculateWithCache(input, type, tableVersion),
+              null,
+              TaskContext.of("CubeService", "ShadowDP", input.getTargetStatType().name()));
+      if (v2Result != null) {
+        logDrift("V1_ACTIVE", v1Result, v2Result, input, tableVersion);
+      }
+    }
+
+    return v1Result;
+  }
+
+  /** v1 엔진: 순열 기반 계산 (기존 로직) */
+  private Double calculateWithV1Engine(CubeCalculationInput input, CubeType type) {
+    if (!input.isReady()) {
+      return 0.0;
+    }
+
+    return executor.execute(
+        () -> doCalculateV1(input, type),
+        TaskContext.of("CubeService", "CalculateV1", type.name()));
+  }
+
+  /**
+   * v1 기대 시도 횟수 계산 (순열 기반)
+   *
+   * <p>반환값: raw 1/p (v2와 동일한 의미)
+   *
+   * <p>p=0 → +∞ (v2와 의미 통일)
+   *
+   * <p>UI 반올림은 Controller/View 레이어에서 처리
+   */
+  private Double doCalculateV1(CubeCalculationInput input, CubeType type) {
+    List<String> targetOptions = new ArrayList<>(input.getOptions());
+    Set<List<String>> permutations = PermutationUtil.generateUniquePermutations(targetOptions);
+    double totalProbability = 0.0;
+
+    for (List<String> caseOptions : permutations) {
+      double caseProb = calculateCaseProbability(input, type, caseOptions);
+      totalProbability += caseProb;
+    }
+
+    // P0: raw 1/p 반환 (v2와 의미 통일)
+    // p=0 → +∞ (불가능한 조합 = 무한대 시도 필요)
+    return (totalProbability > 0) ? (1.0 / totalProbability) : Double.POSITIVE_INFINITY;
+  }
+
+  private double calculateCaseProbability(
+      CubeCalculationInput input, CubeType type, List<String> caseOptions) {
+    // Fetch probabilities for this cube type and level
+    var coreType = type.toCore();
+    List<CubeProbability> v2Probabilities =
+        repository.findProbabilities(type, input.getLevel(), input.getPart(), input.getGrade(), 0);
+
+    // Convert v2.CubeProbability to core.CubeRate
+    List<CubeRate> coreRates =
+        v2Probabilities.stream()
+            .map(
+                p ->
+                    new CubeRate(
+                        coreType,
+                        p.getOptionName(),
+                        p.getRate(),
+                        p.getSlot(),
+                        p.getGrade(),
+                        p.getLevel(),
+                        p.getPart()))
+            .toList();
+
+    double caseProb = 1.0;
+    for (int i = 0; i < 3; i++) {
+      caseProb *=
+          rateCalculator.getOptionRate(
+              coreType,
+              input.getLevel(),
+              input.getPart(),
+              input.getGrade(),
+              i + 1,
+              caseOptions.get(i),
+              coreRates);
+    }
+    return caseProb;
+  }
+
+  private void logDrift(
+      String mode, Double v1, Double v2, CubeCalculationInput input, String tableVersion) {
+    if (v1 == null || v2 == null) {
+      log.warn("[CubeEngine:{}] drift 계산 불가: v1={}, v2={}", mode, v1, v2);
+      return;
+    }
+    double drift = Math.abs(v1 - v2);
+    log.debug(
+        "[CubeEngine:{}] v1={}, v2={}, drift={}, target={}, tableVersion={}",
+        mode,
+        v1,
+        v2,
+        drift,
+        input.getTargetStatType(),
+        tableVersion);
+  }
+
+  @Override
+  public double calculateExpectedTrials(CubeCalculationInput input, maple.expectation.core.domain.model.CubeType type) {
+    CubeType v2Type = CubeType.fromCore(type);
+    Double result = calculateExpectedTrials(input, v2Type);
+    return result != null ? result : 0.0;
+  }
+}

--- a/module-infra/src/main/java/maple/expectation/application/service/cube/CubeTrialsProvider.java
+++ b/module-infra/src/main/java/maple/expectation/application/service/cube/CubeTrialsProvider.java
@@ -1,0 +1,9 @@
+package maple.expectation.application.service.cube;
+
+import maple.expectation.core.dto.cube.CubeCalculationInput;
+import maple.expectation.domain.v2.CubeType;
+
+public interface CubeTrialsProvider {
+  /** 특정 큐브와 설정값에 따른 목표 옵션 도달 기대 시도 횟수를 반환합니다. */
+  Double calculateExpectedTrials(CubeCalculationInput input, CubeType type);
+}

--- a/module-infra/src/main/java/maple/expectation/application/service/cube/component/CubeComputeBuffer.java
+++ b/module-infra/src/main/java/maple/expectation/application/service/cube/component/CubeComputeBuffer.java
@@ -1,0 +1,58 @@
+package maple.expectation.application.service.cube.component;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+import maple.expectation.core.dto.cube.CubeComputeKey;
+import maple.expectation.core.port.inbound.BatchComputeBuffer;
+import org.springframework.stereotype.Component;
+
+/**
+ * Thread-safe batch compute buffer backed by ConcurrentHashMap.
+ *
+ * <p>Memoizes cube probability computation results within a single batch to avoid redundant
+ * calculations for identical keys.
+ *
+ * @see BatchComputeBuffer
+ * @see CubeComputeKey
+ */
+@Component
+public class CubeComputeBuffer implements BatchComputeBuffer {
+
+  private final ConcurrentHashMap<CubeComputeKey, Double> cache = new ConcurrentHashMap<>();
+  private final java.util.concurrent.atomic.AtomicInteger hits =
+      new java.util.concurrent.atomic.AtomicInteger(0);
+  private final java.util.concurrent.atomic.AtomicInteger misses =
+      new java.util.concurrent.atomic.AtomicInteger(0);
+
+  public Double getOrCompute(CubeComputeKey key, Supplier<Double> compute) {
+    Double existing = cache.get(key);
+    if (existing != null) {
+      hits.incrementAndGet();
+      return existing;
+    }
+    Double result =
+        cache.computeIfAbsent(
+            key,
+            k -> {
+              misses.incrementAndGet();
+              return compute.get();
+            });
+    return result;
+  }
+
+  @Override
+  public void clear() {
+    cache.clear();
+    hits.set(0);
+    misses.set(0);
+  }
+
+  @Override
+  public BatchComputeBuffer.BufferStats stats() {
+    return BatchComputeBuffer.BufferStats.of(hits.get(), misses.get(), cache.size());
+  }
+
+  public int size() {
+    return cache.size();
+  }
+}

--- a/module-infra/src/main/java/maple/expectation/application/service/cube/component/CubeDpCalculator.java
+++ b/module-infra/src/main/java/maple/expectation/application/service/cube/component/CubeDpCalculator.java
@@ -1,0 +1,97 @@
+package maple.expectation.application.service.cube.component;
+
+import java.util.List;
+import java.util.stream.IntStream;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import maple.expectation.core.domain.model.calculator.DensePmf;
+import maple.expectation.core.domain.model.calculator.SparsePmf;
+import maple.expectation.core.dto.cube.CubeCalculationInput;
+import maple.expectation.core.probability.ProbabilityConvolver;
+import maple.expectation.core.probability.TailProbabilityCalculator;
+import maple.expectation.domain.v2.CubeType;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Component;
+
+/**
+ * DP 기반 큐브 기대값 계산 컴포넌트
+ *
+ * <h3>핵심 역할</h3>
+ *
+ * <p>@Cacheable self-invocation 방지를 위한 별도 Bean으로 분리하여 Spring 프록시 적용
+ *
+ * <h3>캐시 키 구성</h3>
+ *
+ * <ul>
+ *   <li>type + level + part + grade + targetStatType + minTotal + enableTailClamp + tableVersion
+ *   <li>tableVersion 포함으로 테이블 갱신 시 과거 확률 캐시 방지
+ * </ul>
+ *
+ * <h3>핵심 가정 (이 가정이 틀리면 결과도 틀림)</h3>
+ *
+ * <ul>
+ *   <li>각 슬롯(라인)은 독립적으로 옵션을 추첨한다
+ *   <li>슬롯 간 추첨은 독립이다 (조건부 확률 아님)
+ *   <li>같은 옵션이 여러 슬롯에 중복 등장 가능하다
+ * </ul>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CubeDpCalculator {
+
+  private final SlotDistributionBuilder distributionBuilder;
+  private final ProbabilityConvolver convolver;
+  private final TailProbabilityCalculator tailCalculator;
+  private final CubeSlotCountResolver slotCountResolver;
+
+  /**
+   * DP 기반 기대 시도 횟수 계산 (캐시 적용)
+   *
+   * <p>캐시 키에 tableVersion이 포함되어 테이블 갱신 시 과거 확률 캐시를 방지합니다.
+   *
+   * @param input 계산 입력 (DP 모드 필드 필수)
+   * @param type 큐브 타입
+   * @param tableVersion 테이블 버전 (TOCTOU 방지)
+   * @return 기대 시도 횟수
+   * @throws IllegalArgumentException DP 필수 필드 누락 시
+   */
+  @Cacheable(
+      value = "cubeTrials",
+      key =
+          "#type.name() + ':' + #input.level + ':' + #input.part + ':' + "
+              + "#input.grade + ':' + #input.targetStatType + ':' + #input.minTotal + ':' + "
+              + "#input.enableTailClamp + ':' + #tableVersion")
+  public Double calculateWithCache(CubeCalculationInput input, CubeType type, String tableVersion) {
+    input.validateForDpMode();
+    return doCalculate(input, type, tableVersion);
+  }
+
+  private Double doCalculate(CubeCalculationInput input, CubeType type, String tableVersion) {
+    boolean enableClamp = input.isEnableTailClamp();
+    int target = input.getMinTotal();
+    int slotCount = slotCountResolver.resolve(type);
+
+    List<SparsePmf> slotPmfs = buildSlotDistributions(input, type, tableVersion, slotCount);
+    DensePmf totalPmf = convolver.convolveAll(slotPmfs, target, enableClamp);
+    double tailProb = tailCalculator.calculateTailProbability(totalPmf, target, enableClamp);
+
+    return tailCalculator.calculateExpectedTrials(tailProb);
+  }
+
+  private List<SparsePmf> buildSlotDistributions(
+      CubeCalculationInput input, CubeType type, String tableVersion, int slotCount) {
+    return IntStream.rangeClosed(1, slotCount)
+        .mapToObj(
+            slot ->
+                distributionBuilder.buildDistributionByVersion(
+                    type,
+                    input.getLevel(),
+                    input.getPart(),
+                    input.getGrade(),
+                    slot,
+                    input.getTargetStatType(),
+                    tableVersion))
+        .toList();
+  }
+}

--- a/module-infra/src/main/java/maple/expectation/application/service/cube/component/CubeSlotCountResolver.java
+++ b/module-infra/src/main/java/maple/expectation/application/service/cube/component/CubeSlotCountResolver.java
@@ -1,0 +1,33 @@
+package maple.expectation.application.service.cube.component;
+
+import maple.expectation.domain.v2.CubeType;
+import org.springframework.stereotype.Component;
+
+/**
+ * 큐브 타입별 슬롯 수 결정 컴포넌트
+ *
+ * <p>큐브 종류에 따라 잠재능력 라인(슬롯) 수를 반환합니다.
+ *
+ * <h3>슬롯 규칙</h3>
+ *
+ * <ul>
+ *   <li>BLACK, RED, ADDITIONAL: 3줄
+ * </ul>
+ */
+@Component
+public class CubeSlotCountResolver {
+
+  private static final int DEFAULT_SLOT_COUNT = 3;
+
+  /**
+   * 큐브 타입에 따른 슬롯 수 반환
+   *
+   * @param cubeType 큐브 종류
+   * @return 슬롯 수 (기본 3)
+   */
+  public int resolve(CubeType cubeType) {
+    return switch (cubeType) {
+      case BLACK, RED, ADDITIONAL -> DEFAULT_SLOT_COUNT;
+    };
+  }
+}

--- a/module-infra/src/main/java/maple/expectation/application/service/cube/component/DpModeInferrer.java
+++ b/module-infra/src/main/java/maple/expectation/application/service/cube/component/DpModeInferrer.java
@@ -1,0 +1,231 @@
+package maple.expectation.application.service.cube.component;
+
+import java.util.EnumMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import maple.expectation.core.domain.stat.StatType;
+import maple.expectation.core.dto.cube.CubeCalculationInput;
+import maple.expectation.infrastructure.executor.LogicExecutor;
+import maple.expectation.infrastructure.executor.TaskContext;
+import org.springframework.stereotype.Component;
+
+/**
+ * 옵션 리스트에서 DP 모드 필드를 자동 추론하는 컴포넌트
+ *
+ * <h3>동작 방식</h3>
+ *
+ * <ol>
+ *   <li>옵션 3줄에서 주요 스탯 타입별 기여도 합산
+ *   <li>가장 높은 기여도를 가진 스탯을 targetStatType으로 선택
+ *   <li>해당 스탯의 합계를 minTotal로 설정
+ * </ol>
+ *
+ * <h3>올스탯 처리</h3>
+ *
+ * <p>올스탯 9%는 STR/DEX/INT/LUK 각각에 9%씩 기여
+ *
+ * <h3>지원 스탯 타입</h3>
+ *
+ * <ul>
+ *   <li>STR_PERCENT, DEX_PERCENT, INT_PERCENT, LUK_PERCENT
+ *   <li>ATTACK_POWER_PERCENT, MAGIC_POWER_PERCENT
+ *   <li>BOSS_DAMAGE, IGNORE_DEFENSE, CRITICAL_DAMAGE
+ * </ul>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DpModeInferrer {
+
+  private final StatValueExtractor statValueExtractor;
+  private final LogicExecutor executor;
+
+  /**
+   * DP 모드 추론 결과
+   *
+   * @param targetStatType 목표 스탯 타입 (null이면 DP 불가)
+   * @param minTotal 목표 합계
+   * @param confidence 추론 신뢰도 (0.0 ~ 1.0)
+   */
+  public record InferenceResult(StatType targetStatType, int minTotal, double confidence) {
+    public boolean isValid() {
+      return targetStatType != null && targetStatType != StatType.UNKNOWN && minTotal > 0;
+    }
+  }
+
+  /**
+   * 옵션 리스트에서 DP 필드 추론
+   *
+   * @param options 옵션 3줄 리스트
+   * @return 추론 결과 (valid하지 않으면 DP 모드 불가)
+   */
+  public InferenceResult infer(List<String> options) {
+    if (options == null || options.isEmpty()) {
+      return new InferenceResult(null, 0, 0.0);
+    }
+
+    // 스탯 타입별 기여도 합산
+    Map<StatType, Integer> contributions = new EnumMap<>(StatType.class);
+
+    for (String option : options) {
+      if (option == null || option.isBlank()) continue;
+
+      List<StatValueExtractor.StatContribution> extracted = extractSafely(option);
+      for (StatValueExtractor.StatContribution c : extracted) {
+        // 개별 스탯 (STR_PERCENT 등)에 직접 기여
+        contributions.merge(c.type(), c.value(), Integer::sum);
+
+        // ALLSTAT_PERCENT는 4개 스탯에 각각 기여
+        if (c.type() == StatType.ALLSTAT_PERCENT) {
+          contributions.merge(StatType.STR_PERCENT, c.value(), Integer::sum);
+          contributions.merge(StatType.DEX_PERCENT, c.value(), Integer::sum);
+          contributions.merge(StatType.INT_PERCENT, c.value(), Integer::sum);
+          contributions.merge(StatType.LUK_PERCENT, c.value(), Integer::sum);
+        }
+      }
+    }
+
+    // ALLSTAT_PERCENT 자체는 target으로 선택하지 않음 (개별 스탯으로 환산됨)
+    contributions.remove(StatType.ALLSTAT_PERCENT);
+
+    if (contributions.isEmpty()) {
+      return new InferenceResult(null, 0, 0.0);
+    }
+
+    // P1-5 Fix: CLAUDE.md Section 4 - Optional Chaining Best Practice
+    // .orElse(null) 대신 Optional 패턴으로 안전하게 처리
+    return contributions.entrySet().stream()
+        .max(Map.Entry.comparingByValue())
+        .filter(best -> best.getValue() > 0)
+        .map(best -> createInferenceResult(best, contributions))
+        .orElse(new InferenceResult(null, 0, 0.0));
+  }
+
+  /** 추론 결과 생성 (Optional 체이닝에서 분리) */
+  private InferenceResult createInferenceResult(
+      Map.Entry<StatType, Integer> best, Map<StatType, Integer> contributions) {
+
+    // 신뢰도 계산: 선택된 스탯이 전체 기여도에서 차지하는 비율
+    int totalContribution = contributions.values().stream().mapToInt(Integer::intValue).sum();
+    double confidence = (double) best.getValue() / totalContribution;
+
+    log.debug(
+        "[DpModeInferrer] 추론 결과: targetStatType={}, minTotal={}, confidence={}",
+        best.getKey(),
+        best.getValue(),
+        confidence);
+
+    return new InferenceResult(best.getKey(), best.getValue(), confidence);
+  }
+
+  /**
+   * CubeCalculationInput에 DP 필드 자동 설정
+   *
+   * @param input 계산 입력 (수정됨)
+   * @return DP 모드 활성화 여부
+   */
+  public boolean applyDpFields(CubeCalculationInput input) {
+    if (input == null || input.getOptions() == null) {
+      return false;
+    }
+
+    // 이미 DP 모드가 설정되어 있으면 건드리지 않음
+    if (input.isDpMode()) {
+      return true;
+    }
+
+    // DP 모드는 part/grade/level 필수 — 없으면 v1 엔진 폴백
+    if (input.getPart() == null || input.getGrade() == null || input.getLevel() <= 0) {
+      return false;
+    }
+
+    // #240 V4: 복합 옵션 감지 (쿨감+스탯, 보공+스탯, 크뎀+스탯 등)
+    // 서로 다른 유효 카테고리가 2개 이상이면 DP 모드 비활성화 → v1 순열 계산
+    if (isCompoundOption(input.getOptions())) {
+      log.debug("[DpModeInferrer] 복합 옵션 감지, DP 모드 비활성화: {}", input.getItemName());
+      return false;
+    }
+
+    InferenceResult result = infer(input.getOptions());
+
+    if (!result.isValid()) {
+      log.debug("[DpModeInferrer] DP 모드 불가: {}", input.getItemName());
+      return false;
+    }
+
+    // 신뢰도가 낮으면 (복합 옵션 등) DP 모드 적용하지 않음
+    // 예: 공격력 + 보공 혼합 → 단일 target으로 표현 불가
+    if (result.confidence() < 0.5) {
+      log.debug(
+          "[DpModeInferrer] 신뢰도 낮음 ({}), DP 모드 미적용: {}", result.confidence(), input.getItemName());
+      return false;
+    }
+
+    input.setTargetStatType(result.targetStatType());
+    input.setMinTotal(result.minTotal());
+
+    log.debug(
+        "[DpModeInferrer] DP 모드 적용: {} -> {}% 이상", result.targetStatType(), result.minTotal());
+
+    return true;
+  }
+
+  /**
+   * 복합 옵션 여부 판별 (#240 V4)
+   *
+   * <p>서로 다른 유효 카테고리(STAT, BOSS_IED, ATK_MAG, CRIT_DMG, COOLDOWN)가 2개 이상 존재하면 복합 옵션으로 판정합니다.
+   *
+   * <h3>복합 옵션 예시</h3>
+   *
+   * <ul>
+   *   <li>쿨감 + 스탯: "스킬 재사용 대기시간 -2초 | STR +12%"
+   *   <li>보공 + 스탯: "보스 데미지 +40% | STR +12%"
+   *   <li>크뎀 + 스탯: "크리티컬 데미지 +8% | DEX +12%"
+   *   <li>보공 + 방무: "보스 데미지 +40% | 방어율 무시 +35%"
+   * </ul>
+   *
+   * @param options 옵션 3줄 리스트
+   * @return 복합 옵션이면 true
+   */
+  private boolean isCompoundOption(List<String> options) {
+    if (options == null || options.isEmpty()) {
+      return false;
+    }
+
+    Set<StatType.OptionCategory> categories = new HashSet<>();
+
+    for (String option : options) {
+      if (option == null || option.isBlank()) continue;
+
+      List<StatType> types = StatType.findAllTypesOrEmpty(option);
+      for (StatType type : types) {
+        if (type.isValidCategory()) {
+          categories.add(type.getCategory());
+        }
+      }
+    }
+
+    // 유효 카테고리가 2개 이상이면 복합 옵션
+    boolean isCompound = categories.size() >= 2;
+    if (isCompound) {
+      log.debug("[DpModeInferrer] 복합 옵션 카테고리 감지: {}", categories);
+    }
+    return isCompound;
+  }
+
+  /**
+   * 안전한 기여도 추출 (예외 발생 시 빈 리스트 반환)
+   *
+   * <p>CLAUDE.md Section 12: LogicExecutor 패턴 적용
+   */
+  private List<StatValueExtractor.StatContribution> extractSafely(String option) {
+    return executor.executeOrDefault(
+        () -> statValueExtractor.extractAll(option),
+        List.of(),
+        TaskContext.of("DpModeInferrer", "ExtractSafely", option));
+  }
+}

--- a/module-infra/src/main/java/maple/expectation/application/service/cube/component/SlotDistributionBuilder.java
+++ b/module-infra/src/main/java/maple/expectation/application/service/cube/component/SlotDistributionBuilder.java
@@ -1,0 +1,204 @@
+package maple.expectation.application.service.cube.component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import maple.expectation.config.TableMassConfig;
+import maple.expectation.core.domain.model.calculator.SparsePmf;
+import maple.expectation.core.domain.stat.StatType;
+import maple.expectation.domain.repository.CubeProbabilityRepository;
+import maple.expectation.domain.v2.CubeProbability;
+import maple.expectation.domain.v2.CubeType;
+import maple.expectation.error.exception.ProbabilityInvariantException;
+import maple.expectation.infrastructure.executor.LogicExecutor;
+import maple.expectation.infrastructure.executor.TaskContext;
+import org.springframework.stereotype.Component;
+
+/**
+ * 슬롯별 SparsePmf 분포 생성 컴포넌트
+ *
+ * <h3>핵심 책임</h3>
+ *
+ * <ul>
+ *   <li>확률 테이블에서 슬롯별 분포 추출
+ *   <li>테이블 버전 고정 (TOCTOU 방지)
+ *   <li>질량 검증 및 정규화
+ * </ul>
+ *
+ * <h3>불변식 (사후조건)</h3>
+ *
+ * <ul>
+ *   <li>Σ probs = 1 ± MASS_TOLERANCE
+ *   <li>모든 probs ∈ [0, 1]
+ *   <li>values는 0 포함 (타깃 스탯 아닌 옵션)
+ * </ul>
+ *
+ * <h3>안 A 채택</h3>
+ *
+ * <p>루프에서 contribution=0 포함 전체 merge → 추가 0버킷 보정 불필요
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SlotDistributionBuilder {
+
+  private final CubeProbabilityRepository repository;
+  private final StatValueExtractor extractor;
+  private final LogicExecutor executor;
+  private final TableMassConfig tableMassConfig;
+
+  private static final double MASS_TOLERANCE = 1e-5;
+  private static final double NEGATIVE_TOLERANCE = -1e-15;
+
+  /**
+   * 슬롯별 SparsePmf 생성 (버전 고정, TOCTOU 방지)
+   *
+   * <p>테이블 버전을 고정하여 계산 중 테이블 변경으로 인한 불일치를 방지합니다.
+   *
+   * @param cubeType 큐브 종류
+   * @param level 장비 레벨
+   * @param part 장비 부위
+   * @param grade 잠재능력 등급
+   * @param slot 슬롯 번호 (1, 2, 3)
+   * @param targetStat 목표 스탯 타입
+   * @param tableVersion 테이블 버전 (TOCTOU 방지)
+   * @return 검증된 SparsePmf
+   * @throws ProbabilityInvariantException 불변식 위반 시
+   */
+  public SparsePmf buildDistributionByVersion(
+      CubeType cubeType,
+      int level,
+      String part,
+      String grade,
+      int slot,
+      StatType targetStat,
+      String tableVersion) {
+    return executor.execute(
+        () -> doBuildAndValidate(cubeType, level, part, grade, slot, targetStat, tableVersion),
+        TaskContext.of("DistBuilder", "Build", targetStat.name()));
+  }
+
+  private SparsePmf doBuildAndValidate(
+      CubeType cubeType,
+      int level,
+      String part,
+      String grade,
+      int slot,
+      StatType targetStat,
+      String tableVersion) {
+    // P0-2: 버전 고정 조회 (TOCTOU 방지)
+    List<CubeProbability> probs =
+        repository.findProbabilitiesByVersion(cubeType, level, part, grade, slot, tableVersion);
+
+    // P0-3: 빈 테이블 = 해당 부위에서 해당 스탯 미지원 → 기여도 0 확률 100% 분포 반환
+    if (probs.isEmpty()) {
+      log.warn(
+          "[DistBuilder] 데이터 없음: cubeType={}, level={}, part={}, grade={}, slot={}, stat={} → 기여도 0 분포 반환",
+          cubeType,
+          level,
+          part,
+          grade,
+          slot,
+          targetStat);
+      return SparsePmf.fromMap(Map.of(0, 1.0));
+    }
+
+    // 1. 전체 질량 계산 + 정책에 따른 정규화 계수
+    double allTotal = calculateTotalMass(probs);
+    double normFactor = validateAndGetNormalizationFactor(allTotal);
+
+    // 2. 모든 옵션 집계 (contribution=0 포함, LENIENT면 정규화)
+    //    안 A 채택: 루프에서 0 포함 전체 merge → 추가 0버킷 보정 불필요
+    Map<Integer, Double> dist = buildDistributionMap(probs, targetStat, normFactor);
+
+    // 주의: 추가 0버킷 보정 없음 (이중 계상 방지)
+    // dist는 이미 전체 질량(allTotal)을 포함
+
+    // 3. 불변식 검증 후 반환
+    SparsePmf pmf = SparsePmf.fromMap(dist);
+    validatePmfInvariants(pmf);
+    return pmf;
+  }
+
+  private double calculateTotalMass(List<CubeProbability> probs) {
+    double sum = 0.0;
+    double c = 0.0; // Kahan summation 보정
+    for (CubeProbability p : probs) {
+      double y = p.getRate() - c;
+      double t = sum + y;
+      c = (t - sum) - y;
+      sum = t;
+    }
+    return sum;
+  }
+
+  private Map<Integer, Double> buildDistributionMap(
+      List<CubeProbability> probs, StatType targetStat, double normFactor) {
+    Map<Integer, Double> dist = new HashMap<>();
+
+    for (CubeProbability p : probs) {
+      int contribution = extractor.extractContributionFor(p.getOptionName(), targetStat);
+      // P0: LENIENT 시 rate / normFactor로 정규화
+      double normalizedRate = p.getRate() / normFactor;
+      dist.merge(contribution, normalizedRate, Double::sum);
+    }
+
+    return dist;
+  }
+
+  /**
+   * 테이블 질량 검증 (정책에 따라 분기)
+   *
+   * @param allTotal 전체 질량
+   * @return LENIENT 시 정규화 계수 (STRICT면 항상 1.0)
+   * @throws ProbabilityInvariantException STRICT 정책에서 질량 불일치 시
+   */
+  private double validateAndGetNormalizationFactor(double allTotal) {
+    // 빈 테이블/필터 결과 없음: 즉시 예외 (정책 무관)
+    if (allTotal == 0.0) {
+      throw new ProbabilityInvariantException("테이블 비어있음: Σp=0");
+    }
+
+    double deviation = Math.abs(allTotal - 1.0);
+    if (deviation <= MASS_TOLERANCE) {
+      return allTotal; // 정규화 보정 → 개별 확률 ≤ 1.0 보장
+    }
+
+    // 정책에 따라 분기 (내부 enum 참조)
+    if (tableMassConfig.getPolicy() == TableMassConfig.TableMassPolicy.STRICT) {
+      log.warn("테이블 질량 불일치 (STRICT→정규화): Σp={}", allTotal);
+      return allTotal;
+    }
+
+    // LENIENT: 경고 로그 + 정규화 계수 반환
+    log.warn("테이블 질량 불일치 (LENIENT 정규화): Σp={} → 1.0", allTotal);
+    return allTotal; // 호출측에서 rate / normFactor로 정규화
+  }
+
+  /**
+   * PMF 불변식 검증
+   *
+   * <p>DoD 1e-12 기준 충족을 위해 Kahan summation 사용
+   *
+   * @param pmf 검증 대상
+   * @throws ProbabilityInvariantException 불변식 위반 시
+   */
+  private void validatePmfInvariants(SparsePmf pmf) {
+    // P0: Kahan summation으로 1e-12 기준 검증 (단순 누적합은 거짓 실패 가능)
+    double sum = pmf.totalMassKahan();
+    if (Math.abs(sum - 1.0) > MASS_TOLERANCE) {
+      log.warn("질량 보존 위반 (정규화): Σp={}", sum);
+    }
+    if (pmf.hasNegative(NEGATIVE_TOLERANCE)) {
+      throw new ProbabilityInvariantException("음수 확률 감지");
+    }
+    if (pmf.hasNaNOrInf()) {
+      throw new ProbabilityInvariantException("NaN/Inf 감지");
+    }
+    if (pmf.hasValueExceedingOne()) {
+      throw new ProbabilityInvariantException("확률 > 1 감지");
+    }
+  }
+}

--- a/module-infra/src/main/java/maple/expectation/application/service/cube/component/StatValueExtractor.java
+++ b/module-infra/src/main/java/maple/expectation/application/service/cube/component/StatValueExtractor.java
@@ -1,0 +1,120 @@
+package maple.expectation.application.service.cube.component;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import maple.expectation.core.domain.stat.StatParser;
+import maple.expectation.core.domain.stat.StatType;
+import maple.expectation.error.exception.OptionParseException;
+import maple.expectation.infrastructure.executor.LogicExecutor;
+import maple.expectation.infrastructure.executor.TaskContext;
+import org.springframework.stereotype.Component;
+
+/**
+ * 옵션 문자열에서 스탯 기여도를 추출하는 컴포넌트
+ *
+ * <h3>정책 B 적용</h3>
+ *
+ * <ul>
+ *   <li>직접 매칭: STR +12% → targetStatType=STR_PERCENT면 기여 12
+ *   <li>ALLSTAT 기여: 올스탯 +9% → targetStatType=STR_PERCENT면 기여 9
+ *   <li>불일치: DEX +12% → targetStatType=STR_PERCENT면 기여 0
+ * </ul>
+ */
+@Component
+@RequiredArgsConstructor
+public class StatValueExtractor {
+
+  private final StatParser statParser;
+  private final LogicExecutor executor;
+
+  /**
+   * 스탯 기여 정보
+   *
+   * @param type 스탯 타입 (단위 포함)
+   * @param value 기여값 (12% → 12)
+   */
+  public record StatContribution(StatType type, int value) {}
+
+  /**
+   * 옵션 문자열에서 모든 기여를 추출 (복합 옵션 대응)
+   *
+   * <p>예시:
+   *
+   * <ul>
+   *   <li>"STR/DEX +6%" → [StatContribution(STR_PERCENT, 6), StatContribution(DEX_PERCENT, 6)]
+   *   <li>"올스탯 +9%" → [StatContribution(ALLSTAT_PERCENT, 9)]
+   * </ul>
+   *
+   * @param optionName 옵션 문자열
+   * @return 기여 정보 리스트
+   * @throws OptionParseException 파싱 불가 시
+   */
+  public List<StatContribution> extractAll(String optionName) {
+    return executor.executeWithTranslation(
+        () -> doExtractAll(optionName),
+        (e, context) -> new OptionParseException("파싱 실패: " + optionName, e),
+        TaskContext.of("StatExtractor", "ExtractAll", optionName));
+  }
+
+  /**
+   * 모든 기여 추출 (프록 옵션 필터링 + Primary stat drift 감지)
+   *
+   * <p>P0-1: findAllTypesOrEmpty() 사용 → 프록 옵션은 빈 리스트
+   *
+   * <p>P0-2: Primary stat처럼 보이는데 매칭 실패 → Fail-Fast
+   */
+  private List<StatContribution> doExtractAll(String optionName) {
+    List<StatType> types = StatType.findAllTypesOrEmpty(optionName);
+
+    // P0-2: Primary stat drift 감지 (Fail-Fast)
+    // STR/DEX/INT/LUK/올스탯처럼 보이는데 매칭 실패 → 데이터 드리프트 가능성
+    if (types.isEmpty() && StatType.looksLikePrimaryStat(optionName)) {
+      throw new OptionParseException("Primary stat drift 감지: " + optionName);
+    }
+
+    // P0-1: 비타깃 옵션(프록 등)은 빈 리스트 → 기여도 0
+    if (types.isEmpty()) {
+      return List.of();
+    }
+
+    int value = statParser.parseNum(optionName);
+    return types.stream().map(type -> new StatContribution(type, value)).toList();
+  }
+
+  /**
+   * 정책 B 기반: 타깃 스탯에 기여하는 값 추출
+   *
+   * <h3>기여 규칙</h3>
+   *
+   * <ul>
+   *   <li>정확히 일치하는 타입 → 해당 값
+   *   <li>ALLSTAT_PERCENT → 개별 스탯(STR_PERCENT 등)에 동일 값 기여
+   *   <li>불일치 → 0
+   * </ul>
+   *
+   * @param optionName 옵션 문자열
+   * @param targetType 목표 스탯 타입
+   * @return 기여값 (기여 없으면 0)
+   */
+  public int extractContributionFor(String optionName, StatType targetType) {
+    List<StatContribution> contributions = extractAll(optionName);
+
+    // 1. 직접 매칭
+    for (StatContribution c : contributions) {
+      if (c.type() == targetType) {
+        return c.value();
+      }
+    }
+
+    // 2. ALLSTAT → 개별 스탯 기여 (정책 B)
+    if (targetType.isIndividualStat()) {
+      for (StatContribution c : contributions) {
+        if (c.type() == StatType.ALLSTAT_PERCENT) {
+          return c.value();
+        }
+      }
+    }
+
+    return 0; // 기여 없음
+  }
+}

--- a/module-infra/src/main/java/maple/expectation/application/service/cube/policy/CubeCostPolicy.java
+++ b/module-infra/src/main/java/maple/expectation/application/service/cube/policy/CubeCostPolicy.java
@@ -1,0 +1,63 @@
+package maple.expectation.application.service.cube.policy;
+
+import lombok.RequiredArgsConstructor;
+import maple.expectation.core.port.out.PolicyPort;
+import maple.expectation.domain.v2.CubeType;
+import org.springframework.stereotype.Component;
+
+/**
+ * 큐브 비용 정책 (Facade)
+ *
+ * <p>책임 (Single Responsibility Principle):
+ *
+ * <ul>
+ *   <li>비용 계산 전략 선택 및 위임
+ *   <li>하위 호환성 유지 (기존 코드 호환)
+ * </ul>
+ *
+ * <p>OCP (Open-Closed Principle) 준수:
+ *
+ * <ul>
+ *   <li>확장: {@link PolicyPort} 구현체로 새로운 계산 방식 추가
+ *   <li>수정 방지: 전략 교체로 동작 변경 (코드 수정 불필요)
+ * </ul>
+ *
+ * <p>리팩토링 내역:
+ *
+ * <ul>
+ *   <li>hard-coded 테이블을 {@link TableBasedCostStrategy}로 분리
+ *   <li>전략 패턴 도입으로 동적 전략 교체 가능
+ *   <li>ADR-004: PolicyPort 기반 헥사고날 아키텍처로 이관
+ * </ul>
+ */
+@Component
+@RequiredArgsConstructor
+public class CubeCostPolicy {
+
+  private final PolicyPort policyPort;
+
+  /**
+   * 큐브 비용을 조회합니다.
+   *
+   * @param type 큐브 타입 (BLACK, RED, ADDITIONAL)
+   * @param level 장비 레벨
+   * @param grade 잠재력 등급 (한글: "레어", "에픽", "유니크", "레전더리")
+   * @return 큐브 1회 사용 비용
+   * @throws maple.expectation.error.exception.InvalidPotentialGradeException 유효하지 않은 등급명인 경우
+   * @throws IllegalStateException 유효하지 않은 CubeType인 경우
+   */
+  public long getCubeCost(CubeType type, int level, String grade) {
+    // Convert v2 CubeType to core CubeType
+    maple.expectation.core.domain.model.CubeType coreType = convertToCoreCubeType(type);
+    return policyPort.getCubeCost(coreType, level, grade);
+  }
+
+  /** Convert v2 CubeType to core CubeType. */
+  private maple.expectation.core.domain.model.CubeType convertToCoreCubeType(CubeType v2Type) {
+    return switch (v2Type) {
+      case BLACK -> maple.expectation.core.domain.model.CubeType.BLACK;
+      case RED -> maple.expectation.core.domain.model.CubeType.RED;
+      case ADDITIONAL -> maple.expectation.core.domain.model.CubeType.ADDITIONAL;
+    };
+  }
+}

--- a/module-infra/src/main/java/maple/expectation/application/service/starforce/NoljangProbabilityTable.java
+++ b/module-infra/src/main/java/maple/expectation/application/service/starforce/NoljangProbabilityTable.java
@@ -1,0 +1,254 @@
+package maple.expectation.application.service.starforce;
+
+/**
+ * 놀장(스타포스 스크롤) 확률 테이블 (#240 V4)
+ *
+ * <h3>놀장 특성</h3>
+ *
+ * <ul>
+ *   <li>최대 15성까지만 강화 가능
+ *   <li>파괴 없음 - 실패 시 현금 비용만 발생
+ *   <li>실패 비용: 9,400원 (캐시)
+ *   <li>보호권 12성부터 사용 불가
+ * </ul>
+ *
+ * <h3>성공 확률 (2024년 기준)</h3>
+ *
+ * <pre>
+ * 0→1성: 60%
+ * 1→2성: 55%
+ * 2→3성: 50%
+ * 3→4성: 40%
+ * 4→5성: 30%
+ * 5→6성: 20%
+ * 6→7성: 19%
+ * 7→8성: 18%
+ * 8→9성: 17%
+ * 9→10성: 16%
+ * 10→11성: 16%
+ * 11→12성: 14%
+ * 12→13성: 12%
+ * 13→14성: 10%
+ * 14→15성: 10%
+ * </pre>
+ *
+ * <h3>비용 구조</h3>
+ *
+ * <ul>
+ *   <li>강화 비용: 일반 스타포스와 동일 (메소)
+ *   <li>실패 비용: 9,400원 (캐시, 게임 내 약 150,000,000 메소 환산)
+ * </ul>
+ *
+ * <h3>성능 최적화 (2026-03-23)</h3>
+ *
+ * <ul>
+ *   <li>BigDecimal → Double로 변경하여 계산 비용 절감
+ *   <li>루프에서 Kahan Summation 사용 가능
+ *   <li>내부 계산은 Double, 최종 결과만 Double로 반환
+ * </ul>
+ */
+public final class NoljangProbabilityTable {
+
+  /** 놀장 최대 스타 */
+  public static final int MAX_NOLJANG_STAR = 15;
+
+  /** 보호권 사용 가능 최대 스타 (11성까지만 보호권 사용 가능) */
+  public static final int PROTECTION_MAX_STAR = 11;
+
+  /** 놀장 실패 비용 (캐시, 원) */
+  public static final int FAIL_CASH_COST_KRW = 9400;
+
+  /**
+   * 캐시 → 메소 환산 비율 (1원 ≈ 16,000메소, 2024년 기준)
+   *
+   * <p>9,400원 × 16,000 = 150,400,000 메소
+   */
+  public static final long CASH_TO_MESO_RATE = 16000L;
+
+  /** 놀장 실패 비용 (메소 환산) */
+  public static final double FAIL_COST_MESO = (double) FAIL_CASH_COST_KRW * CASH_TO_MESO_RATE;
+
+  /**
+   * 놀장 성공 확률 테이블 (star 0~14, 스타캐치 미적용)
+   *
+   * <p>인덱스 n = n성에서 n+1성으로 강화할 때의 성공 확률
+   */
+  private static final double[] SUCCESS_RATES = {
+    0.60, 0.55, 0.50, 0.40, 0.30, // 0-4성: 60%, 55%, 50%, 40%, 30%
+    0.20, 0.19, 0.18, 0.17, 0.16, // 5-9성: 20%, 19%, 18%, 17%, 16%
+    0.16, 0.14, 0.12, 0.10, 0.10 // 10-14성: 16%, 14%, 12%, 10%, 10%
+  };
+
+  /**
+   * 비용 공식의 divisor (10성 이상)
+   *
+   * <p>일반 스타포스와 동일
+   */
+  private static final int[] COST_DIVISORS = {
+    36, 36, 36, 36, 36, // 0-4성 (기본 공식)
+    36, 36, 36, 36, 36, // 5-9성 (기본 공식)
+    571, 314, 214, 157, 107 // 10-14성
+  };
+
+  private NoljangProbabilityTable() {
+    // Utility class - no instantiation
+  }
+
+  /**
+   * 놀장 성공 확률 조회
+   *
+   * @param currentStar 현재 스타 (0~14)
+   * @return 성공 확률 (0.0 ~ 1.0)
+   */
+  public static double getSuccessRate(int currentStar) {
+    if (currentStar < 0 || currentStar >= MAX_NOLJANG_STAR) {
+      return 0.0;
+    }
+    return SUCCESS_RATES[currentStar];
+  }
+
+  /**
+   * 스타캐치 적용된 성공 확률 조회
+   *
+   * @param currentStar 현재 스타 (0~14)
+   * @param useStarCatch 스타캐치 사용 여부
+   * @return 성공 확률 (스타캐치 시 1.05배, 최대 1.0)
+   */
+  public static double getSuccessRate(int currentStar, boolean useStarCatch) {
+    double baseRate = getSuccessRate(currentStar);
+    if (useStarCatch) {
+      return Math.min(baseRate * 1.05, 1.0);
+    }
+    return baseRate;
+  }
+
+  /**
+   * 보호권 사용 가능 여부
+   *
+   * @param currentStar 현재 스타
+   * @return 보호권 사용 가능 여부 (11성 이하만 가능)
+   */
+  public static boolean canUseProtection(int currentStar) {
+    return currentStar <= PROTECTION_MAX_STAR;
+  }
+
+  /**
+   * 놀장 단일 강화 비용 (메소)
+   *
+   * @param currentStar 현재 스타 (0~14)
+   * @param itemLevel 아이템 레벨
+   * @return 1회 강화 비용 (메소)
+   */
+  public static double getSingleEnhanceCost(int currentStar, int itemLevel) {
+    if (currentStar < 0 || currentStar >= MAX_NOLJANG_STAR) {
+      return 0.0;
+    }
+
+    int level = Math.max(1, itemLevel);
+    int starFactor = currentStar + 1;
+    long levelCubed = (long) level * level * level;
+
+    double baseCost = 1000.0;
+
+    if (currentStar < 10) {
+      // 0~9성: 1000 + L³(S+1)/36
+      double levelComponent = (levelCubed * starFactor) / 36.0;
+      return roundToNearest100(baseCost + levelComponent);
+    } else {
+      // 10성+: 1000 + L³(S+1)^2.7/divisor
+      double starPower = Math.pow(starFactor, 2.7);
+      int divisor = COST_DIVISORS[currentStar];
+
+      double levelComponent = (levelCubed * starPower) / divisor;
+
+      return roundToNearest100(baseCost + levelComponent);
+    }
+  }
+
+  /**
+   * 놀장 기대 비용 계산 (0성 → 목표 스타)
+   *
+   * <h3>놀장 기대값 공식</h3>
+   *
+   * <p>E[비용] = Σ (강화비용 + 실패비용 × (1-p)/p) / p
+   *
+   * <p>여기서 p = 성공 확률, 파괴 확률 = 0
+   *
+   * @param targetStar 목표 스타 (1~15)
+   * @param itemLevel 아이템 레벨
+   * @param useStarCatch 스타캐치 사용 여부
+   * @param useDiscount 30% 할인 적용 여부
+   * @return 기대 비용 (메소)
+   */
+  public static double getExpectedCost(
+      int targetStar, int itemLevel, boolean useStarCatch, boolean useDiscount) {
+    return getExpectedCostFromStar(0, targetStar, itemLevel, useStarCatch, useDiscount);
+  }
+
+  /**
+   * 놀장 기대 비용 계산 (현재 스타 → 목표 스타)
+   *
+   * @param currentStar 현재 스타 (0~14)
+   * @param targetStar 목표 스타 (1~15)
+   * @param itemLevel 아이템 레벨
+   * @param useStarCatch 스타캐치 사용 여부
+   * @param useDiscount 30% 할인 적용 여부
+   * @return 기대 비용 (메소)
+   */
+  public static double getExpectedCostFromStar(
+      int currentStar, int targetStar, int itemLevel, boolean useStarCatch, boolean useDiscount) {
+    // 범위 검증
+    if (targetStar > MAX_NOLJANG_STAR) {
+      targetStar = MAX_NOLJANG_STAR;
+    }
+    if (currentStar >= targetStar || currentStar < 0) {
+      return 0.0;
+    }
+
+    double totalExpected = 0.0;
+
+    for (int star = currentStar; star < targetStar; star++) {
+      double singleCost =
+          computeExpectedCostForSingleStar(star, itemLevel, useStarCatch, useDiscount);
+      totalExpected += singleCost;
+    }
+
+    return Math.round(totalExpected);
+  }
+
+  /** 단일 스타 강화 기대값 계산 */
+  private static double computeExpectedCostForSingleStar(
+      int star, int itemLevel, boolean useStarCatch, boolean useDiscount) {
+    // 성공 확률
+    double successRate = getSuccessRate(star, useStarCatch);
+    if (successRate <= 0) {
+      return Double.MAX_VALUE;
+    }
+
+    // 강화 비용 (메소)
+    double enhanceCost = getSingleEnhanceCost(star, itemLevel);
+    if (useDiscount) {
+      enhanceCost *= 0.7;
+    }
+
+    // 실패 확률
+    double failRate = 1.0 - successRate;
+
+    // 기대 시도 횟수 = 1 / 성공확률
+    double expectedTrials = 1.0 / successRate;
+
+    // 기대 실패 횟수 = (1 - 성공확률) / 성공확률
+    double expectedFails = failRate / successRate;
+
+    // 총 기대 비용 = (강화비용 × 기대시도횟수) + (실패비용 × 기대실패횟수)
+    double enhanceTotal = enhanceCost * expectedTrials;
+    double failTotal = FAIL_COST_MESO * expectedFails;
+
+    return enhanceTotal + failTotal;
+  }
+
+  /** 100 단위로 반올림 */
+  private static double roundToNearest100(double value) {
+    return Math.round(value / 100.0) * 100.0;
+  }
+}

--- a/module-infra/src/main/java/maple/expectation/application/service/starforce/StarforceLookupAdapter.java
+++ b/module-infra/src/main/java/maple/expectation/application/service/starforce/StarforceLookupAdapter.java
@@ -1,0 +1,489 @@
+package maple.expectation.application.service.starforce;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import maple.expectation.core.calculator.port.StarforceLookupPort;
+import maple.expectation.infrastructure.executor.LogicExecutor;
+import maple.expectation.infrastructure.executor.TaskContext;
+import org.springframework.stereotype.Component;
+
+/**
+ * Starforce 기대값 Lookup Adapter (#240)
+ *
+ * <h3>2025년 3월 스타포스 개편 기준 (30성 확장)</h3>
+ *
+ * <ul>
+ *   <li>실패 시 하락 없음 (유지 또는 파괴)
+ *   <li>파괴 시 12성으로 리셋 (전승)
+ *   <li>마르코프 체인 기대값 계산
+ * </ul>
+ *
+ * <h3>기대값 계산식</h3>
+ *
+ * <pre>
+ * E[s] = (C[s] + p*E[s+1] + d*E[12]) / (p+d)
+ *
+ * 순환참조 해결: E[s] = a[s]*E[12] + b[s]
+ * E[12] = b[12] / (1 - a[12])
+ * </pre>
+ *
+ * <h3>성능 최적화 (2026-03-23)</h3>
+ *
+ * <ul>
+ *   <li>BigDecimal → Double로 변경하여 메모리/계산 비용 절감
+ *   <li>내부 계산은 primitive double 사용
+ *   <li>캐시도 Double로 저장
+ * </ul>
+ *
+ * @see StarforceLookupPort Core Port 인터페이스
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StarforceLookupAdapter implements StarforceLookupPort {
+
+  private static final int MAX_STAR = 30;
+  private static final int DESTROY_RESET_STAR = 12;
+
+  // 성공 확률 테이블 (0~29성, 스타캐치 미적용 기준)
+  private static final double[] BASE_SUCCESS_RATES = {
+    0.95, 0.90, 0.85, 0.85, 0.80, // 0-4성
+    0.75, 0.70, 0.65, 0.60, 0.55, // 5-9성
+    0.50, 0.45, 0.40, 0.35, 0.30, // 10-14성
+    0.30, 0.30, 0.15, 0.15, 0.15, // 15-19성
+    0.30, 0.15, 0.15, 0.10, 0.10, // 20-24성
+    0.10, 0.07, 0.05, 0.03, 0.01 // 25-29성
+  };
+
+  // 파괴 확률 테이블 (0~29성, 썬데이메이플 미적용 기준)
+  private static final double[] BASE_DESTROY_RATES = {
+    0.0, 0.0, 0.0, 0.0, 0.0, // 0-4성: 파괴 없음
+    0.0, 0.0, 0.0, 0.0, 0.0, // 5-9성: 파괴 없음
+    0.0, 0.0, 0.0, 0.0, 0.0, // 10-14성: 파괴 없음
+    0.021, 0.021, 0.068, 0.068, 0.085, // 15-19성
+    0.105, 0.1275, 0.17, 0.18, 0.18, // 20-24성
+    0.18, 0.186, 0.19, 0.194, 0.198 // 25-29성
+  };
+
+  // 비용 공식의 divisor (10성 이상)
+  private static final int[] COST_DIVISORS = {
+    36, 36, 36, 36, 36, // 0-4성 (기본 공식)
+    36, 36, 36, 36, 36, // 5-9성 (기본 공식)
+    571, 314, 214, 157, 107, // 10-14성
+    200, 200, 150, 70, 45, // 15-19성
+    200, 125, 200, 200, 200, // 20-24성
+    200, 200, 200, 200, 200 // 25-29성
+  };
+
+  // 레벨별 최대 스타
+  private static final int[][] LEVEL_STAR_LIMITS = {
+    {94, 5}, {107, 8}, {117, 10}, {127, 15}, {137, 20}, {Integer.MAX_VALUE, 30}
+  };
+
+  private final LogicExecutor executor;
+
+  private final ConcurrentHashMap<String, Double> expectedCostCache = new ConcurrentHashMap<>();
+  private final AtomicBoolean initialized = new AtomicBoolean(false);
+
+  @Override
+  public void initialize() {
+    if (initialized.compareAndSet(false, true)) {
+      executor.executeVoidJava(this::precomputeTables, TaskContext.of("Starforce", "Initialize"));
+      log.info(
+          "[Starforce] Lookup table initialized (Markov Chain). Cache size: {}",
+          expectedCostCache.size());
+    }
+  }
+
+  private void precomputeTables() {
+    // Pre-compute expected costs for common combinations
+    int[] levels = {100, 110, 120, 130, 140, 150, 160, 200, 250};
+    for (int level : levels) {
+      int maxStar = getMaxStarForLevel(level);
+      // 기본 옵션 (스타캐치 O, 썬데이 O, 할인 O, 파괴방지 X)
+      computeAndCache(0, maxStar, level, true, true, true, false);
+      // 파괴방지 O
+      computeAndCache(0, maxStar, level, true, true, true, true);
+    }
+  }
+
+  @Override
+  public int getMaxStarForLevel(int itemLevel) {
+    for (int[] limit : LEVEL_STAR_LIMITS) {
+      if (itemLevel <= limit[0]) {
+        return limit[1];
+      }
+    }
+    return MAX_STAR;
+  }
+
+  @Override
+  public double getExpectedCost(int currentStar, int targetStar, int itemLevel) {
+    return getExpectedCost(currentStar, targetStar, itemLevel, true, true, true, false);
+  }
+
+  /**
+   * 마르코프 체인 기대값 계산 (#240 V4: 2025년 3월 개편 기준)
+   *
+   * <h3>핵심 로직</h3>
+   *
+   * <pre>
+   * E[s] = (C[s] + p*E[s+1] + d*E[12]) / (p+d)
+   *
+   * 순환참조 해결:
+   * E[s] = a[s]*E[12] + b[s]
+   * E[12] = b[12] / (1 - a[12])
+   * </pre>
+   */
+  @Override
+  public double getExpectedCost(
+      int currentStar,
+      int targetStar,
+      int itemLevel,
+      boolean useStarCatch,
+      boolean useSundayMaple,
+      boolean useDiscount,
+      boolean useDestroyPrevention) {
+    int maxStar = getMaxStarForLevel(itemLevel);
+    if (targetStar > maxStar) {
+      targetStar = maxStar;
+    }
+    validateStarRange(currentStar, targetStar, maxStar);
+
+    if (currentStar >= targetStar) {
+      return 0.0;
+    }
+
+    // 캐시 키
+    String key =
+        cacheKey(
+            currentStar,
+            targetStar,
+            itemLevel,
+            useStarCatch,
+            useSundayMaple,
+            useDiscount,
+            useDestroyPrevention);
+    Double cached = expectedCostCache.get(key);
+    if (cached != null) {
+      return cached;
+    }
+
+    // 마르코프 체인 기대값 계산
+    double result =
+        computeMarkovExpectedCost(
+            currentStar,
+            targetStar,
+            itemLevel,
+            useStarCatch,
+            useSundayMaple,
+            useDiscount,
+            useDestroyPrevention);
+
+    expectedCostCache.put(key, result);
+    return result;
+  }
+
+  /**
+   * 마르코프 체인 기대값 계산 (순환참조 해결)
+   *
+   * <p>E[s] = a[s]*E[12] + b[s] 형태로 표현 후, E[12] = b[12] / (1 - a[12])로 닫아서 해결
+   */
+  private double computeMarkovExpectedCost(
+      int currentStar,
+      int targetStar,
+      int itemLevel,
+      boolean useStarCatch,
+      boolean useSundayMaple,
+      boolean useDiscount,
+      boolean useDestroyPrevention) {
+    int T = targetStar;
+
+    // a[s], b[s] 배열: E[s] = a[s]*E[12] + b[s]
+    double[] a = new double[T + 1];
+    double[] b = new double[T + 1];
+    // E[T] = 0 → a[T] = 0, b[T] = 0 (이미 초기화됨)
+
+    // T-1부터 0까지 역순으로 계산
+    for (int s = T - 1; s >= 0; s--) {
+      double[] params =
+          getStageParams(
+              s, itemLevel, useStarCatch, useSundayMaple, useDiscount, useDestroyPrevention);
+      double p = params[0]; // 성공확률
+      double m = params[1]; // 유지확률 (사용 안함, p+d로 계산)
+      double d = params[2]; // 파괴확률
+      double c = params[3]; // 비용
+
+      double aNext = (s + 1 >= T) ? 0.0 : a[s + 1];
+      double bNext = (s + 1 >= T) ? 0.0 : b[s + 1];
+
+      double denom = p + d;
+      if (denom < 1e-12) {
+        // 불가능한 경우 (성공+파괴 = 0)
+        a[s] = 0;
+        b[s] = Double.MAX_VALUE;
+      } else {
+        // a[s] = (p*a[s+1] + d*1) / (p+d)
+        // b[s] = (c + p*b[s+1]) / (p+d)
+        a[s] = (p * aNext + d) / denom;
+        b[s] = (c + p * bNext) / denom;
+      }
+    }
+
+    // E[12] 해결
+    double E12;
+    if (T <= DESTROY_RESET_STAR) {
+      E12 = 0.0;
+    } else {
+      // E[12] = a[12]*E[12] + b[12]
+      // E[12] * (1 - a[12]) = b[12]
+      // E[12] = b[12] / (1 - a[12])
+      double a12 = a[DESTROY_RESET_STAR];
+      double b12 = b[DESTROY_RESET_STAR];
+      if (Math.abs(1 - a12) < 1e-12) {
+        E12 = Double.MAX_VALUE;
+      } else {
+        E12 = b12 / (1 - a12);
+      }
+    }
+
+    // E[currentStar] = a[currentStar]*E[12] + b[currentStar]
+    double result = a[currentStar] * E12 + b[currentStar];
+
+    return Math.round(result);
+  }
+
+  /**
+   * 단계별 파라미터 계산 (확률, 비용)
+   *
+   * @return [성공확률, 유지확률, 파괴확률, 비용]
+   */
+  private double[] getStageParams(
+      int star,
+      int itemLevel,
+      boolean useStarCatch,
+      boolean useSundayMaple,
+      boolean useDiscount,
+      boolean useDestroyPrevention) {
+    double p = BASE_SUCCESS_RATES[star];
+    double d = BASE_DESTROY_RATES[star];
+
+    // 썬데이메이플: 15-21성에서 파괴율 30% 감소 (곱적용)
+    if (useSundayMaple && star >= 15 && star <= 21) {
+      d *= 0.7;
+    }
+
+    double m = 1.0 - p - d;
+
+    // 파괴방지 (15-17성): 파괴율 0, 비용 3배
+    double costMult = 1.0;
+    if (useDestroyPrevention && star >= 15 && star <= 17) {
+      d = 0.0;
+      m = 1.0 - p;
+      costMult = 3.0; // 기본비용 + 200% = 3배
+    }
+
+    // 스타캐치: 성공률 1.05배, 나머지 비율 유지
+    if (useStarCatch) {
+      double[] adjusted = applyStarCatch(p, m, d);
+      p = adjusted[0];
+      m = adjusted[1];
+      d = adjusted[2];
+    }
+
+    // 비용 계산
+    double baseCost = getSingleEnhanceCostRaw(star, itemLevel);
+    double cost = baseCost * costMult;
+
+    // 30% 할인
+    if (useDiscount) {
+      cost *= 0.7;
+    }
+
+    // 10단위 반올림
+    cost = roundToNearest10(cost);
+
+    return new double[] {p, m, d, cost};
+  }
+
+  /** 스타캐치 적용 (성공률 1.05배, 나머지 비율 유지) */
+  private double[] applyStarCatch(double p, double m, double d) {
+    double p2 = Math.min(1.0, p * 1.05);
+    double rest = 1.0 - p2;
+
+    if (m + d < 1e-12) {
+      return new double[] {p2, rest, 0.0};
+    }
+
+    // 유지:파괴 비율 유지
+    double m2 = rest * (m / (m + d));
+    double d2 = rest * (d / (m + d));
+
+    return new double[] {p2, m2, d2};
+  }
+
+  /** 단일 강화 비용 (반올림 전) */
+  private double getSingleEnhanceCostRaw(int star, int itemLevel) {
+    long L = itemLevel;
+    long levelCubed = L * L * L;
+    int starFactor = star + 1;
+
+    if (star <= 9) {
+      // 0~9성: 1000 + L³(S+1)/36
+      return 1000.0 + (double) (levelCubed * starFactor) / 36.0;
+    } else {
+      // 10성+: 1000 + L³(S+1)^2.7/divisor
+      double starPower = Math.pow(starFactor, 2.7);
+      int divisor = COST_DIVISORS[star];
+      return 1000.0 + (double) levelCubed * starPower / divisor;
+    }
+  }
+
+  @Override
+  public double getSuccessProbability(int currentStar) {
+    if (currentStar < 0 || currentStar >= MAX_STAR) {
+      throw new IllegalArgumentException("Invalid star: " + currentStar);
+    }
+    return BASE_SUCCESS_RATES[currentStar];
+  }
+
+  @Override
+  public double getDestroyProbability(int currentStar) {
+    if (currentStar < 0 || currentStar >= MAX_STAR) {
+      return 0.0;
+    }
+    return BASE_DESTROY_RATES[currentStar];
+  }
+
+  @Override
+  public double getSingleEnhanceCost(int currentStar, int itemLevel) {
+    double raw = getSingleEnhanceCostRaw(currentStar, itemLevel);
+    return roundToNearest10(raw);
+  }
+
+  @Override
+  public boolean isInitialized() {
+    return initialized.get();
+  }
+
+  /**
+   * 기대 파괴 횟수 계산 (마르코프 체인)
+   *
+   * <p>B[s] = (p*B[s+1] + d*(1 + B[12])) / (p+d) B[s] = a[s]*B[12] + b[s] B[12] = b[12] / (1 -
+   * a[12])
+   */
+  @Override
+  public double getExpectedDestroyCount(
+      int currentStar,
+      int targetStar,
+      boolean useStarCatch,
+      boolean useSundayMaple,
+      boolean useDestroyPrevention) {
+    int maxStar = MAX_STAR;
+    if (targetStar > maxStar) {
+      targetStar = maxStar;
+    }
+    if (currentStar >= targetStar) {
+      return 0.0;
+    }
+
+    int T = targetStar;
+    double[] a = new double[T + 1];
+    double[] b = new double[T + 1];
+
+    for (int s = T - 1; s >= 0; s--) {
+      double[] params =
+          getStageParams(s, 200, useStarCatch, useSundayMaple, false, useDestroyPrevention);
+      double p = params[0];
+      double d = params[2];
+
+      double aNext = (s + 1 >= T) ? 0.0 : a[s + 1];
+      double bNext = (s + 1 >= T) ? 0.0 : b[s + 1];
+
+      double denom = p + d;
+      if (denom < 1e-12) {
+        a[s] = 0;
+        b[s] = 0;
+      } else {
+        // B[s] = (p*B[s+1] + d*(1 + B[12])) / (p+d)
+        // = (p*B[s+1] + d + d*B[12]) / (p+d)
+        // a[s] = (p*a[s+1] + d) / (p+d)
+        // b[s] = (p*b[s+1] + d) / (p+d)
+        a[s] = (p * aNext + d) / denom;
+        b[s] = (p * bNext + d) / denom;
+      }
+    }
+
+    // B[12] 해결
+    double B12;
+    if (T <= DESTROY_RESET_STAR) {
+      B12 = 0.0;
+    } else {
+      double a12 = a[DESTROY_RESET_STAR];
+      double b12 = b[DESTROY_RESET_STAR];
+      if (Math.abs(1 - a12) < 1e-12) {
+        B12 = Double.MAX_VALUE;
+      } else {
+        B12 = b12 / (1 - a12);
+      }
+    }
+
+    double result = a[currentStar] * B12 + b[currentStar];
+    return Math.round(result * 100.0) / 100.0; // 소수점 2자리로 반올림
+  }
+
+  private void computeAndCache(
+      int currentStar,
+      int targetStar,
+      int level,
+      boolean starCatch,
+      boolean sunday,
+      boolean discount,
+      boolean destroyPrev) {
+    String key = cacheKey(currentStar, targetStar, level, starCatch, sunday, discount, destroyPrev);
+    double cost =
+        computeMarkovExpectedCost(
+            currentStar, targetStar, level, starCatch, sunday, discount, destroyPrev);
+    expectedCostCache.put(key, cost);
+  }
+
+  private void validateStarRange(int currentStar, int targetStar, int maxStar) {
+    if (currentStar < 0 || currentStar > maxStar) {
+      throw new IllegalArgumentException("Invalid current star: " + currentStar);
+    }
+    if (targetStar < 0 || targetStar > maxStar) {
+      throw new IllegalArgumentException("Invalid target star: " + targetStar);
+    }
+  }
+
+  private String cacheKey(
+      int currentStar,
+      int targetStar,
+      int level,
+      boolean starCatch,
+      boolean sunday,
+      boolean discount,
+      boolean destroyPrev) {
+    // Use concatenation instead of String.format() for hot path performance
+    return currentStar
+        + "-"
+        + targetStar
+        + "-"
+        + level
+        + "-"
+        + starCatch
+        + "-"
+        + sunday
+        + "-"
+        + discount
+        + "-"
+        + destroyPrev;
+  }
+
+  /** 10 단위로 반올림 (메이플스토리 스타포스 비용 표시 기준) */
+  private double roundToNearest10(double value) {
+    return Math.floor((value + 5) / 10.0) * 10;
+  }
+}

--- a/module-infra/src/main/java/maple/expectation/config/CubeEngineFeatureFlag.java
+++ b/module-infra/src/main/java/maple/expectation/config/CubeEngineFeatureFlag.java
@@ -1,0 +1,55 @@
+package maple.expectation.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * 큐브 엔진 Feature Flag 설정
+ *
+ * <p>v1(순열) ↔ v2(DP) 엔진 전환 및 Shadow Run을 제어합니다.
+ *
+ * <h3>설정 예시 (application.yml)</h3>
+ *
+ * <pre>
+ * cube:
+ *   engine:
+ *     dp-enabled: false      # true: v2(DP) 활성, false: v1(순열) 활성
+ *     shadow-enabled: false  # true: 비활성 엔진도 병렬 계산하여 비교 로깅
+ * </pre>
+ *
+ * <h3>전환 시나리오</h3>
+ *
+ * <ol>
+ *   <li>dpEnabled=false, shadowEnabled=true: v1 결과 반환, v2 비교 로깅
+ *   <li>dpEnabled=true, shadowEnabled=true: v2 결과 반환, v1 drift 모니터링
+ *   <li>dpEnabled=true, shadowEnabled=false: v2만 실행 (최종 상태)
+ * </ol>
+ */
+@Component
+@ConfigurationProperties(prefix = "cube.engine")
+@Getter
+@Setter
+public class CubeEngineFeatureFlag {
+
+  /**
+   * DP 엔진 활성화 여부
+   *
+   * <ul>
+   *   <li>false: v1(순열) 결과 반환, (shadow=true면) v2도 계산하여 비교 로깅
+   *   <li>true: v2(DP) 결과 반환, (shadow=true면) v1도 계산하여 drift 모니터링
+   * </ul>
+   */
+  private boolean dpEnabled = false;
+
+  /**
+   * Shadow 실행 (비교 로깅)
+   *
+   * <ul>
+   *   <li>true: 비활성 엔진도 병렬 계산하여 결과 비교 로깅
+   *   <li>false: 활성 엔진만 계산
+   * </ul>
+   */
+  private boolean shadowEnabled = false;
+}

--- a/module-infra/src/main/java/maple/expectation/config/TableMassConfig.java
+++ b/module-infra/src/main/java/maple/expectation/config/TableMassConfig.java
@@ -1,0 +1,38 @@
+package maple.expectation.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * 테이블 질량 검증 설정
+ *
+ * <p>확률 테이블의 Σp=1 검증 정책을 외부 설정으로 제어합니다.
+ *
+ * <h3>설정 예시 (application.yml)</h3>
+ *
+ * <pre>
+ * cube:
+ *   table-mass:
+ *     policy: STRICT  # 또는 LENIENT
+ * </pre>
+ */
+@Component
+@ConfigurationProperties(prefix = "cube.table-mass")
+@Getter
+@Setter
+public class TableMassConfig {
+
+  /** 테이블 질량 검증 정책 */
+  public enum TableMassPolicy {
+    /** 엄격 모드: Σ≠1 시 즉시 예외 (금융급 기본값) */
+    STRICT,
+
+    /** 관대 모드: 정규화 후 진행 + 경고 로그 */
+    LENIENT
+  }
+
+  /** 테이블 질량 검증 정책 기본값: STRICT (금융급) */
+  private TableMassPolicy policy = TableMassPolicy.STRICT;
+}

--- a/module-infra/src/main/kotlin/maple/expectation/application/service/calculator/v4/impl/AdditionalCubeDecoratorV4.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/application/service/calculator/v4/impl/AdditionalCubeDecoratorV4.kt
@@ -1,0 +1,40 @@
+package maple.expectation.application.service.calculator.v4.impl
+
+import maple.expectation.application.service.calculator.v4.EquipmentExpectationCalculator
+import maple.expectation.application.service.calculator.v4.EquipmentExpectationCalculator.CostBreakdown
+import maple.expectation.application.service.cube.AbstractCubeDecoratorV4
+import maple.expectation.application.service.cube.CubeTrialsProvider
+import maple.expectation.application.service.cube.policy.CubeCostPolicy
+import maple.expectation.domain.v2.CubeType
+import maple.expectation.core.dto.cube.CubeCalculationInput
+
+/**
+ * V4 에디셔널큐브 데코레이터 (리팩토링: AbstractCubeDecoratorV4 사용)
+ *
+ * 리팩토링 내역:
+ * - 중복 로직 제거: AbstractCubeDecoratorV4 템플릿 사용
+ * - 코드 감소: ~60% (102 → 40 라인)
+ * - 단일 책임: 큐브 타입과 경로 접미사만 정의
+ * - 성능 최적화: BigDecimal → Double로 변경 (2026-03-23)
+ *
+ * 에디셔널큐브 특성:
+ * - 아랫잠재(에디셔널 잠재능력) 재설정
+ * - 에픽 → 유니크 → 레전드리 등급 상승
+ * - 메이플스토리: 에디셔널 옵션은 주력 스탯에 추가 버프 제공
+ *
+ * @see AbstractCubeDecoratorV4 공통 로직 템플릿
+ */
+class AdditionalCubeDecoratorV4(
+    target: EquipmentExpectationCalculator,
+    trialsProvider: CubeTrialsProvider,
+    costPolicy: CubeCostPolicy,
+    input: CubeCalculationInput,
+) : AbstractCubeDecoratorV4(target, trialsProvider, costPolicy, input) {
+
+    override fun getCubeType(): CubeType = CubeType.ADDITIONAL
+
+    override fun getCubePathSuffix(): String = " > 에디셔널큐브(아랫잠)"
+
+    override fun updateCostBreakdown(base: CostBreakdown, cubeCost: Double, trials: Double): CostBreakdown =
+        base.withAdditionalCube(base.additionalCubeCost + cubeCost, trials)
+}

--- a/module-infra/src/main/kotlin/maple/expectation/application/service/calculator/v4/impl/BlackCubeDecoratorV4.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/application/service/calculator/v4/impl/BlackCubeDecoratorV4.kt
@@ -1,0 +1,40 @@
+package maple.expectation.application.service.calculator.v4.impl
+
+import maple.expectation.application.service.calculator.v4.EquipmentExpectationCalculator
+import maple.expectation.application.service.calculator.v4.EquipmentExpectationCalculator.CostBreakdown
+import maple.expectation.application.service.cube.AbstractCubeDecoratorV4
+import maple.expectation.application.service.cube.CubeTrialsProvider
+import maple.expectation.application.service.cube.policy.CubeCostPolicy
+import maple.expectation.domain.v2.CubeType
+import maple.expectation.core.dto.cube.CubeCalculationInput
+
+/**
+ * V4 블랙큐브 데코레이터 (리팩토링: AbstractCubeDecoratorV4 사용)
+ *
+ * 리팩토링 내역:
+ * - 중복 로직 제거: AbstractCubeDecoratorV4 템플릿 사용
+ * - 코드 감소: ~60% (119 → 47 라인)
+ * - 단일 책임: 큐브 타입과 경로 접미사만 정의
+ * - 성능 최적화: BigDecimal → Double로 변경 (2026-03-23)
+ *
+ * 블랙큐브 특성:
+ * - 윗잠재(메인 잠재능력) 재설정
+ * - 레어 → 에픽 → 유니크 → 레전드리 등급 상승
+ * - 큐브 가격: 레벨 × 등급 계수
+ *
+ * @see AbstractCubeDecoratorV4 공통 로직 템플릿
+ */
+class BlackCubeDecoratorV4(
+    target: EquipmentExpectationCalculator,
+    trialsProvider: CubeTrialsProvider,
+    costPolicy: CubeCostPolicy,
+    input: CubeCalculationInput,
+) : AbstractCubeDecoratorV4(target, trialsProvider, costPolicy, input) {
+
+    override fun getCubeType(): CubeType = CubeType.BLACK
+
+    override fun getCubePathSuffix(): String = " > 블랙큐브(윗잠)"
+
+    override fun updateCostBreakdown(base: CostBreakdown, cubeCost: Double, trials: Double): CostBreakdown =
+        base.withBlackCube(base.blackCubeCost + cubeCost, trials)
+}

--- a/module-infra/src/main/kotlin/maple/expectation/domain/v2/CubeType.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/domain/v2/CubeType.kt
@@ -15,4 +15,13 @@ enum class CubeType(val description: String) {
         RED -> maple.expectation.core.domain.model.CubeType.RED
         ADDITIONAL -> maple.expectation.core.domain.model.CubeType.ADDITIONAL
     }
+
+    companion object {
+        @JvmStatic
+        fun fromCore(core: maple.expectation.core.domain.model.CubeType): CubeType = when (core) {
+            maple.expectation.core.domain.model.CubeType.BLACK -> BLACK
+            maple.expectation.core.domain.model.CubeType.RED -> RED
+            maple.expectation.core.domain.model.CubeType.ADDITIONAL -> ADDITIONAL
+        }
+    }
 }

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/config/CalculationPortConfig.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/config/CalculationPortConfig.kt
@@ -1,0 +1,64 @@
+package maple.expectation.infrastructure.config
+
+import maple.expectation.core.calculator.CubeRateCalculator
+import maple.expectation.core.domain.stat.StatParser
+import maple.expectation.core.flame.component.FlameScoreResolver
+import maple.expectation.core.flame.port.FlameTrialsPort
+import maple.expectation.core.flame.service.FlameTrialsService
+import maple.expectation.core.probability.FlameDpCalculator
+import maple.expectation.core.probability.FlameScoreCalculator
+import maple.expectation.core.probability.ProbabilityConvolver
+import maple.expectation.core.probability.TailProbabilityCalculator
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class CalculationPortConfig {
+
+    private val log = LoggerFactory.getLogger(CalculationPortConfig::class.java)
+
+    @Bean
+    fun flameTrialsPort(
+        dpCalculator: FlameDpCalculator,
+        scoreCalculator: FlameScoreCalculator,
+    ): FlameTrialsPort {
+        log.info("[CalculationPort] Initializing FlameTrialsPort bean")
+        return FlameTrialsService(dpCalculator, scoreCalculator)
+    }
+
+    @Bean
+    fun flameDpCalculator(): FlameDpCalculator {
+        return FlameDpCalculator()
+    }
+
+    @Bean
+    fun flameScoreCalculator(): FlameScoreCalculator {
+        return FlameScoreCalculator()
+    }
+
+    @Bean
+    fun cubeRateCalculator(): CubeRateCalculator {
+        return CubeRateCalculator()
+    }
+
+    @Bean
+    fun statParser(): StatParser {
+        return StatParser()
+    }
+
+    @Bean
+    fun probabilityConvolver(): ProbabilityConvolver {
+        return ProbabilityConvolver()
+    }
+
+    @Bean
+    fun tailProbabilityCalculator(): TailProbabilityCalculator {
+        return TailProbabilityCalculator()
+    }
+
+    @Bean
+    fun flameScoreResolver(): FlameScoreResolver {
+        return FlameScoreResolver
+    }
+}

--- a/module-synchronizer/build.gradle
+++ b/module-synchronizer/build.gradle
@@ -1,0 +1,56 @@
+// ========================================
+// Module-Synchronizer: Calculator result files → DB sync
+// ========================================
+
+plugins {
+	alias(libs.plugins.kotlin.jvm)
+	alias(libs.plugins.kotlin.spring)
+	alias(libs.plugins.spring.boot)
+}
+
+dependencies {
+	implementation project(':module-common')
+	implementation project(':module-core')
+	implementation project(':module-infra')
+
+	implementation(libs.kotlin.stdlib)
+	implementation(libs.kotlin.reflect)
+	implementation(libs.kotlin.logging.jvm)
+	implementation(libs.kotlinx.coroutines.core)
+
+	// Spring
+	implementation(libs.spring.boot)
+	implementation(libs.spring.boot.starter.web)
+	implementation(libs.spring.boot.starter.data.jpa)
+	runtimeOnly(libs.postgresql)
+
+	// Metrics
+	implementation(libs.spring.boot.starter.actuator)
+	implementation(libs.micrometer.registry.prometheus)
+
+	// Structured JSON logging
+	implementation(libs.logstash.logback.encoder)
+
+	// Kafka
+	implementation(libs.spring.kafka)
+
+	// Jackson
+	implementation(libs.jackson.databind)
+	implementation(libs.jackson.module.kotlin)
+
+	// Testing
+	testImplementation(libs.spring.boot.starter.test)
+	testImplementation(libs.assertj.core)
+	testImplementation(libs.mockito.kotlin)
+}
+
+bootJar {
+	enabled = true
+	archiveClassifier = ""
+	mainClass.set("maple.synchronizer.SynchronizerApplication")
+}
+
+tasks.named("jar") {
+	enabled = true
+	archiveClassifier = "plain"
+}

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/builder/EquipmentDocumentBuilder.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/builder/EquipmentDocumentBuilder.kt
@@ -1,0 +1,52 @@
+package maple.synchronizer.builder
+
+import maple.synchronizer.domain.CalculatedEquipmentItem
+import maple.synchronizer.domain.EquipmentReadDocument
+import maple.synchronizer.domain.EquipmentReadMetadata
+import maple.synchronizer.domain.EquipmentSummary
+import maple.synchronizer.domain.GroupedEquipmentResult
+import java.math.BigDecimal
+import java.time.Instant
+
+class EquipmentDocumentBuilder {
+
+    fun build(runId: String, chunkId: String, grouped: GroupedEquipmentResult): EquipmentReadDocument {
+        val totalCost = grouped.items.fold(BigDecimal.ZERO) { acc, item -> acc + item.totalCost }
+        val equipmentCount = grouped.items.count { it.status != "SKIPPED" }
+
+        return EquipmentReadDocument(
+            ocid = grouped.ocid,
+            presetNo = grouped.presetNo,
+            userIgn = grouped.userIgn,
+            summary = EquipmentSummary(
+                totalCost = totalCost,
+                equipmentCount = equipmentCount,
+            ),
+            equipment = grouped.items.map { it.toMap() },
+            metadata = EquipmentReadMetadata(
+                sourceRunId = runId,
+                sourceChunkId = chunkId,
+                calculatedAt = Instant.now(),
+            ),
+        )
+    }
+
+    private fun CalculatedEquipmentItem.toMap(): Map<String, Any?> = mapOf(
+        "itemName" to itemName,
+        "itemLevel" to itemLevel,
+        "itemPart" to itemPart,
+        "itemEquipmentPart" to itemEquipmentPart,
+        "potentialGrade" to potentialGrade,
+        "potentialOptions" to potentialOptions,
+        "additionalGrade" to additionalGrade,
+        "additionalOptions" to additionalOptions,
+        "currentStar" to currentStar,
+        "targetStar" to targetStar,
+        "status" to status,
+        "totalCost" to totalCost,
+        "blackCubeCost" to blackCubeCost,
+        "additionalCubeCost" to additionalCubeCost,
+        "starforceCost" to starforceCost,
+        "errorMessage" to errorMessage,
+    )
+}

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/KafkaResultChunkConsumer.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/KafkaResultChunkConsumer.kt
@@ -1,0 +1,126 @@
+package maple.synchronizer.consumer
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.micrometer.core.instrument.Timer
+import jakarta.annotation.PreDestroy
+import maple.expectation.infrastructure.executor.LogicExecutor
+import maple.expectation.infrastructure.executor.TaskContext
+import maple.expectation.common.event.CalculatorResultChunkReadyEvent
+import maple.synchronizer.metrics.SynchronizerMetrics
+import maple.synchronizer.processor.ChunkProcessInput
+import maple.synchronizer.processor.ChunkProcessor
+import maple.synchronizer.repository.SynchronizerChunkStatusRepository
+import org.slf4j.LoggerFactory
+import org.slf4j.MDC
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.kafka.support.Acknowledgment
+import org.springframework.stereotype.Component
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executors
+import java.util.concurrent.Semaphore
+
+@Component
+class KafkaResultChunkConsumer(
+    private val objectMapper: ObjectMapper,
+    private val chunkProcessor: ChunkProcessor,
+    private val chunkStatusRepository: SynchronizerChunkStatusRepository,
+    private val metrics: SynchronizerMetrics,
+    private val logicExecutor: LogicExecutor,
+) {
+    private val log = LoggerFactory.getLogger(KafkaResultChunkConsumer::class.java)
+    private val vtExecutor = Executors.newVirtualThreadPerTaskExecutor()
+    private val processingPermit = Semaphore(2)
+
+    @KafkaListener(
+        topics = ["\${synchronizer.kafka.result-chunk-ready-topic}"],
+        groupId = "\${synchronizer.kafka.consumer-group-id}",
+    )
+    fun consume(message: String, acknowledgment: Acknowledgment) {
+        val event = objectMapper.readValue(message, CalculatorResultChunkReadyEvent::class.java)
+        val runId = event.sourceRunId
+        val chunkId = event.sourceChunkId
+
+        log.info("[Synchronizer] received: runId={} chunkId={} objectKey={} results={}",
+            runId, chunkId, event.objectKey, event.resultCount)
+
+        if (chunkStatusRepository.isAlreadySuccess(runId, chunkId)) {
+            log.info("[Synchronizer] skip already-successful chunk: runId={} chunkId={}", runId, chunkId)
+            acknowledgment.acknowledge()
+            return
+        }
+
+        if (!chunkStatusRepository.claimChunk(runId, chunkId, event.objectKey)) {
+            log.info("[Synchronizer] skip - chunk already claimed by another worker: runId={} chunkId={}", runId, chunkId)
+            acknowledgment.acknowledge()
+            return
+        }
+
+        if (!processingPermit.tryAcquire()) {
+            log.info("[Synchronizer] processing permit busy, will retry: runId={} chunkId={}", runId, chunkId)
+            return
+        }
+
+        metrics.incrementReceived()
+        metrics.incrementProcessing()
+        MDC.put("runId", runId)
+        MDC.put("chunkId", chunkId)
+        MDC.put("kafkaTopic", "calculator.result.chunk-ready")
+
+        CompletableFuture.runAsync({
+            val chunkSample = Timer.start()
+            logicExecutor.executeWithFinally(
+                task = {
+                    logicExecutor.executeOrCatch(
+                        task = {
+                            chunkProcessor.process(ChunkProcessInput(
+                                objectKey = event.objectKey,
+                                sourceRunId = runId,
+                                sourceChunkId = chunkId,
+                                resultCount = event.resultCount,
+                            ))
+                            chunkStatusRepository.markSuccess(runId, chunkId)
+                            metrics.incrementProcessed()
+                            metrics.recordStatusTransition("SUCCESS")
+                            chunkSample.stop(metrics.chunkTimer())
+
+                            metrics.recordChunkBytes(event.compressedBytes)
+                            recordPreUpsertVolume(event)
+                            acknowledgment.acknowledge()
+                        },
+                        recovery = { ex ->
+                            chunkStatusRepository.markFailed(runId, chunkId, ex.message ?: "unknown")
+                            metrics.incrementFailed()
+                            metrics.recordStatusTransition("FAILED")
+                            log.error("[Synchronizer] chunk processing failed: runId={} chunkId={}", runId, chunkId, ex)
+                            null
+                        },
+                        context = TaskContext.of("Synchronizer", "ChunkProcess", chunkId),
+                    )
+                },
+                finallyBlock = {
+                    metrics.decrementProcessing()
+                    processingPermit.release()
+                    MDC.clear()
+                },
+                context = TaskContext.of("Synchronizer", "ChunkLifecycle", chunkId),
+            )
+        }, vtExecutor)
+    }
+
+    private fun recordPreUpsertVolume(event: CalculatorResultChunkReadyEvent) {
+        metrics.recordPreUpsertVolume(event.compressedBytes, event.uncompressedBytes, event.resultCount.toLong())
+        val ratio = if (event.compressedBytes > 0)
+            "%.2f".format(event.uncompressedBytes.toDouble() / event.compressedBytes.toDouble())
+        else "N/A"
+        log.info(
+            "[preUpsertVolume] runId={} chunkId={} compressedBytes={} uncompressedBytes={} jsonRows={} compressionRatio={}",
+            event.sourceRunId, event.sourceChunkId, event.compressedBytes, event.uncompressedBytes,
+            event.resultCount, ratio,
+        )
+    }
+
+    @PreDestroy
+    fun close() {
+        vtExecutor.close()
+    }
+}

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/domain/CalculatedEquipmentItem.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/domain/CalculatedEquipmentItem.kt
@@ -1,0 +1,53 @@
+package maple.synchronizer.domain
+
+import java.math.BigDecimal
+import java.time.Instant
+
+data class CalculatedEquipmentItem(
+    val ocid: String,
+    val presetNo: Int,
+    val itemName: String,
+    val itemLevel: Int,
+    val itemPart: String,
+    val itemEquipmentPart: String?,
+    val potentialGrade: String?,
+    val potentialOptions: List<String>?,
+    val additionalGrade: String?,
+    val additionalOptions: List<String>?,
+    val currentStar: Int,
+    val targetStar: Int,
+    val status: String,
+    val totalCost: BigDecimal,
+    val blackCubeCost: BigDecimal,
+    val additionalCubeCost: BigDecimal,
+    val starforceCost: BigDecimal,
+    val errorMessage: String?,
+)
+
+data class GroupedEquipmentResult(
+    val readKey: String,
+    val ocid: String,
+    val presetNo: Int,
+    val userIgn: String? = null,
+    val items: List<CalculatedEquipmentItem>,
+)
+
+data class EquipmentReadDocument(
+    val ocid: String,
+    val presetNo: Int,
+    val userIgn: String? = null,
+    val summary: EquipmentSummary,
+    val equipment: List<Map<String, Any?>>,
+    val metadata: EquipmentReadMetadata,
+)
+
+data class EquipmentSummary(
+    val totalCost: BigDecimal,
+    val equipmentCount: Int,
+)
+
+data class EquipmentReadMetadata(
+    val sourceRunId: String,
+    val sourceChunkId: String,
+    val calculatedAt: Instant,
+)

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/metrics/SynchronizerMetrics.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/metrics/SynchronizerMetrics.kt
@@ -1,0 +1,123 @@
+package maple.synchronizer.metrics
+
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.DistributionSummary
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Timer
+import org.springframework.stereotype.Component
+import java.util.concurrent.atomic.AtomicInteger
+
+@Component
+class SynchronizerMetrics(private val registry: MeterRegistry) {
+
+    // Chunk counters
+    private val chunksReceived = registry.counter("synchronizer_chunks_received_total")
+    private val chunksProcessing = AtomicInteger(0)
+    private val chunksProcessed = registry.counter("synchronizer_chunks_processed_total")
+    private val chunksFailed = registry.counter("synchronizer_chunks_failed_total")
+
+    init {
+        registry.gauge("synchronizer_chunks_processing", chunksProcessing)
+    }
+
+    // Document / item counters
+    private val documentsProcessed = registry.counter("synchronizer_documents_processed_total")
+    private val itemsProcessed = registry.counter("synchronizer_items_processed_total")
+
+    // Timers — 각 단계별 latency
+    private val chunkTimer = Timer.builder("synchronizer_chunk_duration_seconds")
+        .description("Total time to process a single chunk end-to-end")
+        .publishPercentileHistogram()
+        .register(registry)
+
+    private val fileReadTimer = Timer.builder("synchronizer_file_read_duration_seconds")
+        .description("Time to read and decompress gzip JSONL file")
+        .publishPercentileHistogram()
+        .register(registry)
+
+    private val documentBuildTimer = Timer.builder("synchronizer_document_build_duration_seconds")
+        .description("Time to build read model documents from grouped results")
+        .publishPercentileHistogram()
+        .register(registry)
+
+    private val mainUpsertTimer = Timer.builder("synchronizer_main_upsert_duration_seconds")
+        .description("Time to bulk upsert documents into main read model table")
+        .publishPercentileHistogram()
+        .register(registry)
+
+    // Distribution summaries — chunk 크기/분포
+    private val chunkDocumentsSummary = DistributionSummary.builder("synchronizer_chunk_documents")
+        .description("Number of documents per chunk")
+        .register(registry)
+
+    private val chunkItemsSummary = DistributionSummary.builder("synchronizer_chunk_items")
+        .description("Number of items per chunk")
+        .register(registry)
+
+    private val chunkBytesSummary = DistributionSummary.builder("synchronizer_chunk_bytes")
+        .description("Compressed document bytes per chunk")
+        .register(registry)
+
+    private val documentEquipmentSummary = DistributionSummary.builder("synchronizer_document_equipment_count")
+        .description("Equipment count per document")
+        .register(registry)
+
+    // Volume metrics — pre-upsert data volume
+    private val preUpsertCompressedBytesTotal = registry.counter("synchronizer_pre_upsert_compressed_bytes_total")
+    private val preUpsertUncompressedBytesTotal = registry.counter("synchronizer_pre_upsert_uncompressed_bytes_total")
+    private val preUpsertJsonRowsTotal = registry.counter("synchronizer_pre_upsert_json_rows_total")
+
+    private val preUpsertCompressedSummary = DistributionSummary.builder("synchronizer_pre_upsert_compressed_bytes")
+        .description("Compressed artifact bytes per chunk before DB upsert")
+        .register(registry)
+
+    private val preUpsertUncompressedSummary = DistributionSummary.builder("synchronizer_pre_upsert_uncompressed_bytes")
+        .description("Uncompressed artifact bytes per chunk before DB upsert")
+        .register(registry)
+
+    private val preUpsertCompressionRatio = DistributionSummary.builder("synchronizer_pre_upsert_compression_ratio")
+        .description("Compression ratio (uncompressed/compressed) per chunk before DB upsert")
+        .register(registry)
+
+    // Status transition counter
+    private fun statusCounter(status: String) =
+        registry.counter("synchronizer_chunk_status_transition_total", "status", status)
+
+    fun incrementReceived() = chunksReceived.increment()
+    fun incrementProcessing() = chunksProcessing.incrementAndGet()
+    fun decrementProcessing() = chunksProcessing.decrementAndGet()
+    fun incrementProcessed() = chunksProcessed.increment()
+    fun incrementFailed() = chunksFailed.increment()
+
+    fun incrementDocuments(count: Int) = documentsProcessed.increment(count.toDouble())
+    fun incrementItems(count: Long) = itemsProcessed.increment(count.toDouble())
+
+    fun recordStatusTransition(status: String) = statusCounter(status).increment()
+
+    fun recordChunkSize(documents: Int, items: Long) {
+        chunkDocumentsSummary.record(documents.toDouble())
+        chunkItemsSummary.record(items.toDouble())
+    }
+
+    fun recordChunkBytes(bytes: Long) {
+        chunkBytesSummary.record(bytes.toDouble())
+    }
+
+    fun recordDocumentEquipment(count: Int) = documentEquipmentSummary.record(count.toDouble())
+
+    fun recordPreUpsertVolume(compressedBytes: Long, uncompressedBytes: Long, jsonRows: Long) {
+        preUpsertCompressedBytesTotal.increment(compressedBytes.toDouble())
+        preUpsertUncompressedBytesTotal.increment(uncompressedBytes.toDouble())
+        preUpsertJsonRowsTotal.increment(jsonRows.toDouble())
+        preUpsertCompressedSummary.record(compressedBytes.toDouble())
+        preUpsertUncompressedSummary.record(uncompressedBytes.toDouble())
+        if (compressedBytes > 0) {
+            preUpsertCompressionRatio.record(uncompressedBytes.toDouble() / compressedBytes.toDouble())
+        }
+    }
+
+    fun chunkTimer(): Timer = chunkTimer
+    fun fileReadTimer(): Timer = fileReadTimer
+    fun documentBuildTimer(): Timer = documentBuildTimer
+    fun mainUpsertTimer(): Timer = mainUpsertTimer
+}

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/preparer/EquipmentDocumentPreparer.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/preparer/EquipmentDocumentPreparer.kt
@@ -1,0 +1,46 @@
+package maple.synchronizer.preparer
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import maple.expectation.util.GzipUtils
+import maple.synchronizer.domain.EquipmentReadDocument
+import java.security.MessageDigest
+import java.sql.Timestamp
+
+class EquipmentDocumentPreparer(private val objectMapper: ObjectMapper) {
+
+    fun prepare(documents: List<EquipmentReadDocument>): List<PreppedDocument> {
+        return documents.map { prepareOne(it) }
+    }
+
+    private fun prepareOne(doc: EquipmentReadDocument): PreppedDocument {
+        val json = objectMapper.writeValueAsString(doc)
+        return PreppedDocument(
+            readKey = "${doc.ocid}:${doc.presetNo}",
+            ocid = doc.ocid,
+            presetNo = doc.presetNo.toShort(),
+            userIgn = doc.userIgn,
+            compressed = GzipUtils.compress(json),
+            documentHash = sha256Hex(json),
+            totalCost = doc.summary.totalCost,
+            equipmentCount = doc.summary.equipmentCount,
+            calculatedAt = Timestamp.from(doc.metadata.calculatedAt),
+        )
+    }
+
+    private fun sha256Hex(input: String): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(input.toByteArray(Charsets.UTF_8))
+        return digest.joinToString("") { "%02x".format(it) }
+    }
+}
+
+data class PreppedDocument(
+    val readKey: String,
+    val ocid: String,
+    val presetNo: Short,
+    val userIgn: String?,
+    val compressed: ByteArray,
+    val documentHash: String,
+    val totalCost: java.math.BigDecimal,
+    val equipmentCount: Int,
+    val calculatedAt: Timestamp,
+)

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/processor/ChunkProcessInput.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/processor/ChunkProcessInput.kt
@@ -1,0 +1,8 @@
+package maple.synchronizer.processor
+
+data class ChunkProcessInput(
+    val objectKey: String,
+    val sourceRunId: String,
+    val sourceChunkId: String,
+    val resultCount: Int,
+)

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/processor/ChunkProcessResult.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/processor/ChunkProcessResult.kt
@@ -1,0 +1,7 @@
+package maple.synchronizer.processor
+
+data class ChunkProcessResult(
+    val documentCount: Int,
+    val itemCount: Long,
+    val jsonRowCount: Long,
+)

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/processor/ChunkProcessor.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/processor/ChunkProcessor.kt
@@ -1,0 +1,5 @@
+package maple.synchronizer.processor
+
+interface ChunkProcessor {
+    fun process(input: ChunkProcessInput): ChunkProcessResult
+}

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/processor/DefaultChunkProcessor.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/processor/DefaultChunkProcessor.kt
@@ -1,0 +1,68 @@
+package maple.synchronizer.processor
+
+import io.micrometer.core.instrument.Timer
+import maple.synchronizer.builder.EquipmentDocumentBuilder
+import maple.synchronizer.metrics.SynchronizerMetrics
+import maple.synchronizer.preparer.EquipmentDocumentPreparer
+import maple.synchronizer.repository.EquipmentReadModelRepository
+import maple.synchronizer.resolver.OcidUserIgnResolver
+import maple.synchronizer.storage.ResultFileReader
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+@Component
+class DefaultChunkProcessor(
+    private val resultFileReader: ResultFileReader,
+    private val readModelRepository: EquipmentReadModelRepository,
+    private val ocidUserIgnResolver: OcidUserIgnResolver,
+    private val metrics: SynchronizerMetrics,
+    objectMapper: com.fasterxml.jackson.databind.ObjectMapper,
+) : ChunkProcessor {
+
+    private val documentBuilder = EquipmentDocumentBuilder()
+    private val preparer = EquipmentDocumentPreparer(objectMapper)
+
+    private val log = LoggerFactory.getLogger(DefaultChunkProcessor::class.java)
+
+    override fun process(input: ChunkProcessInput): ChunkProcessResult {
+        val grouped = timed(metrics.fileReadTimer()) {
+            resultFileReader.readAndGroupByCompositeKey(input.objectKey)
+        }
+
+        val ocids = grouped.map { it.ocid }.toSet()
+        val ocidToUserIgn = ocidUserIgnResolver.resolve(ocids)
+
+        val documents = timed(metrics.documentBuildTimer()) {
+            grouped.map { g ->
+                val withUserIgn = g.copy(userIgn = ocidToUserIgn[g.ocid])
+                documentBuilder.build(input.sourceRunId, input.sourceChunkId, withUserIgn)
+            }
+        }
+
+        val itemsCount = grouped.sumOf { it.items.size.toLong() }
+
+        log.info("[Synchronizer] grouped {} results into {} documents", input.resultCount, documents.size)
+
+        metrics.incrementDocuments(documents.size)
+        metrics.incrementItems(itemsCount)
+        metrics.recordChunkSize(documents.size, itemsCount)
+        documents.forEach { metrics.recordDocumentEquipment(it.summary.equipmentCount) }
+
+        val prepped = preparer.prepare(documents)
+
+        metrics.mainUpsertTimer().record(Runnable {
+            readModelRepository.bulkUpsert(input.sourceRunId, input.sourceChunkId, prepped)
+        })
+
+        return ChunkProcessResult(
+            documentCount = documents.size,
+            itemCount = itemsCount,
+            jsonRowCount = input.resultCount.toLong(),
+        )
+    }
+
+    private inline fun <T> timed(timer: Timer, block: () -> T): T {
+        val sample = Timer.start()
+        return block().also { sample.stop(timer) }
+    }
+}

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/repository/EquipmentReadModelRepository.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/repository/EquipmentReadModelRepository.kt
@@ -1,0 +1,85 @@
+package maple.synchronizer.repository
+
+import maple.synchronizer.preparer.PreppedDocument
+import org.slf4j.LoggerFactory
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.stereotype.Repository
+
+@Repository
+class EquipmentReadModelRepository(
+    private val jdbc: NamedParameterJdbcTemplate,
+) {
+    private val log = LoggerFactory.getLogger(EquipmentReadModelRepository::class.java)
+
+    companion object {
+        private const val SUB_BATCH_SIZE = 100
+    }
+
+    fun bulkUpsert(runId: String, chunkId: String, documents: List<PreppedDocument>) {
+        val batches = documents.chunked(SUB_BATCH_SIZE)
+        val compSizes = documents.map { it.compressed.size }
+        val totalStart = System.currentTimeMillis()
+
+        log.info("[Synchronizer] upsert start: docs={} batches={} batchSize={} " +
+            "compressedBytes avg={} max={} total={} : runId={} chunkId={}",
+            documents.size, batches.size, SUB_BATCH_SIZE,
+            compSizes.average().toInt(), compSizes.max(), compSizes.sum(),
+            runId, chunkId)
+
+        var totalAffected = 0
+        batches.forEachIndexed { idx, batch ->
+            val batchStart = System.currentTimeMillis()
+            val affected = upsertBatch(runId, chunkId, batch)
+            val batchMs = System.currentTimeMillis() - batchStart
+            totalAffected += affected
+            log.info("[Synchronizer] upsert batch: batchNo={}/{} attempted={} affected={} durationMs={}",
+                idx + 1, batches.size, batch.size, affected, batchMs)
+        }
+
+        val totalMs = System.currentTimeMillis() - totalStart
+        log.info("[Synchronizer] upsert done: docs={} affected={} totalDurationMs={} : runId={} chunkId={}",
+            documents.size, totalAffected, totalMs, runId, chunkId)
+    }
+
+    private fun upsertBatch(runId: String, chunkId: String, batch: List<PreppedDocument>): Int {
+        val sql = """
+            INSERT INTO character_equipment_read_model (
+                read_key, ocid, preset_no, user_ign, document, document_hash,
+                total_cost, equipment_count, calculated_at,
+                source_run_id, source_chunk_id, updated_at
+            )
+            SELECT
+                unnest(:readKeys), unnest(:ocids), unnest(:presetNos),
+                unnest(:userIgns), unnest(:documents), unnest(:documentHashes),
+                unnest(:totalCosts), unnest(:equipmentCounts), unnest(:calculatedAts),
+                :runId, :chunkId, now()
+            ON CONFLICT (read_key) DO UPDATE SET
+                user_ign = excluded.user_ign,
+                document = excluded.document,
+                document_hash = excluded.document_hash,
+                total_cost = excluded.total_cost,
+                equipment_count = excluded.equipment_count,
+                calculated_at = excluded.calculated_at,
+                source_run_id = excluded.source_run_id,
+                source_chunk_id = excluded.source_chunk_id,
+                updated_at = now()
+            WHERE character_equipment_read_model.document_hash IS DISTINCT FROM excluded.document_hash
+               OR character_equipment_read_model.user_ign IS DISTINCT FROM excluded.user_ign
+        """.trimIndent()
+
+        return jdbc.update(sql, MapSqlParameterSource()
+            .addValue("runId", runId)
+            .addValue("chunkId", chunkId)
+            .addValue("readKeys", batch.map { it.readKey }.toTypedArray())
+            .addValue("ocids", batch.map { it.ocid }.toTypedArray())
+            .addValue("presetNos", batch.map { it.presetNo }.toTypedArray())
+            .addValue("userIgns", batch.map { it.userIgn }.toTypedArray())
+            .addValue("documents", batch.map { it.compressed }.toTypedArray())
+            .addValue("documentHashes", batch.map { it.documentHash }.toTypedArray())
+            .addValue("totalCosts", batch.map { it.totalCost }.toTypedArray())
+            .addValue("equipmentCounts", batch.map { it.equipmentCount }.toTypedArray())
+            .addValue("calculatedAts", batch.map { it.calculatedAt }.toTypedArray())
+        )
+    }
+}

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/repository/SynchronizerChunkStatusRepository.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/repository/SynchronizerChunkStatusRepository.kt
@@ -1,0 +1,79 @@
+package maple.synchronizer.repository
+
+import org.slf4j.LoggerFactory
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.stereotype.Repository
+
+@Repository
+class SynchronizerChunkStatusRepository(
+    private val jdbc: NamedParameterJdbcTemplate,
+) {
+    private val log = LoggerFactory.getLogger(SynchronizerChunkStatusRepository::class.java)
+
+    fun isAlreadySuccess(runId: String, chunkId: String): Boolean {
+        val sql = """
+            SELECT COUNT(*) FROM synchronizer_chunk_status
+            WHERE run_id = :runId AND chunk_id = :chunkId AND status = 'SUCCESS'
+        """.trimIndent()
+        val count = jdbc.queryForObject(sql, params(runId, chunkId), Long::class.java)
+        return count != null && count > 0
+    }
+
+    /**
+     * Atomic claim: only succeeds if status is FAILED, or PROCESSING with updated_at > 15 min ago.
+     * Returns true if this worker successfully claimed the chunk.
+     */
+    fun claimChunk(runId: String, chunkId: String, resultObjectKey: String): Boolean {
+        val sql = """
+            INSERT INTO synchronizer_chunk_status (
+                run_id, chunk_id, result_object_key, status,
+                received_at, started_at, updated_at
+            ) VALUES (
+                :runId, :chunkId, :resultObjectKey, 'PROCESSING',
+                now(), now(), now()
+            )
+            ON CONFLICT (run_id, chunk_id) DO UPDATE SET
+                status = 'PROCESSING',
+                result_object_key = :resultObjectKey,
+                started_at = now(),
+                updated_at = now(),
+                error_message = NULL
+            WHERE synchronizer_chunk_status.status = 'FAILED'
+               OR (
+                   synchronizer_chunk_status.status = 'PROCESSING'
+                   AND synchronizer_chunk_status.updated_at < now() - interval '15 minutes'
+               )
+        """.trimIndent()
+        val affected = jdbc.update(sql, params(runId, chunkId, resultObjectKey))
+        return affected > 0
+    }
+
+    fun markSuccess(runId: String, chunkId: String) {
+        val sql = """
+            UPDATE synchronizer_chunk_status
+            SET status = 'SUCCESS', completed_at = now(), updated_at = now()
+            WHERE run_id = :runId AND chunk_id = :chunkId
+        """.trimIndent()
+        jdbc.update(sql, params(runId, chunkId))
+    }
+
+    fun markFailed(runId: String, chunkId: String, errorMessage: String) {
+        val sql = """
+            UPDATE synchronizer_chunk_status
+            SET status = 'FAILED', error_message = :errorMessage, updated_at = now()
+            WHERE run_id = :runId AND chunk_id = :chunkId
+        """.trimIndent()
+        jdbc.update(sql, mapOf(
+            "runId" to runId,
+            "chunkId" to chunkId,
+            "errorMessage" to errorMessage.take(2000),
+        ))
+        log.error("[Synchronizer] chunk failed: runId={} chunkId={} error={}", runId, chunkId, errorMessage)
+    }
+
+    private fun params(runId: String, chunkId: String, resultObjectKey: String = "") = mapOf(
+        "runId" to runId,
+        "chunkId" to chunkId,
+        "resultObjectKey" to resultObjectKey,
+    )
+}

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/resolver/OcidUserIgnResolver.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/resolver/OcidUserIgnResolver.kt
@@ -1,0 +1,32 @@
+package maple.synchronizer.resolver
+
+import org.slf4j.LoggerFactory
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.stereotype.Component
+
+@Component
+class OcidUserIgnResolver(
+    private val jdbc: NamedParameterJdbcTemplate,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun resolve(ocids: Set<String>): Map<String, String> {
+        if (ocids.isEmpty()) return emptyMap()
+
+        val sql = """
+            SELECT ocid, user_ign FROM game_character WHERE ocid IN (:ocids)
+        """.trimIndent()
+
+        val params = MapSqlParameterSource("ocids", ocids.toList())
+
+        val rows = jdbc.queryForList(sql, params, Map::class.java)
+
+        val mapping = rows.mapNotNull { row ->
+            val ign = row["user_ign"]?.toString() ?: return@mapNotNull null
+            row["ocid"].toString() to ign
+        }.toMap()
+        log.debug("Resolved {} of {} ocids to userIgn", mapping.size, ocids.size)
+        return mapping
+    }
+}

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/storage/ResultFileReader.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/storage/ResultFileReader.kt
@@ -1,0 +1,81 @@
+package maple.synchronizer.storage
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import maple.synchronizer.domain.CalculatedEquipmentItem
+import maple.synchronizer.domain.GroupedEquipmentResult
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import java.math.BigDecimal
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.util.zip.GZIPInputStream
+
+@Component
+class ResultFileReader(
+    @Value("\${synchronizer.store.base-path:../module-external-api/external-api-data}")
+    private val basePath: String,
+    @Value("\${synchronizer.chunk.max-rows:100000}")
+    private val maxRowsPerChunk: Int,
+    private val objectMapper: ObjectMapper,
+) {
+    fun readAndGroupByCompositeKey(objectKey: String): List<GroupedEquipmentResult> {
+        val path = Paths.get(basePath, objectKey)
+        if (!Files.exists(path)) {
+            throw IllegalStateException("Result file not found: $path")
+        }
+
+        GZIPInputStream(Files.newInputStream(path)).bufferedReader().use { reader ->
+            var rowCount = 0
+            val grouped = mutableMapOf<String, MutableList<CalculatedEquipmentItem>>()
+
+            reader.lineSequence()
+                .filter { it.isNotBlank() }
+                .forEach { line ->
+                    rowCount++
+                    require(rowCount <= maxRowsPerChunk) {
+                        "Chunk row limit exceeded: objectKey=$objectKey, maxRows=$maxRowsPerChunk, current=$rowCount"
+                    }
+                    parseItem(line)?.let { item ->
+                        grouped.getOrPut("${item.ocid}:${item.presetNo}") { mutableListOf() }.add(item)
+                    }
+                }
+
+            return grouped.map { (readKey, group) ->
+                GroupedEquipmentResult(
+                    readKey = readKey,
+                    ocid = group.first().ocid,
+                    presetNo = group.first().presetNo,
+                    items = group,
+                )
+            }
+        }
+    }
+
+    fun parseItem(line: String): CalculatedEquipmentItem? {
+        return runCatching {
+            val node = objectMapper.readTree(line)
+            val ocid = node.get("ocid")?.asText() ?: return null
+            val presetNo = node.get("presetNo")?.asInt() ?: return null
+            CalculatedEquipmentItem(
+                ocid = ocid,
+                presetNo = presetNo,
+                itemName = node.get("itemName")?.asText() ?: "",
+                itemLevel = node.get("itemLevel")?.asInt() ?: 0,
+                itemPart = node.get("itemPart")?.asText() ?: "",
+                itemEquipmentPart = node.get("itemEquipmentPart")?.asText(),
+                potentialGrade = node.get("potentialGrade")?.asText(),
+                potentialOptions = node.get("potentialOptions")?.map { it.asText() },
+                additionalGrade = node.get("additionalGrade")?.asText(),
+                additionalOptions = node.get("additionalOptions")?.map { it.asText() },
+                currentStar = node.get("currentStar")?.asInt() ?: 0,
+                targetStar = node.get("targetStar")?.asInt() ?: 0,
+                status = node.get("status")?.asText() ?: "UNKNOWN",
+                totalCost = node.get("totalCost")?.decimalValue() ?: BigDecimal.ZERO,
+                blackCubeCost = node.get("blackCubeCost")?.decimalValue() ?: BigDecimal.ZERO,
+                additionalCubeCost = node.get("additionalCubeCost")?.decimalValue() ?: BigDecimal.ZERO,
+                starforceCost = node.get("starforceCost")?.decimalValue() ?: BigDecimal.ZERO,
+                errorMessage = node.get("errorMessage")?.asText(),
+            )
+        }.getOrNull()
+    }
+}

--- a/module-synchronizer/src/main/resources/application-local.yml
+++ b/module-synchronizer/src/main/resources/application-local.yml
@@ -1,0 +1,22 @@
+# Synchronizer local profile — local PostgreSQL via docker compose
+# Usage: docker compose -f docker-compose.postgres.yml up -d postgres
+#        SPRING_PROFILES_ACTIVE=local ./gradlew :module-synchronizer:bootRun
+
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/maple_expectation
+    username: maple
+    password: maple123
+    driver-class-name: org.postgresql.Driver
+    hikari:
+      maximum-pool-size: 10
+      minimum-idle: 2
+      connection-timeout: 5000
+      keepalive-time: 30000
+      max-lifetime: 600000
+      connection-test-query: SELECT 1
+  jpa:
+    open-in-view: false
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+    hibernate:
+      ddl-auto: none

--- a/module-synchronizer/src/main/resources/logback-spring.xml
+++ b/module-synchronizer/src/main/resources/logback-spring.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <springProperty scope="context" name="APP_NAME" source="spring.application.name" defaultValue="synchronizer"/>
+    <springProperty scope="context" name="SERVER_PORT" source="server.port" defaultValue="8083"/>
+    <property name="HOST" value="${HOSTNAME:-${HOST:-unknown}}"/>
+
+    <appender name="JSON_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <customFields>{
+                "service":"${APP_NAME}",
+                "port":"${SERVER_PORT}",
+                "host":"${HOST}"
+            }</customFields>
+            <includeMdc>true</includeMdc>
+            <includeContext>true</includeContext>
+            <fieldNames>
+                <timestamp>timestamp</timestamp>
+                <version>[ignore]</version>
+                <levelValue>[ignore]</levelValue>
+            </fieldNames>
+        </encoder>
+    </appender>
+
+    <appender name="JSON_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/${APP_NAME}.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>logs/${APP_NAME}.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+            <maxFileSize>100MB</maxFileSize>
+            <maxHistory>3</maxHistory>
+            <totalSizeCap>500MB</totalSizeCap>
+        </rollingPolicy>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <customFields>{
+                "service":"${APP_NAME}",
+                "port":"${SERVER_PORT}",
+                "host":"${HOST}"
+            }</customFields>
+            <includeMdc>true</includeMdc>
+            <includeContext>true</includeContext>
+            <fieldNames>
+                <timestamp>timestamp</timestamp>
+                <version>[ignore]</version>
+                <levelValue>[ignore]</levelValue>
+            </fieldNames>
+        </encoder>
+    </appender>
+
+    <springProfile name="local">
+        <appender name="PLAIN_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            </encoder>
+        </appender>
+        <root level="INFO">
+            <appender-ref ref="PLAIN_CONSOLE"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="!local">
+        <root level="INFO">
+            <appender-ref ref="JSON_CONSOLE"/>
+            <appender-ref ref="JSON_FILE"/>
+        </root>
+    </springProfile>
+
+    <logger name="maple.synchronizer" level="INFO"/>
+</configuration>

--- a/module-synchronizer/src/test/kotlin/maple/synchronizer/builder/EquipmentDocumentBuilderTest.kt
+++ b/module-synchronizer/src/test/kotlin/maple/synchronizer/builder/EquipmentDocumentBuilderTest.kt
@@ -1,0 +1,53 @@
+package maple.synchronizer.builder
+
+import maple.synchronizer.domain.CalculatedEquipmentItem
+import maple.synchronizer.domain.GroupedEquipmentResult
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+class EquipmentDocumentBuilderTest {
+
+    private val builder = EquipmentDocumentBuilder()
+
+    @Test
+    fun `should build document with userIgn`() {
+        val grouped = GroupedEquipmentResult(
+            readKey = "ocid1:1",
+            ocid = "ocid1",
+            presetNo = 1,
+            userIgn = "진격캐넌",
+            items = listOf(
+                CalculatedEquipmentItem(
+                    ocid = "ocid1", presetNo = 1, itemName = "item1",
+                    itemLevel = 200, itemPart = "Weapon", itemEquipmentPart = null,
+                    potentialGrade = null, potentialOptions = null,
+                    additionalGrade = null, additionalOptions = null,
+                    currentStar = 0, targetStar = 0, status = "SKIPPED",
+                    totalCost = BigDecimal.ZERO, blackCubeCost = BigDecimal.ZERO,
+                    additionalCubeCost = BigDecimal.ZERO, starforceCost = BigDecimal.ZERO,
+                    errorMessage = null,
+                )
+            ),
+        )
+
+        val doc = builder.build("run1", "chunk1", grouped)
+        assertThat(doc.userIgn).isEqualTo("진격캐넌")
+        assertThat(doc.ocid).isEqualTo("ocid1")
+        assertThat(doc.presetNo).isEqualTo(1)
+    }
+
+    @Test
+    fun `should build document with null userIgn`() {
+        val grouped = GroupedEquipmentResult(
+            readKey = "ocid1:1",
+            ocid = "ocid1",
+            presetNo = 1,
+            userIgn = null,
+            items = emptyList(),
+        )
+
+        val doc = builder.build("run1", "chunk1", grouped)
+        assertThat(doc.userIgn).isNull()
+    }
+}

--- a/module-synchronizer/src/test/kotlin/maple/synchronizer/preparer/EquipmentDocumentPreparerTest.kt
+++ b/module-synchronizer/src/test/kotlin/maple/synchronizer/preparer/EquipmentDocumentPreparerTest.kt
@@ -1,0 +1,80 @@
+package maple.synchronizer.preparer
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import maple.synchronizer.domain.EquipmentReadDocument
+import maple.synchronizer.domain.EquipmentReadMetadata
+import maple.synchronizer.domain.EquipmentSummary
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Instant
+
+class EquipmentDocumentPreparerTest {
+
+    private val objectMapper = ObjectMapper().registerKotlinModule().registerModule(JavaTimeModule())
+    private val preparer = EquipmentDocumentPreparer(objectMapper)
+
+    @Test
+    fun `prepare - serializes document and produces valid prepped document`() {
+        val doc = testDocument()
+        val result = preparer.prepare(listOf(doc))
+
+        assertThat(result).hasSize(1)
+        val prepped = result.first()
+        assertThat(prepped.readKey).isEqualTo("oc1:1")
+        assertThat(prepped.ocid).isEqualTo("oc1")
+        assertThat(prepped.presetNo).isEqualTo(1.toShort())
+        assertThat(prepped.documentHash).hasSize(64) // SHA-256 hex
+        assertThat(prepped.compressed).isNotEmpty()
+        assertThat(prepped.totalCost).isEqualByComparingTo(BigDecimal("150000000000"))
+        assertThat(prepped.equipmentCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `prepare - different documents produce different hashes`() {
+        val doc1 = testDocument(ocid = "oc1")
+        val doc2 = testDocument(ocid = "oc2")
+
+        val result = preparer.prepare(listOf(doc1, doc2))
+
+        assertThat(result).hasSize(2)
+        assertThat(result[0].documentHash).isNotEqualTo(result[1].documentHash)
+    }
+
+    @Test
+    fun `prepare - same document produces same hash`() {
+        val doc = testDocument()
+
+        val result = preparer.prepare(listOf(doc, doc))
+
+        assertThat(result[0].documentHash).isEqualTo(result[1].documentHash)
+    }
+
+    @Test
+    fun `prepare - empty list returns empty list`() {
+        val result = preparer.prepare(emptyList())
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `prepare - compressed data can be decompressed back to JSON`() {
+        val doc = testDocument()
+        val result = preparer.prepare(listOf(doc))
+
+        val json = objectMapper.writeValueAsString(doc)
+        val decompressed = maple.expectation.util.GzipUtils.decompress(result.first().compressed)
+        assertThat(decompressed).isEqualTo(json)
+    }
+
+    private fun testDocument(
+        ocid: String = "oc1",
+    ) = EquipmentReadDocument(
+        ocid = ocid,
+        presetNo = 1,
+        summary = EquipmentSummary(totalCost = BigDecimal("150000000000"), equipmentCount = 1),
+        equipment = listOf(mapOf("itemName" to "Test Sword", "status" to "SUCCESS")),
+        metadata = EquipmentReadMetadata(sourceRunId = "run-1", sourceChunkId = "chunk-001", calculatedAt = Instant.parse("2026-05-14T00:00:00Z")),
+    )
+}

--- a/module-synchronizer/src/test/kotlin/maple/synchronizer/processor/DefaultChunkProcessorTest.kt
+++ b/module-synchronizer/src/test/kotlin/maple/synchronizer/processor/DefaultChunkProcessorTest.kt
@@ -1,0 +1,140 @@
+package maple.synchronizer.processor
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import maple.synchronizer.domain.CalculatedEquipmentItem
+import maple.synchronizer.domain.GroupedEquipmentResult
+import maple.synchronizer.metrics.SynchronizerMetrics
+import maple.synchronizer.preparer.EquipmentDocumentPreparer
+import maple.synchronizer.repository.EquipmentReadModelRepository
+import maple.synchronizer.resolver.OcidUserIgnResolver
+import maple.synchronizer.storage.ResultFileReader
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+
+class DefaultChunkProcessorTest {
+
+    private val resultFileReader: ResultFileReader = mock()
+    private val readModelRepository: EquipmentReadModelRepository = mock()
+    private val ocidUserIgnResolver: OcidUserIgnResolver = mock()
+    private val metrics = SynchronizerMetrics(SimpleMeterRegistry())
+    private val objectMapper = ObjectMapper().registerModule(JavaTimeModule())
+
+    private lateinit var chunkProcessor: DefaultChunkProcessor
+
+    @BeforeEach
+    fun setUp() {
+        chunkProcessor = DefaultChunkProcessor(resultFileReader, readModelRepository, ocidUserIgnResolver, metrics, objectMapper)
+        whenever(ocidUserIgnResolver.resolve(any())).thenReturn(emptyMap())
+    }
+
+    @Test
+    fun `process - happy path returns result with correct counts`() {
+        val input = testInput()
+        val grouped = listOf(GroupedEquipmentResult(readKey = "oc1:1", ocid = "oc1", presetNo = 1, items = listOf(testItem())))
+
+        whenever(resultFileReader.readAndGroupByCompositeKey(any())).thenReturn(grouped)
+
+        val result = chunkProcessor.process(input)
+
+        assertThat(result.documentCount).isEqualTo(1)
+        assertThat(result.itemCount).isEqualTo(1)
+        assertThat(result.jsonRowCount).isEqualTo(input.resultCount.toLong())
+    }
+
+    @Test
+    fun `process - calls preparer then repository bulkUpsert`() {
+        val input = testInput()
+        val grouped = listOf(GroupedEquipmentResult(readKey = "oc1:1", ocid = "oc1", presetNo = 1, items = listOf(testItem())))
+
+        whenever(resultFileReader.readAndGroupByCompositeKey(any())).thenReturn(grouped)
+
+        chunkProcessor.process(input)
+
+        verify(readModelRepository).bulkUpsert(eq(input.sourceRunId), eq(input.sourceChunkId), any())
+    }
+
+    @Test
+    fun `process - file not found propagates exception`() {
+        val input = testInput()
+        whenever(resultFileReader.readAndGroupByCompositeKey(any()))
+            .thenThrow(IllegalStateException("Result file not found"))
+
+        assertThatThrownBy { chunkProcessor.process(input) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("Result file not found")
+    }
+
+    @Test
+    fun `process - upsert failure propagates exception`() {
+        val input = testInput()
+        val grouped = listOf(GroupedEquipmentResult(readKey = "oc1:1", ocid = "oc1", presetNo = 1, items = listOf(testItem())))
+
+        whenever(resultFileReader.readAndGroupByCompositeKey(any())).thenReturn(grouped)
+        whenever(readModelRepository.bulkUpsert(any(), any(), any()))
+            .thenThrow(RuntimeException("DB connection failed"))
+
+        assertThatThrownBy { chunkProcessor.process(input) }
+            .isInstanceOf(RuntimeException::class.java)
+            .hasMessageContaining("DB connection failed")
+    }
+
+    @Test
+    fun `process - multiple groups produce multiple documents`() {
+        val input = testInput(resultCount = 3)
+        val grouped = listOf(
+            GroupedEquipmentResult(readKey = "oc1:1", ocid = "oc1", presetNo = 1, items = listOf(testItem(ocid = "oc1"))),
+            GroupedEquipmentResult(readKey = "oc2:1", ocid = "oc2", presetNo = 1, items = listOf(testItem(ocid = "oc2"), testItem(ocid = "oc2"))),
+        )
+
+        whenever(resultFileReader.readAndGroupByCompositeKey(any())).thenReturn(grouped)
+
+        val result = chunkProcessor.process(input)
+
+        assertThat(result.documentCount).isEqualTo(2)
+        assertThat(result.itemCount).isEqualTo(3)
+    }
+
+    private fun testInput(
+        objectKey: String = "run1/chunk001.jsonl.gz",
+        resultCount: Int = 1,
+    ) = ChunkProcessInput(
+        objectKey = objectKey,
+        sourceRunId = "run-1",
+        sourceChunkId = "chunk-001",
+        resultCount = resultCount,
+    )
+
+    private fun testItem(
+        ocid: String = "oc1",
+        presetNo: Int = 1,
+    ) = CalculatedEquipmentItem(
+        ocid = ocid,
+        presetNo = presetNo,
+        itemName = "Test Sword",
+        itemLevel = 160,
+        itemPart = "Weapon",
+        itemEquipmentPart = "무기",
+        potentialGrade = "레전드리",
+        potentialOptions = listOf("공격력 +12%"),
+        additionalGrade = "에픽",
+        additionalOptions = listOf("STR +9%"),
+        currentStar = 17,
+        targetStar = 22,
+        status = "SUCCESS",
+        totalCost = BigDecimal("150000000000"),
+        blackCubeCost = BigDecimal("50000000000"),
+        additionalCubeCost = BigDecimal("30000000000"),
+        starforceCost = BigDecimal("70000000000"),
+        errorMessage = null,
+    )
+}

--- a/module-synchronizer/src/test/kotlin/maple/synchronizer/resolver/OcidUserIgnResolverTest.kt
+++ b/module-synchronizer/src/test/kotlin/maple/synchronizer/resolver/OcidUserIgnResolverTest.kt
@@ -1,0 +1,50 @@
+package maple.synchronizer.resolver
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+
+class OcidUserIgnResolverTest {
+
+    private val jdbc: NamedParameterJdbcTemplate = mock()
+    private val resolver = OcidUserIgnResolver(jdbc)
+
+    @Test
+    fun `should return empty map for empty ocids`() {
+        val result = resolver.resolve(emptySet())
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `should resolve ocids to userIgn map`() {
+        @Suppress("UNCHECKED_CAST")
+        whenever(jdbc.queryForList(any<String>(), any<MapSqlParameterSource>(), eq(Map::class.java) as Class<Any>))
+            .thenReturn(listOf(
+                mapOf("ocid" to "ocid1", "user_ign" to "아델"),
+                mapOf("ocid" to "ocid2", "user_ign" to "강은호")
+            ))
+
+        val result = resolver.resolve(setOf("ocid1", "ocid2"))
+        assertThat(result).hasSize(2)
+        assertThat(result["ocid1"]).isEqualTo("아델")
+        assertThat(result["ocid2"]).isEqualTo("강은호")
+    }
+
+    @Test
+    fun `should handle partial miss — return only found mappings`() {
+        @Suppress("UNCHECKED_CAST")
+        whenever(jdbc.queryForList(any<String>(), any<MapSqlParameterSource>(), eq(Map::class.java) as Class<Any>))
+            .thenReturn(listOf(
+                mapOf("ocid" to "ocid1", "user_ign" to "아델")
+            ))
+
+        val result = resolver.resolve(setOf("ocid1", "ocid_not_found"))
+        assertThat(result).containsEntry("ocid1", "아델")
+        assertThat(result).hasSize(1)
+    }
+}

--- a/module-synchronizer/src/test/kotlin/maple/synchronizer/storage/ResultFileReaderTest.kt
+++ b/module-synchronizer/src/test/kotlin/maple/synchronizer/storage/ResultFileReaderTest.kt
@@ -1,0 +1,77 @@
+package maple.synchronizer.storage
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+class ResultFileReaderTest {
+
+    private val objectMapper = ObjectMapper().registerKotlinModule()
+    private val reader = ResultFileReader(basePath = "/nonexistent", maxRowsPerChunk = 100000, objectMapper = objectMapper)
+
+    @Test
+    fun `parseItem - valid JSON line produces item`() {
+        val line = """{"ocid":"oc1","presetNo":1,"itemName":"Sword","itemLevel":160,"itemPart":"Weapon","status":"SUCCESS","totalCost":1000}"""
+
+        val item = reader.parseItem(line)
+
+        assertThat(item).isNotNull
+        assertThat(item!!.ocid).isEqualTo("oc1")
+        assertThat(item.presetNo).isEqualTo(1)
+        assertThat(item.itemName).isEqualTo("Sword")
+        assertThat(item.itemLevel).isEqualTo(160)
+        assertThat(item.status).isEqualTo("SUCCESS")
+        assertThat(item.totalCost).isEqualByComparingTo(BigDecimal("1000"))
+    }
+
+    @Test
+    fun `parseItem - missing ocid returns null`() {
+        val line = """{"presetNo":1,"itemName":"Sword"}"""
+
+        val item = reader.parseItem(line)
+
+        assertThat(item).isNull()
+    }
+
+    @Test
+    fun `parseItem - missing presetNo returns null`() {
+        val line = """{"ocid":"oc1","itemName":"Sword"}"""
+
+        val item = reader.parseItem(line)
+
+        assertThat(item).isNull()
+    }
+
+    @Test
+    fun `parseItem - invalid JSON returns null`() {
+        val line = "not json at all"
+
+        val item = reader.parseItem(line)
+
+        assertThat(item).isNull()
+    }
+
+    @Test
+    fun `parseItem - uses defaults for missing optional fields`() {
+        val line = """{"ocid":"oc1","presetNo":2}"""
+
+        val item = reader.parseItem(line)
+
+        assertThat(item).isNotNull
+        assertThat(item!!.itemName).isEmpty()
+        assertThat(item.itemLevel).isEqualTo(0)
+        assertThat(item.totalCost).isEqualByComparingTo(BigDecimal.ZERO)
+        assertThat(item.status).isEqualTo("UNKNOWN")
+        assertThat(item.errorMessage).isNull()
+    }
+
+    @Test
+    fun `readAndGroupByCompositeKey - nonexistent file throws`() {
+        assertThatThrownBy { reader.readAndGroupByCompositeKey("missing.jsonl.gz") }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("Result file not found")
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,5 +17,14 @@ include 'module-chaos-test'
 // ADR-017: Web layer (GlobalExceptionHandler, Filter)
 include 'module-web'
 
+// External API data collection module (Nexon API -> Local Storage)
+include 'module-external-api'
+
+// Calculator module (Kafka-driven chunk processing pipeline)
+include 'module-calculator'
+
+// Synchronizer module (Calculator result files -> DB sync)
+include 'module-synchronizer'
+
 // Standalone V6 REST read controller
 include 'module-rest-controller'


### PR DESCRIPTION
## Summary
- Restore urgent worker modules removed by the mistaken master-base revert path: `module-external-api`, `module-calculator`, and `module-synchronizer`.
- Restore shared event/cleanup/calculation support classes required by the worker pipeline.
- Re-add worker module includes and version catalog aliases needed for compile.

## Test plan
- [x] `./gradlew :module-external-api:compileKotlin :module-calculator:compileKotlin :module-synchronizer:compileKotlin --continue`
- [x] `./gradlew :module-common:test :module-external-api:test :module-calculator:test :module-synchronizer:test --continue`