### PR TITLE
feat: add equipment ranking projection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ scripts/*
 # Patch/build artifacts
 *.orig
 *.rej
+.codex-measure/
 
 # Verification/analysis reports (temporary)
 claude-rules-verification-report.md

--- a/module-infra/src/main/resources/db/migration/V127__equipment_total_cost_ranking_index.sql
+++ b/module-infra/src/main/resources/db/migration/V127__equipment_total_cost_ranking_index.sql
@@ -1,0 +1,4 @@
+CREATE INDEX IF NOT EXISTS idx_equipment_read_model_total_cost_rank
+    ON character_equipment_read_model (preset_no, total_cost DESC)
+    INCLUDE (user_ign)
+    WHERE user_ign IS NOT NULL;

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/config/V6ReadConfig.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/config/V6ReadConfig.kt
@@ -3,6 +3,9 @@ package maple.restcontroller.config
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.micrometer.core.instrument.MeterRegistry
 import maple.restcontroller.metrics.V6ReadMetrics
+import maple.restcontroller.ranking.EquipmentRankingCacheService
+import maple.restcontroller.ranking.EquipmentRankingQueryService
+import maple.restcontroller.ranking.EquipmentRankingService
 import maple.restcontroller.read.*
 import maple.restcontroller.urgent.UrgentTriggerPublisher
 import org.springframework.beans.factory.ObjectProvider
@@ -50,6 +53,22 @@ class V6ReadConfig(
         redisTemplate: StringRedisTemplate,
         objectMapper: ObjectMapper
     ): ReadModelCacheService = ReadModelCacheService(redisTemplate, objectMapper, properties)
+
+    @Bean
+    fun equipmentRankingCacheService(
+        redisTemplate: StringRedisTemplate
+    ): EquipmentRankingCacheService = EquipmentRankingCacheService(redisTemplate, properties)
+
+    @Bean
+    fun equipmentRankingQueryService(
+        jdbc: NamedParameterJdbcTemplate
+    ): EquipmentRankingQueryService = EquipmentRankingQueryService(jdbc)
+
+    @Bean
+    fun equipmentRankingService(
+        cacheService: EquipmentRankingCacheService,
+        queryService: EquipmentRankingQueryService
+    ): EquipmentRankingService = EquipmentRankingService(cacheService, queryService, properties)
 
     @Bean
     fun expectationReadFacade(

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/config/V6ReadProperties.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/config/V6ReadProperties.kt
@@ -14,4 +14,10 @@ class V6ReadProperties {
     var urgentPendingTtlSeconds: Long = 30
     var statusRetryAfterSeconds: Long = 3
     var statusEstimatedThroughputPerSecond: Double = 5.0
+    var ranking: Ranking = Ranking()
+
+    class Ranking {
+        var redisKeyPrefix: String = "ranking:equipment:total-cost"
+        var topSize: Int = 10
+    }
 }

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/controller/EquipmentRankingController.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/controller/EquipmentRankingController.kt
@@ -1,0 +1,22 @@
+package maple.restcontroller.controller
+
+import maple.restcontroller.ranking.EquipmentRankingService
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v6/rankings/equipment")
+@ConditionalOnProperty(name = ["expectation.v6.enabled"], havingValue = "true")
+class EquipmentRankingController(
+    private val rankingService: EquipmentRankingService,
+) {
+    @GetMapping("/total-cost/top10")
+    fun topTotalCost(
+        @RequestParam(defaultValue = "1") presetNo: Int,
+    ): ResponseEntity<*> =
+        ResponseEntity.ok(rankingService.topByTotalCost(presetNo))
+}

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/ranking/EquipmentRankingCacheService.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/ranking/EquipmentRankingCacheService.kt
@@ -1,0 +1,41 @@
+package maple.restcontroller.ranking
+
+import maple.restcontroller.config.V6ReadProperties
+import org.slf4j.LoggerFactory
+import org.springframework.data.redis.core.StringRedisTemplate
+
+class EquipmentRankingCacheService(
+    private val redisTemplate: StringRedisTemplate,
+    private val properties: V6ReadProperties,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun topByTotalCost(presetNo: Int, limit: Int): List<EquipmentRankingEntry>? {
+        val entries = runCatching {
+            redisTemplate.opsForZSet()
+                .reverseRangeWithScores(rankingKey(presetNo), 0, (limit - 1).toLong())
+                ?.mapIndexedNotNull { index, tuple ->
+                    val userIgn = tuple.value ?: return@mapIndexedNotNull null
+                    val score = tuple.score ?: return@mapIndexedNotNull null
+                    EquipmentRankingEntry(
+                        rank = index + 1,
+                        userIgn = userIgn,
+                        presetNo = presetNo,
+                        totalCost = score.toLong(),
+                    )
+                }
+                .orEmpty()
+        }.getOrElse { error ->
+            log.warn("Equipment ranking Redis read failed: presetNo={} limit={} error={}", presetNo, limit, error.javaClass.simpleName)
+            return null
+        }
+
+        if (entries.isEmpty()) {
+            log.debug("Equipment ranking Redis miss: presetNo={} limit={}", presetNo, limit)
+        }
+        return entries
+    }
+
+    private fun rankingKey(presetNo: Int): String =
+        "${properties.ranking.redisKeyPrefix}:preset:$presetNo"
+}

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/ranking/EquipmentRankingModels.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/ranking/EquipmentRankingModels.kt
@@ -1,0 +1,19 @@
+package maple.restcontroller.ranking
+
+data class EquipmentRankingEntry(
+    val rank: Int,
+    val userIgn: String,
+    val presetNo: Int,
+    val totalCost: Long,
+)
+
+data class EquipmentRankingResponse(
+    val presetNo: Int,
+    val source: EquipmentRankingSource,
+    val rankings: List<EquipmentRankingEntry>,
+)
+
+enum class EquipmentRankingSource {
+    REDIS,
+    DB,
+}

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/ranking/EquipmentRankingQueryService.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/ranking/EquipmentRankingQueryService.kt
@@ -1,0 +1,32 @@
+package maple.restcontroller.ranking
+
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+
+class EquipmentRankingQueryService(
+    private val jdbc: NamedParameterJdbcTemplate,
+) {
+    fun topByTotalCost(presetNo: Int, limit: Int): List<EquipmentRankingEntry> {
+        val sql = """
+            SELECT user_ign, preset_no, total_cost
+            FROM character_equipment_read_model
+            WHERE preset_no = :presetNo
+              AND user_ign IS NOT NULL
+            ORDER BY total_cost DESC
+            LIMIT :limit
+        """.trimIndent()
+
+        val params = MapSqlParameterSource()
+            .addValue("presetNo", presetNo)
+            .addValue("limit", limit)
+
+        return jdbc.query(sql, params) { rs, rowNum ->
+            EquipmentRankingEntry(
+                rank = rowNum + 1,
+                userIgn = rs.getString("user_ign"),
+                presetNo = rs.getInt("preset_no"),
+                totalCost = rs.getLong("total_cost"),
+            )
+        }
+    }
+}

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/ranking/EquipmentRankingService.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/ranking/EquipmentRankingService.kt
@@ -1,0 +1,23 @@
+package maple.restcontroller.ranking
+
+import maple.restcontroller.config.V6ReadProperties
+
+class EquipmentRankingService(
+    private val cacheService: EquipmentRankingCacheService,
+    private val queryService: EquipmentRankingQueryService,
+    private val properties: V6ReadProperties,
+) {
+    fun topByTotalCost(presetNo: Int): EquipmentRankingResponse {
+        val limit = properties.ranking.topSize.coerceAtLeast(1)
+        val cached = cacheService.topByTotalCost(presetNo, limit)
+        if (cached != null) {
+            return EquipmentRankingResponse(presetNo, EquipmentRankingSource.REDIS, cached)
+        }
+
+        return EquipmentRankingResponse(
+            presetNo = presetNo,
+            source = EquipmentRankingSource.DB,
+            rankings = queryService.topByTotalCost(presetNo, limit),
+        )
+    }
+}

--- a/module-rest-controller/src/main/resources/application.yml
+++ b/module-rest-controller/src/main/resources/application.yml
@@ -45,6 +45,9 @@ expectation:
     shutdown-drain-timeout-seconds: 5 # graceful shutdown deadline
     status-retry-after-seconds: 3     # frontend polling hint after 202/status
     status-estimated-throughput-per-second: 5.0 # approximate urgent pipeline throughput
+    ranking:
+      redis-key-prefix: ranking:equipment:total-cost
+      top-size: 10
     urgent:
       enabled: false                              # feature flag
       request-topic: urgent-character-request

--- a/module-rest-controller/src/test/kotlin/maple/restcontroller/ranking/EquipmentRankingServiceTest.kt
+++ b/module-rest-controller/src/test/kotlin/maple/restcontroller/ranking/EquipmentRankingServiceTest.kt
@@ -1,0 +1,48 @@
+package maple.restcontroller.ranking
+
+import maple.restcontroller.config.V6ReadProperties
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class EquipmentRankingServiceTest {
+
+    private val cacheService: EquipmentRankingCacheService = mock()
+    private val queryService: EquipmentRankingQueryService = mock()
+    private val properties = V6ReadProperties().apply {
+        ranking.topSize = 10
+    }
+    private val service = EquipmentRankingService(cacheService, queryService, properties)
+
+    @Test
+    fun `uses Redis ranking when Redis read succeeds`() {
+        val cached = listOf(entry("캐릭터A", 1, "1000"))
+        whenever(cacheService.topByTotalCost(1, 10)).thenReturn(cached)
+
+        val result = service.topByTotalCost(1)
+
+        assertThat(result.source).isEqualTo(EquipmentRankingSource.REDIS)
+        assertThat(result.rankings).isEqualTo(cached)
+    }
+
+    @Test
+    fun `falls back to DB when Redis read fails`() {
+        val db = listOf(entry("캐릭터B", 1, "2000"))
+        whenever(cacheService.topByTotalCost(1, 10)).thenReturn(null)
+        whenever(queryService.topByTotalCost(1, 10)).thenReturn(db)
+
+        val result = service.topByTotalCost(1)
+
+        assertThat(result.source).isEqualTo(EquipmentRankingSource.DB)
+        assertThat(result.rankings).isEqualTo(db)
+    }
+
+    private fun entry(userIgn: String, presetNo: Int, totalCost: String): EquipmentRankingEntry =
+        EquipmentRankingEntry(
+            rank = 1,
+            userIgn = userIgn,
+            presetNo = presetNo,
+            totalCost = totalCost.toLong(),
+        )
+}

--- a/module-synchronizer/build.gradle
+++ b/module-synchronizer/build.gradle
@@ -34,6 +34,9 @@ dependencies {
 	// Kafka
 	implementation(libs.spring.kafka)
 
+	// Redis ranking projection
+	implementation(libs.spring.boot.starter.data.redis)
+
 	// Jackson
 	implementation(libs.jackson.databind)
 	implementation(libs.jackson.module.kotlin)

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/SynchronizerApplication.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/SynchronizerApplication.kt
@@ -1,10 +1,13 @@
 package maple.synchronizer
 
+import maple.synchronizer.ranking.EquipmentRankingProperties
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.runApplication
 import org.springframework.context.annotation.Import
 
 @SpringBootApplication(scanBasePackages = ["maple.synchronizer", "maple.expectation.infrastructure.executor"])
+@EnableConfigurationProperties(EquipmentRankingProperties::class)
 @Import(maple.expectation.infrastructure.config.ExecutorConfig::class)
 class SynchronizerApplication
 

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/processor/DefaultChunkProcessor.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/processor/DefaultChunkProcessor.kt
@@ -4,6 +4,7 @@ import io.micrometer.core.instrument.Timer
 import maple.synchronizer.builder.EquipmentDocumentBuilder
 import maple.synchronizer.metrics.SynchronizerMetrics
 import maple.synchronizer.preparer.EquipmentDocumentPreparer
+import maple.synchronizer.ranking.EquipmentRankingRedisWriter
 import maple.synchronizer.repository.EquipmentReadModelRepository
 import maple.synchronizer.resolver.OcidUserIgnResolver
 import maple.synchronizer.storage.ResultFileReader
@@ -16,6 +17,7 @@ class DefaultChunkProcessor(
     private val readModelRepository: EquipmentReadModelRepository,
     private val ocidUserIgnResolver: OcidUserIgnResolver,
     private val metrics: SynchronizerMetrics,
+    private val rankingWriter: EquipmentRankingRedisWriter,
     objectMapper: com.fasterxml.jackson.databind.ObjectMapper,
 ) : ChunkProcessor {
 
@@ -53,6 +55,7 @@ class DefaultChunkProcessor(
         metrics.mainUpsertTimer().record(Runnable {
             readModelRepository.bulkUpsert(input.sourceRunId, input.sourceChunkId, prepped)
         })
+        rankingWriter.update(prepped)
 
         return ChunkProcessResult(
             documentCount = documents.size,

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/ranking/EquipmentRankingProperties.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/ranking/EquipmentRankingProperties.kt
@@ -1,0 +1,11 @@
+package maple.synchronizer.ranking
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "synchronizer.ranking")
+class EquipmentRankingProperties {
+    var enabled: Boolean = true
+    var keyPrefix: String = "ranking:equipment:total-cost"
+    var batchSize: Int = 1000
+    var topSize: Int = 10
+}

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/ranking/EquipmentRankingRedisWriter.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/ranking/EquipmentRankingRedisWriter.kt
@@ -1,0 +1,62 @@
+package maple.synchronizer.ranking
+
+import maple.expectation.infrastructure.executor.LogicExecutor
+import maple.expectation.infrastructure.executor.TaskContext
+import maple.synchronizer.preparer.PreppedDocument
+import org.slf4j.LoggerFactory
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Component
+import java.nio.charset.StandardCharsets
+
+@Component
+class EquipmentRankingRedisWriter(
+    private val redisTemplate: StringRedisTemplate,
+    private val properties: EquipmentRankingProperties,
+    private val executor: LogicExecutor,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun update(documents: List<PreppedDocument>) {
+        if (!properties.enabled || documents.isEmpty()) return
+
+        val rankable = documents.filter { it.userIgn?.isNotBlank() == true }
+        if (rankable.isEmpty()) return
+
+        val updated = executor.executeOrDefault(
+            {
+                rankable
+                    .groupBy { it.presetNo.toInt() }
+                    .values
+                    .sumOf(::updatePreset)
+            },
+            0,
+            TaskContext.of("Synchronizer", "UpdateEquipmentRanking"),
+        )
+
+        log.debug("Equipment ranking Redis update: attempted={} updated={}", rankable.size, updated)
+    }
+
+    private fun updatePreset(documents: List<PreppedDocument>): Int {
+        var updated = 0
+        documents.chunked(properties.batchSize.coerceAtLeast(1)).forEach { batch ->
+            redisTemplate.executePipelined { connection ->
+                val key = rankingKey(documents.first().presetNo.toInt()).toByteArray(StandardCharsets.UTF_8)
+                batch.forEach { document ->
+                    val userIgn = document.userIgn ?: return@forEach
+                    connection.zSetCommands().zAdd(
+                        key,
+                        document.totalCost.toDouble(),
+                        userIgn.toByteArray(StandardCharsets.UTF_8),
+                    )
+                    updated += 1
+                }
+                connection.zSetCommands().zRemRange(key, 0, -properties.topSize.coerceAtLeast(1).toLong() - 1)
+                null
+            }
+        }
+        return updated
+    }
+
+    private fun rankingKey(presetNo: Int): String =
+        "${properties.keyPrefix}:preset:$presetNo"
+}

--- a/module-synchronizer/src/main/resources/application.yml
+++ b/module-synchronizer/src/main/resources/application.yml
@@ -37,6 +37,10 @@ spring:
       enable-auto-commit: false
     listener:
       ack-mode: manual_immediate
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
 
 synchronizer:
   kafka:
@@ -50,6 +54,11 @@ synchronizer:
     base-path: ../module-external-api/external-api-data
   chunk:
     max-rows: 100000
+  ranking:
+    enabled: true
+    key-prefix: ranking:equipment:total-cost
+    batch-size: 1000
+    top-size: 10
 
 management:
   endpoints:

--- a/module-synchronizer/src/test/kotlin/maple/synchronizer/processor/DefaultChunkProcessorTest.kt
+++ b/module-synchronizer/src/test/kotlin/maple/synchronizer/processor/DefaultChunkProcessorTest.kt
@@ -7,6 +7,7 @@ import maple.synchronizer.domain.CalculatedEquipmentItem
 import maple.synchronizer.domain.GroupedEquipmentResult
 import maple.synchronizer.metrics.SynchronizerMetrics
 import maple.synchronizer.preparer.EquipmentDocumentPreparer
+import maple.synchronizer.ranking.EquipmentRankingRedisWriter
 import maple.synchronizer.repository.EquipmentReadModelRepository
 import maple.synchronizer.resolver.OcidUserIgnResolver
 import maple.synchronizer.storage.ResultFileReader
@@ -26,6 +27,7 @@ class DefaultChunkProcessorTest {
     private val resultFileReader: ResultFileReader = mock()
     private val readModelRepository: EquipmentReadModelRepository = mock()
     private val ocidUserIgnResolver: OcidUserIgnResolver = mock()
+    private val rankingWriter: EquipmentRankingRedisWriter = mock()
     private val metrics = SynchronizerMetrics(SimpleMeterRegistry())
     private val objectMapper = ObjectMapper().registerModule(JavaTimeModule())
 
@@ -33,7 +35,14 @@ class DefaultChunkProcessorTest {
 
     @BeforeEach
     fun setUp() {
-        chunkProcessor = DefaultChunkProcessor(resultFileReader, readModelRepository, ocidUserIgnResolver, metrics, objectMapper)
+        chunkProcessor = DefaultChunkProcessor(
+            resultFileReader,
+            readModelRepository,
+            ocidUserIgnResolver,
+            metrics,
+            rankingWriter,
+            objectMapper,
+        )
         whenever(ocidUserIgnResolver.resolve(any())).thenReturn(emptyMap())
     }
 
@@ -61,6 +70,7 @@ class DefaultChunkProcessorTest {
         chunkProcessor.process(input)
 
         verify(readModelRepository).bulkUpsert(eq(input.sourceRunId), eq(input.sourceChunkId), any())
+        verify(rankingWriter).update(any())
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Project equipment total-cost Top10 into Redis sorted sets after synchronizer DB upsert succeeds
- Add V6 ranking API with Redis-first read and DB fallback on Redis failure
- Add DB fallback index for `character_equipment_read_model` total-cost ranking

## Verification
- `./gradlew --console=plain :module-synchronizer:compileKotlin :module-rest-controller:compileKotlin :module-synchronizer:test --tests maple.synchronizer.processor.DefaultChunkProcessorTest :module-rest-controller:test --tests maple.restcontroller.ranking.EquipmentRankingServiceTest`
- `./gradlew --console=plain :module-rest-controller:compileKotlin :module-rest-controller:test --tests maple.restcontroller.ranking.EquipmentRankingServiceTest`