### PR TITLE
Rebuild V6 urgent Kafka pipeline from PR 825 base

### DIFF
--- a/.claude/rules/workflow-rules.md
+++ b/.claude/rules/workflow-rules.md
@@ -28,7 +28,20 @@
    - 202만 보고 성공 판단 금지 — 비동기 파이프라인 전체 완료까지 로그로 추적
 4. **컴파일 + 테스트 통과 ≠ 런타임 정상 동작 보장** — 반드시 실제 서버에서 검증
 
-## 11. 검증 명령어
+## 11. 테스트용 userIGN 우선순위
+
+userIGN이 필요한 테스트 및 런타임 검증 시 다음 순서로 선택:
+
+1. **1순위 (고정 캐릭터):** `진격캐넌`, `아델`, `강은호`
+2. **2순위 (CSV 랜덤 추출):** `module-app/src/main/resources/data/userIgn_List.csv`에서 추출
+   ```bash
+   # 1개 추출
+   shuf -n 1 module-app/src/main/resources/data/userIgn_List.csv
+   # 여러개 추출 (필요 시)
+   shuf -n 3 module-app/src/main/resources/data/userIgn_List.csv
+   ```
+
+## 12. 검증 명령어
 
 ```bash
 ./gradlew compileKotlin compileJava --continue  # 컴파일 확인
@@ -37,13 +50,13 @@
 - 컴파일검증시 --continue 반드시 사용할것.
 - 컴파일, 테스트 검증시 처음부터 실패하는경우, 에러나는경우만 메시지 나타나도록 할것. 없으면 성공.
 
-## 12. Flaky Test Prevention
+## 13. Flaky Test Prevention
 - kotlin `delay()` 사용금지
 - `Thread.sleep()` 금지 → `Awaitility` 사용
 - 테스트 간 상태 공유 금지
 - `@DirtiesContext` 남용 금지
 
-## 13. 부하테스트 (Load Test)
+## 14. 부하테스트 (Load Test)
 
 **기본 명령어:**
 ```bash

--- a/.claude/rules/workflow-rules.md
+++ b/.claude/rules/workflow-rules.md
@@ -28,20 +28,7 @@
    - 202만 보고 성공 판단 금지 — 비동기 파이프라인 전체 완료까지 로그로 추적
 4. **컴파일 + 테스트 통과 ≠ 런타임 정상 동작 보장** — 반드시 실제 서버에서 검증
 
-## 11. 테스트용 userIGN 우선순위
-
-userIGN이 필요한 테스트 및 런타임 검증 시 다음 순서로 선택:
-
-1. **1순위 (고정 캐릭터):** `진격캐넌`, `아델`, `강은호`
-2. **2순위 (CSV 랜덤 추출):** `module-app/src/main/resources/data/userIgn_List.csv`에서 추출
-   ```bash
-   # 1개 추출
-   shuf -n 1 module-app/src/main/resources/data/userIgn_List.csv
-   # 여러개 추출 (필요 시)
-   shuf -n 3 module-app/src/main/resources/data/userIgn_List.csv
-   ```
-
-## 12. 검증 명령어
+## 11. 검증 명령어
 
 ```bash
 ./gradlew compileKotlin compileJava --continue  # 컴파일 확인
@@ -50,13 +37,13 @@ userIGN이 필요한 테스트 및 런타임 검증 시 다음 순서로 선택:
 - 컴파일검증시 --continue 반드시 사용할것.
 - 컴파일, 테스트 검증시 처음부터 실패하는경우, 에러나는경우만 메시지 나타나도록 할것. 없으면 성공.
 
-## 13. Flaky Test Prevention
+## 12. Flaky Test Prevention
 - kotlin `delay()` 사용금지
 - `Thread.sleep()` 금지 → `Awaitility` 사용
 - 테스트 간 상태 공유 금지
 - `@DirtiesContext` 남용 금지
 
-## 14. 부하테스트 (Load Test)
+## 13. 부하테스트 (Load Test)
 
 **기본 명령어:**
 ```bash

