### PR TITLE
Tune external-api Nexon async fetch pipeline

### DIFF
--- a/.claude/rules/async-patterns.md
+++ b/.claude/rules/async-patterns.md
@@ -4,6 +4,29 @@
 
 서버 코드(Controller, Service, Worker)에서 `join()`, `get()`, `runBlocking` 사용 금지.
 
+### CompletableFuture + blocking anti-pattern
+
+`CompletableFuture`를 만든 뒤 같은 실행 흐름에서 `join()`/`get()`으로 기다리는 코드는 **비동기 + 블로킹 혼합 안티패턴**이다.
+이 패턴은 WebClient/Reactor Netty의 async contract를 깨고, 가상 스레드나 worker thread를 대기 상태로 묶어 TCP read drain, connection pool 회전, Kafka worker 처리량을 모두 악화시킬 수 있다.
+
+**금지 예시:**
+
+```kotlin
+val future = webClientCall()
+val body = future.join()
+sink.submit(body)
+```
+
+**허용 패턴:**
+
+```kotlin
+webClientCall()
+    .thenAcceptAsync({ body -> sink.submit(body) }, boundedExecutor)
+    .whenComplete { _, ex -> lifecycleCleanup(ex) }
+```
+
+원칙: `CompletableFuture` 결과가 필요하면 기다리지 말고 `thenApply`, `thenCompose`, `thenAcceptAsync`, `handle`, `whenComplete`로 다음 작업을 연결한다.
+
 **금지 패턴:**
 - `thread.join()` / `future.join()` / `future.get()` — 스레드 블로킹
 - `runBlocking { }` — 코루틴 장점 상실, blocking 세계로 회귀

--- a/docs/01_ADR/ADR-717-external-api-nexon-throughput-tuning.md
+++ b/docs/01_ADR/ADR-717-external-api-nexon-throughput-tuning.md
@@ -1,0 +1,102 @@
+# ADR-717: External API Nexon Throughput Tuning
+
+- Status: Accepted
+- Date: 2026-05-17
+- Owner: Backend
+
+---
+
+## 1. Background / Problem
+
+### Background
+
+- `module-external-api` fetches large Nexon `ITEM_EQUIPMENT` payloads through WebClient/Reactor Netty.
+- `ITEM_EQUIPMENT` is the meaningful production load path; `CHARACTER_BASIC` is small and can hide the real bottleneck.
+- The urgent Kafka pipeline depends on this stage draining steadily before calculator and synchronizer can keep up.
+
+### Problem
+
+- The previous default connection pool was too small for sustained `ITEM_EQUIPMENT` collection.
+- Raising only the rate limit above the connection pool's stable capacity creates pending connection pressure without reaching the configured rate.
+- Sink submit time was negligible, so tuning should start with HTTP connection pool and external API rate, not storage writer changes.
+
+### Goal
+
+- Make the default external-api runtime use the observed stable operating point.
+- Keep the values externally overrideable for future load tests and production tuning.
+- Preserve before/after evidence for later TCP/read-path or async-contract work.
+
+---
+
+## 2. Decision
+
+> Run the Nexon snapshot fetch path with a default HTTP connection pool of 150 and default `ITEM_EQUIPMENT` fetch rate of 250 requests per second.
+
+```text
+NEXON_HTTP_MAX_CONNECTIONS default: 150
+external-api.rate-limit.permits-per-second default: 250
+```
+
+The rate remains configurable through `EXTERNAL_API_RATE_LIMIT_PERMITS_PER_SECOND`.
+The pool remains configurable through `NEXON_HTTP_MAX_CONNECTIONS`.
+
+---
+
+## 3. Trade-offs
+
+### Sensitivity
+
+* Nexon `ITEM_EQUIPMENT` response size, commonly around 200KB+.
+* Nexon external latency and tail response distribution.
+* Reactor Netty connection pool active/pending count.
+* Kafka chunk-ready throughput after snapshot files are written.
+* JVM heap and network bandwidth under larger response volume.
+
+### Trade-off
+
+| 선택 | 얻는 것 | 포기한 것 |
+| -- | ---- | ----- |
+| Pool 150 / rate 250 default | Stable pressure point close to measured capacity | Does not chase configured 300/s |
+| Keep `.join()` path unchanged | Avoids behavior change in snapshot pipeline | Blocking join may become next bottleneck after HTTP pool is no longer saturated |
+| Keep sink architecture unchanged | Avoids unnecessary writer complexity | Does not decouple fetch and disk/Kafka publication yet |
+
+### Risk
+
+* Actual production throughput may vary with Nexon latency and response size.
+* Pool 150 can still saturate under `ITEM_EQUIPMENT`; pending connections must be monitored.
+* If pool pressure drops after future improvements, `.join()` and batch wait may become the next bottleneck.
+
+### Non-Risk
+
+* Snapshot sink submit is not the current bottleneck; observed submit time was near zero.
+* `CHARACTER_BASIC` throughput is not a useful proxy for production pressure.
+* Pool 200 did not prove better during the sampled run and should not be the default.
+
+---
+
+## 4. Result / Evidence
+
+### Metrics
+
+| Metric | Value | Notes |
+| ------ | ----: | ----- |
+| Pool 50 / rate 200 body avg | ~510ms | Pool active 50/50, pending observed |
+| Pool 100 / rate 200 throughput | ~200/s | Reached configured cap |
+| Pool 150 / rate 300 throughput | ~220-235/s | Pool often 150/150 with pending |
+| Pool 200 / rate 300 early throughput | ~180/s | Unstable early run; pool snapshots alternated saturated and idle |
+| Pool 150 / rate 250 throughput | ~215/s | Sample0->4: 51,759 item-equipment responses over 241s |
+| Pool 150 / rate 250 pool state | 150/150 active with pending in hot samples | Pending 68-83 observed in early samples |
+| Sink submit avg | <0.01ms | Not the limiting stage in sampled runs |
+
+### Observed Result
+
+* Increasing pool from 50 to 100 removed the first connection bottleneck and allowed the configured 200/s rate.
+* Increasing target rate to 300/s did not produce 300/s actual throughput.
+* Pool 150 with rate 250 keeps pressure controlled while matching the observed stable band.
+* The next investigation should use pool/rate metrics plus body-received latency before changing the async contract.
+
+---
+
+## 5. Summary
+
+> Default external-api Nexon fetch tuning is pool 150 and rate 250 because measured `ITEM_EQUIPMENT` throughput stabilized around 215-235/s and sink work was not the bottleneck.

--- a/module-external-api/src/main/kotlin/maple/externalapi/ExternalApiApplication.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/ExternalApiApplication.kt
@@ -1,5 +1,6 @@
 package maple.externalapi
 
+import maple.externalapi.config.NexonHttpClientProperties
 import maple.externalapi.snapshot.SnapshotChunkingProperties
 import maple.externalapi.snapshot.event.SnapshotEventProperties
 import org.springframework.boot.autoconfigure.SpringBootApplication
@@ -10,7 +11,7 @@ import org.springframework.scheduling.annotation.EnableScheduling
 @SpringBootApplication(scanBasePackages = ["maple.externalapi", "maple.expectation.infrastructure.executor"])
 @Import(maple.expectation.infrastructure.config.ExecutorConfig::class)
 @EnableScheduling