--- a/docs/superpowers/specs/2026-05-16-character-basic-sync-design.md
+++ b/docs/superpowers/specs/2026-05-16-character-basic-sync-design.md
@@ -1,0 +1,40 @@
+# CHARACTER_BASIC Synchronizer Pipeline Design
+
+## Goal
+CHARACTER_BASIC snapshot chunks를 Kafka → Synchronizer → DB 파이프라인으로 저장.
+
+## Architecture
+```
+External API (CHARACTER_BASIC chunk ready)
+  → Kafka "external-api.snapshot.chunk-ready" (endpoint=character-basic)
+  → Synchronizer BasicSnapshotChunkConsumer
+  → Read gzip JSONL chunk file
+  → Parse: ocid (key), character_name/level/class/world (body)
+  → gzip compress body
+  → Bulk upsert to character_basic_read_model
+```
+
+## Table: character_basic_read_model
+```sql
+CREATE TABLE character_basic_read_model (
+    user_ign        TEXT PRIMARY KEY,
+    ocid            TEXT NOT NULL,
+    world_name      TEXT,
+    character_class  TEXT,
+    character_level  INT,
+    guild_name      TEXT,
+    basic_data      BYTEA NOT NULL,
+    document_hash   TEXT,
+    source_run_id   TEXT NOT NULL,
+    source_chunk_id TEXT NOT NULL,
+    created_at      TIMESTAMPTZ DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ DEFAULT NOW(),
+    CONSTRAINT uq_basic_ocid UNIQUE (ocid)
+);
+```
+
+## Changes
+- DB: V126 migration
+- External API: characterBasicSnapshotPublisher Kafka 활성화
+- Synchronizer: BasicSnapshotChunkConsumer + BasicChunkFileReader + CharacterBasicRepository
+- Config: application.yml 양쪽 모두

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -95,6 +95,7 @@ spring-boot-starter-actuator = { module = "org.springframework.boot:spring-boot-
 spring-boot-starter-data-jpa = { module = "org.springframework.boot:spring-boot-starter-data-jpa" }
 spring-boot-starter-jdbc = { module = "org.springframework.boot:spring-boot-starter-jdbc" }
 spring-boot-starter-cache = { module = "org.springframework.boot:spring-boot-starter-cache" }
+spring-boot-starter-data-redis = { module = "org.springframework.boot:spring-boot-starter-data-redis" }
 spring-boot-starter-batch = { module = "org.springframework.boot:spring-boot-starter-batch" }
 spring-boot-starter-aop = { module = "org.springframework.boot:spring-boot-starter-aop" }
 spring-kafka = { module = "org.springframework.kafka:spring-kafka" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -104,7 +104,6 @@ spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-star
 
 # Spring Boot Core
 spring-boot = { module = "org.springframework.boot:spring-boot" }
-spring-kafka = { module = "org.springframework.kafka:spring-kafka" }
 
 # Databases
 h2 = { module = "com.h2database:h2", version.ref = "h2" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -104,6 +104,7 @@ spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-star
 
 # Spring Boot Core
 spring-boot = { module = "org.springframework.boot:spring-boot" }
+spring-kafka = { module = "org.springframework.kafka:spring-kafka" }
 
 # Databases
 h2 = { module = "com.h2database:h2", version.ref = "h2" }

--- a/module-calculator/src/main/kotlin/maple/calculator/consumer/KafkaSnapshotChunkReadyConsumer.kt
+++ b/module-calculator/src/main/kotlin/maple/calculator/consumer/KafkaSnapshotChunkReadyConsumer.kt
@@ -29,4 +29,18 @@ class KafkaSnapshotChunkReadyConsumer(
         runBlocking { coordinator.handle(event) }
         acknowledgment.acknowledge()
     }
+
+    @KafkaListener(
+        topics = ["\${calculator.kafka.urgent-snapshot-chunk-ready-topic}"],
+        groupId = "\${calculator.kafka.urgent-consumer-group-id}",
+    )
+    fun consumeUrgent(message: String, acknowledgment: Acknowledgment) {
+        val event = objectMapper.readValue(message, SnapshotChunkReadyEvent::class.java)
+        log.info(
+            "[Consumer] received URGENT chunk-ready: runId={} endpoint={} chunkId={} objectKey={} recordCount={}",
+            event.runId, event.endpoint, event.chunkId, event.objectKey, event.recordCount,
+        )
+        runBlocking { coordinator.handle(event) }
+        acknowledgment.acknowledge()
+    }
 }

--- a/module-calculator/src/main/resources/application.yml
+++ b/module-calculator/src/main/resources/application.yml
@@ -22,6 +22,8 @@ calculator:
     snapshot-chunk-ready-topic: external-api.snapshot.chunk-ready
     result-chunk-ready-topic: calculator.result.chunk-ready
     consumer-group-id: calculator-snapshot-chunk-processor
+    urgent-snapshot-chunk-ready-topic: external-api.urgent.snapshot.chunk-ready
+    urgent-consumer-group-id: calculator-urgent-chunk-processor
   store:
     input-base-path: ../module-external-api/external-api-data
   cleanup:

--- a/module-common/src/main/kotlin/maple/expectation/util/StringMaskingUtils.kt
+++ b/module-common/src/main/kotlin/maple/expectation/util/StringMaskingUtils.kt
@@ -21,15 +21,6 @@ object StringMaskingUtils {
     private const val IGN_SUFFIX_LENGTH = 1
 
     /**
-     * IGN 마스킹: 앞 1자리 + "***"
-     */
-    @JvmStatic
-    fun maskIgn(value: String?): String {
-        if (value.isNullOrBlank()) return "***"
-        return value.take(1) + "***"
-    }
-
-    /**
      * OCID 마스킹: 앞 4자리 + "***"
      *
      * @param value OCID 문자열

--- a/module-common/src/main/kotlin/maple/expectation/util/StringMaskingUtils.kt
+++ b/module-common/src/main/kotlin/maple/expectation/util/StringMaskingUtils.kt
@@ -21,6 +21,15 @@ object StringMaskingUtils {
     private const val IGN_SUFFIX_LENGTH = 1
 
     /**
+     * IGN 마스킹: 앞 1자리 + "***"
+     */
+    @JvmStatic
+    fun maskIgn(value: String?): String {
+        if (value.isNullOrBlank()) return "***"
+        return value.take(1) + "***"
+    }
+
+    /**
      * OCID 마스킹: 앞 4자리 + "***"
      *
      * @param value OCID 문자열

--- a/module-external-api/src/main/kotlin/maple/externalapi/ExternalApiApplication.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/ExternalApiApplication.kt
@@ -4,9 +4,11 @@ import maple.externalapi.snapshot.SnapshotChunkingProperties
 import maple.externalapi.snapshot.event.SnapshotEventProperties
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Import
 import org.springframework.scheduling.annotation.EnableScheduling
 
-@SpringBootApplication
+@SpringBootApplication(scanBasePackages = ["maple.externalapi", "maple.expectation.infrastructure.executor"])
+@Import(maple.expectation.infrastructure.config.ExecutorConfig::class)
 @EnableScheduling
 @EnableConfigurationProperties(SnapshotChunkingProperties::class, SnapshotEventProperties::class)
 class ExternalApiApplication

--- a/module-external-api/src/main/kotlin/maple/externalapi/snapshot/event/SnapshotEventPublisherConfig.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/snapshot/event/SnapshotEventPublisherConfig.kt
@@ -44,6 +44,32 @@ class SnapshotEventPublisherConfig {
 
     @Bean
     @Qualifier("characterBasicSnapshotPublisher")
-    fun characterBasicSnapshotPublisher(): SnapshotChunkEventPublisher =
+    @ConditionalOnProperty(
+        prefix = "external-api.snapshot.events.kafka",
+        name = ["enabled"],
+        havingValue = "false",
+        matchIfMissing = true,
+    )
+    fun noOpCharacterBasicSnapshotPublisher(): SnapshotChunkEventPublisher =
         NoOpSnapshotChunkEventPublisher()
+
+    @Bean
+    @Qualifier("characterBasicSnapshotPublisher")
+    @ConditionalOnProperty(
+        prefix = "external-api.snapshot.events.kafka",
+        name = ["enabled"],
+        havingValue = "true",
+    )
+    fun kafkaCharacterBasicSnapshotPublisher(
+        kafkaTemplate: KafkaTemplate<String, String>,
+        objectMapper: ObjectMapper,
+        properties: SnapshotEventProperties,
+    ): SnapshotChunkEventPublisher =
+        KafkaSnapshotChunkEventPublisher(
+            kafkaTemplate = kafkaTemplate,
+            objectMapper = objectMapper,
+            chunkReadyTopic = properties.kafka.chunkReadyTopic,
+            runCompletedTopic = properties.kafka.runCompletedTopic,
+            runFailedTopic = properties.kafka.runFailedTopic,
+        )
 }

--- a/module-external-api/src/main/kotlin/maple/externalapi/urgent/UrgentCharacterRequestConsumer.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/urgent/UrgentCharacterRequestConsumer.kt
@@ -1,0 +1,178 @@
+package maple.externalapi.urgent
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import maple.externalapi.domain.ExternalApiEndpoint
+import maple.externalapi.domain.ExternalApiProvider
+import maple.externalapi.port.out.ExternalApiClientPort
+import maple.externalapi.snapshot.GzipJsonlChunkWriter
+import maple.externalapi.snapshot.SnapshotChunkRecord
+import maple.externalapi.snapshot.event.SnapshotChunkReadyEvent
+import maple.expectation.util.StringMaskingUtils.maskIgn
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.support.Acknowledgment
+import org.springframework.stereotype.Component
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Instant
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+
+@Component
+@ConditionalOnProperty(
+    name = ["external-api.urgent.enabled"],
+    havingValue = "true",
+    matchIfMissing = false,
+)
+class UrgentCharacterRequestConsumer(
+    private val clientPort: ExternalApiClientPort,
+    private val objectMapper: ObjectMapper,
+    private val kafkaTemplate: KafkaTemplate<String, String>,
+    @Value("\${external-api.urgent.not-found-topic}")
+    private val notFoundTopic: String,
+    @Value("\${external-api.urgent.chunk-ready-topic}")
+    private val urgentChunkReadyTopic: String,
+    @Value("\${external-api.store.base-path}")
+    private val storeBasePath: String,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @KafkaListener(
+        topics = ["\${external-api.urgent.request-topic}"],
+        groupId = "\${external-api.urgent.consumer-group-id}",
+    )
+    fun consume(message: String, acknowledgment: Acknowledgment) {
+        val request = objectMapper.readValue(message, UrgentCharacterRequest::class.java)
+        log.info("[Urgent] received: userIgn={}", maskIgn(request.userIgn))
+
+        processUrgentCharacter(request)
+
+        acknowledgment.acknowledge()
+        log.info("[Urgent] completed: userIgn={}", maskIgn(request.userIgn))
+    }
+
+    private fun processUrgentCharacter(request: UrgentCharacterRequest) {
+        val ocidData = clientPort.fetch(
+            ExternalApiProvider.NEXON,
+            ExternalApiEndpoint.OCID_LOOKUP,
+            request.userIgn,
+        ).join()
+
+        val ocidNode = objectMapper.readTree(ocidData).get("ocid")
+        if (ocidNode == null || ocidNode.isNull) {
+            log.info("[Urgent] OCID not found: userIgn={}", maskIgn(request.userIgn))
+            publishNotFound(request.userIgn)
+            return
+        }
+
+        val ocid = ocidNode.asText()
+        log.info("[Urgent] OCID resolved: userIgn={}", maskIgn(request.userIgn))
+
+        val basicFuture = clientPort.fetch(
+            ExternalApiProvider.NEXON,
+            ExternalApiEndpoint.CHARACTER_BASIC,
+            ocid,
+        )
+        val equipmentFuture = clientPort.fetch(
+            ExternalApiProvider.NEXON,
+            ExternalApiEndpoint.ITEM_EQUIPMENT,
+            ocid,
+        )
+
+        val basicData = basicFuture.join()
+        val equipmentData = equipmentFuture.join()
+
+        val runId = "urgent-${UUID.randomUUID()}"
+
+        publishUrgentChunk(
+            runId = runId,
+            endpoint = ExternalApiEndpoint.CHARACTER_BASIC,
+            userIgn = request.userIgn,
+            data = basicData,
+            keyType = "OCID",
+        )
+        publishUrgentChunk(
+            runId = runId,
+            endpoint = ExternalApiEndpoint.ITEM_EQUIPMENT,
+            userIgn = request.userIgn,
+            data = equipmentData,
+            keyType = "OCID",
+        )
+
+        log.info(
+            "[Urgent] data fetch complete: userIgn={}, runId={}",
+            maskIgn(request.userIgn),
+            runId,
+        )
+    }
+
+    private fun publishUrgentChunk(
+        runId: String,
+        endpoint: ExternalApiEndpoint,
+        userIgn: String,
+        data: ByteArray,
+        keyType: String,
+    ) {
+        val endpointDir = endpoint.storageSubDir()
+        val chunksDir = Path.of(storeBasePath, "runs", runId, endpointDir, "chunks")
+        Files.createDirectories(chunksDir)
+
+        val writer = GzipJsonlChunkWriter(chunksDir, 1, 1, Long.MAX_VALUE, objectMapper)
+        writer.append(
+            SnapshotChunkRecord.Success(
+                key = userIgn,
+                endpoint = endpointDir,
+                keyType = keyType,
+                httpStatus = 200,
+                fetchedAt = Instant.now(),
+                bodyBytes = data,
+            ),
+        )
+        val stats = writer.close()
+
+        val objectKey = "runs/$runId/$endpointDir/${stats.path}"
+        val event = SnapshotChunkReadyEvent(
+            eventId = UUID.randomUUID().toString(),
+            runId = runId,
+            endpoint = endpointDir,
+            chunkId = "part-000001",
+            objectKey = objectKey,
+            recordCount = stats.recordCount,
+            uncompressedBytes = stats.uncompressedBytes,
+            compressedBytes = stats.compressedBytes,
+            createdAt = Instant.now(),
+        )
+
+        val eventJson = objectMapper.writeValueAsString(event)
+        val key = "${event.runId}:${event.endpoint}:${event.chunkId}"
+        kafkaTemplate.send(urgentChunkReadyTopic, key, eventJson).get(30, TimeUnit.SECONDS)
+
+        log.info(
+            "[Urgent] published chunk: endpoint={}, userIgn={}, objectKey={}",
+            endpointDir,
+            maskIgn(userIgn),
+            objectKey,
+        )
+    }
+
+    private fun publishNotFound(userIgn: String) {
+        val event = mapOf(
+            "userIgn" to userIgn,
+            "reason" to "OCID_NOT_FOUND",
+            "occurredAt" to Instant.now().toString(),
+        )
+        val json = objectMapper.writeValueAsString(event)
+        kafkaTemplate.send(notFoundTopic, userIgn, json)
+        log.info("[Urgent] published not-found: userIgn={}", maskIgn(userIgn))
+    }
+}
+
+data class UrgentCharacterRequest(
+    val eventId: String,
+    val userIgn: String,
+    val presetNo: Int = 1,
+    val requestedAt: Instant,
+)

--- a/module-external-api/src/main/resources/application.yml
+++ b/module-external-api/src/main/resources/application.yml
@@ -42,6 +42,12 @@ external-api:
     enabled: true
     run-on-startup: true
     skip-character-basic: false
+  urgent:
+    enabled: false                                    # feature flag for urgent pipeline
+    request-topic: urgent-character-request
+    not-found-topic: urgent-character-not-found
+    chunk-ready-topic: external-api.urgent.snapshot.chunk-ready
+    consumer-group-id: external-api-urgent-processor
   snapshot:
     chunk:
       character-basic:

--- a/module-external-api/src/test/kotlin/maple/externalapi/urgent/UrgentCharacterRequestConsumerTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/urgent/UrgentCharacterRequestConsumerTest.kt
@@ -1,0 +1,161 @@
+package maple.externalapi.urgent
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import maple.externalapi.domain.ExternalApiEndpoint
+import maple.externalapi.domain.ExternalApiProvider
+import maple.externalapi.port.out.ExternalApiClientPort
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.clients.producer.RecordMetadata
+import org.apache.kafka.common.TopicPartition
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.support.Acknowledgment
+import org.springframework.kafka.support.SendResult
+import java.nio.file.Path
+import java.time.Instant
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
+
+class UrgentCharacterRequestConsumerTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    private lateinit var clientPort: ExternalApiClientPort
+    private lateinit var objectMapper: ObjectMapper
+    private lateinit var kafkaTemplate: KafkaTemplate<String, String>
+    private lateinit var consumer: UrgentCharacterRequestConsumer
+
+    @BeforeEach
+    fun setUp() {
+        clientPort = mock()
+        objectMapper = ObjectMapper().registerKotlinModule().registerModule(JavaTimeModule())
+        kafkaTemplate = mock()
+
+        consumer = UrgentCharacterRequestConsumer(
+            clientPort = clientPort,
+            objectMapper = objectMapper,
+            kafkaTemplate = kafkaTemplate,
+            notFoundTopic = "urgent-character-not-found",
+            urgentChunkReadyTopic = "external-api.urgent.snapshot.chunk-ready",
+            storeBasePath = tempDir.toString(),
+        )
+    }
+
+    private fun stubSendResult(): CompletableFuture<SendResult<String, String>> {
+        val future = CompletableFuture<SendResult<String, String>>()
+        val record = ProducerRecord<String, String>("topic", "key", "value")
+        val metadata = RecordMetadata(TopicPartition("topic", 0), 0L, 0, 0L, 0, 0)
+        future.complete(SendResult(record, metadata))
+        return future
+    }
+
+    @Test
+    fun `successful path - resolves OCID, fetches basic and equipment, publishes 2 chunks`() {
+        // Given
+        val userIgn = "TestCharacter"
+        val ocid = "abc123ocid"
+        val request = UrgentCharacterRequest(
+            eventId = UUID.randomUUID().toString(),
+            userIgn = userIgn,
+            presetNo = 1,
+            requestedAt = Instant.now(),
+        )
+        val message = objectMapper.writeValueAsString(request)
+
+        val ocidResponse = """{"ocid":"$ocid"}""".toByteArray()
+        val basicResponse = """{"character_name":"TestCharacter","level":300}""".toByteArray()
+        val equipmentResponse = """{"item_equipment":[{"item_name":"sword"}]}""".toByteArray()
+
+        whenever(clientPort.fetch(ExternalApiProvider.NEXON, ExternalApiEndpoint.OCID_LOOKUP, userIgn))
+            .thenReturn(CompletableFuture.completedFuture(ocidResponse))
+        whenever(clientPort.fetch(ExternalApiProvider.NEXON, ExternalApiEndpoint.CHARACTER_BASIC, ocid))
+            .thenReturn(CompletableFuture.completedFuture(basicResponse))
+        whenever(clientPort.fetch(ExternalApiProvider.NEXON, ExternalApiEndpoint.ITEM_EQUIPMENT, ocid))
+            .thenReturn(CompletableFuture.completedFuture(equipmentResponse))
+        whenever(kafkaTemplate.send(any(), any(), any()))
+            .thenReturn(stubSendResult())
+
+        val acknowledgment = mock<Acknowledgment>()
+
+        // When
+        consumer.consume(message, acknowledgment)
+
+        // Then - verify 2 chunk-ready events published
+        val captor = argumentCaptor<String>()
+        verify(kafkaTemplate, times(2)).send(
+            eq("external-api.urgent.snapshot.chunk-ready"),
+            any(),
+            captor.capture(),
+        )
+
+        val chunkEvents = captor.allValues.map { objectMapper.readTree(it) }
+        assertThat(chunkEvents.all { it["eventType"].asText() == "SNAPSHOT_CHUNK_READY" }).isTrue()
+
+        val endpoints = chunkEvents.map { it["endpoint"].asText() }.toSet()
+        assertThat(endpoints).containsExactlyInAnyOrder("character-basic", "item-equipment")
+
+        // Verify chunk files exist on disk (consumer creates tempDir/runs/urgent-xxx/...)
+        val runsDir = tempDir.resolve("runs").toFile()
+        assertThat(runsDir.exists()).isTrue()
+        val urgentDirs = runsDir.listFiles()?.filter { it.isDirectory && it.name.startsWith("urgent-") }
+        assertThat(urgentDirs).isNotEmpty
+
+        val runDir = urgentDirs!!.first()
+        val chunksFiles = runDir.walkTopDown().filter { it.extension == "gz" }.toList()
+        assertThat(chunksFiles).hasSize(2)
+    }
+
+    @Test
+    fun `not-found path - OCID response missing ocid field publishes not-found event`() {
+        // Given
+        val userIgn = "NonExistent"
+        val request = UrgentCharacterRequest(
+            eventId = UUID.randomUUID().toString(),
+            userIgn = userIgn,
+            presetNo = 1,
+            requestedAt = Instant.now(),
+        )
+        val message = objectMapper.writeValueAsString(request)
+
+        val ocidResponse = """{"error":{"name":"OPENAPI00004","message":"Data not found"}}""".toByteArray()
+
+        whenever(clientPort.fetch(ExternalApiProvider.NEXON, ExternalApiEndpoint.OCID_LOOKUP, userIgn))
+            .thenReturn(CompletableFuture.completedFuture(ocidResponse))
+        whenever(kafkaTemplate.send(any(), any(), any()))
+            .thenReturn(stubSendResult())
+
+        val acknowledgment = mock<Acknowledgment>()
+
+        // When
+        consumer.consume(message, acknowledgment)
+
+        // Then
+        val captor = argumentCaptor<String>()
+        verify(kafkaTemplate).send(
+            eq("urgent-character-not-found"),
+            any(),
+            captor.capture(),
+        )
+
+        val notFoundEvent = objectMapper.readTree(captor.firstValue)
+        assertThat(notFoundEvent["userIgn"].asText()).isEqualTo(userIgn)
+        assertThat(notFoundEvent["reason"].asText()).isEqualTo("OCID_NOT_FOUND")
+
+        // No chunk files created
+        val runsDir = tempDir.resolve("runs").toFile()
+        assertThat(runsDir.exists()).isFalse()
+    }
+}

--- a/module-infra/src/main/resources/db/migration/V126__character_basic_read_model.sql
+++ b/module-infra/src/main/resources/db/migration/V126__character_basic_read_model.sql
@@ -1,0 +1,19 @@
+-- CHARACTER_BASIC read model for V6 read path
+CREATE TABLE IF NOT EXISTS character_basic_read_model (
+    user_ign        TEXT PRIMARY KEY,
+    ocid            TEXT NOT NULL,
+    world_name      TEXT,
+    character_class  TEXT,
+    character_level  INT,
+    guild_name      TEXT,
+    basic_data      BYTEA NOT NULL,
+    document_hash   TEXT,
+    source_run_id   TEXT NOT NULL,
+    source_chunk_id TEXT NOT NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT uq_basic_read_model_ocid UNIQUE (ocid)
+);
+
+CREATE INDEX idx_basic_read_model_ocid ON character_basic_read_model (ocid);

--- a/module-rest-controller/build.gradle
+++ b/module-rest-controller/build.gradle
@@ -27,6 +27,9 @@ dependencies {
 	implementation(libs.spring.boot.starter.jdbc)
 	runtimeOnly(libs.postgresql)
 
+	// Redis for V6 read model cache
+	implementation(libs.spring.boot.starter.data.redis)
+
 	// Jackson
 	implementation(libs.jackson.module.kotlin)
 

--- a/module-rest-controller/build.gradle
+++ b/module-rest-controller/build.gradle
@@ -30,6 +30,9 @@ dependencies {
 	// Redis for V6 read model cache
 	implementation(libs.spring.boot.starter.data.redis)
 
+	// Kafka for urgent pipeline trigger
+	implementation(libs.spring.kafka)
+
 	// Jackson
 	implementation(libs.jackson.module.kotlin)
 

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/config/V6ReadConfig.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/config/V6ReadConfig.kt
@@ -6,12 +6,15 @@ import maple.restcontroller.advice.RestControllerExceptionHandler
 import maple.restcontroller.controller.ExpectationV6Controller
 import maple.restcontroller.metrics.V6ReadMetrics
 import maple.restcontroller.read.*
+import maple.restcontroller.urgent.UrgentTriggerPublisher
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.scheduling.annotation.EnableScheduling
 
 @Configuration
@@ -73,4 +76,12 @@ class V6ReadConfig(
     @Bean
     fun restControllerExceptionHandler(): RestControllerExceptionHandler =
         RestControllerExceptionHandler()
+
+    @Bean
+    @ConditionalOnProperty(name = ["expectation.v6.urgent.enabled"], havingValue = "true")
+    fun urgentTriggerPublisher(
+        kafkaTemplate: KafkaTemplate<String, String>,
+        objectMapper: ObjectMapper,
+        @Value("\${expectation.v6.urgent.request-topic}") topic: String
+    ): UrgentTriggerPublisher = UrgentTriggerPublisher(kafkaTemplate, objectMapper, topic)
 }

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/config/V6ReadConfig.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/config/V6ReadConfig.kt
@@ -10,6 +10,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.scheduling.annotation.EnableScheduling
 
@@ -43,6 +44,12 @@ class V6ReadConfig(
     ): ReadModelQueryService = ReadModelQueryService(jdbc, objectMapper)
 
     @Bean
+    fun readModelCacheService(
+        redisTemplate: StringRedisTemplate,
+        objectMapper: ObjectMapper
+    ): ReadModelCacheService = ReadModelCacheService(redisTemplate, objectMapper, properties)
+
+    @Bean
     fun expectationReadFacade(
         registry: InflightRequestRegistry,
         buffer: LocalRequestBuffer,
@@ -54,8 +61,9 @@ class V6ReadConfig(
         buffer: LocalRequestBuffer,
         registry: InflightRequestRegistry,
         queryService: ReadModelQueryService,
+        cacheService: ReadModelCacheService,
         v6ReadMetrics: V6ReadMetrics
-    ): BatchReadScheduler = BatchReadScheduler(buffer, registry, queryService, v6ReadMetrics, properties)
+    ): BatchReadScheduler = BatchReadScheduler(buffer, registry, queryService, cacheService, v6ReadMetrics, properties)
 
     @Bean
     fun expectationV6Controller(

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/config/V6ReadConfig.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/config/V6ReadConfig.kt
@@ -2,8 +2,6 @@ package maple.restcontroller.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.micrometer.core.instrument.MeterRegistry
-import maple.restcontroller.advice.RestControllerExceptionHandler
-import maple.restcontroller.controller.ExpectationV6Controller
 import maple.restcontroller.metrics.V6ReadMetrics
 import maple.restcontroller.read.*
 import maple.restcontroller.urgent.UrgentTriggerPublisher
@@ -57,8 +55,9 @@ class V6ReadConfig(
     fun expectationReadFacade(
         registry: InflightRequestRegistry,
         buffer: LocalRequestBuffer,
-        metrics: V6ReadMetrics
-    ): ExpectationReadFacade = ExpectationReadFacade(registry, buffer, metrics)
+        metrics: V6ReadMetrics,
+        cacheService: ReadModelCacheService
+    ): ExpectationReadFacade = ExpectationReadFacade(registry, buffer, metrics, cacheService, properties)
 
     @Bean
     fun batchReadScheduler(
@@ -73,15 +72,6 @@ class V6ReadConfig(
         urgentPublisherProvider.ifAvailable,
         v6ReadMetrics, properties
     )
-
-    @Bean
-    fun expectationV6Controller(
-        facade: ExpectationReadFacade
-    ): ExpectationV6Controller = ExpectationV6Controller(facade, properties)
-
-    @Bean
-    fun restControllerExceptionHandler(): RestControllerExceptionHandler =
-        RestControllerExceptionHandler()
 
     @Bean
     @ConditionalOnProperty(name = ["expectation.v6.urgent.enabled"], havingValue = "true")

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/config/V6ReadConfig.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/config/V6ReadConfig.kt
@@ -7,6 +7,7 @@ import maple.restcontroller.controller.ExpectationV6Controller
 import maple.restcontroller.metrics.V6ReadMetrics
 import maple.restcontroller.read.*
 import maple.restcontroller.urgent.UrgentTriggerPublisher
+import org.springframework.beans.factory.ObjectProvider
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
@@ -65,8 +66,13 @@ class V6ReadConfig(
         registry: InflightRequestRegistry,
         queryService: ReadModelQueryService,
         cacheService: ReadModelCacheService,
-        v6ReadMetrics: V6ReadMetrics
-    ): BatchReadScheduler = BatchReadScheduler(buffer, registry, queryService, cacheService, v6ReadMetrics, properties)
+        v6ReadMetrics: V6ReadMetrics,
+        urgentPublisherProvider: ObjectProvider<UrgentTriggerPublisher>
+    ): BatchReadScheduler = BatchReadScheduler(
+        buffer, registry, queryService, cacheService,
+        urgentPublisherProvider.ifAvailable,
+        v6ReadMetrics, properties
+    )
 
     @Bean
     fun expectationV6Controller(

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/config/V6ReadProperties.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/config/V6ReadProperties.kt
@@ -12,4 +12,6 @@ class V6ReadProperties {
     var shutdownDrainTimeoutSeconds: Long = 5
     var cacheTtlSeconds: Long = 300
     var urgentPendingTtlSeconds: Long = 30
+    var statusRetryAfterSeconds: Long = 3
+    var statusEstimatedThroughputPerSecond: Double = 5.0
 }

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/config/V6ReadProperties.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/config/V6ReadProperties.kt
@@ -10,4 +10,5 @@ class V6ReadProperties {
     var maxBatchSize: Int = 200
     var queueCapacity: Int = 5000
     var shutdownDrainTimeoutSeconds: Long = 5
+    var cacheTtlSeconds: Long = 300
 }

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/config/V6ReadProperties.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/config/V6ReadProperties.kt
@@ -11,4 +11,5 @@ class V6ReadProperties {
     var queueCapacity: Int = 5000
     var shutdownDrainTimeoutSeconds: Long = 5
     var cacheTtlSeconds: Long = 300
+    var urgentPendingTtlSeconds: Long = 30
 }

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/controller/ExpectationV6Controller.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/controller/ExpectationV6Controller.kt
@@ -1,37 +1,63 @@
 package maple.restcontroller.controller
 
+import maple.expectation.util.StringMaskingUtils.maskIgn
 import maple.restcontroller.config.V6ReadProperties
 import maple.restcontroller.read.ExpectationReadFacade
+import maple.restcontroller.read.ReadModelCacheService
+import maple.restcontroller.read.ReadModelQueryService
+import maple.restcontroller.read.UrgentReadState
 import maple.restcontroller.validation.ValidUserIgn
 import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.context.request.async.DeferredResult
-import maple.expectation.util.StringMaskingUtils.maskIgn
 
 @RestController
 @RequestMapping("/api/v6/characters")
 @Validated
 class ExpectationV6Controller(
     private val facade: ExpectationReadFacade,
-    private val properties: V6ReadProperties
+    private val properties: V6ReadProperties,
+    private val cacheService: ReadModelCacheService,
+    private val queryService: ReadModelQueryService,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
     @GetMapping("/{userIgn}/expectation")
     fun getExpectation(
         @PathVariable @ValidUserIgn userIgn: String,
-        @RequestParam(defaultValue = "1") presetNo: Int
+        @RequestParam(defaultValue = "1") presetNo: Int,
     ): DeferredResult<ResponseEntity<*>> {
         log.debug("V6 read request userIgn={} presetNo={}", maskIgn(userIgn), presetNo)
-
-        val deferred = DeferredResult<ResponseEntity<*>>(
-            properties.requestTimeoutMs
-        )
-
+        val deferred = DeferredResult<ResponseEntity<*>>(properties.requestTimeoutMs)
         facade.enqueue(userIgn, presetNo, deferred)
-
         return deferred
+    }
+
+    @GetMapping("/{userIgn}/status")
+    fun getStatus(
+        @PathVariable @ValidUserIgn userIgn: String,
+        @RequestParam(defaultValue = "1") presetNo: Int,
+    ): ResponseEntity<*> {
+        val current = cacheService.status(userIgn, presetNo)
+        val status = if (current.state == UrgentReadState.PENDING || current.state == UrgentReadState.UNKNOWN) {
+            val dbResult = queryService.batchQuery(mapOf(userIgn to presetNo))
+            if (dbResult.isNotEmpty()) {
+                cacheService.multiPut(dbResult)
+                cacheService.status(userIgn, presetNo)
+            } else {
+                current
+            }
+        } else {
+            current
+        }
+        return ResponseEntity.ok()
+            .header("Retry-After", status.retryAfterSeconds.toString())
+            .body(status)
     }
 }

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/metrics/V6ReadMetrics.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/metrics/V6ReadMetrics.kt
@@ -32,6 +32,10 @@ class V6ReadMetrics(
         .description("Buffer full to 503 rejection count")
         .register(meterRegistry)
 
+    val urgentTriggerTotal: Counter = Counter.builder("v6_urgent_trigger_total")
+        .description("Total urgent pipeline triggers")
+        .register(meterRegistry)
+
     private val hitCounter: Counter = Counter.builder("v6_read_hit_total")
         .description("V6 read model cache hits")
         .register(meterRegistry)

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/metrics/V6ReadMetrics.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/metrics/V6ReadMetrics.kt
@@ -36,6 +36,14 @@ class V6ReadMetrics(
         .description("V6 read model cache hits")
         .register(meterRegistry)
 
+    private val redisHitCounter: Counter = Counter.builder("v6_redis_hit_total")
+        .description("V6 Redis cache hits")
+        .register(meterRegistry)
+
+    private val dbHitCounter: Counter = Counter.builder("v6_db_hit_total")
+        .description("V6 DB query hits (cache miss -> DB fallback)")
+        .register(meterRegistry)
+
     private val missCounters = mutableMapOf<String, Counter>()
     private val meterRegistry = meterRegistry
 
@@ -44,6 +52,10 @@ class V6ReadMetrics(
         .register(meterRegistry)
 
     fun recordHit() = hitCounter.increment()
+
+    fun recordRedisHit() = redisHitCounter.increment()
+
+    fun recordDbHit() = dbHitCounter.increment()
 
     fun recordMiss(reason: String) {
         val counter = missCounters.getOrPut(reason) {

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/read/BatchReadScheduler.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/read/BatchReadScheduler.kt
@@ -12,6 +12,7 @@ class BatchReadScheduler(
     private val buffer: LocalRequestBuffer,
     private val registry: InflightRequestRegistry,
     private val queryService: ReadModelQueryService,
+    private val cacheService: ReadModelCacheService,
     private val metrics: V6ReadMetrics,
     private val properties: V6ReadProperties
 ) : SmartLifecycle {
@@ -73,21 +74,43 @@ class BatchReadScheduler(
         if (batch.isEmpty()) return 0
 
         val requests = batch.associate { it.userIgn to it.presetNo }
-        val results = queryService.batchQuery(requests)
         var resolved = 0
 
-        batch.forEach { request ->
-            val deferreds = registry.getAndRemove(request.userIgn)
-            val response = results[request.userIgn]
+        // 1. Redis cache lookup — split hits / misses
+        val (cacheHits, cacheMisses) = cacheService.multiGet(requests)
 
-            if (response != null) {
-                metrics.recordHit()
-                deferreds.forEach { it.setResult(ResponseEntity.ok(response)) }
-                resolved++
-            } else {
-                metrics.recordMiss("read_model_empty")
+        // 2. Resolve cache hits directly
+        cacheHits.forEach { (userIgn, response) ->
+            val deferreds = registry.getAndRemove(userIgn)
+            metrics.recordHit()
+            metrics.recordRedisHit()
+            deferreds.forEach { it.setResult(ResponseEntity.ok(response)) }
+            resolved++
+        }
+
+        // 3. DB batch query for cache misses only
+        if (cacheMisses.isNotEmpty()) {
+            val dbResults = queryService.batchQuery(cacheMisses)
+
+            // 4. Write DB results to Redis cache
+            cacheService.multiPut(dbResults)
+
+            // 5. Resolve miss deferreds
+            cacheMisses.keys.forEach { userIgn ->
+                val deferreds = registry.getAndRemove(userIgn)
+                val response = dbResults[userIgn]
+
+                if (response != null) {
+                    metrics.recordHit()
+                    metrics.recordDbHit()
+                    deferreds.forEach { it.setResult(ResponseEntity.ok(response)) }
+                    resolved++
+                } else {
+                    metrics.recordMiss("read_model_empty")
+                }
             }
         }
+
         return resolved
     }
 

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/read/BatchReadScheduler.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/read/BatchReadScheduler.kt
@@ -1,7 +1,10 @@
 package maple.restcontroller.read
 
+import maple.expectation.util.StringMaskingUtils.maskIgn
 import maple.restcontroller.config.V6ReadProperties
 import maple.restcontroller.metrics.V6ReadMetrics
+import maple.restcontroller.urgent.UrgentCharacterRequest
+import maple.restcontroller.urgent.UrgentTriggerPublisher
 import org.slf4j.LoggerFactory
 import org.springframework.context.SmartLifecycle
 import org.springframework.http.ResponseEntity
@@ -13,6 +16,7 @@ class BatchReadScheduler(
     private val registry: InflightRequestRegistry,
     private val queryService: ReadModelQueryService,
     private val cacheService: ReadModelCacheService,
+    private val urgentPublisher: UrgentTriggerPublisher?,
     private val metrics: V6ReadMetrics,
     private val properties: V6ReadProperties
 ) : SmartLifecycle {
@@ -107,6 +111,26 @@ class BatchReadScheduler(
                     resolved++
                 } else {
                     metrics.recordMiss("read_model_empty")
+
+                    // Check negative cache first (character previously confirmed not found by Nexon)
+                    if (cacheService.getNegativeCache(userIgn)) {
+                        val notFoundResponse = ResponseEntity.status(404)
+                            .header("X-Error-Reason", "character-not-found")
+                            .build<Any>()
+                        deferreds.forEach { it.setResult(notFoundResponse) }
+                        resolved++
+                        return@forEach
+                    }
+
+                    // Trigger urgent pipeline (with dedup via Redis SETNX)
+                    if (urgentPublisher != null && cacheService.tryMarkUrgentPending(userIgn)) {
+                        val presetNo = cacheMisses[userIgn] ?: 1
+                        urgentPublisher.publish(UrgentCharacterRequest(userIgn = userIgn, presetNo = presetNo))
+                        metrics.urgentTriggerTotal.increment()
+                        log.info("Triggered urgent pipeline: userIgn={}", maskIgn(userIgn))
+                    }
+
+                    // Otherwise DeferredResult will time out → 202 Accepted
                 }
             }
         }

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/read/BatchReadScheduler.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/read/BatchReadScheduler.kt
@@ -92,9 +92,17 @@ class BatchReadScheduler(
             resolved++
         }
 
-        // 3. DB batch query for cache misses only
+        // 3. DB batch query for cache misses only (skip characters with urgent pending)
         if (cacheMisses.isNotEmpty()) {
-            val dbResults = queryService.batchQuery(cacheMisses)
+            val dbLookupCandidates = cacheMisses.filterKeys { userIgn ->
+                !cacheService.isUrgentPending(userIgn)
+            }
+
+            val dbResults = if (dbLookupCandidates.isNotEmpty()) {
+                queryService.batchQuery(dbLookupCandidates)
+            } else {
+                emptyMap()
+            }
 
             // 4. Write DB results to Redis cache
             cacheService.multiPut(dbResults)

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/read/ExpectationReadFacade.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/read/ExpectationReadFacade.kt
@@ -1,35 +1,34 @@
 package maple.restcontroller.read
 
+import maple.expectation.util.StringMaskingUtils.maskIgn
+import maple.restcontroller.config.V6ReadProperties
 import maple.restcontroller.metrics.V6ReadMetrics
 import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.web.context.request.async.DeferredResult
-import maple.expectation.util.StringMaskingUtils.maskIgn
 
 class ExpectationReadFacade(
     private val registry: InflightRequestRegistry,
     private val buffer: RequestBuffer,
-    private val metrics: V6ReadMetrics
+    private val metrics: V6ReadMetrics,
+    private val cacheService: ReadModelCacheService,
+    private val properties: V6ReadProperties,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
     fun enqueue(userIgn: String, presetNo: Int, deferred: DeferredResult<ResponseEntity<*>>) {
         metrics.requestTotal.increment()
-
-        val isFirst = registry.register(userIgn, deferred)
-
-        if (isFirst) {
+        val firstRequest = registry.register(userIgn, deferred)
+        if (firstRequest) {
             metrics.dedupMissTotal.increment()
-            val request = ReadRequest(userIgn = userIgn, presetNo = presetNo)
-
-            if (!buffer.offer(request)) {
+            if (!buffer.offer(ReadRequest(userIgn = userIgn, presetNo = presetNo))) {
                 metrics.bufferRejectedTotal.increment()
                 registry.cleanup(userIgn, deferred)
                 log.warn("Buffer full, rejecting request userIgn={}", maskIgn(userIgn))
                 deferred.setErrorResult(
                     ResponseEntity.status(503)
                         .header("Retry-After", "1")
-                        .build<Any>()
+                        .build<Any>(),
                 )
                 return
             }
@@ -42,10 +41,12 @@ class ExpectationReadFacade(
         deferred.onTimeout {
             metrics.timeoutTotal.increment()
             deferred.setErrorResult(
-                ResponseEntity.accepted().build<Any>()
+                ResponseEntity.accepted()
+                    .header("Location", cacheService.statusUrl(userIgn, presetNo))
+                    .header("Retry-After", properties.statusRetryAfterSeconds.toString())
+                    .body(cacheService.status(userIgn, presetNo)),
             )
         }
-
         deferred.onCompletion {
             registry.cleanup(userIgn, deferred)
         }

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelCacheService.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelCacheService.kt
@@ -1,0 +1,72 @@
+package maple.restcontroller.read
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import maple.restcontroller.config.V6ReadProperties
+import org.slf4j.LoggerFactory
+import org.springframework.data.redis.core.StringRedisTemplate
+import java.time.Duration
+
+class ReadModelCacheService(
+    private val redisTemplate: StringRedisTemplate,
+    private val objectMapper: ObjectMapper,
+    private val properties: V6ReadProperties
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    companion object {
+        private const val KEY_PREFIX = "v6:read"
+    }
+
+    fun cacheKey(userIgn: String, presetNo: Int): String =
+        "$KEY_PREFIX:$userIgn:$presetNo"
+
+    /**
+     * Redis multiGet for partial cache lookup.
+     * @return Pair of (cacheHits: userIgn -> V6ExpectationResponse, cacheMissKeys: userIgn -> presetNo)
+     */
+    fun multiGet(
+        requests: Map<String, Int>
+    ): Pair<Map<String, V6ExpectationResponse>, Map<String, Int>> {
+        if (requests.isEmpty()) return emptyMap<String, V6ExpectationResponse>() to emptyMap()
+
+        val keys = requests.entries.associate { (userIgn, presetNo) ->
+            cacheKey(userIgn, presetNo) to (userIgn to presetNo)
+        }
+
+        val values = redisTemplate.opsForValue().multiGet(keys.keys.toList())
+
+        val hits = mutableMapOf<String, V6ExpectationResponse>()
+        val misses = mutableMapOf<String, Int>()
+
+        keys.entries.forEachIndexed { index, (key, userIgnAndPresetNo) ->
+            val (userIgn, presetNo) = userIgnAndPresetNo
+            val value = values?.get(index)
+
+            if (value != null) {
+                val response = objectMapper.readValue(value, V6ExpectationResponse::class.java)
+                hits[userIgn] = response
+            } else {
+                misses[userIgn] = presetNo
+            }
+        }
+
+        log.debug("Redis cache lookup: hits={}, misses={}", hits.size, misses.size)
+        return hits to misses
+    }
+
+    /**
+     * Write DB results to Redis cache with TTL.
+     */
+    fun multiPut(results: Map<String, V6ExpectationResponse>) {
+        if (results.isEmpty()) return
+
+        val ttl = Duration.ofSeconds(properties.cacheTtlSeconds)
+        results.forEach { (userIgn, response) ->
+            val key = cacheKey(userIgn, response.presetNo)
+            val json = objectMapper.writeValueAsString(response)
+            redisTemplate.opsForValue().set(key, json, ttl)
+        }
+
+        log.debug("Redis cache write: {} entries, TTL={}s", results.size, ttl.seconds)
+    }
+}

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelCacheService.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelCacheService.kt
@@ -18,6 +18,7 @@ class ReadModelCacheService(
         private const val KEY_PREFIX = "v6:read"
         private const val NEGATIVE_KEY_PREFIX = "v6:not-found"
         private const val URGENT_PENDING_PREFIX = "v6:urgent-pending"
+        private const val URGENT_STATUS_QUEUE_KEY = "v6:urgent:status-queue"
     }
 
     fun cacheKey(userIgn: String, presetNo: Int): String =
@@ -69,6 +70,7 @@ class ReadModelCacheService(
             val json = objectMapper.writeValueAsString(response)
             redisTemplate.opsForValue().set(key, json, ttl)
             clearUrgentPending(userIgn)
+            removeUrgentStatus(userIgn)
         }
 
         log.debug("Redis cache write: {} entries, TTL={}s", results.size, ttl.seconds)
@@ -84,6 +86,8 @@ class ReadModelCacheService(
 
     fun setNegativeCache(userIgn: String, ttlSeconds: Long) {
         redisTemplate.opsForValue().set(negativeCacheKey(userIgn), "NOT_FOUND", Duration.ofSeconds(ttlSeconds))
+        clearUrgentPending(userIgn)
+        removeUrgentStatus(userIgn)
         log.info("Set negative cache: userIgn={}", maskIgn(userIgn))
     }
 
@@ -93,7 +97,12 @@ class ReadModelCacheService(
 
     fun tryMarkUrgentPending(userIgn: String): Boolean {
         val result = redisTemplate.opsForValue()
-            .setIfAbsent(urgentPendingKey(userIgn), "1", Duration.ofSeconds(properties.urgentPendingTtlSeconds))
+            .setIfAbsent(urgentPendingKey(userIgn), System.currentTimeMillis().toString(), Duration.ofSeconds(properties.urgentPendingTtlSeconds))
+        if (result == true) {
+            redisTemplate.opsForZSet().add(URGENT_STATUS_QUEUE_KEY, userIgn, System.currentTimeMillis().toDouble())
+        } else if (isUrgentPending(userIgn) && redisTemplate.opsForZSet().rank(URGENT_STATUS_QUEUE_KEY, userIgn) == null) {
+            redisTemplate.opsForZSet().add(URGENT_STATUS_QUEUE_KEY, userIgn, System.currentTimeMillis().toDouble())
+        }
         return result == true
     }
 
@@ -102,5 +111,40 @@ class ReadModelCacheService(
 
     fun clearUrgentPending(userIgn: String) {
         redisTemplate.delete(urgentPendingKey(userIgn))
+    }
+
+    fun statusUrl(userIgn: String, presetNo: Int): String = "/api/v6/characters/$userIgn/status?presetNo=$presetNo"
+
+    fun status(userIgn: String, presetNo: Int): UrgentReadStatusResponse {
+        val state = when {
+            hasReadyCache(userIgn, presetNo) -> UrgentReadState.READY
+            getNegativeCache(userIgn) -> UrgentReadState.NOT_FOUND
+            isUrgentPending(userIgn) -> UrgentReadState.PENDING
+            else -> UrgentReadState.UNKNOWN
+        }
+        val position = if (state == UrgentReadState.PENDING) queuePosition(userIgn) else null
+        return UrgentReadStatusResponse(
+            state = state,
+            userIgn = userIgn,
+            statusUrl = statusUrl(userIgn, presetNo),
+            queuePositionApprox = position,
+            estimatedWaitSeconds = position?.let(::estimateWaitSeconds),
+            retryAfterSeconds = if (state == UrgentReadState.READY || state == UrgentReadState.NOT_FOUND) 0 else properties.statusRetryAfterSeconds,
+        )
+    }
+
+    private fun hasReadyCache(userIgn: String, presetNo: Int): Boolean =
+        redisTemplate.hasKey(cacheKey(userIgn, presetNo))
+
+    private fun queuePosition(userIgn: String): Long? =
+        redisTemplate.opsForZSet().rank(URGENT_STATUS_QUEUE_KEY, userIgn)?.plus(1)
+
+    private fun estimateWaitSeconds(queuePosition: Long): Long {
+        val throughput = properties.statusEstimatedThroughputPerSecond.takeIf { it > 0.0 } ?: 1.0
+        return kotlin.math.ceil(queuePosition / throughput).toLong().coerceAtLeast(1)
+    }
+
+    private fun removeUrgentStatus(userIgn: String) {
+        redisTemplate.opsForZSet().remove(URGENT_STATUS_QUEUE_KEY, userIgn)
     }
 }

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelCacheService.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelCacheService.kt
@@ -68,6 +68,7 @@ class ReadModelCacheService(
             val key = cacheKey(userIgn, response.presetNo)
             val json = objectMapper.writeValueAsString(response)
             redisTemplate.opsForValue().set(key, json, ttl)
+            clearUrgentPending(userIgn)
         }
 
         log.debug("Redis cache write: {} entries, TTL={}s", results.size, ttl.seconds)
@@ -90,9 +91,16 @@ class ReadModelCacheService(
 
     fun urgentPendingKey(userIgn: String): String = "$URGENT_PENDING_PREFIX:$userIgn"
 
-    fun tryMarkUrgentPending(userIgn: String, ttlSeconds: Long = 30): Boolean {
+    fun tryMarkUrgentPending(userIgn: String): Boolean {
         val result = redisTemplate.opsForValue()
-            .setIfAbsent(urgentPendingKey(userIgn), "1", Duration.ofSeconds(ttlSeconds))
+            .setIfAbsent(urgentPendingKey(userIgn), "1", Duration.ofSeconds(properties.urgentPendingTtlSeconds))
         return result == true
+    }
+
+    fun isUrgentPending(userIgn: String): Boolean =
+        redisTemplate.hasKey(urgentPendingKey(userIgn))
+
+    fun clearUrgentPending(userIgn: String) {
+        redisTemplate.delete(urgentPendingKey(userIgn))
     }
 }

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelCacheService.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelCacheService.kt
@@ -15,6 +15,8 @@ class ReadModelCacheService(
 
     companion object {
         private const val KEY_PREFIX = "v6:read"
+        private const val NEGATIVE_KEY_PREFIX = "v6:not-found"
+        private const val URGENT_PENDING_PREFIX = "v6:urgent-pending"
     }
 
     fun cacheKey(userIgn: String, presetNo: Int): String =
@@ -68,5 +70,28 @@ class ReadModelCacheService(
         }
 
         log.debug("Redis cache write: {} entries, TTL={}s", results.size, ttl.seconds)
+    }
+
+    // --- Negative cache (non-existent characters) ---
+
+    fun negativeCacheKey(userIgn: String): String = "$NEGATIVE_KEY_PREFIX:$userIgn"
+
+    fun getNegativeCache(userIgn: String): Boolean {
+        return redisTemplate.hasKey(negativeCacheKey(userIgn))
+    }
+
+    fun setNegativeCache(userIgn: String, ttlSeconds: Long) {
+        redisTemplate.opsForValue().set(negativeCacheKey(userIgn), "NOT_FOUND", Duration.ofSeconds(ttlSeconds))
+        log.info("Set negative cache: userIgn={}", userIgn)
+    }
+
+    // --- Urgent dedup (prevent duplicate triggers) ---
+
+    fun urgentPendingKey(userIgn: String): String = "$URGENT_PENDING_PREFIX:$userIgn"
+
+    fun tryMarkUrgentPending(userIgn: String, ttlSeconds: Long = 30): Boolean {
+        val result = redisTemplate.opsForValue()
+            .setIfAbsent(urgentPendingKey(userIgn), "1", Duration.ofSeconds(ttlSeconds))
+        return result == true
     }
 }

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelCacheService.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelCacheService.kt
@@ -1,6 +1,7 @@
 package maple.restcontroller.read
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import maple.expectation.util.StringMaskingUtils.maskIgn
 import maple.restcontroller.config.V6ReadProperties
 import org.slf4j.LoggerFactory
 import org.springframework.data.redis.core.StringRedisTemplate
@@ -82,7 +83,7 @@ class ReadModelCacheService(
 
     fun setNegativeCache(userIgn: String, ttlSeconds: Long) {
         redisTemplate.opsForValue().set(negativeCacheKey(userIgn), "NOT_FOUND", Duration.ofSeconds(ttlSeconds))
-        log.info("Set negative cache: userIgn={}", userIgn)
+        log.info("Set negative cache: userIgn={}", maskIgn(userIgn))
     }
 
     // --- Urgent dedup (prevent duplicate triggers) ---

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelQueryService.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelQueryService.kt
@@ -36,29 +36,40 @@ class ReadModelQueryService(
             .addValue("userIgns", userIgns)
             .addValue("presetNos", presetNos)
 
-        @Suppress("UNCHECKED_CAST")
-        val rows = jdbc.queryForList(sql, params, Map::class.java) as List<Map<String, Any>>
-
-        return rows.associate { row ->
+        val rows = jdbc.queryForList(sql, params)
+        val result = LinkedHashMap<String, V6ExpectationResponse>()
+        rows.forEach { row ->
             val userIgn = row["user_ign"].toString()
             val compressed = row["document"] as ByteArray
             val json = GzipUtils.decompress(compressed)
             val tree = objectMapper.readTree(json)
+            val equipmentNode = tree["equipment"]
+            val equipment = if (equipmentNode != null && !equipmentNode.isNull) {
+                @Suppress("UNCHECKED_CAST")
+                objectMapper.readValue(
+                    equipmentNode.toString(),
+                    objectMapper.typeFactory.constructCollectionType(List::class.java, Map::class.java),
+                ) as List<Map<String, Any?>>
+            } else {
+                emptyList()
+            }
 
-            userIgn to V6ExpectationResponse(
+            result[userIgn] = V6ExpectationResponse(
                 userIgn = userIgn,
-                presetNo = tree.get("presetNo")?.asInt() ?: 1,
-                totalCost = tree.get("summary")?.get("totalCost")?.decimalValue() ?: BigDecimal.ZERO,
-                equipmentCount = tree.get("summary")?.get("equipmentCount")?.asInt() ?: 0,
-                equipment = tree.get("equipment")?.let {
-                    objectMapper.readValue(it.toString(),
-                        objectMapper.typeFactory.constructCollectionType(List::class.java, Map::class.java))
-                } ?: emptyList(),
-                calculatedAt = Instant.parse(
-                    tree.get("metadata")?.get("calculatedAt")?.asText()
-                        ?: Instant.now().toString()
-                ),
+                presetNo = tree["presetNo"]?.asInt() ?: (row["preset_no"] as Number).toInt(),
+                totalCost = tree["summary"]?.get("totalCost")?.decimalValue()
+                    ?: row["total_cost"] as? BigDecimal
+                    ?: BigDecimal.ZERO,
+                equipmentCount = tree["summary"]?.get("equipmentCount")?.asInt()
+                    ?: (row["equipment_count"] as? Number)?.toInt()
+                    ?: 0,
+                equipment = equipment,
+                calculatedAt = tree["metadata"]?.get("calculatedAt")?.asText()?.let(Instant::parse)
+                    ?: (row["calculated_at"] as? java.sql.Timestamp)?.toInstant()
+                    ?: Instant.now(),
             )
         }
+        log.debug("Read model query: requested={}, hits={}", requests.size, result.size)
+        return result
     }
 }

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/read/UrgentReadStatus.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/read/UrgentReadStatus.kt
@@ -1,0 +1,17 @@
+package maple.restcontroller.read
+
+enum class UrgentReadState {
+    PENDING,
+    READY,
+    NOT_FOUND,
+    UNKNOWN,
+}
+
+data class UrgentReadStatusResponse(
+    val state: UrgentReadState,
+    val userIgn: String,
+    val statusUrl: String,
+    val queuePositionApprox: Long?,
+    val estimatedWaitSeconds: Long?,
+    val retryAfterSeconds: Long,
+)

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/urgent/UrgentCharacterNotFoundConsumer.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/urgent/UrgentCharacterNotFoundConsumer.kt
@@ -1,0 +1,31 @@
+package maple.restcontroller.urgent
+
+import maple.restcontroller.read.ReadModelCacheService
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.kafka.support.Acknowledgment
+import org.springframework.stereotype.Component
+
+@Component
+@ConditionalOnProperty(name = ["expectation.v6.urgent.enabled"], havingValue = "true")
+class UrgentCharacterNotFoundConsumer(
+    private val cacheService: ReadModelCacheService,
+    private val objectMapper: ObjectMapper,
+    @Value("\${expectation.v6.urgent.negative-cache-ttl-seconds}") private val negativeCacheTtlSeconds: Long
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @KafkaListener(
+        topics = ["\${expectation.v6.urgent.not-found-topic}"],
+        groupId = "\${spring.kafka.consumer.group-id}"
+    )
+    fun consume(message: String, acknowledgment: Acknowledgment) {
+        val userIgn = objectMapper.readTree(message).get("userIgn").asText()
+        log.info("Received character-not-found event: userIgn={}", userIgn)
+        cacheService.setNegativeCache(userIgn, negativeCacheTtlSeconds)
+        acknowledgment.acknowledge()
+    }
+}

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/urgent/UrgentCharacterNotFoundConsumer.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/urgent/UrgentCharacterNotFoundConsumer.kt
@@ -1,5 +1,6 @@
 package maple.restcontroller.urgent
 
+import maple.expectation.util.StringMaskingUtils.maskIgn
 import maple.restcontroller.read.ReadModelCacheService
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.slf4j.LoggerFactory
@@ -23,8 +24,13 @@ class UrgentCharacterNotFoundConsumer(
         groupId = "\${spring.kafka.consumer.group-id}"
     )
     fun consume(message: String, acknowledgment: Acknowledgment) {
-        val userIgn = objectMapper.readTree(message).get("userIgn").asText()
-        log.info("Received character-not-found event: userIgn={}", userIgn)
+        val userIgn = objectMapper.readTree(message).get("userIgn")?.asText()
+        if (userIgn == null) {
+            log.warn("Missing userIgn in not-found message, acknowledging to skip")
+            acknowledgment.acknowledge()
+            return
+        }
+        log.info("Received character-not-found event: userIgn={}", maskIgn(userIgn))
         cacheService.setNegativeCache(userIgn, negativeCacheTtlSeconds)
         acknowledgment.acknowledge()
     }

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/urgent/UrgentCharacterRequest.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/urgent/UrgentCharacterRequest.kt
@@ -1,0 +1,11 @@
+package maple.restcontroller.urgent
+
+import java.time.Instant
+import java.util.UUID
+
+data class UrgentCharacterRequest(
+    val eventId: String = UUID.randomUUID().toString(),
+    val userIgn: String,
+    val presetNo: Int = 1,
+    val requestedAt: Instant = Instant.now()
+)

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/urgent/UrgentTriggerPublisher.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/urgent/UrgentTriggerPublisher.kt
@@ -1,0 +1,26 @@
+package maple.restcontroller.urgent
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.slf4j.LoggerFactory
+import org.springframework.kafka.core.KafkaTemplate
+
+class UrgentTriggerPublisher(
+    private val kafkaTemplate: KafkaTemplate<String, String>,
+    private val objectMapper: ObjectMapper,
+    private val topic: String
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun publish(request: UrgentCharacterRequest) {
+        val json = objectMapper.writeValueAsString(request)
+        kafkaTemplate.send(topic, request.userIgn, json)
+            .whenComplete { result, ex ->
+                if (ex != null) {
+                    log.error("Failed to publish urgent request: userIgn={}, topic={}", request.userIgn, topic, ex)
+                } else {
+                    log.info("Published urgent request: userIgn={}, topic={}, partition={}, offset={}",
+                        request.userIgn, topic, result.recordMetadata.partition(), result.recordMetadata.offset())
+                }
+            }
+    }
+}

--- a/module-rest-controller/src/main/resources/application-local.yml
+++ b/module-rest-controller/src/main/resources/application-local.yml
@@ -5,7 +5,13 @@ spring:
     url: ${DB_URL}
     username: ${DB_USER}
     password: ${DB_PASSWORD}
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
 
 expectation:
   v6:
     enabled: true
+    request-timeout-ms: 5000
+    cache-ttl-seconds: 300  # Redis cache TTL for read model entries

--- a/module-rest-controller/src/main/resources/application.yml
+++ b/module-rest-controller/src/main/resources/application.yml
@@ -43,6 +43,8 @@ expectation:
     max-batch-size: 200               # scheduler batch size (Phase 2)
     queue-capacity: 5000              # RequestBuffer max capacity
     shutdown-drain-timeout-seconds: 5 # graceful shutdown deadline
+    status-retry-after-seconds: 3     # frontend polling hint after 202/status
+    status-estimated-throughput-per-second: 5.0 # approximate urgent pipeline throughput
     urgent:
       enabled: false                              # feature flag
       request-topic: urgent-character-request

--- a/module-rest-controller/src/main/resources/application.yml
+++ b/module-rest-controller/src/main/resources/application.yml
@@ -48,3 +48,4 @@ expectation:
       request-topic: urgent-character-request
       not-found-topic: urgent-character-not-found
       negative-cache-ttl-seconds: 3600            # 1 hour
+      pending-ttl-seconds: 30                     # urgent dedup TTL

--- a/module-rest-controller/src/main/resources/application.yml
+++ b/module-rest-controller/src/main/resources/application.yml
@@ -13,6 +13,21 @@ spring:
     hikari:
       maximum-pool-size: 5
       minimum-idle: 2
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+      acks: all
+      retries: 3
+    consumer:
+      group-id: rest-controller-urgent-feedback
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      auto-offset-reset: earliest
+      enable-auto-commit: false
+    listener:
+      ack-mode: manual_immediate
 
 management:
   endpoints:
@@ -28,3 +43,8 @@ expectation:
     max-batch-size: 200               # scheduler batch size (Phase 2)
     queue-capacity: 5000              # RequestBuffer max capacity
     shutdown-drain-timeout-seconds: 5 # graceful shutdown deadline
+    urgent:
+      enabled: false                              # feature flag
+      request-topic: urgent-character-request
+      not-found-topic: urgent-character-not-found
+      negative-cache-ttl-seconds: 3600            # 1 hour

--- a/module-rest-controller/src/test/kotlin/maple/restcontroller/urgent/UrgentCharacterNotFoundConsumerTest.kt
+++ b/module-rest-controller/src/test/kotlin/maple/restcontroller/urgent/UrgentCharacterNotFoundConsumerTest.kt
@@ -23,4 +23,14 @@ class UrgentCharacterNotFoundConsumerTest {
         verify(cacheService).setNegativeCache("unknownChar", 3600L)
         verify(acknowledgment).acknowledge()
     }
+
+    @Test
+    fun `consume with missing userIgn acknowledges without setting negative cache`() {
+        val message = """{"reason":"OPENAPI00004"}"""
+
+        consumer.consume(message, acknowledgment)
+
+        verify(cacheService, never()).setNegativeCache(any(), any())
+        verify(acknowledgment).acknowledge()
+    }
 }

--- a/module-rest-controller/src/test/kotlin/maple/restcontroller/urgent/UrgentCharacterNotFoundConsumerTest.kt
+++ b/module-rest-controller/src/test/kotlin/maple/restcontroller/urgent/UrgentCharacterNotFoundConsumerTest.kt
@@ -1,0 +1,26 @@
+package maple.restcontroller.urgent
+
+import maple.restcontroller.read.ReadModelCacheService
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.*
+import org.springframework.kafka.support.Acknowledgment
+
+class UrgentCharacterNotFoundConsumerTest {
+
+    private val cacheService: ReadModelCacheService = mock()
+    private val objectMapper = ObjectMapper().registerKotlinModule()
+    private val acknowledgment: Acknowledgment = mock()
+    private val consumer = UrgentCharacterNotFoundConsumer(cacheService, objectMapper, 3600L)
+
+    @Test
+    fun `consume sets negative cache and acknowledges`() {
+        val message = """{"userIgn":"unknownChar","reason":"OPENAPI00004"}"""
+
+        consumer.consume(message, acknowledgment)
+
+        verify(cacheService).setNegativeCache("unknownChar", 3600L)
+        verify(acknowledgment).acknowledge()
+    }
+}

--- a/module-rest-controller/src/test/kotlin/maple/restcontroller/urgent/UrgentTriggerPublisherTest.kt
+++ b/module-rest-controller/src/test/kotlin/maple/restcontroller/urgent/UrgentTriggerPublisherTest.kt
@@ -1,0 +1,37 @@
+package maple.restcontroller.urgent
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.clients.producer.RecordMetadata
+import org.apache.kafka.common.TopicPartition
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.*
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.support.SendResult
+import java.util.concurrent.CompletableFuture
+
+class UrgentTriggerPublisherTest {
+
+    private val kafkaTemplate: KafkaTemplate<String, String> = mock()
+    private val objectMapper = ObjectMapper().registerKotlinModule().registerModule(JavaTimeModule())
+    private val topic = "urgent-character-request"
+    private val publisher = UrgentTriggerPublisher(kafkaTemplate, objectMapper, topic)
+
+    @Test
+    fun `publish sends message with userIgn as key`() {
+        val request = UrgentCharacterRequest(userIgn = "testCharacter")
+        val producerRecord = ProducerRecord(topic, "testCharacter", "{}")
+        val recordMetadata = RecordMetadata(TopicPartition(topic, 0), 0L, 0L, 0L, 0L.toLong(), 0, 0)
+        val sendResult = CompletableFuture.completedFuture(
+            SendResult<String, String>(producerRecord, recordMetadata)
+        )
+
+        whenever(kafkaTemplate.send(eq(topic), eq("testCharacter"), any())).thenReturn(sendResult)
+
+        publisher.publish(request)
+
+        verify(kafkaTemplate).send(eq(topic), eq("testCharacter"), argThat { contains("testCharacter") })
+    }
+}

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/SynchronizerApplication.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/SynchronizerApplication.kt
@@ -2,8 +2,10 @@ package maple.synchronizer
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.context.annotation.Import
 
-@SpringBootApplication(scanBasePackages = ["maple.synchronizer"])
+@SpringBootApplication(scanBasePackages = ["maple.synchronizer", "maple.expectation.infrastructure.executor"])
+@Import(maple.expectation.infrastructure.config.ExecutorConfig::class)
 class SynchronizerApplication
 
 fun main(args: Array<String>) {

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/BasicSnapshotChunkConsumer.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/BasicSnapshotChunkConsumer.kt
@@ -7,9 +7,12 @@ import maple.expectation.infrastructure.executor.TaskContext
 import maple.synchronizer.repository.CharacterBasicRepository
 import maple.synchronizer.repository.SynchronizerChunkStatusRepository
 import maple.synchronizer.storage.BasicChunkFileReader
+import maple.synchronizer.storage.BasicRecord
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.kafka.annotation.KafkaListener
 import org.springframework.kafka.support.Acknowledgment
 import org.springframework.stereotype.Component
@@ -24,6 +27,7 @@ class BasicSnapshotChunkConsumer(
     private val repository: CharacterBasicRepository,
     private val chunkStatusRepository: SynchronizerChunkStatusRepository,
     private val logicExecutor: LogicExecutor,
+    private val jdbc: NamedParameterJdbcTemplate,
     @Value("\${synchronizer.store.base-path:../module-external-api/external-api-data}")
     private val basePath: String,
 ) {
@@ -94,6 +98,91 @@ class BasicSnapshotChunkConsumer(
                 context = TaskContext.of("BasicSync", "ChunkLifecycle", chunkId),
             )
         }, vtExecutor)
+    }
+
+    @KafkaListener(
+        topics = ["\${synchronizer.kafka.urgent-basic-chunk-ready-topic}"],
+        groupId = "\${synchronizer.kafka.urgent-basic-consumer-group-id}",
+    )
+    fun consumeUrgentBasic(message: String, acknowledgment: Acknowledgment) {
+        val event = objectMapper.readValue(message, SnapshotChunkReadyEvent::class.java)
+
+        if (event.endpoint != "character-basic") {
+            acknowledgment.acknowledge()
+            return
+        }
+
+        val runId = event.runId
+        val chunkId = event.chunkId
+
+        log.info("[BasicSync] received URGENT: runId={} chunkId={} objectKey={} records={}",
+            runId, chunkId, event.objectKey, event.recordCount)
+
+        if (chunkStatusRepository.isAlreadySuccess(runId, chunkId)) {
+            log.info("[BasicSync] skip already-successful urgent chunk: runId={} chunkId={}", runId, chunkId)
+            acknowledgment.acknowledge()
+            return
+        }
+
+        if (!chunkStatusRepository.claimChunk(runId, chunkId, event.objectKey)) {
+            log.info("[BasicSync] skip - urgent chunk already claimed: runId={} chunkId={}", runId, chunkId)
+            acknowledgment.acknowledge()
+            return
+        }
+
+        if (!processingPermit.tryAcquire()) {
+            log.info("[BasicSync] processing permit busy, urgent will retry: runId={} chunkId={}", runId, chunkId)
+            return
+        }
+
+        MDC.put("runId", runId)
+        MDC.put("chunkId", chunkId)
+
+        CompletableFuture.runAsync({
+            logicExecutor.executeWithFinally(
+                task = {
+                    logicExecutor.executeOrCatch(
+                        task = {
+                            val records = fileReader.read(event.objectKey)
+                            repository.bulkUpsert(runId, chunkId, records)
+                            chunkStatusRepository.markSuccess(runId, chunkId)
+
+                            upsertOcidFromBasicRecords(records)
+
+                            log.info("[BasicSync] urgent chunk processed: runId={} chunkId={} records={}",
+                                runId, chunkId, records.size)
+                            acknowledgment.acknowledge()
+                        },
+                        recovery = { ex ->
+                            chunkStatusRepository.markFailed(runId, chunkId, ex.message ?: "unknown")
+                            log.error("[BasicSync] urgent chunk processing failed: runId={} chunkId={}",
+                                runId, chunkId, ex)
+                            null
+                        },
+                        context = TaskContext.of("BasicSync", "UrgentChunkProcess", chunkId),
+                    )
+                },
+                finallyBlock = {
+                    processingPermit.release()
+                    MDC.clear()
+                },
+                context = TaskContext.of("BasicSync", "UrgentChunkLifecycle", chunkId),
+            )
+        }, vtExecutor)
+    }
+
+    private fun upsertOcidFromBasicRecords(records: List<BasicRecord>) {
+        records.forEach { record ->
+            jdbc.update(
+                """INSERT INTO game_character (user_ign, ocid, created_at, updated_at)
+                   VALUES (:userIgn, :ocid, NOW(), NOW())
+                   ON CONFLICT (user_ign) DO UPDATE SET ocid = EXCLUDED.ocid, updated_at = NOW()""",
+                MapSqlParameterSource()
+                    .addValue("userIgn", record.userIgn)
+                    .addValue("ocid", record.ocid)
+            )
+            log.info("[BasicSync] upserted OCID to game_character: userIgn={}", record.userIgn)
+        }
     }
 
     @PreDestroy

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/BasicSnapshotChunkConsumer.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/BasicSnapshotChunkConsumer.kt
@@ -1,0 +1,111 @@
+package maple.synchronizer.consumer
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import jakarta.annotation.PreDestroy
+import maple.expectation.infrastructure.executor.LogicExecutor
+import maple.expectation.infrastructure.executor.TaskContext
+import maple.synchronizer.repository.CharacterBasicRepository
+import maple.synchronizer.repository.SynchronizerChunkStatusRepository
+import maple.synchronizer.storage.BasicChunkFileReader
+import org.slf4j.LoggerFactory
+import org.slf4j.MDC
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.kafka.support.Acknowledgment
+import org.springframework.stereotype.Component
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executors
+import java.util.concurrent.Semaphore
+
+@Component
+class BasicSnapshotChunkConsumer(
+    private val objectMapper: ObjectMapper,
+    private val fileReader: BasicChunkFileReader,
+    private val repository: CharacterBasicRepository,
+    private val chunkStatusRepository: SynchronizerChunkStatusRepository,
+    private val logicExecutor: LogicExecutor,
+    @Value("\${synchronizer.store.base-path:../module-external-api/external-api-data}")
+    private val basePath: String,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+    private val vtExecutor = Executors.newVirtualThreadPerTaskExecutor()
+    private val processingPermit = Semaphore(2)
+
+    @KafkaListener(
+        topics = ["\${synchronizer.kafka.basic-chunk-ready-topic}"],
+        groupId = "\${synchronizer.kafka.basic-consumer-group-id}",
+    )
+    fun consume(message: String, acknowledgment: Acknowledgment) {
+        val event = objectMapper.readValue(message, SnapshotChunkReadyEvent::class.java)
+
+        if (event.endpoint != "character-basic") return
+
+        val runId = event.runId
+        val chunkId = event.chunkId
+
+        log.info("[BasicSync] received: runId={} chunkId={} objectKey={} records={}",
+            runId, chunkId, event.objectKey, event.recordCount)
+
+        if (chunkStatusRepository.isAlreadySuccess(runId, chunkId)) {
+            log.info("[BasicSync] skip already-successful chunk: runId={} chunkId={}", runId, chunkId)
+            acknowledgment.acknowledge()
+            return
+        }
+
+        if (!chunkStatusRepository.claimChunk(runId, chunkId, event.objectKey)) {
+            log.info("[BasicSync] skip - chunk already claimed: runId={} chunkId={}", runId, chunkId)
+            acknowledgment.acknowledge()
+            return
+        }
+
+        if (!processingPermit.tryAcquire()) {
+            log.info("[BasicSync] processing permit busy, will retry: runId={} chunkId={}", runId, chunkId)
+            return
+        }
+
+        MDC.put("runId", runId)
+        MDC.put("chunkId", chunkId)
+
+        CompletableFuture.runAsync({
+            logicExecutor.executeWithFinally(
+                task = {
+                    logicExecutor.executeOrCatch(
+                        task = {
+                            val records = fileReader.read(event.objectKey)
+                            repository.bulkUpsert(runId, chunkId, records)
+                            chunkStatusRepository.markSuccess(runId, chunkId)
+                            log.info("[BasicSync] chunk processed: runId={} chunkId={} records={}",
+                                runId, chunkId, records.size)
+                            acknowledgment.acknowledge()
+                        },
+                        recovery = { ex ->
+                            chunkStatusRepository.markFailed(runId, chunkId, ex.message ?: "unknown")
+                            log.error("[BasicSync] chunk processing failed: runId={} chunkId={}",
+                                runId, chunkId, ex)
+                            null
+                        },
+                        context = TaskContext.of("BasicSync", "ChunkProcess", chunkId),
+                    )
+                },
+                finallyBlock = {
+                    processingPermit.release()
+                    MDC.clear()
+                },
+                context = TaskContext.of("BasicSync", "ChunkLifecycle", chunkId),
+            )
+        }, vtExecutor)
+    }
+
+    @PreDestroy
+    fun close() {
+        vtExecutor.close()
+    }
+}
+
+private data class SnapshotChunkReadyEvent(
+    val runId: String,
+    val endpoint: String,
+    val chunkId: String,
+    val objectKey: String,
+    val recordCount: Int,
+)

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/BasicSnapshotChunkConsumer.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/BasicSnapshotChunkConsumer.kt
@@ -8,6 +8,7 @@ import maple.synchronizer.repository.CharacterBasicRepository
 import maple.synchronizer.repository.SynchronizerChunkStatusRepository
 import maple.synchronizer.storage.BasicChunkFileReader
 import maple.synchronizer.storage.BasicRecord
+import maple.expectation.util.StringMaskingUtils.maskIgn
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC
 import org.springframework.beans.factory.annotation.Value
@@ -181,7 +182,7 @@ class BasicSnapshotChunkConsumer(
                     .addValue("userIgn", record.userIgn)
                     .addValue("ocid", record.ocid)
             )
-            log.info("[BasicSync] upserted OCID to game_character: userIgn={}", record.userIgn)
+            log.info("[BasicSync] upserted OCID to game_character: userIgn={}", maskIgn(record.userIgn))
         }
     }
 

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/repository/CharacterBasicRepository.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/repository/CharacterBasicRepository.kt
@@ -1,0 +1,74 @@
+package maple.synchronizer.repository
+
+import maple.synchronizer.storage.BasicRecord
+import org.slf4j.LoggerFactory
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.stereotype.Repository
+
+@Repository
+class CharacterBasicRepository(
+    private val jdbc: NamedParameterJdbcTemplate,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    companion object {
+        private const val SUB_BATCH_SIZE = 100
+    }
+
+    fun bulkUpsert(runId: String, chunkId: String, records: List<BasicRecord>) {
+        val batches = records.chunked(SUB_BATCH_SIZE)
+        log.info("[CharacterBasic] upsert start: records={} batches={}: runId={} chunkId={}",
+            records.size, batches.size, runId, chunkId)
+
+        var totalAffected = 0
+        batches.forEachIndexed { idx, batch ->
+            val affected = upsertBatch(runId, chunkId, batch)
+            totalAffected += affected
+            log.info("[CharacterBasic] upsert batch: batchNo={}/{} attempted={} affected={}",
+                idx + 1, batches.size, batch.size, affected)
+        }
+
+        log.info("[CharacterBasic] upsert done: records={} affected={}: runId={} chunkId={}",
+            records.size, totalAffected, runId, chunkId)
+    }
+
+    private fun upsertBatch(runId: String, chunkId: String, batch: List<BasicRecord>): Int {
+        val sql = """
+            INSERT INTO character_basic_read_model (
+                user_ign, ocid, world_name, character_class, character_level,
+                guild_name, basic_data, document_hash, source_run_id, source_chunk_id, updated_at
+            )
+            SELECT
+                unnest(:userIgns), unnest(:ocids), unnest(:worldNames),
+                unnest(:characterClasses), unnest(:characterLevels),
+                unnest(:guildNames), unnest(:basicData), unnest(:documentHashes),
+                :runId, :chunkId, now()
+            ON CONFLICT (user_ign) DO UPDATE SET
+                ocid = excluded.ocid,
+                world_name = excluded.world_name,
+                character_class = excluded.character_class,
+                character_level = excluded.character_level,
+                guild_name = excluded.guild_name,
+                basic_data = excluded.basic_data,
+                document_hash = excluded.document_hash,
+                source_run_id = excluded.source_run_id,
+                source_chunk_id = excluded.source_chunk_id,
+                updated_at = now()
+            WHERE character_basic_read_model.document_hash IS DISTINCT FROM excluded.document_hash
+        """.trimIndent()
+
+        return jdbc.update(sql, MapSqlParameterSource()
+            .addValue("runId", runId)
+            .addValue("chunkId", chunkId)
+            .addValue("userIgns", batch.map { it.userIgn }.toTypedArray())
+            .addValue("ocids", batch.map { it.ocid }.toTypedArray())
+            .addValue("worldNames", batch.map { it.worldName }.toTypedArray())
+            .addValue("characterClasses", batch.map { it.characterClass }.toTypedArray())
+            .addValue("characterLevels", batch.map { it.characterLevel }.toTypedArray())
+            .addValue("guildNames", batch.map { it.guildName }.toTypedArray())
+            .addValue("basicData", batch.map { it.compressedBody }.toTypedArray())
+            .addValue("documentHashes", batch.map { it.bodyHash }.toTypedArray())
+        )
+    }
+}

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/storage/BasicChunkFileReader.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/storage/BasicChunkFileReader.kt
@@ -1,0 +1,85 @@
+package maple.synchronizer.storage
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import maple.expectation.util.GzipUtils
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.security.MessageDigest
+import java.util.zip.GZIPInputStream
+
+data class BasicRecord(
+    val userIgn: String,
+    val ocid: String,
+    val worldName: String?,
+    val characterClass: String?,
+    val characterLevel: Int?,
+    val guildName: String?,
+    val compressedBody: ByteArray,
+    val bodyHash: String,
+) {
+    override fun equals(other: Any?): Boolean = this === other
+    override fun hashCode(): Int = System.identityHashCode(this)
+}
+
+@Component
+class BasicChunkFileReader(
+    @Value("\${synchronizer.store.base-path:../module-external-api/external-api-data}")
+    private val basePath: String,
+    private val objectMapper: ObjectMapper,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun read(objectKey: String): List<BasicRecord> {
+        val path = Paths.get(basePath, objectKey)
+        require(Files.exists(path)) { "Chunk file not found: $path" }
+
+        GZIPInputStream(Files.newInputStream(path)).bufferedReader().use { reader ->
+            val records = mutableListOf<BasicRecord>()
+            reader.lineSequence()
+                .filter { it.isNotBlank() }
+                .forEach { line -> parseRecord(line)?.let { records.add(it) } }
+            log.info("[BasicChunkFileReader] parsed {} records from {}", records.size, objectKey)
+            return records
+        }
+    }
+
+    private fun parseRecord(line: String): BasicRecord? {
+        return runCatching {
+            val node = objectMapper.readTree(line)
+            if (node.get("status")?.asText() != "SUCCESS") return null
+            if (node.get("endpoint")?.asText() != "character-basic") return null
+
+            val ocid = node.get("key")?.asText() ?: return null
+            val body = node.get("body") ?: return null
+
+            val userIgn = body.get("character_name")?.asText() ?: return null
+            val worldName = body.get("world_name")?.asText()
+            val characterClass = body.get("character_class")?.asText()
+            val characterLevel = body.get("character_level")?.asInt()
+            val guildName = body.get("guild_name")?.asText()
+
+            val bodyJson = objectMapper.writeValueAsString(body)
+            val compressed = GzipUtils.compress(bodyJson)
+            val hash = sha256Hex(bodyJson.toByteArray(Charsets.UTF_8))
+
+            BasicRecord(
+                userIgn = userIgn,
+                ocid = ocid,
+                worldName = worldName,
+                characterClass = characterClass,
+                characterLevel = characterLevel,
+                guildName = guildName,
+                compressedBody = compressed,
+                bodyHash = hash,
+            )
+        }.getOrNull()
+    }
+
+    private fun sha256Hex(input: ByteArray): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(input)
+        return digest.joinToString("") { "%02x".format(it) }
+    }
+}

--- a/module-synchronizer/src/main/resources/application.yml
+++ b/module-synchronizer/src/main/resources/application.yml
@@ -44,6 +44,8 @@ synchronizer:
     basic-chunk-ready-topic: external-api.snapshot.chunk-ready
     consumer-group-id: synchronizer-result-chunk-consumer
     basic-consumer-group-id: synchronizer-basic-chunk-consumer
+    urgent-basic-chunk-ready-topic: external-api.urgent.snapshot.chunk-ready
+    urgent-basic-consumer-group-id: synchronizer-urgent-basic-chunk-consumer
   store:
     base-path: ../module-external-api/external-api-data
   chunk:

--- a/module-synchronizer/src/main/resources/application.yml
+++ b/module-synchronizer/src/main/resources/application.yml
@@ -41,7 +41,9 @@ spring:
 synchronizer:
   kafka:
     result-chunk-ready-topic: calculator.result.chunk-ready
+    basic-chunk-ready-topic: external-api.snapshot.chunk-ready
     consumer-group-id: synchronizer-result-chunk-consumer
+    basic-consumer-group-id: synchronizer-basic-chunk-consumer
   store:
     base-path: ../module-external-api/external-api-data
   chunk:


### PR DESCRIPTION
## Summary
- Rebuild V6 urgent status polling and Kafka urgent pipeline on top of restored PR 825 develop state
- Restore referenced PR 826/828/829/830/831/833 behavior without dropping external-api/calculator/synchronizer modules
- Add cleanup fixes for integration conflicts and duplicate IGN masking helper

## Verification
- `./gradlew :module-rest-controller:compileKotlin :module-external-api:compileKotlin :module-calculator:compileKotlin :module-synchronizer:compileKotlin --continue`
- 30-minute E2E run with `:module-external-api:bootRun`, `:module-calculator:bootRun`, `:module-synchronizer:bootRun`
- Health stayed UP on 8081/8082/8083 through final monitor sample
- Observed character-basic chunk-ready messages and synchronizer batch upserts through `part-000099`

## Notes
- Initial external-api boot failed without env in the temporary worktree; restarted with repo `.env` and completed the 30-minute monitor.
- Nexon OCID lookup produced expected invalid-IGN 400 responses for some CSV rows; services stayed running and downstream character-basic sync progressed.