-@EnableConfigurationProperties(SnapshotChunkingProperties::class, SnapshotEventProperties::class)
+@EnableConfigurationProperties(SnapshotChunkingProperties::class, SnapshotEventProperties::class, NexonHttpClientProperties::class)
 class ExternalApiApplication
 
 fun main(args: Array<String>) {

--- a/module-external-api/src/main/kotlin/maple/externalapi/config/NexonHttpClientProperties.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/config/NexonHttpClientProperties.kt
@@ -5,7 +5,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties(prefix = "nexon.http-client")
 data class NexonHttpClientProperties(
     val poolName: String = "nexon-pool",
-    val maxConnections: Int = 50,
+    val maxConnections: Int = 150,
     val pendingAcquireMaxCount: Int = 1000,
     val pendingAcquireTimeoutMs: Long = 5000,
     val connectTimeoutMs: Int = 3000,

--- a/module-external-api/src/main/kotlin/maple/externalapi/config/NexonHttpClientProperties.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/config/NexonHttpClientProperties.kt
@@ -1,0 +1,15 @@
+package maple.externalapi.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "nexon.http-client")
+data class NexonHttpClientProperties(
+    val poolName: String = "nexon-pool",
+    val maxConnections: Int = 50,
+    val pendingAcquireMaxCount: Int = 1000,
+    val pendingAcquireTimeoutMs: Long = 5000,
+    val connectTimeoutMs: Int = 3000,
+    val responseTimeoutSeconds: Long = 5,
+    val maxInMemorySizeBytes: Int = 2 * 1024 * 1024,
+    val metricsEnabled: Boolean = true,
+)

--- a/module-external-api/src/main/kotlin/maple/externalapi/infra/nexon/NexonExternalApiClientAdapter.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/infra/nexon/NexonExternalApiClientAdapter.kt
@@ -2,10 +2,13 @@ package maple.externalapi.infra.nexon
 
 import io.netty.channel.ChannelOption
 import java.time.Duration
+import java.time.Instant
 import java.util.concurrent.CompletableFuture
+import maple.externalapi.config.NexonHttpClientProperties
 import maple.externalapi.domain.ExternalApiEndpoint
 import maple.externalapi.domain.ExternalApiProvider
 import maple.externalapi.domain.KeyType
+import maple.externalapi.metrics.SnapshotFetchMetrics
 import maple.externalapi.port.out.ExternalApiClientPort
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
@@ -17,11 +20,14 @@ import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import org.springframework.web.util.DefaultUriBuilderFactory
 import reactor.netty.http.client.HttpClient
+import reactor.netty.resources.ConnectionProvider
 
 @Component
 class NexonExternalApiClientAdapter(
     @Value("\${nexon.api.key}")
     private val apiKey: String,
+    private val properties: NexonHttpClientProperties,
+    private val fetchMetrics: SnapshotFetchMetrics,
 ) : ExternalApiClientPort {
 
     private val log = LoggerFactory.getLogger(NexonExternalApiClientAdapter::class.java)
@@ -30,16 +36,35 @@ class NexonExternalApiClientAdapter(
         val factory = DefaultUriBuilderFactory("https://open.api.nexon.com")
         factory.encodingMode = DefaultUriBuilderFactory.EncodingMode.VALUES_ONLY
 
-        val httpClient = HttpClient.create()
-            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 3000)
-            .responseTimeout(Duration.ofSeconds(5))
+        val provider = ConnectionProvider.builder(properties.poolName)
+            .maxConnections(properties.maxConnections)
+            .pendingAcquireMaxCount(properties.pendingAcquireMaxCount)
+            .pendingAcquireTimeout(Duration.ofMillis(properties.pendingAcquireTimeoutMs))
+            .metrics(properties.metricsEnabled)
+            .build()
+
+        log.info(
+            "[NexonAdapter] http client pool configured: name={}, maxConnections={}, pendingAcquireMaxCount={}, pendingAcquireTimeoutMs={}, connectTimeoutMs={}, responseTimeoutSeconds={}, metricsEnabled={}",
+            properties.poolName,
+            properties.maxConnections,
+            properties.pendingAcquireMaxCount,
+            properties.pendingAcquireTimeoutMs,
+            properties.connectTimeoutMs,
+            properties.responseTimeoutSeconds,
+            properties.metricsEnabled,
+        )
+
+        val httpClient = HttpClient.create(provider)
+            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, properties.connectTimeoutMs)
+            .responseTimeout(Duration.ofSeconds(properties.responseTimeoutSeconds))
+            .metrics(properties.metricsEnabled) { uri -> uri }
 
         WebClient.builder()
             .uriBuilderFactory(factory)
             .baseUrl("https://open.api.nexon.com")
             .clientConnector(ReactorClientHttpConnector(httpClient))
             .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
-            .codecs { it.defaultCodecs().maxInMemorySize(2 * 1024 * 1024) }
+            .codecs { it.defaultCodecs().maxInMemorySize(properties.maxInMemorySizeBytes) }
             .build()
     }
 
@@ -53,6 +78,7 @@ class NexonExternalApiClientAdapter(
             KeyType.OCID -> "ocid"
         }
 
+        val startedAt = Instant.now()
         return webClient.get()
             .uri { builder ->
                 builder
@@ -63,8 +89,32 @@ class NexonExternalApiClientAdapter(
             .header("x-nxopen-api-key", apiKey)
             .retrieve()
             .bodyToMono(ByteArray::class.java)
-            .doOnNext { log.debug("[NexonAdapter] fetch OK: endpoint={}, key={}", endpoint.name, requestKey) }
+            .doOnNext { bodyBytes ->
+                val elapsed = Duration.between(startedAt, Instant.now())
+                fetchMetrics.recordNexonBodyReceived(endpoint.name, elapsed, bodyBytes.size)
+                log.debug(
+                    "[NexonAdapter] body received: endpoint={}, key={}, bytes={}, durationMs={}",
+                    endpoint.name,
+                    requestKey,
+                    bodyBytes.size,
+                    elapsed.toMillis(),
+                )
+            }
+            .doOnError { ex ->
+                if (ex !is WebClientResponseException) {
+                    val elapsed = Duration.between(startedAt, Instant.now())
+                    fetchMetrics.recordNexonFailure(endpoint.name, elapsed)
+                    log.warn(
+                        "[NexonAdapter] fetch failed: endpoint={}, key={}, durationMs={}, error={}",
+                        endpoint.name,
+                        requestKey,
+                        elapsed.toMillis(),
+                        ex.message,
+                    )
+                }
+            }
             .onErrorResume(WebClientResponseException::class.java) { ex ->
+                fetchMetrics.recordNexonFailure(endpoint.name, Duration.between(startedAt, Instant.now()))
                 log.warn("[NexonAdapter] fetch failed: endpoint={}, key={}, status={}, body={}", endpoint.name, requestKey, ex.statusCode, ex.responseBodyAsString)
                 throw ex
             }

--- a/module-external-api/src/main/kotlin/maple/externalapi/metrics/SnapshotFetchMetrics.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/metrics/SnapshotFetchMetrics.kt
@@ -1,0 +1,52 @@
+package maple.externalapi.metrics
+
+import io.micrometer.core.instrument.DistributionSummary
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Timer
+import org.springframework.stereotype.Component
+import java.time.Duration
+
+@Component
+class SnapshotFetchMetrics(private val registry: MeterRegistry) {
+
+    fun recordNexonBodyReceived(endpoint: String, duration: Duration, bytes: Int) {
+        timer("external_api_nexon_body_received_seconds", endpoint)
+            .record(duration)
+        summary("external_api_nexon_response_bytes", endpoint)
+            .record(bytes.toDouble())
+    }
+
+    fun recordNexonFailure(endpoint: String, duration: Duration) {
+        timer("external_api_nexon_failure_seconds", endpoint)
+            .record(duration)
+    }
+
+    fun recordFetchJoin(endpoint: String, duration: Duration) {
+        timer("external_api_snapshot_fetch_join_seconds", endpoint)
+            .record(duration)
+    }
+
+    fun recordSinkSubmit(endpoint: String, duration: Duration, queueDepthBeforeSubmit: Int) {
+        timer("external_api_snapshot_sink_submit_seconds", endpoint)
+            .record(duration)
+        summary("external_api_snapshot_sink_queue_depth", endpoint)
+            .record(queueDepthBeforeSubmit.toDouble())
+    }
+
+    fun recordBatchWait(endpoint: String, duration: Duration, size: Int) {
+        timer("external_api_snapshot_batch_wait_seconds", endpoint)
+            .record(duration)
+        summary("external_api_snapshot_batch_size", endpoint)
+            .record(size.toDouble())
+    }
+
+    private fun timer(name: String, endpoint: String): Timer =
+        Timer.builder(name)
+            .tag("endpoint", endpoint)
+            .register(registry)
+
+    private fun summary(name: String, endpoint: String): DistributionSummary =
+        DistributionSummary.builder(name)
+            .tag("endpoint", endpoint)
+            .register(registry)
+}

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/ExternalApiScheduler.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/ExternalApiScheduler.kt
@@ -51,41 +51,64 @@ class ExternalApiScheduler(
             log.warn("[Scheduler] could not acquire lock for daily refresh, skipping")
             return
         }
-        try {
-            if (skipCharacterBasic) {
-                log.info("[Scheduler] skip-character-basic enabled, loading OCID cache from existing data")
-                ocidCacheProvider.refresh()
-            } else {
-                ocidLookupPhase.execute(executor)
+        if (skipCharacterBasic) {
+            log.info("[Scheduler] skip-character-basic enabled, loading OCID cache from existing data")
+            ocidCacheProvider.refresh()
+            running.set(false)
+            return
+        }
+
+        ocidLookupPhase.execute(executor)
+            .thenCompose {
                 val cache = ocidCacheProvider.refresh()
                 snapshotFetchPhase.executeCharacterBasic(executor, cache)
             }
-        } finally {
-            running.set(false)
-        }
+            .whenComplete { _, ex ->
+                if (ex != null) {
+                    log.error("[Scheduler] daily refresh failed", ex)
+                }
+                running.set(false)
+            }
     }
 
     private fun runItemEquipmentLoop() {
         log.info("[Scheduler] ITEM_EQUIPMENT continuous loop started")
-        while (!shutdown.get()) {
-            val entries = ocidCacheProvider.current().entries.toList()
-            if (entries.isEmpty()) {
-                log.warn("[Scheduler] OCID cache empty, waiting 30s")
+        runItemEquipmentCycle()
+    }
+
+    private fun runItemEquipmentCycle() {
+        if (shutdown.get()) {
+            log.info("[Scheduler] ITEM_EQUIPMENT continuous loop stopped")
+            return
+        }
+
+        val entries = ocidCacheProvider.current().entries.toList()
+        if (entries.isEmpty()) {
+            log.warn("[Scheduler] OCID cache empty, waiting 30s")
+            executor.submit {
                 Thread.sleep(Duration.ofSeconds(30))
                 ocidCacheProvider.refresh()
-                continue
+                runItemEquipmentCycle()
             }
-            if (!acquireLock(120_000)) {
-                Thread.sleep(Duration.ofSeconds(5))
-                continue
-            }
-            try {
-                snapshotFetchPhase.executeItemEquipment(executor, entries)
-            } finally {
-                running.set(false)
-            }
+            return
         }
-        log.info("[Scheduler] ITEM_EQUIPMENT continuous loop stopped")
+
+        if (!acquireLock(120_000)) {
+            executor.submit {
+                Thread.sleep(Duration.ofSeconds(5))
+                runItemEquipmentCycle()
+            }
+            return
+        }
+
+        snapshotFetchPhase.executeItemEquipment(executor, entries)
+            .whenComplete { _, ex ->
+                if (ex != null) {
+                    log.error("[Scheduler] ITEM_EQUIPMENT cycle failed", ex)
+                }
+                running.set(false)
+                executor.submit { runItemEquipmentCycle() }
+            }
     }
 
     private fun acquireLock(timeoutMs: Long): Boolean {

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/OcidLookupPhase.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/OcidLookupPhase.kt
@@ -2,8 +2,6 @@ package maple.externalapi.scheduler.phase
 
 import maple.externalapi.domain.ExternalApiEndpoint
 import maple.externalapi.domain.ExternalApiProvider
-import maple.expectation.infrastructure.executor.LogicExecutor
-import maple.expectation.infrastructure.executor.TaskContext
 import maple.externalapi.port.out.ExternalApiClientPort
 import maple.externalapi.port.out.ExternalApiArtifactStorePort
 import maple.externalapi.reader.UserIgnCsvReader
@@ -12,8 +10,9 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
 import java.time.Instant
-import java.util.concurrent.Callable
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutorService
+import java.util.concurrent.atomic.AtomicInteger
 
 @Component
 @ConditionalOnProperty(name = ["external-api.schedule.enabled"], havingValue = "true")
@@ -21,7 +20,6 @@ class OcidLookupPhase(
     private val clientPort: ExternalApiClientPort,
     private val csvReader: UserIgnCsvReader,
     private val artifactStore: ExternalApiArtifactStorePort,
-    private val executor: LogicExecutor,
     @Value("\${external-api.rate-limit.ocid-lookup-permits-per-second:400}")
     private val ocidLookupPermitsPerSecond: Int,
     @Value("\${external-api.batch-size:1000}")
@@ -31,11 +29,11 @@ class OcidLookupPhase(
 ) {
     private val log = LoggerFactory.getLogger(OcidLookupPhase::class.java)
 
-    fun execute(executor: ExecutorService) {
+    fun execute(workerExecutor: ExecutorService): CompletableFuture<Void> {
         val existingOcids = artifactStore.listStoredKeys(ExternalApiEndpoint.OCID_LOOKUP)
         if (existingOcids.isNotEmpty()) {
             log.info("[Scheduler] OCID lookup already done ({} files), skipping", existingOcids.size)
-            return
+            return CompletableFuture.completedFuture(null)
         }
 
         val rateLimiter = SchedulerPhaseUtils.newRateLimiter(ocidLookupPermitsPerSecond)
@@ -43,7 +41,7 @@ class OcidLookupPhase(
         val igns = csvReader.readAll()
         if (igns.isEmpty()) {
             log.warn("[Scheduler] no IGNs to process")
-            return
+            return CompletableFuture.completedFuture(null)
         }
 
         log.info("[Scheduler] ========== OCID lookup start ==========")
@@ -53,60 +51,80 @@ class OcidLookupPhase(
         )
 
         val start = Instant.now()
-        val successCount = java.util.concurrent.atomic.AtomicInteger(0)
-        val failCount = java.util.concurrent.atomic.AtomicInteger(0)
-        val storedCount = java.util.concurrent.atomic.AtomicInteger(0)
-        var processed = 0
-        var lastProgressLog = 0
+        val successCount = AtomicInteger(0)
+        val failCount = AtomicInteger(0)
+        val storedCount = AtomicInteger(0)
+        val lastProgressLog = AtomicInteger(0)
 
-        while (processed < igns.size) {
-            val permits = SchedulerPhaseUtils.acquirePermits(rateLimiter, batchSize, igns.size - processed)
-            if (permits == 0) continue
+        return processBatch(
+            workerExecutor = workerExecutor,
+            rateLimiter = rateLimiter,
+            igns = igns,
+            processed = 0,
+            successCount = successCount,
+            failCount = failCount,
+            storedCount = storedCount,
+            lastProgressLog = lastProgressLog,
+            start = start,
+        ).whenComplete { _, _ ->
+            SchedulerPhaseUtils.logSummary("OCID lookup", igns.size, successCount.get(), storedCount.get(), failCount.get(), start)
+        }
+    }
 
-            val chunk = igns.subList(processed, processed + permits)
-            processed += permits
-
-            val futures = chunk.map { ign ->
-                executor.submit(Callable { fetchAndStoreOcid(ign, successCount, failCount, storedCount) })
-            }
-
-            futures.forEach { it.get() }
-
-            val progress = successCount.get() + failCount.get()
-            if (progress - lastProgressLog >= 5000) {
-                lastProgressLog = progress
-                SchedulerPhaseUtils.logProgress("OCID lookup", progress, igns.size, storedCount.get(), failCount.get(), start)
-            }
+    private fun processBatch(
+        workerExecutor: ExecutorService,
+        rateLimiter: io.github.bucket4j.Bucket,
+        igns: List<String>,
+        processed: Int,
+        successCount: AtomicInteger,
+        failCount: AtomicInteger,
+        storedCount: AtomicInteger,
+        lastProgressLog: AtomicInteger,
+        start: Instant,
+    ): CompletableFuture<Void> {
+        if (processed >= igns.size) {
+            return CompletableFuture.completedFuture(null)
         }
 
-        SchedulerPhaseUtils.logSummary("OCID lookup", igns.size, successCount.get(), storedCount.get(), failCount.get(), start)
+        val permits = SchedulerPhaseUtils.acquirePermits(rateLimiter, batchSize, igns.size - processed)
+        if (permits == 0) {
+            return processBatch(workerExecutor, rateLimiter, igns, processed, successCount, failCount, storedCount, lastProgressLog, start)
+        }
+
+        val chunk = igns.subList(processed, processed + permits)
+        val futures = chunk.map { ign ->
+            fetchAndStoreOcidAsync(ign, workerExecutor, successCount, failCount, storedCount)
+        }
+
+        return CompletableFuture.allOf(*futures.toTypedArray()).thenCompose {
+            val progress = successCount.get() + failCount.get()
+            if (progress - lastProgressLog.get() >= 5000) {
+                lastProgressLog.set(progress)
+                SchedulerPhaseUtils.logProgress("OCID lookup", progress, igns.size, storedCount.get(), failCount.get(), start)
+            }
+            processBatch(workerExecutor, rateLimiter, igns, processed + permits, successCount, failCount, storedCount, lastProgressLog, start)
+        }
     }
 
-    private fun fetchAndStoreOcid(
+    private fun fetchAndStoreOcidAsync(
         ign: String,
-        successCount: java.util.concurrent.atomic.AtomicInteger,
-        failCount: java.util.concurrent.atomic.AtomicInteger,
-        storedCount: java.util.concurrent.atomic.AtomicInteger,
-    ) {
-        executor.executeWithFallback(
-            { performOcidFetch(ign, successCount, storedCount) },
-            { failCount.incrementAndGet() },
-            TaskContext.of("OcidLookup", "FetchStore", ign),
-        )
-    }
-
-    private fun performOcidFetch(
-        ign: String,
-        successCount: java.util.concurrent.atomic.AtomicInteger,
-        storedCount: java.util.concurrent.atomic.AtomicInteger,
-    ) {
-        val data = clientPort.fetch(
+        workerExecutor: ExecutorService,
+        successCount: AtomicInteger,
+        failCount: AtomicInteger,
+        storedCount: AtomicInteger,
+    ): CompletableFuture<Void> =
+        clientPort.fetch(
             ExternalApiProvider.NEXON,
             ExternalApiEndpoint.OCID_LOOKUP,
             ign,
-        ).join()
-        val payloadRef = artifactStore.store(ExternalApiEndpoint.OCID_LOOKUP, ign, data)
-        successCount.incrementAndGet()
-        if (payloadRef != null) storedCount.incrementAndGet()
-    }
+        )
+            .thenAcceptAsync({ data ->
+                artifactStore.store(ExternalApiEndpoint.OCID_LOOKUP, ign, data)
+                successCount.incrementAndGet()
+                storedCount.incrementAndGet()
+            }, workerExecutor)
+            .handle { _, ex ->
+                if (ex != null) failCount.incrementAndGet()
+                null
+            }
 }

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/SnapshotFetchPhase.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/SnapshotFetchPhase.kt
@@ -5,6 +5,7 @@ import maple.externalapi.domain.ExternalApiProvider
 import maple.expectation.infrastructure.executor.LogicExecutor
 import maple.expectation.infrastructure.executor.TaskContext
 import maple.externalapi.metrics.ExternalApiMetrics
+import maple.externalapi.metrics.SnapshotFetchMetrics
 import maple.externalapi.metrics.SnapshotVolumeMetrics
 import maple.externalapi.port.out.ExternalApiArtifactStorePort
 import maple.externalapi.port.out.ExternalApiClientPort
@@ -44,6 +45,7 @@ class SnapshotFetchPhase(
     private val chunkingProperties: SnapshotChunkingProperties,
     private val volumeMetrics: SnapshotVolumeMetrics,
     private val metrics: ExternalApiMetrics,
+    private val fetchMetrics: SnapshotFetchMetrics,
     private val executor: LogicExecutor,
     @Qualifier("characterBasicSnapshotPublisher")
     private val characterBasicPublisher: SnapshotChunkEventPublisher,
@@ -144,11 +146,25 @@ class SnapshotFetchPhase(
                 val chunk = entries.subList(processed, processed + permits)
                 processed += permits
 
+                val batchWaitStart = Instant.now()
                 val futures = chunk.map { (ign, ocid) ->
                     executor.submit(Callable { fetchSingle(ocid, config, sink, successCount, failCount) })
                 }
 
                 futures.forEach { it.get() }
+                val batchWaitDuration = Duration.between(batchWaitStart, Instant.now())
+                fetchMetrics.recordBatchWait(config.endpoint, batchWaitDuration, chunk.size)
+                if (batchWaitDuration.toMillis() >= 1_000) {
+                    log.info(
+                        "[SnapshotFetchMetrics] batch wait: endpoint={}, runId={}, batchSize={}, durationMs={}, success={}, failed={}",
+                        config.endpoint,
+                        runId,
+                        chunk.size,
+                        batchWaitDuration.toMillis(),
+                        successCount.get(),
+                        failCount.get(),
+                    )
+                }
 
                 val progress = successCount.get() + failCount.get()
                 if (progress - lastProgressLog >= 5000) {
@@ -184,11 +200,17 @@ class SnapshotFetchPhase(
         sink: ChunkedSnapshotSink,
         successCount: AtomicInteger,
     ) {
+        val fetchStart = Instant.now()
         val bodyBytes = clientPort.fetch(
             ExternalApiProvider.NEXON,
             config.apiEndpoint,
             ocid,
         ).join()
+        val fetchDuration = Duration.between(fetchStart, Instant.now())
+        fetchMetrics.recordFetchJoin(config.endpoint, fetchDuration)
+
+        val queueDepthBeforeSubmit = sink.queueDepth()
+        val submitStart = Instant.now()
         sink.submit(
             SnapshotChunkRecord.Success(
                 key = ocid,
@@ -199,6 +221,19 @@ class SnapshotFetchPhase(
                 bodyBytes = bodyBytes,
             ),
         )
+        val submitDuration = Duration.between(submitStart, Instant.now())
+        fetchMetrics.recordSinkSubmit(config.endpoint, submitDuration, queueDepthBeforeSubmit)
+        if (fetchDuration.toMillis() >= 500 || submitDuration.toMillis() >= 100) {
+            log.info(
+                "[SnapshotFetchMetrics] fetch/sink: endpoint={}, ocid={}, responseBytes={}, fetchJoinMs={}, sinkSubmitMs={}, sinkQueueDepthBeforeSubmit={}",
+                config.endpoint,
+                ocid,
+                bodyBytes.size,
+                fetchDuration.toMillis(),
+                submitDuration.toMillis(),
+                queueDepthBeforeSubmit,
+            )
+        }
         successCount.incrementAndGet()
         config.onFetched()
     }

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/SnapshotFetchPhase.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/SnapshotFetchPhase.kt
@@ -2,8 +2,6 @@ package maple.externalapi.scheduler.phase
 
 import maple.externalapi.domain.ExternalApiEndpoint
 import maple.externalapi.domain.ExternalApiProvider
-import maple.expectation.infrastructure.executor.LogicExecutor
-import maple.expectation.infrastructure.executor.TaskContext
 import maple.externalapi.metrics.ExternalApiMetrics
 import maple.externalapi.metrics.SnapshotFetchMetrics
 import maple.externalapi.metrics.SnapshotVolumeMetrics
@@ -22,7 +20,7 @@ import org.springframework.stereotype.Component
 import java.nio.file.Paths
 import java.time.Duration
 import java.time.Instant
-import java.util.concurrent.Callable
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -46,7 +44,6 @@ class SnapshotFetchPhase(
     private val volumeMetrics: SnapshotVolumeMetrics,
     private val metrics: ExternalApiMetrics,
     private val fetchMetrics: SnapshotFetchMetrics,
-    private val executor: LogicExecutor,
     @Qualifier("characterBasicSnapshotPublisher")
     private val characterBasicPublisher: SnapshotChunkEventPublisher,
     private val itemEquipmentPublisher: SnapshotChunkEventPublisher,
@@ -59,9 +56,9 @@ class SnapshotFetchPhase(
 ) {
     private val log = LoggerFactory.getLogger(SnapshotFetchPhase::class.java)
 
-    fun executeCharacterBasic(executor: ExecutorService, ocidCache: Map<String, String>) {
+    fun executeCharacterBasic(workerExecutor: ExecutorService, ocidCache: Map<String, String>): CompletableFuture<Void> =
         execute(
-            executor,
+            workerExecutor,
             ocidCache.entries.toList(),
             SnapshotFetchConfig(
                 endpoint = "character-basic",
@@ -73,11 +70,10 @@ class SnapshotFetchPhase(
                 skipIfExisting = true,
             ),
         )
-    }
 
-    fun executeItemEquipment(executor: ExecutorService, entries: List<Map.Entry<String, String>>) {
+    fun executeItemEquipment(workerExecutor: ExecutorService, entries: List<Map.Entry<String, String>>): CompletableFuture<Void> =
         execute(
-            executor,
+            workerExecutor,
             entries,
             SnapshotFetchConfig(
                 endpoint = "item-equipment",
@@ -88,24 +84,23 @@ class SnapshotFetchPhase(
                 recordDuration = { metrics.itemEquipmentTimer().record(it) },
             ),
         )
-    }
 
     private fun execute(
-        executor: ExecutorService,
+        workerExecutor: ExecutorService,
         entries: List<Map.Entry<String, String>>,
         config: SnapshotFetchConfig,
-    ) {
+    ): CompletableFuture<Void> {
         if (config.skipIfExisting) {
             val existing = artifactStore.listStoredKeys(config.apiEndpoint)
             if (existing.isNotEmpty()) {
                 log.info("[Scheduler] {} already done ({} files), skipping", config.endpoint, existing.size)
-                return
+                return CompletableFuture.completedFuture(null)
             }
         }
 
         if (entries.isEmpty()) {
             log.warn("[Scheduler] OCID cache empty, skipping {}", config.endpoint)
-            return
+            return CompletableFuture.completedFuture(null)
         }
 
         val runId = SchedulerPhaseUtils.newRunId()
@@ -135,77 +130,112 @@ class SnapshotFetchPhase(
         val start = Instant.now()
         val successCount = AtomicInteger(0)
         val failCount = AtomicInteger(0)
-        var processed = 0
-        var lastProgressLog = 0
+        val lastProgressLog = AtomicInteger(0)
 
-        try {
-            while (processed < entries.size) {
-                val permits = SchedulerPhaseUtils.acquirePermits(rateLimiter, batchSize, entries.size - processed)
-                if (permits == 0) continue
-
-                val chunk = entries.subList(processed, processed + permits)
-                processed += permits
-
-                val batchWaitStart = Instant.now()
-                val futures = chunk.map { (ign, ocid) ->
-                    executor.submit(Callable { fetchSingle(ocid, config, sink, successCount, failCount) })
-                }
-
-                futures.forEach { it.get() }
-                val batchWaitDuration = Duration.between(batchWaitStart, Instant.now())
-                fetchMetrics.recordBatchWait(config.endpoint, batchWaitDuration, chunk.size)
-                if (batchWaitDuration.toMillis() >= 1_000) {
-                    log.info(
-                        "[SnapshotFetchMetrics] batch wait: endpoint={}, runId={}, batchSize={}, durationMs={}, success={}, failed={}",
-                        config.endpoint,
-                        runId,
-                        chunk.size,
-                        batchWaitDuration.toMillis(),
-                        successCount.get(),
-                        failCount.get(),
-                    )
-                }
-
-                val progress = successCount.get() + failCount.get()
-                if (progress - lastProgressLog >= 5000) {
-                    lastProgressLog = progress
-                    SchedulerPhaseUtils.logProgress(config.endpoint, progress, entries.size, successCount.get(), failCount.get(), start)
-                }
-            }
-        } finally {
+        return processBatch(
+            workerExecutor = workerExecutor,
+            rateLimiter = rateLimiter,
+            entries = entries,
+            processed = 0,
+            config = config,
+            sink = sink,
+            runId = runId,
+            successCount = successCount,
+            failCount = failCount,
+            lastProgressLog = lastProgressLog,
+            start = start,
+        ).whenComplete { _, _ ->
             sink.close()
+            config.recordDuration(Duration.between(start, Instant.now()))
+            SchedulerPhaseUtils.logSummary(config.endpoint, entries.size, successCount.get(), successCount.get(), failCount.get(), start)
         }
-
-        config.recordDuration(Duration.between(start, Instant.now()))
-        SchedulerPhaseUtils.logSummary(config.endpoint, entries.size, successCount.get(), successCount.get(), failCount.get(), start)
     }
 
-    private fun fetchSingle(
-        ocid: String,
+    private fun processBatch(
+        workerExecutor: ExecutorService,
+        rateLimiter: io.github.bucket4j.Bucket,
+        entries: List<Map.Entry<String, String>>,
+        processed: Int,
         config: SnapshotFetchConfig,
         sink: ChunkedSnapshotSink,
+        runId: String,
         successCount: AtomicInteger,
         failCount: AtomicInteger,
-    ) {
-        executor.executeWithFallback(
-            { performSnapshotFetch(ocid, config, sink, successCount) },
-            { ex -> handleSnapshotFailure(ocid, config, sink, failCount, ex) },
-            TaskContext.of("SnapshotFetch", "FetchSingle", ocid),
-        )
+        lastProgressLog: AtomicInteger,
+        start: Instant,
+    ): CompletableFuture<Void> {
+        if (processed >= entries.size) {
+            return CompletableFuture.completedFuture(null)
+        }
+
+        val permits = SchedulerPhaseUtils.acquirePermits(rateLimiter, batchSize, entries.size - processed)
+        if (permits == 0) {
+            return processBatch(workerExecutor, rateLimiter, entries, processed, config, sink, runId, successCount, failCount, lastProgressLog, start)
+        }
+
+        val chunk = entries.subList(processed, processed + permits)
+        val batchWaitStart = Instant.now()
+        val futures = chunk.map { (_, ocid) ->
+            fetchSingleAsync(ocid, config, sink, workerExecutor, successCount, failCount)
+        }
+
+        return CompletableFuture.allOf(*futures.toTypedArray()).thenCompose {
+            val batchWaitDuration = Duration.between(batchWaitStart, Instant.now())
+            fetchMetrics.recordBatchWait(config.endpoint, batchWaitDuration, chunk.size)
+            if (batchWaitDuration.toMillis() >= 1_000) {
+                log.info(
+                    "[SnapshotFetchMetrics] batch wait: endpoint={}, runId={}, batchSize={}, durationMs={}, success={}, failed={}",
+                    config.endpoint,
+                    runId,
+                    chunk.size,
+                    batchWaitDuration.toMillis(),
+                    successCount.get(),
+                    failCount.get(),
+                )
+            }
+
+            val progress = successCount.get() + failCount.get()
+            if (progress - lastProgressLog.get() >= 5000) {
+                lastProgressLog.set(progress)
+                SchedulerPhaseUtils.logProgress(config.endpoint, progress, entries.size, successCount.get(), failCount.get(), start)
+            }
+            processBatch(workerExecutor, rateLimiter, entries, processed + permits, config, sink, runId, successCount, failCount, lastProgressLog, start)
+        }
     }
 
-    private fun performSnapshotFetch(
+    private fun fetchSingleAsync(
         ocid: String,
         config: SnapshotFetchConfig,
         sink: ChunkedSnapshotSink,
+        workerExecutor: ExecutorService,
         successCount: AtomicInteger,
-    ) {
+        failCount: AtomicInteger,
+    ): CompletableFuture<Void> {
         val fetchStart = Instant.now()
-        val bodyBytes = clientPort.fetch(
+        return clientPort.fetch(
             ExternalApiProvider.NEXON,
             config.apiEndpoint,
             ocid,
-        ).join()
+        )
+            .thenAcceptAsync({ bodyBytes ->
+                handleSnapshotSuccess(ocid, config, sink, successCount, fetchStart, bodyBytes)
+            }, workerExecutor)
+            .handle { _, ex ->
+                if (ex != null) {
+                    handleSnapshotFailure(ocid, config, sink, failCount, ex)
+                }
+                null
+            }
+    }
+
+    private fun handleSnapshotSuccess(
+        ocid: String,
+        config: SnapshotFetchConfig,
+        sink: ChunkedSnapshotSink,
+        successCount: AtomicInteger,
+        fetchStart: Instant,
+        bodyBytes: ByteArray,
+    ) {
         val fetchDuration = Duration.between(fetchStart, Instant.now())
         fetchMetrics.recordFetchJoin(config.endpoint, fetchDuration)
 

--- a/module-external-api/src/main/kotlin/maple/externalapi/snapshot/ChunkedSnapshotSink.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/snapshot/ChunkedSnapshotSink.kt
@@ -69,6 +69,8 @@ class ChunkedSnapshotSink(
         }
     }
 
+    fun queueDepth(): Int = queue.size
+
     fun close() {
         accepting.set(false)
         if (!queue.offer(SnapshotChunkRecord.CloseSignal, 30, java.util.concurrent.TimeUnit.SECONDS)) {

--- a/module-external-api/src/main/kotlin/maple/externalapi/snapshot/event/KafkaSnapshotChunkEventPublisher.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/snapshot/event/KafkaSnapshotChunkEventPublisher.kt
@@ -3,7 +3,6 @@ package maple.externalapi.snapshot.event
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.slf4j.LoggerFactory
 import org.springframework.kafka.core.KafkaTemplate
-import java.util.concurrent.TimeUnit
 
 class KafkaSnapshotChunkEventPublisher(
     private val kafkaTemplate: KafkaTemplate<String, String>,
@@ -17,21 +16,36 @@ class KafkaSnapshotChunkEventPublisher(
     override fun publishChunkReady(event: SnapshotChunkReadyEvent) {
         val key = "${event.runId}:${event.endpoint}:${event.chunkId}"
         val payload = objectMapper.writeValueAsString(event)
-        kafkaTemplate.send(chunkReadyTopic, key, payload).get(30, TimeUnit.SECONDS)
-        log.info("[Event] published chunk-ready: runId={} endpoint={} chunkId={}", event.runId, event.endpoint, event.chunkId)
+        kafkaTemplate.send(chunkReadyTopic, key, payload).whenComplete { _, ex ->
+            if (ex != null) {
+                log.warn("[Event] failed chunk-ready: runId={} endpoint={} chunkId={} error={}", event.runId, event.endpoint, event.chunkId, ex.message)
+            } else {
+                log.info("[Event] published chunk-ready: runId={} endpoint={} chunkId={}", event.runId, event.endpoint, event.chunkId)
+            }
+        }
     }
 
     override fun publishRunCompleted(event: SnapshotRunCompletedEvent) {
         val key = "${event.runId}:${event.endpoint}"
         val payload = objectMapper.writeValueAsString(event)
-        kafkaTemplate.send(runCompletedTopic, key, payload).get(30, TimeUnit.SECONDS)
-        log.info("[Event] published run-completed: runId={} endpoint={} chunks={}", event.runId, event.endpoint, event.chunkCount)
+        kafkaTemplate.send(runCompletedTopic, key, payload).whenComplete { _, ex ->
+            if (ex != null) {
+                log.warn("[Event] failed run-completed: runId={} endpoint={} error={}", event.runId, event.endpoint, ex.message)
+            } else {
+                log.info("[Event] published run-completed: runId={} endpoint={} chunks={}", event.runId, event.endpoint, event.chunkCount)
+            }
+        }
     }
 
     override fun publishRunFailed(event: SnapshotRunFailedEvent) {
         val key = "${event.runId}:${event.endpoint}"
         val payload = objectMapper.writeValueAsString(event)
-        kafkaTemplate.send(runFailedTopic, key, payload).get(30, TimeUnit.SECONDS)
-        log.info("[Event] published run-failed: runId={} endpoint={}", event.runId, event.endpoint)
+        kafkaTemplate.send(runFailedTopic, key, payload).whenComplete { _, ex ->
+            if (ex != null) {
+                log.warn("[Event] failed run-failed: runId={} endpoint={} error={}", event.runId, event.endpoint, ex.message)
+            } else {
+                log.info("[Event] published run-failed: runId={} endpoint={}", event.runId, event.endpoint)
+            }
+        }
     }
 }

--- a/module-external-api/src/main/kotlin/maple/externalapi/urgent/UrgentCharacterRequestConsumer.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/urgent/UrgentCharacterRequestConsumer.kt
@@ -1,5 +1,6 @@
 package maple.externalapi.urgent
 
+import jakarta.annotation.PreDestroy
 import com.fasterxml.jackson.databind.ObjectMapper
 import maple.externalapi.domain.ExternalApiEndpoint
 import maple.externalapi.domain.ExternalApiProvider
@@ -18,8 +19,9 @@ import org.springframework.stereotype.Component
 import java.nio.file.Files
 import java.nio.file.Path
 import java.time.Instant
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executors
 import java.util.UUID
-import java.util.concurrent.TimeUnit
 
 @Component
 @ConditionalOnProperty(
@@ -39,6 +41,7 @@ class UrgentCharacterRequestConsumer(
     private val storeBasePath: String,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
+    private val workerExecutor = Executors.newVirtualThreadPerTaskExecutor()
 
     @KafkaListener(
         topics = ["\${external-api.urgent.request-topic}"],
@@ -48,125 +51,133 @@ class UrgentCharacterRequestConsumer(
         val request = objectMapper.readValue(message, UrgentCharacterRequest::class.java)
         log.info("[Urgent] received: userIgn={}", maskIgn(request.userIgn))
 
-        processUrgentCharacter(request)
-
-        acknowledgment.acknowledge()
-        log.info("[Urgent] completed: userIgn={}", maskIgn(request.userIgn))
+        processUrgentCharacterAsync(request)
+            .whenComplete { _, ex ->
+                if (ex != null) {
+                    log.error("[Urgent] failed: userIgn={}", maskIgn(request.userIgn), ex)
+                } else {
+                    acknowledgment.acknowledge()
+                    log.info("[Urgent] completed: userIgn={}", maskIgn(request.userIgn))
+                }
+            }
     }
 
-    private fun processUrgentCharacter(request: UrgentCharacterRequest) {
-        val ocidData = clientPort.fetch(
+    private fun processUrgentCharacterAsync(request: UrgentCharacterRequest): CompletableFuture<Void> =
+        clientPort.fetch(
             ExternalApiProvider.NEXON,
             ExternalApiEndpoint.OCID_LOOKUP,
             request.userIgn,
-        ).join()
-
-        val ocidNode = objectMapper.readTree(ocidData).get("ocid")
-        if (ocidNode == null || ocidNode.isNull) {
-            log.info("[Urgent] OCID not found: userIgn={}", maskIgn(request.userIgn))
-            publishNotFound(request.userIgn)
-            return
-        }
-
-        val ocid = ocidNode.asText()
-        log.info("[Urgent] OCID resolved: userIgn={}", maskIgn(request.userIgn))
-
-        val basicFuture = clientPort.fetch(
-            ExternalApiProvider.NEXON,
-            ExternalApiEndpoint.CHARACTER_BASIC,
-            ocid,
         )
-        val equipmentFuture = clientPort.fetch(
-            ExternalApiProvider.NEXON,
-            ExternalApiEndpoint.ITEM_EQUIPMENT,
-            ocid,
-        )
+            .thenComposeAsync({ ocidData ->
+                val ocidNode = objectMapper.readTree(ocidData).get("ocid")
+                if (ocidNode == null || ocidNode.isNull) {
+                    log.info("[Urgent] OCID not found: userIgn={}", maskIgn(request.userIgn))
+                    return@thenComposeAsync publishNotFoundAsync(request.userIgn)
+                }
 
-        val basicData = basicFuture.join()
-        val equipmentData = equipmentFuture.join()
+                val ocid = ocidNode.asText()
+                log.info("[Urgent] OCID resolved: userIgn={}", maskIgn(request.userIgn))
 
+                val basicFuture = clientPort.fetch(
+                    ExternalApiProvider.NEXON,
+                    ExternalApiEndpoint.CHARACTER_BASIC,
+                    ocid,
+                )
+                val equipmentFuture = clientPort.fetch(
+                    ExternalApiProvider.NEXON,
+                    ExternalApiEndpoint.ITEM_EQUIPMENT,
+                    ocid,
+                )
+
+                basicFuture.thenCompose { basicData ->
+                    equipmentFuture.thenComposeAsync({ equipmentData ->
+                        publishUrgentChunksAsync(request, basicData, equipmentData)
+                    }, workerExecutor)
+                }
+            }, workerExecutor)
+
+    private fun publishUrgentChunksAsync(
+        request: UrgentCharacterRequest,
+        basicData: ByteArray,
+        equipmentData: ByteArray,
+    ): CompletableFuture<Void> {
         val runId = "urgent-${UUID.randomUUID()}"
 
-        publishUrgentChunk(
-            runId = runId,
-            endpoint = ExternalApiEndpoint.CHARACTER_BASIC,
-            userIgn = request.userIgn,
-            data = basicData,
-            keyType = "OCID",
-        )
-        publishUrgentChunk(
-            runId = runId,
-            endpoint = ExternalApiEndpoint.ITEM_EQUIPMENT,
-            userIgn = request.userIgn,
-            data = equipmentData,
-            keyType = "OCID",
-        )
-
-        log.info(
-            "[Urgent] data fetch complete: userIgn={}, runId={}",
-            maskIgn(request.userIgn),
-            runId,
-        )
+        return publishUrgentChunkAsync(runId, ExternalApiEndpoint.CHARACTER_BASIC, request.userIgn, basicData, "OCID")
+            .thenCompose { publishUrgentChunkAsync(runId, ExternalApiEndpoint.ITEM_EQUIPMENT, request.userIgn, equipmentData, "OCID") }
+            .thenAccept {
+                log.info(
+                    "[Urgent] data fetch complete: userIgn={}, runId={}",
+                    maskIgn(request.userIgn),
+                    runId,
+                )
+            }
     }
 
-    private fun publishUrgentChunk(
+    private fun publishUrgentChunkAsync(
         runId: String,
         endpoint: ExternalApiEndpoint,
         userIgn: String,
         data: ByteArray,
         keyType: String,
-    ) {
-        val endpointDir = endpoint.storageSubDir()
-        val chunksDir = Path.of(storeBasePath, "runs", runId, endpointDir, "chunks")
-        Files.createDirectories(chunksDir)
+    ): CompletableFuture<Void> =
+        CompletableFuture.supplyAsync({
+            val endpointDir = endpoint.storageSubDir()
+            val chunksDir = Path.of(storeBasePath, "runs", runId, endpointDir, "chunks")
+            Files.createDirectories(chunksDir)
 
-        val writer = GzipJsonlChunkWriter(chunksDir, 1, 1, Long.MAX_VALUE, objectMapper)
-        writer.append(
-            SnapshotChunkRecord.Success(
-                key = userIgn,
+            val writer = GzipJsonlChunkWriter(chunksDir, 1, 1, Long.MAX_VALUE, objectMapper)
+            writer.append(
+                SnapshotChunkRecord.Success(
+                    key = userIgn,
+                    endpoint = endpointDir,
+                    keyType = keyType,
+                    httpStatus = 200,
+                    fetchedAt = Instant.now(),
+                    bodyBytes = data,
+                ),
+            )
+            val stats = writer.close()
+
+            val objectKey = "runs/$runId/$endpointDir/${stats.path}"
+            SnapshotChunkReadyEvent(
+                eventId = UUID.randomUUID().toString(),
+                runId = runId,
                 endpoint = endpointDir,
-                keyType = keyType,
-                httpStatus = 200,
-                fetchedAt = Instant.now(),
-                bodyBytes = data,
-            ),
-        )
-        val stats = writer.close()
+                chunkId = "part-000001",
+                objectKey = objectKey,
+                recordCount = stats.recordCount,
+                uncompressedBytes = stats.uncompressedBytes,
+                compressedBytes = stats.compressedBytes,
+                createdAt = Instant.now(),
+            )
+        }, workerExecutor).thenCompose { event ->
+            val eventJson = objectMapper.writeValueAsString(event)
+            val key = "${event.runId}:${event.endpoint}:${event.chunkId}"
+            kafkaTemplate.send(urgentChunkReadyTopic, key, eventJson).thenAccept {
+                log.info(
+                    "[Urgent] published chunk: endpoint={}, userIgn={}, objectKey={}",
+                    event.endpoint,
+                    maskIgn(userIgn),
+                    event.objectKey,
+                )
+            }
+        }
 
-        val objectKey = "runs/$runId/$endpointDir/${stats.path}"
-        val event = SnapshotChunkReadyEvent(
-            eventId = UUID.randomUUID().toString(),
-            runId = runId,
-            endpoint = endpointDir,
-            chunkId = "part-000001",
-            objectKey = objectKey,
-            recordCount = stats.recordCount,
-            uncompressedBytes = stats.uncompressedBytes,
-            compressedBytes = stats.compressedBytes,
-            createdAt = Instant.now(),
-        )
-
-        val eventJson = objectMapper.writeValueAsString(event)
-        val key = "${event.runId}:${event.endpoint}:${event.chunkId}"
-        kafkaTemplate.send(urgentChunkReadyTopic, key, eventJson).get(30, TimeUnit.SECONDS)
-
-        log.info(
-            "[Urgent] published chunk: endpoint={}, userIgn={}, objectKey={}",
-            endpointDir,
-            maskIgn(userIgn),
-            objectKey,
-        )
-    }
-
-    private fun publishNotFound(userIgn: String) {
+    private fun publishNotFoundAsync(userIgn: String): CompletableFuture<Void> {
         val event = mapOf(
             "userIgn" to userIgn,
             "reason" to "OCID_NOT_FOUND",
             "occurredAt" to Instant.now().toString(),
         )
         val json = objectMapper.writeValueAsString(event)
-        kafkaTemplate.send(notFoundTopic, userIgn, json)
-        log.info("[Urgent] published not-found: userIgn={}", maskIgn(userIgn))
+        return kafkaTemplate.send(notFoundTopic, userIgn, json)
+            .thenAccept { log.info("[Urgent] published not-found: userIgn={}", maskIgn(userIgn)) }
+    }
+
+    @PreDestroy
+    fun close() {
+        workerExecutor.close()
     }
 }
 

--- a/module-external-api/src/main/resources/application.yml
+++ b/module-external-api/src/main/resources/application.yml
@@ -17,6 +17,15 @@ spring:
 nexon:
   api:
     key: ${NEXON_API_KEY}
+  http-client:
+    pool-name: ${NEXON_HTTP_POOL_NAME:nexon-pool}
+    max-connections: ${NEXON_HTTP_MAX_CONNECTIONS:50}
+    pending-acquire-max-count: ${NEXON_HTTP_PENDING_ACQUIRE_MAX_COUNT:1000}
+    pending-acquire-timeout-ms: ${NEXON_HTTP_PENDING_ACQUIRE_TIMEOUT_MS:5000}
+    connect-timeout-ms: ${NEXON_HTTP_CONNECT_TIMEOUT_MS:3000}
+    response-timeout-seconds: ${NEXON_HTTP_RESPONSE_TIMEOUT_SECONDS:5}
+    max-in-memory-size-bytes: ${NEXON_HTTP_MAX_IN_MEMORY_SIZE_BYTES:2097152}
+    metrics-enabled: ${NEXON_HTTP_METRICS_ENABLED:true}
 
 external-api:
   csv:

--- a/module-external-api/src/main/resources/application.yml
+++ b/module-external-api/src/main/resources/application.yml
@@ -19,7 +19,7 @@ nexon:
     key: ${NEXON_API_KEY}
   http-client:
     pool-name: ${NEXON_HTTP_POOL_NAME:nexon-pool}
-    max-connections: ${NEXON_HTTP_MAX_CONNECTIONS:50}
+    max-connections: ${NEXON_HTTP_MAX_CONNECTIONS:150}
     pending-acquire-max-count: ${NEXON_HTTP_PENDING_ACQUIRE_MAX_COUNT:1000}
     pending-acquire-timeout-ms: ${NEXON_HTTP_PENDING_ACQUIRE_TIMEOUT_MS:5000}
     connect-timeout-ms: ${NEXON_HTTP_CONNECT_TIMEOUT_MS:3000}
@@ -31,7 +31,7 @@ external-api:
   csv:
     path: ../module-app/src/main/resources/data/userIgn_List.csv
   rate-limit:
-    permits-per-second: 200
+    permits-per-second: ${EXTERNAL_API_RATE_LIMIT_PERMITS_PER_SECOND:250}
     ocid-lookup-permits-per-second: 400
   batch-size: 1000
   store:

--- a/module-external-api/src/test/kotlin/maple/externalapi/urgent/UrgentCharacterRequestConsumerTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/urgent/UrgentCharacterRequestConsumerTest.kt
@@ -11,6 +11,7 @@ import org.apache.kafka.clients.producer.RecordMetadata
 import org.apache.kafka.common.TopicPartition
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import org.mockito.kotlin.any
@@ -18,6 +19,7 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
+import org.mockito.kotlin.timeout
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.kafka.core.KafkaTemplate
@@ -52,6 +54,11 @@ class UrgentCharacterRequestConsumerTest {
             urgentChunkReadyTopic = "external-api.urgent.snapshot.chunk-ready",
             storeBasePath = tempDir.toString(),
         )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        consumer.close()
     }
 
     private fun stubSendResult(): CompletableFuture<SendResult<String, String>> {
@@ -95,7 +102,7 @@ class UrgentCharacterRequestConsumerTest {
 
         // Then - verify 2 chunk-ready events published
         val captor = argumentCaptor<String>()
-        verify(kafkaTemplate, times(2)).send(
+        verify(kafkaTemplate, timeout(5_000).times(2)).send(
             eq("external-api.urgent.snapshot.chunk-ready"),
             any(),
             captor.capture(),
@@ -144,7 +151,7 @@ class UrgentCharacterRequestConsumerTest {
 
         // Then
         val captor = argumentCaptor<String>()
-        verify(kafkaTemplate).send(
+        verify(kafkaTemplate, timeout(5_000)).send(
             eq("urgent-character-not-found"),
             any(),
             captor.capture(),

--- a/module-rest-controller/src/test/kotlin/maple/restcontroller/controller/ExpectationV6ControllerTest.kt
+++ b/module-rest-controller/src/test/kotlin/maple/restcontroller/controller/ExpectationV6ControllerTest.kt
@@ -8,6 +8,7 @@ import maple.restcontroller.read.*
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -19,6 +20,8 @@ class ExpectationV6ControllerTest {
     private lateinit var buffer: LocalRequestBuffer
     private lateinit var registry: InflightRequestRegistry
     private lateinit var facade: ExpectationReadFacade
+    private lateinit var cacheService: ReadModelCacheService
+    private lateinit var queryService: ReadModelQueryService
     private val properties = V6ReadProperties().apply {
         requestTimeoutMs = 100
         queueCapacity = 10
@@ -32,10 +35,12 @@ class ExpectationV6ControllerTest {
         buffer = LocalRequestBuffer(properties.queueCapacity)
         registry = InflightRequestRegistry()
         val metrics = V6ReadMetrics(SimpleMeterRegistry(), buffer, registry)
-        facade = ExpectationReadFacade(registry, buffer, metrics)
+        cacheService = mock()
+        queryService = mock()
+        facade = ExpectationReadFacade(registry, buffer, metrics, cacheService, properties)
 
         mockMvc = MockMvcBuilders
-            .standaloneSetup(ExpectationV6Controller(facade, properties))
+            .standaloneSetup(ExpectationV6Controller(facade, properties, cacheService, queryService))
             .setControllerAdvice(RestControllerExceptionHandler())
             .build()
     }

--- a/module-rest-controller/src/test/kotlin/maple/restcontroller/read/ExpectationReadFacadeTest.kt
+++ b/module-rest-controller/src/test/kotlin/maple/restcontroller/read/ExpectationReadFacadeTest.kt
@@ -2,9 +2,11 @@ package maple.restcontroller.read
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import maple.restcontroller.metrics.V6ReadMetrics
+import maple.restcontroller.config.V6ReadProperties
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
 import org.springframework.http.ResponseEntity
 import org.springframework.web.context.request.async.DeferredResult
 
@@ -15,13 +17,17 @@ class ExpectationReadFacadeTest {
     private lateinit var registry: InflightRequestRegistry
     private lateinit var metrics: V6ReadMetrics
     private lateinit var facade: ExpectationReadFacade
+    private lateinit var cacheService: ReadModelCacheService
+    private lateinit var properties: V6ReadProperties
 
     @BeforeEach
     fun setup() {
         buffer = LocalRequestBuffer(100)
         registry = InflightRequestRegistry()
         metrics = V6ReadMetrics(meterRegistry, buffer, registry)
-        facade = ExpectationReadFacade(registry, buffer, metrics)
+        cacheService = mock()
+        properties = V6ReadProperties()
+        facade = ExpectationReadFacade(registry, buffer, metrics, cacheService, properties)
     }
 
     private fun enqueue(ign: String, presetNo: Int = 1): DeferredResult<ResponseEntity<*>> {
@@ -54,7 +60,7 @@ class ExpectationReadFacadeTest {
     fun `enqueue sets 503 error when buffer is full`() {
         val smallBuffer = LocalRequestBuffer(1)
         val smallMetrics = V6ReadMetrics(SimpleMeterRegistry(), smallBuffer, registry)
-        val fullFacade = ExpectationReadFacade(registry, smallBuffer, smallMetrics)
+        val fullFacade = ExpectationReadFacade(registry, smallBuffer, smallMetrics, cacheService, properties)
 
         val d1 = DeferredResult<ResponseEntity<*>>()
         fullFacade.enqueue("a", 1, d1)

--- a/module-rest-controller/src/test/kotlin/maple/restcontroller/read/ReadModelQueryServiceTest.kt
+++ b/module-rest-controller/src/test/kotlin/maple/restcontroller/read/ReadModelQueryServiceTest.kt
@@ -34,7 +34,7 @@ class ReadModelQueryServiceTest {
         ))
         val compressed = GzipUtils.compress(String(docJson))
 
-        whenever(jdbc.queryForList(any<String>(), any<MapSqlParameterSource>(), any<Class<*>>()))
+        whenever(jdbc.queryForList(any<String>(), any<MapSqlParameterSource>()))
             .thenReturn(listOf(
                 mapOf<String, Any>(
                     "user_ign" to "아델",
@@ -63,7 +63,7 @@ class ReadModelQueryServiceTest {
 
     @Test
     fun `should return empty when no rows match`() {
-        whenever(jdbc.queryForList(any<String>(), any<MapSqlParameterSource>(), any<Class<*>>()))
+        whenever(jdbc.queryForList(any<String>(), any<MapSqlParameterSource>()))
             .thenReturn(emptyList())
 
         val requests = mapOf("존재하지않는닉네임" to 1)
@@ -88,7 +88,7 @@ class ReadModelQueryServiceTest {
             "metadata" to mapOf("calculatedAt" to now.toString())
         ))
 
-        whenever(jdbc.queryForList(any<String>(), any<MapSqlParameterSource>(), any<Class<*>>()))
+        whenever(jdbc.queryForList(any<String>(), any<MapSqlParameterSource>()))
             .thenReturn(listOf(
                 mapOf<String, Any>(
                     "user_ign" to "아델",


### PR DESCRIPTION
## Summary
- restore/expose Nexon WebClient connection-pool metrics and HTTP client tuning
- default external-api Nexon pool to 150 and item-equipment fetch rate to 250/s
- remove CompletableFuture/Kafka send get/join blocking from external-api fetch paths
- add ADR-717 with pool/rate evidence and trade-offs
- add CLAUDE async rule for CompletableFuture + blocking anti-pattern

## Verification
- ./gradlew --console=plain :module-external-api:compileKotlin