### PR TITLE
feat(synchronizer): add chunk execution state

### DIFF
--- a/docs/superpowers/plans/2026-05-18-chunk-execution-foundation.md
+++ b/docs/superpowers/plans/2026-05-18-chunk-execution-foundation.md
@@ -1,0 +1,543 @@
+# Chunk Execution Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Kafka chunk processing recoverable by recording execution state before ack. PR1 scope only: create `chunk_execution` foundation, insert `PENDING` on first consume, atomically claim `PROCESSING`, persist `SUCCEEDED` / `FAILED_*`, then ack. Retry scheduler, retry topics, cleanup guard, and admin replay are later PRs.
+
+**Architecture:** Kafka consumer owns execution state for its handler. Normal topic missing row creates `PENDING`; retry topic does not exist in PR1. `chunk_execution` row identity is `(execution_type, run_id, endpoint, chunk_id)`. `lease_until` prevents stuck `PROCESSING`. `event_payload_jsonb` stores original metadata event for future replay.
+
+**Tech Stack:** Kotlin, Spring Kafka manual ack, PostgreSQL, `NamedParameterJdbcTemplate`, Flyway migration, module-common event DTOs
+
+---
+
+## Design Decisions
+
+| Decision | Choice |
+|----------|--------|
+| Execution owner | Consumer creates row on first consume |
+| Row identity | `UNIQUE(execution_type, run_id, endpoint, chunk_id)` |
+| Payload storage | `event_payload_jsonb` in `chunk_execution` |
+| Schema version | Store in payload and DB column |
+| Processing recovery | `lease_until` on `PROCESSING` |
+| Ack rule | Ack only after terminal/current state write succeeds |
+| PR1 retry behavior | No scheduler. Failed chunks become `FAILED_RETRYABLE` or `FAILED_TERMINAL`; later PR handles retry |
+| `SUCCEEDED` replay | Not in PR1. Later admin API forbids same-execution replay |
+
+---
+
+## File Structure
+
+### New Files
+
+| File | Responsibility |
+|------|----------------|
+| `module-infra/src/main/resources/db/migration/V128__chunk_execution.sql` | Create `chunk_execution` table/indexes |
+| `module-common/src/main/kotlin/maple/expectation/common/event/ChunkExecutionType.kt` | Execution type enum |
+| `module-common/src/main/kotlin/maple/expectation/common/event/ChunkExecutionStatus.kt` | Status enum |
+| `module-common/src/main/kotlin/maple/expectation/common/event/ChunkExecutionIdentity.kt` | Natural identity value |
+| `module-synchronizer/src/main/kotlin/maple/synchronizer/repository/ChunkExecutionRepository.kt` | Insert/claim/mark execution rows |
+| `module-synchronizer/src/test/kotlin/maple/synchronizer/repository/ChunkExecutionRepositoryTest.kt` | Repository behavior tests |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `module-synchronizer/.../consumer/ChunkConsumerTemplate.kt` | Use `ChunkExecutionRepository` instead of legacy status callbacks |
+| `module-synchronizer/.../consumer/BasicSnapshotChunkConsumer.kt` | Use `SYNCHRONIZER_BASIC_CHUNK` identity |
+| `module-synchronizer/.../consumer/KafkaResultChunkConsumer.kt` | Use `SYNCHRONIZER_RESULT_CHUNK` identity |
+| `module-calculator/.../consumer/KafkaSnapshotChunkReadyConsumer.kt` | Add calculator execution state if PR1 includes calculator |
+| `module-calculator/.../CalculatorChunkProcessingCoordinator.kt` | Accept execution identity/status callbacks if calculator included |
+| `module-infra/src/test/.../DatabaseCleaner.kt` variants | Include `chunk_execution` cleanup if tests require |
+
+---
+
+## Task 0: Scope Lock
+
+- [x] **Step 1: Confirm PR1 includes synchronizer only or synchronizer + calculator**
+
+Recommended split:
+
+```text
+PR1a: synchronizer chunk_execution foundation (current scope)
+PR1b: calculator chunk_execution foundation (deferred)
+```
+
+If user wants one PR1, include both. If risk control matters, start synchronizer because DB upsert is highest consistency risk.
+
+- [x] **Step 2: Do not implement retry scheduler**
+
+Explicitly out of scope:
+
+- retry topic
+- `REPUBLISHING`
+- scheduler claim/publish
+- cleanup `RunDeletionGuard`
+- admin replay
+
+---
+
+## Task 1: Migration
+
+**Files:**
+- Create: `module-infra/src/main/resources/db/migration/V128__chunk_execution.sql`
+
+- [x] **Step 1: Create table**
+
+```sql
+CREATE TABLE IF NOT EXISTS chunk_execution (
+    id BIGSERIAL PRIMARY KEY,
+
+    execution_type TEXT NOT NULL,
+    run_id TEXT NOT NULL,
+    endpoint TEXT NOT NULL,
+    chunk_id TEXT NOT NULL,
+
+    topic TEXT NOT NULL,
+    message_key TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    schema_version INT NOT NULL,
+    event_payload_jsonb JSONB NOT NULL,
+
+    status TEXT NOT NULL,
+
+    attempt_count INT NOT NULL DEFAULT 0,
+    next_retry_at TIMESTAMPTZ NULL,
+    first_failed_at TIMESTAMPTZ NULL,
+    last_failed_at TIMESTAMPTZ NULL,
+    last_error TEXT NULL,
+    terminal_reason TEXT NULL,
+
+    processing_started_at TIMESTAMPTZ NULL,
+    lease_until TIMESTAMPTZ NULL,
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    CONSTRAINT uq_chunk_execution_identity
+        UNIQUE (execution_type, run_id, endpoint, chunk_id),
+    CONSTRAINT chk_chunk_execution_status CHECK (
+        status IN (
+            'PENDING',
+            'PROCESSING',
+            'FAILED_RETRYABLE',
+            'FAILED_TERMINAL',
+            'SUCCEEDED'
+        )
+    )
+);
+```
+
+- [x] **Step 2: Add indexes**
+
+```sql
+CREATE INDEX IF NOT EXISTS idx_chunk_execution_retry
+ON chunk_execution (status, next_retry_at)
+WHERE status = 'FAILED_RETRYABLE';
+
+CREATE INDEX IF NOT EXISTS idx_chunk_execution_processing_lease
+ON chunk_execution (status, lease_until)
+WHERE status = 'PROCESSING';
+
+CREATE INDEX IF NOT EXISTS idx_chunk_execution_run
+ON chunk_execution (run_id, endpoint, chunk_id);
+```
+
+- [x] **Step 3: Keep old `synchronizer_chunk_status` table**
+
+Do not drop old table in PR1. Keep rollback easy. New code can stop writing old table after tests pass.
+
+---
+
+## Task 2: Common Types
+
+**Files:**
+- Create: `module-common/src/main/kotlin/maple/expectation/common/event/ChunkExecutionType.kt`
+- Create: `module-common/src/main/kotlin/maple/expectation/common/event/ChunkExecutionStatus.kt`
+- Create: `module-common/src/main/kotlin/maple/expectation/common/event/ChunkExecutionIdentity.kt`
+
+- [x] **Step 1: Create execution type enum**
+
+```kotlin
+package maple.expectation.common.event
+
+enum class ChunkExecutionType {
+    CALCULATOR_SNAPSHOT_CHUNK,
+    SYNCHRONIZER_RESULT_CHUNK,
+    SYNCHRONIZER_BASIC_CHUNK,
+}
+```
+
+- [x] **Step 2: Create status enum**
+
+```kotlin
+package maple.expectation.common.event
+
+enum class ChunkExecutionStatus {
+    PENDING,
+    PROCESSING,
+    FAILED_RETRYABLE,
+    FAILED_TERMINAL,
+    SUCCEEDED,
+}
+```
+
+- [x] **Step 3: Create identity value**
+
+```kotlin
+package maple.expectation.common.event
+
+data class ChunkExecutionIdentity(
+    val executionType: ChunkExecutionType,
+    val runId: String,
+    val endpoint: String,
+    val chunkId: String,
+)
+```
+
+---
+
+## Task 3: Repository Contract
+
+**Files:**
+- Create: `module-synchronizer/src/main/kotlin/maple/synchronizer/repository/ChunkExecutionRepository.kt`
+- Create: `module-synchronizer/src/test/kotlin/maple/synchronizer/repository/ChunkExecutionRepositoryTest.kt`
+
+- [x] **Step 1: Define repository operations**
+
+Repository should expose:
+
+```kotlin
+fun insertPendingIfAbsent(command: InsertChunkExecutionCommand): Boolean
+fun findStatus(identity: ChunkExecutionIdentity): ChunkExecutionStatus?
+fun claimProcessing(identity: ChunkExecutionIdentity, processingTimeout: Duration): ChunkExecutionClaim?
+fun markSucceeded(identity: ChunkExecutionIdentity, claimedAttempt: Int): Boolean
+fun markFailedRetryable(identity: ChunkExecutionIdentity, claimedAttempt: Int, error: String, nextRetryAt: Instant): Boolean
+fun markFailedTerminal(identity: ChunkExecutionIdentity, claimedAttempt: Int, error: String, terminalReason: String): Boolean
+```
+
+- [x] **Step 2: Implement `insertPendingIfAbsent`**
+
+Use `ON CONFLICT DO NOTHING`.
+
+Must store:
+
+- `execution_type`
+- `run_id`
+- `endpoint`
+- `chunk_id`
+- `topic`
+- `message_key`
+- `event_type`
+- `schema_version`
+- `event_payload_jsonb`
+- `status='PENDING'`
+- `attempt_count=0`
+
+- [x] **Step 3: Implement atomic claim**
+
+```sql
+UPDATE chunk_execution
+SET
+  status = 'PROCESSING',
+  attempt_count = attempt_count + 1,
+  processing_started_at = now(),
+  lease_until = now() + (:processingTimeoutSeconds * interval '1 second'),
+  updated_at = now()
+WHERE execution_type = :executionType
+  AND run_id = :runId
+  AND endpoint = :endpoint
+  AND chunk_id = :chunkId
+  AND (
+    status = 'PENDING'
+    OR (status = 'FAILED_RETRYABLE' AND next_retry_at <= now())
+    OR (status = 'PROCESSING' AND lease_until < now())
+  )
+RETURNING attempt_count;
+```
+
+Return a claim containing `attempt_count` when row returned.
+
+- [x] **Step 4: Implement success**
+
+```sql
+UPDATE chunk_execution
+SET
+  status = 'SUCCEEDED',
+  lease_until = NULL,
+  updated_at = now()
+WHERE execution_type = :executionType
+  AND run_id = :runId
+  AND endpoint = :endpoint
+  AND chunk_id = :chunkId
+  AND status = 'PROCESSING';
+```
+
+- [x] **Step 5: Implement retryable failure**
+
+```sql
+UPDATE chunk_execution
+SET
+  status = 'FAILED_RETRYABLE',
+  next_retry_at = :nextRetryAt,
+  first_failed_at = COALESCE(first_failed_at, now()),
+  last_failed_at = now(),
+  last_error = :error,
+  lease_until = NULL,
+  updated_at = now()
+WHERE execution_type = :executionType
+  AND run_id = :runId
+  AND endpoint = :endpoint
+  AND chunk_id = :chunkId
+  AND status = 'PROCESSING';
+```
+
+- [x] **Step 6: Implement terminal failure**
+
+Same as retryable, but:
+
+```sql
+status = 'FAILED_TERMINAL',
+terminal_reason = :terminalReason,
+next_retry_at = NULL
+```
+
+---
+
+## Task 4: Consumer Rule Integration
+
+**Files:**
+- Modify: `module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/ChunkConsumerTemplate.kt`
+- Modify: `module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/BasicSnapshotChunkConsumer.kt`
+- Modify: `module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/KafkaResultChunkConsumer.kt`
+
+- [x] **Step 1: Add event metadata to template request**
+
+`ChunkConsumerRequest` needs:
+
+- `identity: ChunkExecutionIdentity`
+- `topic`
+- `messageKey`
+- `eventType`
+- `schemaVersion`
+- `eventPayloadJson`
+
+- [x] **Step 2: Normal topic missing row rule**
+
+On consume:
+
+```text
+insert PENDING if absent
+read status
+apply status rule
+```
+
+PR1 has only normal topics. Missing row always means first consume.
+
+- [x] **Step 3: Status rules**
+
+```text
+SUCCEEDED -> ack
+FAILED_TERMINAL -> ack
+FAILED_RETRYABLE and now < next_retry_at -> ack
+FAILED_RETRYABLE and now >= next_retry_at -> claim PROCESSING
+PENDING -> claim PROCESSING
+PROCESSING not expired -> ack
+PROCESSING expired -> claim PROCESSING
+```
+
+`REPUBLISHING` not in PR1.
+
+- [x] **Step 4: Ack after state write**
+
+Only ack after:
+
+- `SUCCEEDED` row update succeeds
+- `FAILED_RETRYABLE` row update succeeds
+- `FAILED_TERMINAL` row update succeeds
+- skip state observed and logged
+
+If status write fails, do not ack. Kafka redelivery handles it.
+
+- [x] **Step 5: Failure classification**
+
+PR1 simple policy:
+
+```text
+Artifact missing -> FAILED_RETRYABLE for first N attempts, then FAILED_TERMINAL
+Unsupported schema -> FAILED_TERMINAL
+Other exception -> FAILED_RETRYABLE
+```
+
+Config:
+
+```yaml
+chunk-execution:
+  processing-timeout-seconds: 600
+  retry:
+    max-attempts: 5
+    base-backoff-seconds: 60
+    artifact-missing-max-attempts: 2
+```
+
+---
+
+## Task 5: Tests
+
+### Repository Tests
+
+- [x] **Step 1: `insertPendingIfAbsent` idempotent**
+
+Given same `(execution_type, run_id, endpoint, chunk_id)` twice:
+
+- first insert returns true
+- second returns false
+- row count remains 1
+
+- [x] **Step 2: claim PENDING**
+
+PENDING row -> claim returns true -> status PROCESSING -> attempt_count 1 -> lease_until not null.
+
+- [x] **Step 3: reject non-expired PROCESSING**
+
+PROCESSING with future `lease_until` -> claim returns false.
+
+- [x] **Step 4: reclaim expired PROCESSING**
+
+PROCESSING with past `lease_until` -> claim returns true -> attempt_count increments.
+
+- [x] **Step 5: mark success**
+
+PROCESSING -> SUCCEEDED. lease cleared.
+
+- [x] **Step 6: mark retryable failure**
+
+PROCESSING -> FAILED_RETRYABLE. `first_failed_at`, `last_failed_at`, `next_retry_at`, `last_error` populated.
+
+- [x] **Step 7: mark terminal failure**
+
+PROCESSING -> FAILED_TERMINAL. `terminal_reason` populated.
+
+### Consumer Tests
+
+- [x] **Step 8: first consume inserts PENDING then processes**
+
+Verify order:
+
+```text
+insertPendingIfAbsent
+claimProcessing
+business process
+markSucceeded
+ack
+```
+
+- [x] **Step 9: SUCCEEDED skip acks**
+
+Existing SUCCEEDED -> no process -> ack.
+
+- [x] **Step 10: PROCESSING not expired acks**
+
+Existing PROCESSING with future lease -> no process -> ack.
+
+- [x] **Step 11: expired PROCESSING reclaims**
+
+Existing PROCESSING with expired lease -> process.
+
+- [x] **Step 12: business failure writes failure before ack**
+
+Process throws -> mark failure -> ack.
+
+---
+
+## Task 6: Observability
+
+**Files:**
+- Modify: `module-synchronizer/src/main/kotlin/maple/synchronizer/metrics/SynchronizerMetrics.kt`
+- Add calculator metrics if calculator included.
+
+- [x] **Step 1: Add counters**
+
+```text
+chunk_execution_inserted_total{execution_type}
+chunk_execution_claimed_total{execution_type}
+chunk_execution_skipped_total{execution_type,status}
+chunk_execution_succeeded_total{execution_type}
+chunk_execution_failed_total{execution_type,status,reason}
+chunk_execution_reclaimed_expired_total{execution_type}
+```
+
+- [x] **Step 2: Add gauge query later (deferred; out of PR1)**
+
+Out of PR1 unless cheap:
+
+```text
+chunk_execution_status_count{execution_type,status}
+```
+
+---
+
+## Task 7: Validation
+
+- [x] **Step 1: Run focused tests**
+
+```bash
+./gradlew --console=plain \
+  :module-common:compileKotlin \
+  :module-infra:compileKotlin \
+  :module-synchronizer:compileKotlin \
+  :module-synchronizer:test --tests '*ChunkExecution*'
+```
+
+- [x] **Step 2: Run existing synchronizer tests**
+
+```bash
+./gradlew --console=plain \
+  :module-synchronizer:test --tests maple.synchronizer.processor.DefaultChunkProcessorTest
+```
+
+- [x] **Step 3: If calculator included, run calculator tests (not applicable; calculator deferred to PR1b)**
+
+```bash
+./gradlew --console=plain \
+  :module-calculator:compileKotlin \
+  :module-calculator:test --tests maple.calculator.CalculatorChunkProcessingCoordinatorTest
+```
+
+---
+
+## Rollback
+
+- Code rollback safe because old `synchronizer_chunk_status` table remains.
+- Do not drop old table in PR1.
+- If production issue occurs, disable new repository usage via config flag if implemented:
+
+```yaml
+chunk-execution:
+  enabled: false
+```
+
+If no flag, revert PR.
+
+---
+
+## Out of Scope
+
+- retry scheduler
+- retry topics
+- `REPUBLISHING`
+- `RunDeletionGuard`
+- admin replay
+- `SUCCEEDED` force replay
+- cleanup retention invariant
+- upcaster registry
+
+---
+
+## Done Criteria
+
+- `chunk_execution` migration exists
+- consumer creates PENDING row on first consume
+- atomic claim uses `lease_until`
+- success/failure state persisted before ack
+- duplicate/redelivery status rules covered by tests
+- no retry scheduler in this PR

--- a/module-common/src/main/kotlin/maple/expectation/common/event/ChunkExecutionIdentity.kt
+++ b/module-common/src/main/kotlin/maple/expectation/common/event/ChunkExecutionIdentity.kt
@@ -1,0 +1,8 @@
+package maple.expectation.common.event
+
+data class ChunkExecutionIdentity(
+    val executionType: ChunkExecutionType,
+    val runId: String,
+    val endpoint: String,
+    val chunkId: String,
+)

--- a/module-common/src/main/kotlin/maple/expectation/common/event/ChunkExecutionStatus.kt
+++ b/module-common/src/main/kotlin/maple/expectation/common/event/ChunkExecutionStatus.kt
@@ -1,0 +1,9 @@
+package maple.expectation.common.event
+
+enum class ChunkExecutionStatus {
+    PENDING,
+    PROCESSING,
+    FAILED_RETRYABLE,
+    FAILED_TERMINAL,
+    SUCCEEDED,
+}

--- a/module-common/src/main/kotlin/maple/expectation/common/event/ChunkExecutionType.kt
+++ b/module-common/src/main/kotlin/maple/expectation/common/event/ChunkExecutionType.kt
@@ -1,0 +1,7 @@
+package maple.expectation.common.event
+
+enum class ChunkExecutionType {
+    CALCULATOR_SNAPSHOT_CHUNK,
+    SYNCHRONIZER_RESULT_CHUNK,
+    SYNCHRONIZER_BASIC_CHUNK,
+}

--- a/module-infra/src/main/resources/db/migration/V128__chunk_execution.sql
+++ b/module-infra/src/main/resources/db/migration/V128__chunk_execution.sql
@@ -1,0 +1,52 @@
+CREATE TABLE IF NOT EXISTS chunk_execution (
+    id BIGSERIAL PRIMARY KEY,
+
+    execution_type TEXT NOT NULL,
+    run_id TEXT NOT NULL,
+    endpoint TEXT NOT NULL,
+    chunk_id TEXT NOT NULL,
+
+    topic TEXT NOT NULL,
+    message_key TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    schema_version INT NOT NULL,
+    event_payload_jsonb JSONB NOT NULL,
+
+    status TEXT NOT NULL,
+
+    attempt_count INT NOT NULL DEFAULT 0,
+    next_retry_at TIMESTAMPTZ NULL,
+    first_failed_at TIMESTAMPTZ NULL,
+    last_failed_at TIMESTAMPTZ NULL,
+    last_error TEXT NULL,
+    terminal_reason TEXT NULL,
+
+    processing_started_at TIMESTAMPTZ NULL,
+    lease_until TIMESTAMPTZ NULL,
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    CONSTRAINT uq_chunk_execution_identity
+        UNIQUE (execution_type, run_id, endpoint, chunk_id),
+    CONSTRAINT chk_chunk_execution_status CHECK (
+        status IN (
+            'PENDING',
+            'PROCESSING',
+            'FAILED_RETRYABLE',
+            'FAILED_TERMINAL',
+            'SUCCEEDED'
+        )
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_chunk_execution_retry
+ON chunk_execution (status, next_retry_at)
+WHERE status = 'FAILED_RETRYABLE';
+
+CREATE INDEX IF NOT EXISTS idx_chunk_execution_processing_lease
+ON chunk_execution (status, lease_until)
+WHERE status = 'PROCESSING';
+
+CREATE INDEX IF NOT EXISTS idx_chunk_execution_run
+ON chunk_execution (run_id, endpoint, chunk_id);

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/BasicSnapshotChunkConsumer.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/BasicSnapshotChunkConsumer.kt
@@ -1,20 +1,23 @@
 package maple.synchronizer.consumer
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import maple.expectation.common.event.ChunkExecutionIdentity
+import maple.expectation.common.event.ChunkExecutionType
 import maple.expectation.common.event.SnapshotChunkReadyEvent
 import maple.expectation.infrastructure.executor.TaskContext
 import maple.expectation.infrastructure.lifecycle.ManagedLifecycle
+import maple.expectation.util.StringMaskingUtils.maskIgn
 import maple.synchronizer.repository.CharacterBasicRepository
-import maple.synchronizer.repository.SynchronizerChunkStatusRepository
 import maple.synchronizer.storage.BasicChunkFileReader
 import maple.synchronizer.storage.BasicRecord
-import maple.expectation.util.StringMaskingUtils.maskIgn
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.kafka.annotation.KafkaListener
 import org.springframework.kafka.support.Acknowledgment
+import org.springframework.kafka.support.KafkaHeaders
+import org.springframework.messaging.handler.annotation.Header
 import org.springframework.stereotype.Component
 import java.util.concurrent.Executors
 import java.util.concurrent.Semaphore
@@ -24,12 +27,11 @@ class BasicSnapshotChunkConsumer(
     private val objectMapper: ObjectMapper,
     private val fileReader: BasicChunkFileReader,
     private val repository: CharacterBasicRepository,
-    private val chunkStatusRepository: SynchronizerChunkStatusRepository,
     private val chunkConsumerTemplate: ChunkConsumerTemplate,
     private val jdbc: NamedParameterJdbcTemplate,
     @Value("\${synchronizer.store.base-path:../module-external-api/external-api-data}")
     private val basePath: String,
-	) : ManagedLifecycle {
+) : ManagedLifecycle {
     private val log = LoggerFactory.getLogger(javaClass)
     private val vtExecutor = Executors.newVirtualThreadPerTaskExecutor()
     private val processingPermit = Semaphore(2)
@@ -38,10 +40,18 @@ class BasicSnapshotChunkConsumer(
         topics = ["\${synchronizer.kafka.basic-chunk-ready-topic}"],
         groupId = "\${synchronizer.kafka.basic-consumer-group-id}",
     )
-    fun consume(message: String, acknowledgment: Acknowledgment) {
+    fun consume(
+        message: String,
+        acknowledgment: Acknowledgment,
+        @Header(name = KafkaHeaders.RECEIVED_TOPIC, required = false) topic: String?,
+        @Header(name = KafkaHeaders.RECEIVED_KEY, required = false) messageKey: String?,
+    ) {
         val event = objectMapper.readValue(message, SnapshotChunkReadyEvent::class.java)
 
-        if (event.endpoint != "character-basic") return
+        if (event.endpoint != "character-basic") {
+            acknowledgment.acknowledge()
+            return
+        }
 
         val runId = event.runId
         val chunkId = event.chunkId
@@ -49,14 +59,19 @@ class BasicSnapshotChunkConsumer(
         log.info("[BasicSync] received: runId={} chunkId={} objectKey={} records={}",
             runId, chunkId, event.objectKey, event.recordCount)
 
-        submitBasicChunk(event, acknowledgment, urgent = false)
+        submitBasicChunk(event, message, acknowledgment, topic, messageKey, urgent = false)
     }
 
     @KafkaListener(
         topics = ["\${synchronizer.kafka.urgent-basic-chunk-ready-topic}"],
         groupId = "\${synchronizer.kafka.urgent-basic-consumer-group-id}",
     )
-    fun consumeUrgentBasic(message: String, acknowledgment: Acknowledgment) {
+    fun consumeUrgentBasic(
+        message: String,
+        acknowledgment: Acknowledgment,
+        @Header(name = KafkaHeaders.RECEIVED_TOPIC, required = false) topic: String?,
+        @Header(name = KafkaHeaders.RECEIVED_KEY, required = false) messageKey: String?,
+    ) {
         val event = objectMapper.readValue(message, SnapshotChunkReadyEvent::class.java)
 
         if (event.endpoint != "character-basic") {
@@ -70,32 +85,43 @@ class BasicSnapshotChunkConsumer(
         log.info("[BasicSync] received URGENT: runId={} chunkId={} objectKey={} records={}",
             runId, chunkId, event.objectKey, event.recordCount)
 
-        submitBasicChunk(event, acknowledgment, urgent = true)
+        submitBasicChunk(event, message, acknowledgment, topic, messageKey, urgent = true)
     }
 
     private fun submitBasicChunk(
         event: SnapshotChunkReadyEvent,
+        eventPayloadJson: String,
         acknowledgment: Acknowledgment,
+        topic: String?,
+        messageKey: String?,
         urgent: Boolean,
     ) {
         val runId = event.runId
         val chunkId = event.chunkId
         val operation = if (urgent) "UrgentChunk" else "Chunk"
+        val identity = ChunkExecutionIdentity(
+            executionType = ChunkExecutionType.SYNCHRONIZER_BASIC_CHUNK,
+            runId = runId,
+            endpoint = event.endpoint,
+            chunkId = chunkId,
+        )
 
         chunkConsumerTemplate.submit(
             ChunkConsumerRequest(
                 logPrefix = "BasicSync",
                 log = log,
-                runId = runId,
-                chunkId = chunkId,
+                identity = identity,
+                topic = topic ?: event.eventType,
+                messageKey = messageKey ?: event.kafkaKey(),
+                eventType = event.eventType,
+                schemaVersion = event.schemaVersion,
+                eventPayloadJson = eventPayloadJson,
                 objectKey = event.objectKey,
                 acknowledgment = acknowledgment,
                 processingPermit = processingPermit,
                 executor = vtExecutor,
                 processContext = TaskContext.of("BasicSync", "${operation}Process", chunkId),
                 lifecycleContext = TaskContext.of("BasicSync", "${operation}Lifecycle", chunkId),
-                isAlreadySuccess = { chunkStatusRepository.isAlreadySuccess(runId, chunkId) },
-                claimChunk = { chunkStatusRepository.claimChunk(runId, chunkId, event.objectKey) },
                 process = {
                     val records = fileReader.read(event.objectKey)
                     repository.bulkUpsert(runId, chunkId, records)
@@ -110,8 +136,6 @@ class BasicSnapshotChunkConsumer(
                         records.size,
                     )
                 },
-                markSuccess = { chunkStatusRepository.markSuccess(runId, chunkId) },
-                markFailed = { reason -> chunkStatusRepository.markFailed(runId, chunkId, reason) },
                 onFailure = { ex ->
                     log.error(
                         "[BasicSync] {}chunk processing failed: runId={} chunkId={}",

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/ChunkConsumerTemplate.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/ChunkConsumerTemplate.kt
@@ -1,26 +1,63 @@
 package maple.synchronizer.consumer
 
+import maple.expectation.common.event.ChunkExecutionIdentity
+import maple.expectation.common.event.ChunkExecutionStatus
 import maple.expectation.infrastructure.executor.LogicExecutor
 import maple.expectation.infrastructure.executor.TaskContext
+import maple.synchronizer.metrics.SynchronizerMetrics
+import maple.synchronizer.repository.ChunkExecutionClaim
+import maple.synchronizer.repository.ChunkExecutionState
+import maple.synchronizer.repository.ChunkExecutionRepository
+import maple.synchronizer.repository.InsertChunkExecutionCommand
 import org.slf4j.Logger
 import org.slf4j.MDC
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.kafka.support.Acknowledgment
 import org.springframework.stereotype.Component
+import java.time.Duration
+import java.time.Instant
 import java.util.concurrent.Executor
 import java.util.concurrent.Semaphore
 
 @Component
 class ChunkConsumerTemplate(
     private val logicExecutor: LogicExecutor,
+    private val chunkExecutionRepository: ChunkExecutionRepository,
+    private val metrics: SynchronizerMetrics,
+    @Value("#{T(java.time.Duration).ofSeconds(\${chunk-execution.processing-timeout-seconds:600})}")
+    private val processingTimeout: Duration = Duration.ofSeconds(600),
+    @Value("#{T(java.time.Duration).ofSeconds(\${chunk-execution.retry.base-backoff-seconds:60})}")
+    private val retryBaseBackoff: Duration = Duration.ofSeconds(60),
+    @Value("\${chunk-execution.retry.max-attempts:5}")
+    private val maxAttempts: Int = 5,
+    @Value("\${chunk-execution.retry.artifact-missing-max-attempts:2}")
+    private val artifactMissingMaxAttempts: Int = 2,
 ) {
     fun submit(request: ChunkConsumerRequest) {
-        if (request.isAlreadySuccess()) {
-            request.log.info(
-                "[{}] skip already-successful chunk: runId={} chunkId={}",
+        if (chunkExecutionRepository.insertPendingIfAbsent(request.toInsertCommand())) {
+            metrics.recordChunkExecutionInserted(request.identity.executionType)
+        }
+
+        val state = chunkExecutionRepository.findExecutionState(request.identity)
+        if (state == null) {
+            request.log.warn(
+                "[{}] chunk execution row missing after insert: runId={} chunkId={}",
                 request.logPrefix,
                 request.runId,
                 request.chunkId,
             )
+            return
+        }
+
+        if (state.shouldAckSkip()) {
+            request.log.info(
+                "[{}] skip chunk in terminal/current state: runId={} chunkId={} status={}",
+                request.logPrefix,
+                request.runId,
+                request.chunkId,
+                state.status,
+            )
+            metrics.recordChunkExecutionSkipped(request.identity.executionType, state.status)
             request.acknowledgment.acknowledge()
             return
         }
@@ -35,16 +72,23 @@ class ChunkConsumerTemplate(
             return
         }
 
-        if (!request.claimChunk()) {
+        val claim = chunkExecutionRepository.claimProcessing(request.identity, processingTimeout)
+        if (claim == null) {
             request.processingPermit.release()
             request.log.info(
-                "[{}] skip - chunk already claimed: runId={} chunkId={}",
+                "[{}] skip - chunk not eligible for claim: runId={} chunkId={} status={}",
                 request.logPrefix,
                 request.runId,
                 request.chunkId,
+                state.status,
             )
+            metrics.recordChunkExecutionSkipped(request.identity.executionType, state.status)
             request.acknowledgment.acknowledge()
             return
+        }
+        metrics.recordChunkExecutionClaimed(request.identity.executionType)
+        if (state.status == ChunkExecutionStatus.PROCESSING) {
+            metrics.recordChunkExecutionReclaimedExpired(request.identity.executionType)
         }
 
         request.onAccepted()
@@ -55,20 +99,7 @@ class ChunkConsumerTemplate(
         request.executor.execute {
             logicExecutor.executeWithFinally(
                 task = {
-                    logicExecutor.executeOrCatch(
-                        task = {
-                            request.process()
-                            request.markSuccess()
-                            request.onSuccess()
-                            request.acknowledgment.acknowledge()
-                        },
-                        recovery = { ex ->
-                            request.markFailed(ex.message ?: "unknown")
-                            request.onFailure(ex)
-                            null
-                        },
-                        context = request.processContext,
-                    )
+                    processClaimed(request, claim)
                 },
                 finallyBlock = {
                     request.onFinally()
@@ -79,13 +110,199 @@ class ChunkConsumerTemplate(
             )
         }
     }
+
+    private fun processClaimed(
+        request: ChunkConsumerRequest,
+        claim: ChunkExecutionClaim,
+    ) {
+        if (request.schemaVersion != SUPPORTED_SCHEMA_VERSION) {
+            markUnsupportedSchema(request, claim)
+            return
+        }
+
+        logicExecutor.executeOrCatch(
+            task = {
+                request.process()
+                markSucceededAndAck(request, claim)
+            },
+            recovery = { ex ->
+                markFailureAndAck(request, claim, ex)
+                null
+            },
+            context = request.processContext,
+        )
+    }
+
+    private fun markSucceededAndAck(
+        request: ChunkConsumerRequest,
+        claim: ChunkExecutionClaim,
+    ) {
+        val marked = chunkExecutionRepository.markSucceeded(request.identity, claim.attemptCount)
+        if (marked) {
+            metrics.recordChunkExecutionSucceeded(request.identity.executionType)
+            request.onSuccess()
+            request.acknowledgment.acknowledge()
+            return
+        }
+
+        request.log.warn(
+            "[{}] success state write lost race, leaving unacked: runId={} chunkId={} attempt={}",
+            request.logPrefix,
+            request.runId,
+            request.chunkId,
+            claim.attemptCount,
+        )
+    }
+
+    private fun markUnsupportedSchema(
+        request: ChunkConsumerRequest,
+        claim: ChunkExecutionClaim,
+    ) {
+        val message = "Unsupported schemaVersion=${request.schemaVersion}"
+        val marked = chunkExecutionRepository.markFailedTerminal(
+            request.identity,
+            claim.attemptCount,
+            message,
+            UNSUPPORTED_SCHEMA_VERSION,
+        )
+        if (marked) {
+            metrics.recordChunkExecutionFailed(
+                request.identity.executionType,
+                ChunkExecutionStatus.FAILED_TERMINAL,
+                UNSUPPORTED_SCHEMA_VERSION,
+            )
+            request.log.warn(
+                "[{}] terminal chunk failure: runId={} chunkId={} reason={}",
+                request.logPrefix,
+                request.runId,
+                request.chunkId,
+                UNSUPPORTED_SCHEMA_VERSION,
+            )
+            request.acknowledgment.acknowledge()
+            return
+        }
+
+        logFailedStateWrite(request, claim)
+    }
+
+    private fun markFailureAndAck(
+        request: ChunkConsumerRequest,
+        claim: ChunkExecutionClaim,
+        ex: Throwable,
+    ) {
+        val failure = classifyFailure(ex, claim)
+        val error = ex.message ?: ex.javaClass.simpleName
+        val marked = if (failure.terminalReason == null) {
+            chunkExecutionRepository.markFailedRetryable(
+                request.identity,
+                claim.attemptCount,
+                error,
+                Instant.now().plus(retryBaseBackoff.multipliedBy(claim.attemptCount.toLong())),
+            )
+        } else {
+            chunkExecutionRepository.markFailedTerminal(
+                request.identity,
+                claim.attemptCount,
+                error,
+                failure.terminalReason,
+            )
+        }
+
+        if (marked) {
+            val status = if (failure.terminalReason == null) {
+                ChunkExecutionStatus.FAILED_RETRYABLE
+            } else {
+                ChunkExecutionStatus.FAILED_TERMINAL
+            }
+            metrics.recordChunkExecutionFailed(
+                request.identity.executionType,
+                status,
+                failure.terminalReason ?: RETRYABLE_FAILURE,
+            )
+            request.onFailure(ex)
+            request.acknowledgment.acknowledge()
+            return
+        }
+
+        logFailedStateWrite(request, claim)
+    }
+
+    private fun classifyFailure(
+        ex: Throwable,
+        claim: ChunkExecutionClaim,
+    ): FailureDecision {
+        val artifactMissing = ex.message?.contains("file not found", ignoreCase = true) == true
+        if (artifactMissing && claim.attemptCount >= artifactMissingMaxAttempts) {
+            return FailureDecision(ARTIFACT_MISSING_MAX_ATTEMPTS)
+        }
+        if (!artifactMissing && claim.attemptCount >= maxAttempts) {
+            return FailureDecision(MAX_ATTEMPTS_EXCEEDED)
+        }
+        return FailureDecision(terminalReason = null)
+    }
+
+    private fun logFailedStateWrite(
+        request: ChunkConsumerRequest,
+        claim: ChunkExecutionClaim,
+    ) {
+        request.log.warn(
+            "[{}] failure state write lost race, leaving unacked: runId={} chunkId={} attempt={}",
+            request.logPrefix,
+            request.runId,
+            request.chunkId,
+            claim.attemptCount,
+        )
+    }
+
+    private fun ChunkExecutionStatus.isTerminalSkip(): Boolean =
+        this == ChunkExecutionStatus.SUCCEEDED || this == ChunkExecutionStatus.FAILED_TERMINAL
+
+    private fun ChunkExecutionState.shouldAckSkip(): Boolean {
+        val now = Instant.now()
+        if (status.isTerminalSkip()) {
+            return true
+        }
+        if (status == ChunkExecutionStatus.FAILED_RETRYABLE && nextRetryAt?.isAfter(now) == true) {
+            return true
+        }
+        if (status == ChunkExecutionStatus.PROCESSING && leaseUntil?.isAfter(now) == true) {
+            return true
+        }
+        return false
+    }
+
+    private fun ChunkConsumerRequest.toInsertCommand(): InsertChunkExecutionCommand =
+        InsertChunkExecutionCommand(
+            identity = identity,
+            topic = topic,
+            messageKey = messageKey,
+            eventType = eventType,
+            schemaVersion = schemaVersion,
+            eventPayloadJson = eventPayloadJson,
+        )
+
+    private data class FailureDecision(
+        val terminalReason: String?,
+    )
+
+    private companion object {
+        private const val SUPPORTED_SCHEMA_VERSION = 1
+        private const val UNSUPPORTED_SCHEMA_VERSION = "UNSUPPORTED_SCHEMA_VERSION"
+        private const val ARTIFACT_MISSING_MAX_ATTEMPTS = "ARTIFACT_MISSING_MAX_ATTEMPTS"
+        private const val MAX_ATTEMPTS_EXCEEDED = "MAX_ATTEMPTS_EXCEEDED"
+        private const val RETRYABLE_FAILURE = "RETRYABLE_FAILURE"
+    }
 }
 
 data class ChunkConsumerRequest(
     val logPrefix: String,
     val log: Logger,
-    val runId: String,
-    val chunkId: String,
+    val identity: ChunkExecutionIdentity,
+    val topic: String,
+    val messageKey: String,
+    val eventType: String,
+    val schemaVersion: Int,
+    val eventPayloadJson: String,
     val objectKey: String,
     val acknowledgment: Acknowledgment,
     val processingPermit: Semaphore,
@@ -93,13 +310,12 @@ data class ChunkConsumerRequest(
     val processContext: TaskContext,
     val lifecycleContext: TaskContext,
     val mdcValues: Map<String, String> = emptyMap(),
-    val isAlreadySuccess: () -> Boolean,
-    val claimChunk: () -> Boolean,
     val process: () -> Unit,
-    val markSuccess: () -> Unit,
-    val markFailed: (String) -> Unit,
     val onAccepted: () -> Unit = {},
     val onSuccess: () -> Unit = {},
     val onFailure: (Throwable) -> Unit = {},
     val onFinally: () -> Unit = {},
-)
+) {
+    val runId: String = identity.runId
+    val chunkId: String = identity.chunkId
+}

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/KafkaResultChunkConsumer.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/KafkaResultChunkConsumer.kt
@@ -2,16 +2,19 @@ package maple.synchronizer.consumer
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.micrometer.core.instrument.Timer
-import maple.expectation.infrastructure.executor.TaskContext
 import maple.expectation.common.event.CalculatorResultChunkReadyEvent
+import maple.expectation.common.event.ChunkExecutionIdentity
+import maple.expectation.common.event.ChunkExecutionType
+import maple.expectation.infrastructure.executor.TaskContext
 import maple.expectation.infrastructure.lifecycle.ManagedLifecycle
 import maple.synchronizer.metrics.SynchronizerMetrics
 import maple.synchronizer.processor.ChunkProcessInput
 import maple.synchronizer.processor.ChunkProcessor
-import maple.synchronizer.repository.SynchronizerChunkStatusRepository
 import org.slf4j.LoggerFactory
 import org.springframework.kafka.annotation.KafkaListener
 import org.springframework.kafka.support.Acknowledgment
+import org.springframework.kafka.support.KafkaHeaders
+import org.springframework.messaging.handler.annotation.Header
 import org.springframework.stereotype.Component
 import java.util.concurrent.Executors
 import java.util.concurrent.Semaphore
@@ -20,10 +23,9 @@ import java.util.concurrent.Semaphore
 class KafkaResultChunkConsumer(
     private val objectMapper: ObjectMapper,
     private val chunkProcessor: ChunkProcessor,
-    private val chunkStatusRepository: SynchronizerChunkStatusRepository,
     private val metrics: SynchronizerMetrics,
     private val chunkConsumerTemplate: ChunkConsumerTemplate,
-		) : ManagedLifecycle {
+) : ManagedLifecycle {
     private val log = LoggerFactory.getLogger(KafkaResultChunkConsumer::class.java)
     private val vtExecutor = Executors.newVirtualThreadPerTaskExecutor()
     private val processingPermit = Semaphore(2)
@@ -32,10 +34,21 @@ class KafkaResultChunkConsumer(
         topics = ["\${synchronizer.kafka.result-chunk-ready-topic}"],
         groupId = "\${synchronizer.kafka.consumer-group-id}",
     )
-    fun consume(message: String, acknowledgment: Acknowledgment) {
+    fun consume(
+        message: String,
+        acknowledgment: Acknowledgment,
+        @Header(name = KafkaHeaders.RECEIVED_TOPIC, required = false) topic: String?,
+        @Header(name = KafkaHeaders.RECEIVED_KEY, required = false) messageKey: String?,
+    ) {
         val event = objectMapper.readValue(message, CalculatorResultChunkReadyEvent::class.java)
         val runId = event.sourceRunId
         val chunkId = event.sourceChunkId
+        val identity = ChunkExecutionIdentity(
+            executionType = ChunkExecutionType.SYNCHRONIZER_RESULT_CHUNK,
+            runId = runId,
+            endpoint = event.sourceEndpoint.ifBlank { "result" },
+            chunkId = chunkId,
+        )
 
         log.info("[Synchronizer] received: runId={} chunkId={} objectKey={} results={}",
             runId, chunkId, event.objectKey, event.resultCount)
@@ -45,17 +58,19 @@ class KafkaResultChunkConsumer(
             ChunkConsumerRequest(
                 logPrefix = "Synchronizer",
                 log = log,
-                runId = runId,
-                chunkId = chunkId,
+                identity = identity,
+                topic = topic ?: event.eventType,
+                messageKey = messageKey ?: event.kafkaKey(),
+                eventType = event.eventType,
+                schemaVersion = event.schemaVersion,
+                eventPayloadJson = message,
                 objectKey = event.objectKey,
                 acknowledgment = acknowledgment,
                 processingPermit = processingPermit,
                 executor = vtExecutor,
                 processContext = TaskContext.of("Synchronizer", "ChunkProcess", chunkId),
                 lifecycleContext = TaskContext.of("Synchronizer", "ChunkLifecycle", chunkId),
-                mdcValues = mapOf("kafkaTopic" to "calculator.result.chunk-ready"),
-                isAlreadySuccess = { chunkStatusRepository.isAlreadySuccess(runId, chunkId) },
-                claimChunk = { chunkStatusRepository.claimChunk(runId, chunkId, event.objectKey) },
+                mdcValues = mapOf("kafkaTopic" to (topic ?: event.eventType)),
                 process = {
                     chunkProcessor.process(ChunkProcessInput(
                         objectKey = event.objectKey,
@@ -64,8 +79,6 @@ class KafkaResultChunkConsumer(
                         resultCount = event.resultCount,
                     ))
                 },
-                markSuccess = { chunkStatusRepository.markSuccess(runId, chunkId) },
-                markFailed = { reason -> chunkStatusRepository.markFailed(runId, chunkId, reason) },
                 onAccepted = {
                     chunkSample = Timer.start()
                     metrics.incrementReceived()

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/metrics/SynchronizerMetrics.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/metrics/SynchronizerMetrics.kt
@@ -4,6 +4,8 @@ import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.DistributionSummary
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Timer
+import maple.expectation.common.event.ChunkExecutionStatus
+import maple.expectation.common.event.ChunkExecutionType
 import org.springframework.stereotype.Component
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -83,11 +85,62 @@ class SynchronizerMetrics(private val registry: MeterRegistry) {
     private fun statusCounter(status: String) =
         registry.counter("synchronizer_chunk_status_transition_total", "status", status)
 
+    private fun chunkExecutionCounter(name: String, executionType: ChunkExecutionType): Counter =
+        registry.counter(name, "execution_type", executionType.name)
+
+    private fun chunkExecutionSkippedCounter(
+        executionType: ChunkExecutionType,
+        status: ChunkExecutionStatus,
+    ): Counter =
+        registry.counter(
+            "chunk_execution_skipped_total",
+            "execution_type",
+            executionType.name,
+            "status",
+            status.name,
+        )
+
+    private fun chunkExecutionFailedCounter(
+        executionType: ChunkExecutionType,
+        status: ChunkExecutionStatus,
+        reason: String,
+    ): Counter =
+        registry.counter(
+            "chunk_execution_failed_total",
+            "execution_type",
+            executionType.name,
+            "status",
+            status.name,
+            "reason",
+            reason,
+        )
+
     fun incrementReceived() = chunksReceived.increment()
     fun incrementProcessing() = chunksProcessing.incrementAndGet()
     fun decrementProcessing() = chunksProcessing.decrementAndGet()
     fun incrementProcessed() = chunksProcessed.increment()
     fun incrementFailed() = chunksFailed.increment()
+
+    fun recordChunkExecutionInserted(executionType: ChunkExecutionType) =
+        chunkExecutionCounter("chunk_execution_inserted_total", executionType).increment()
+
+    fun recordChunkExecutionClaimed(executionType: ChunkExecutionType) =
+        chunkExecutionCounter("chunk_execution_claimed_total", executionType).increment()
+
+    fun recordChunkExecutionSkipped(executionType: ChunkExecutionType, status: ChunkExecutionStatus) =
+        chunkExecutionSkippedCounter(executionType, status).increment()
+
+    fun recordChunkExecutionSucceeded(executionType: ChunkExecutionType) =
+        chunkExecutionCounter("chunk_execution_succeeded_total", executionType).increment()
+
+    fun recordChunkExecutionFailed(
+        executionType: ChunkExecutionType,
+        status: ChunkExecutionStatus,
+        reason: String,
+    ) = chunkExecutionFailedCounter(executionType, status, reason).increment()
+
+    fun recordChunkExecutionReclaimedExpired(executionType: ChunkExecutionType) =
+        chunkExecutionCounter("chunk_execution_reclaimed_expired_total", executionType).increment()
 
     fun incrementDocuments(count: Int) = documentsProcessed.increment(count.toDouble())
     fun incrementItems(count: Long) = itemsProcessed.increment(count.toDouble())

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/repository/ChunkExecutionRepository.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/repository/ChunkExecutionRepository.kt
@@ -1,0 +1,247 @@
+package maple.synchronizer.repository
+
+import maple.expectation.common.event.ChunkExecutionIdentity
+import maple.expectation.common.event.ChunkExecutionStatus
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.stereotype.Repository
+import java.sql.Timestamp
+import java.time.Duration
+import java.time.Instant
+
+data class InsertChunkExecutionCommand(
+    val identity: ChunkExecutionIdentity,
+    val topic: String,
+    val messageKey: String,
+    val eventType: String,
+    val schemaVersion: Int,
+    val eventPayloadJson: String,
+)
+
+data class ChunkExecutionClaim(
+    val attemptCount: Int,
+)
+
+data class ChunkExecutionState(
+    val status: ChunkExecutionStatus,
+    val nextRetryAt: Instant?,
+    val leaseUntil: Instant?,
+    val attemptCount: Int,
+)
+
+@Repository
+class ChunkExecutionRepository(
+    private val jdbc: NamedParameterJdbcTemplate,
+) {
+    fun insertPendingIfAbsent(command: InsertChunkExecutionCommand): Boolean {
+        val sql = """
+            INSERT INTO chunk_execution (
+                execution_type,
+                run_id,
+                endpoint,
+                chunk_id,
+                topic,
+                message_key,
+                event_type,
+                schema_version,
+                event_payload_jsonb,
+                status,
+                attempt_count
+            ) VALUES (
+                :executionType,
+                :runId,
+                :endpoint,
+                :chunkId,
+                :topic,
+                :messageKey,
+                :eventType,
+                :schemaVersion,
+                CAST(:eventPayloadJson AS jsonb),
+                :status,
+                :attemptCount
+            )
+            ON CONFLICT (execution_type, run_id, endpoint, chunk_id) DO NOTHING
+        """.trimIndent()
+
+        return jdbc.update(sql, command.toParams()) > 0
+    }
+
+    fun findStatus(identity: ChunkExecutionIdentity): ChunkExecutionStatus? {
+        val sql = """
+            SELECT status
+            FROM chunk_execution
+            WHERE execution_type = :executionType
+              AND run_id = :runId
+              AND endpoint = :endpoint
+              AND chunk_id = :chunkId
+        """.trimIndent()
+
+        return jdbc.query(sql, identity.toParams()) { rs, _ -> rs.getString("status") }
+            .firstOrNull()
+            ?.let(ChunkExecutionStatus::valueOf)
+    }
+
+    fun findExecutionState(identity: ChunkExecutionIdentity): ChunkExecutionState? {
+        val sql = """
+            SELECT
+                status,
+                next_retry_at,
+                lease_until,
+                attempt_count
+            FROM chunk_execution
+            WHERE execution_type = :executionType
+              AND run_id = :runId
+              AND endpoint = :endpoint
+              AND chunk_id = :chunkId
+        """.trimIndent()
+
+        return jdbc.query(sql, identity.toParams()) { rs, _ ->
+            ChunkExecutionState(
+                status = ChunkExecutionStatus.valueOf(rs.getString("status")),
+                nextRetryAt = rs.getTimestamp("next_retry_at")?.toInstant(),
+                leaseUntil = rs.getTimestamp("lease_until")?.toInstant(),
+                attemptCount = rs.getInt("attempt_count"),
+            )
+        }.firstOrNull()
+    }
+
+    fun claimProcessing(identity: ChunkExecutionIdentity, processingTimeout: Duration): ChunkExecutionClaim? {
+        val sql = """
+            UPDATE chunk_execution
+            SET
+              status = 'PROCESSING',
+              attempt_count = attempt_count + 1,
+              processing_started_at = now(),
+              lease_until = now() + (:processingTimeoutSeconds * interval '1 second'),
+              updated_at = now()
+            WHERE execution_type = :executionType
+              AND run_id = :runId
+              AND endpoint = :endpoint
+              AND chunk_id = :chunkId
+              AND (
+                status = 'PENDING'
+                OR (status = 'FAILED_RETRYABLE' AND (next_retry_at IS NULL OR next_retry_at <= now()))
+                OR (status = 'PROCESSING' AND lease_until < now())
+              )
+            RETURNING attempt_count
+        """.trimIndent()
+
+        val params = identity.toParams()
+            .addValue("processingTimeoutSeconds", processingTimeout.seconds)
+
+        return jdbc.query(sql, params) { rs, _ -> ChunkExecutionClaim(rs.getInt("attempt_count")) }
+            .firstOrNull()
+    }
+
+    fun markSucceeded(identity: ChunkExecutionIdentity, claimedAttempt: Int): Boolean {
+        val sql = """
+            UPDATE chunk_execution
+            SET
+              status = 'SUCCEEDED',
+              next_retry_at = NULL,
+              last_error = NULL,
+              terminal_reason = NULL,
+              lease_until = NULL,
+              updated_at = now()
+            WHERE execution_type = :executionType
+              AND run_id = :runId
+              AND endpoint = :endpoint
+              AND chunk_id = :chunkId
+              AND status = 'PROCESSING'
+              AND attempt_count = :claimedAttempt
+        """.trimIndent()
+
+        return jdbc.update(sql, identity.toParams().addValue("claimedAttempt", claimedAttempt)) > 0
+    }
+
+    fun markFailedRetryable(
+        identity: ChunkExecutionIdentity,
+        claimedAttempt: Int,
+        error: String,
+        nextRetryAt: Instant,
+    ): Boolean {
+        val sql = """
+            UPDATE chunk_execution
+            SET
+              status = 'FAILED_RETRYABLE',
+              next_retry_at = :nextRetryAt,
+              first_failed_at = COALESCE(first_failed_at, now()),
+              last_failed_at = now(),
+              last_error = :error,
+              terminal_reason = NULL,
+              lease_until = NULL,
+              updated_at = now()
+            WHERE execution_type = :executionType
+              AND run_id = :runId
+              AND endpoint = :endpoint
+              AND chunk_id = :chunkId
+              AND status = 'PROCESSING'
+              AND attempt_count = :claimedAttempt
+        """.trimIndent()
+
+        return jdbc.update(
+            sql,
+            identity.toParams()
+                .addValue("claimedAttempt", claimedAttempt)
+                .addValue("nextRetryAt", Timestamp.from(nextRetryAt))
+                .addValue("error", error.safeError()),
+        ) > 0
+    }
+
+    fun markFailedTerminal(
+        identity: ChunkExecutionIdentity,
+        claimedAttempt: Int,
+        error: String,
+        terminalReason: String,
+    ): Boolean {
+        val sql = """
+            UPDATE chunk_execution
+            SET
+              status = 'FAILED_TERMINAL',
+              terminal_reason = :terminalReason,
+              next_retry_at = NULL,
+              first_failed_at = COALESCE(first_failed_at, now()),
+              last_failed_at = now(),
+              last_error = :error,
+              lease_until = NULL,
+              updated_at = now()
+            WHERE execution_type = :executionType
+              AND run_id = :runId
+              AND endpoint = :endpoint
+              AND chunk_id = :chunkId
+              AND status = 'PROCESSING'
+              AND attempt_count = :claimedAttempt
+        """.trimIndent()
+
+        return jdbc.update(
+            sql,
+            identity.toParams()
+                .addValue("claimedAttempt", claimedAttempt)
+                .addValue("terminalReason", terminalReason)
+                .addValue("error", error.safeError()),
+        ) > 0
+    }
+
+    private fun InsertChunkExecutionCommand.toParams(): MapSqlParameterSource =
+        identity.toParams()
+            .addValue("topic", topic)
+            .addValue("messageKey", messageKey)
+            .addValue("eventType", eventType)
+            .addValue("schemaVersion", schemaVersion)
+            .addValue("eventPayloadJson", eventPayloadJson)
+            .addValue("status", ChunkExecutionStatus.PENDING.name)
+            .addValue("attemptCount", 0)
+
+    private fun ChunkExecutionIdentity.toParams(): MapSqlParameterSource =
+        MapSqlParameterSource()
+            .addValue("executionType", executionType.name)
+            .addValue("runId", runId)
+            .addValue("endpoint", endpoint)
+            .addValue("chunkId", chunkId)
+
+    private fun String.safeError(): String = take(MAX_ERROR_LENGTH)
+
+    private companion object {
+        private const val MAX_ERROR_LENGTH = 2_000
+    }
+}

--- a/module-synchronizer/src/test/kotlin/maple/synchronizer/consumer/ChunkConsumerMappingTest.kt
+++ b/module-synchronizer/src/test/kotlin/maple/synchronizer/consumer/ChunkConsumerMappingTest.kt
@@ -1,0 +1,110 @@
+package maple.synchronizer.consumer
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import maple.expectation.common.event.ChunkExecutionType
+import maple.synchronizer.metrics.SynchronizerMetrics
+import maple.synchronizer.processor.ChunkProcessor
+import maple.synchronizer.repository.CharacterBasicRepository
+import maple.synchronizer.storage.BasicChunkFileReader
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.kafka.support.Acknowledgment
+
+class ChunkConsumerMappingTest {
+
+    private val objectMapper = jacksonObjectMapper().findAndRegisterModules()
+
+    @Test
+    fun `basic consumer maps event metadata to basic chunk execution request`() {
+        val template = mock<ChunkConsumerTemplate>()
+        val consumer = BasicSnapshotChunkConsumer(
+            objectMapper = objectMapper,
+            fileReader = mock<BasicChunkFileReader>(),
+            repository = mock<CharacterBasicRepository>(),
+            chunkConsumerTemplate = template,
+            jdbc = mock<NamedParameterJdbcTemplate>(),
+            basePath = "base",
+        )
+
+        consumer.consume(basicMessage, mock<Acknowledgment>(), "basic-topic", null)
+
+        val captor = argumentCaptor<ChunkConsumerRequest>()
+        verify(template).submit(captor.capture())
+        val request = captor.firstValue
+        assertThat(request.identity.executionType).isEqualTo(ChunkExecutionType.SYNCHRONIZER_BASIC_CHUNK)
+        assertThat(request.identity.runId).isEqualTo("run-basic")
+        assertThat(request.identity.endpoint).isEqualTo("character-basic")
+        assertThat(request.identity.chunkId).isEqualTo("chunk-1")
+        assertThat(request.topic).isEqualTo("basic-topic")
+        assertThat(request.messageKey).isEqualTo("run-basic:character-basic:chunk-1")
+        assertThat(request.eventType).isEqualTo("SNAPSHOT_CHUNK_READY")
+        assertThat(request.schemaVersion).isEqualTo(1)
+        assertThat(request.eventPayloadJson).isEqualTo(basicMessage)
+    }
+
+    @Test
+    fun `result consumer maps event metadata to result chunk execution request`() {
+        val template = mock<ChunkConsumerTemplate>()
+        val consumer = KafkaResultChunkConsumer(
+            objectMapper = objectMapper,
+            chunkProcessor = mock<ChunkProcessor>(),
+            metrics = mock<SynchronizerMetrics>(),
+            chunkConsumerTemplate = template,
+        )
+
+        consumer.consume(resultMessage, mock<Acknowledgment>(), "result-topic", "result-key")
+
+        val captor = argumentCaptor<ChunkConsumerRequest>()
+        verify(template).submit(captor.capture())
+        val request = captor.firstValue
+        assertThat(request.identity.executionType).isEqualTo(ChunkExecutionType.SYNCHRONIZER_RESULT_CHUNK)
+        assertThat(request.identity.runId).isEqualTo("run-result")
+        assertThat(request.identity.endpoint).isEqualTo("equipment")
+        assertThat(request.identity.chunkId).isEqualTo("chunk-2")
+        assertThat(request.topic).isEqualTo("result-topic")
+        assertThat(request.messageKey).isEqualTo("result-key")
+        assertThat(request.eventType).isEqualTo("CALCULATOR_RESULT_CHUNK_READY")
+        assertThat(request.schemaVersion).isEqualTo(1)
+        assertThat(request.eventPayloadJson).isEqualTo(resultMessage)
+    }
+
+    private companion object {
+        private val basicMessage = """
+            {
+              "eventId": "event-basic",
+              "eventType": "SNAPSHOT_CHUNK_READY",
+              "schemaVersion": 1,
+              "runId": "run-basic",
+              "endpoint": "character-basic",
+              "chunkId": "chunk-1",
+              "objectKey": "basic/chunk-1.jsonl.gz",
+              "recordCount": 10,
+              "uncompressedBytes": 100,
+              "compressedBytes": 50,
+              "createdAt": "2026-05-18T00:00:00Z"
+            }
+        """.trimIndent()
+
+        private val resultMessage = """
+            {
+              "eventId": "event-result",
+              "eventType": "CALCULATOR_RESULT_CHUNK_READY",
+              "schemaVersion": 1,
+              "sourceRunId": "run-result",
+              "sourceEndpoint": "equipment",
+              "sourceChunkId": "chunk-2",
+              "objectKey": "result/chunk-2.jsonl.gz",
+              "sourceRecordCount": 10,
+              "resultCount": 9,
+              "errorCount": 1,
+              "uncompressedBytes": 200,
+              "compressedBytes": 80,
+              "createdAt": "2026-05-18T00:00:00Z"
+            }
+        """.trimIndent()
+    }
+}

--- a/module-synchronizer/src/test/kotlin/maple/synchronizer/consumer/ChunkConsumerTemplateTest.kt
+++ b/module-synchronizer/src/test/kotlin/maple/synchronizer/consumer/ChunkConsumerTemplateTest.kt
@@ -1,0 +1,286 @@
+package maple.synchronizer.consumer
+
+import maple.expectation.common.event.ChunkExecutionIdentity
+import maple.expectation.common.event.ChunkExecutionStatus
+import maple.expectation.common.event.ChunkExecutionType
+import maple.expectation.common.function.ThrowingSupplier
+import maple.expectation.infrastructure.executor.LogicExecutor
+import maple.expectation.infrastructure.executor.TaskContext
+import maple.expectation.infrastructure.executor.function.ThrowingRunnable
+import maple.expectation.infrastructure.executor.strategy.ExceptionTranslator
+import maple.synchronizer.metrics.SynchronizerMetrics
+import maple.synchronizer.repository.ChunkExecutionClaim
+import maple.synchronizer.repository.ChunkExecutionState
+import maple.synchronizer.repository.ChunkExecutionRepository
+import maple.synchronizer.repository.InsertChunkExecutionCommand
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.inOrder
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.slf4j.LoggerFactory
+import org.springframework.kafka.support.Acknowledgment
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.Executor
+import java.util.concurrent.Semaphore
+
+class ChunkConsumerTemplateTest {
+
+    private val repository = mock<ChunkExecutionRepository>()
+    private val metrics = mock<SynchronizerMetrics>()
+    private val acknowledgment = mock<Acknowledgment>()
+    private val executor = Executor { command -> command.run() }
+    private val template = ChunkConsumerTemplate(
+        logicExecutor = ImmediateLogicExecutor(),
+        chunkExecutionRepository = repository,
+        metrics = metrics,
+        processingTimeout = Duration.ofSeconds(600),
+        retryBaseBackoff = Duration.ofSeconds(60),
+        maxAttempts = 5,
+        artifactMissingMaxAttempts = 2,
+    )
+
+    @Test
+    fun `first consume inserts pending claims processes marks success then acks`() {
+        val events = mutableListOf<String>()
+        whenever(repository.findExecutionState(identity)).thenReturn(state(ChunkExecutionStatus.PENDING))
+        whenever(repository.claimProcessing(eq(identity), any())).thenReturn(ChunkExecutionClaim(attemptCount = 1))
+        whenever(repository.markSucceeded(identity, 1)).thenReturn(true)
+
+        template.submit(request(process = { events.add("process") }))
+
+        val order = inOrder(repository, acknowledgment)
+        order.verify(repository).insertPendingIfAbsent(any())
+        order.verify(repository).findExecutionState(identity)
+        order.verify(repository).claimProcessing(eq(identity), any())
+        order.verify(repository).markSucceeded(identity, 1)
+        order.verify(acknowledgment).acknowledge()
+        assertThat(events).containsExactly("process")
+    }
+
+    @Test
+    fun `succeeded chunk skips processing and acks`() {
+        whenever(repository.findExecutionState(identity)).thenReturn(state(ChunkExecutionStatus.SUCCEEDED))
+
+        template.submit(request(process = { error("must not process") }))
+
+        verify(repository).insertPendingIfAbsent(any())
+        verify(repository, never()).claimProcessing(any(), any())
+        verify(acknowledgment).acknowledge()
+    }
+
+    @Test
+    fun `processing with active lease acks without permit or claim`() {
+        val permit = Semaphore(0)
+        whenever(repository.findExecutionState(identity)).thenReturn(
+            state(ChunkExecutionStatus.PROCESSING, leaseUntil = Instant.now().plusSeconds(60)),
+        )
+
+        template.submit(request(processingPermit = permit, process = { error("must not process") }))
+
+        verify(repository, never()).claimProcessing(any(), any())
+        verify(acknowledgment).acknowledge()
+    }
+
+    @Test
+    fun `retryable failure not due acks without permit or claim`() {
+        val permit = Semaphore(0)
+        whenever(repository.findExecutionState(identity)).thenReturn(
+            state(ChunkExecutionStatus.FAILED_RETRYABLE, nextRetryAt = Instant.now().plusSeconds(60)),
+        )
+
+        template.submit(request(processingPermit = permit, process = { error("must not process") }))
+
+        verify(repository, never()).claimProcessing(any(), any())
+        verify(acknowledgment).acknowledge()
+    }
+
+    @Test
+    fun `pending chunk with busy permit does not ack or claim`() {
+        val permit = Semaphore(0)
+        whenever(repository.findExecutionState(identity)).thenReturn(state(ChunkExecutionStatus.PENDING))
+
+        template.submit(request(processingPermit = permit, process = { error("must not process") }))
+
+        verify(repository, never()).claimProcessing(any(), any())
+        verify(acknowledgment, never()).acknowledge()
+    }
+
+    @Test
+    fun `due retryable failure with busy permit does not ack or claim`() {
+        val permit = Semaphore(0)
+        whenever(repository.findExecutionState(identity)).thenReturn(
+            state(ChunkExecutionStatus.FAILED_RETRYABLE, nextRetryAt = Instant.now().minusSeconds(60)),
+        )
+
+        template.submit(request(processingPermit = permit, process = { error("must not process") }))
+
+        verify(repository, never()).claimProcessing(any(), any())
+        verify(acknowledgment, never()).acknowledge()
+    }
+
+    @Test
+    fun `business failure writes retryable failure before ack`() {
+        whenever(repository.findExecutionState(identity)).thenReturn(state(ChunkExecutionStatus.PENDING))
+        whenever(repository.claimProcessing(eq(identity), any())).thenReturn(ChunkExecutionClaim(attemptCount = 1))
+        whenever(repository.markFailedRetryable(eq(identity), eq(1), any(), any())).thenReturn(true)
+
+        template.submit(request(process = { error("boom") }))
+
+        val order = inOrder(repository, acknowledgment)
+        order.verify(repository).markFailedRetryable(eq(identity), eq(1), any(), any())
+        order.verify(acknowledgment).acknowledge()
+        verify(repository, never()).markSucceeded(any(), any())
+    }
+
+    @Test
+    fun `failed state write does not ack`() {
+        whenever(repository.findExecutionState(identity)).thenReturn(state(ChunkExecutionStatus.PENDING))
+        whenever(repository.claimProcessing(eq(identity), any())).thenReturn(ChunkExecutionClaim(attemptCount = 1))
+        whenever(repository.markSucceeded(identity, 1)).thenReturn(false)
+
+        template.submit(request())
+
+        verify(acknowledgment, never()).acknowledge()
+    }
+
+    @Test
+    fun `unsupported schema marks terminal before business process`() {
+        whenever(repository.findExecutionState(identity)).thenReturn(state(ChunkExecutionStatus.PENDING))
+        whenever(repository.claimProcessing(eq(identity), any())).thenReturn(ChunkExecutionClaim(attemptCount = 1))
+        whenever(repository.markFailedTerminal(eq(identity), eq(1), any(), eq("UNSUPPORTED_SCHEMA_VERSION"))).thenReturn(true)
+
+        template.submit(request(schemaVersion = 2, process = { error("must not process") }))
+
+        val order = inOrder(repository, acknowledgment)
+        order.verify(repository).markFailedTerminal(eq(identity), eq(1), any(), eq("UNSUPPORTED_SCHEMA_VERSION"))
+        order.verify(acknowledgment).acknowledge()
+    }
+
+    @Test
+    fun `artifact missing becomes terminal after artifact missing max attempts`() {
+        whenever(repository.findExecutionState(identity)).thenReturn(state(ChunkExecutionStatus.PENDING))
+        whenever(repository.claimProcessing(eq(identity), any())).thenReturn(ChunkExecutionClaim(attemptCount = 2))
+        whenever(repository.markFailedTerminal(eq(identity), eq(2), any(), eq("ARTIFACT_MISSING_MAX_ATTEMPTS"))).thenReturn(true)
+
+        template.submit(request(process = { throw IllegalStateException("Result file not found: /tmp/missing") }))
+
+        verify(repository).markFailedTerminal(eq(identity), eq(2), any(), eq("ARTIFACT_MISSING_MAX_ATTEMPTS"))
+        verify(acknowledgment).acknowledge()
+    }
+
+    @Test
+    fun `request insert command carries kafka and event metadata`() {
+        whenever(repository.findExecutionState(identity)).thenReturn(state(ChunkExecutionStatus.SUCCEEDED))
+
+        template.submit(request())
+
+        val captor = argumentCaptor<InsertChunkExecutionCommand>()
+        verify(repository).insertPendingIfAbsent(captor.capture())
+        assertThat(captor.firstValue.identity).isEqualTo(identity)
+        assertThat(captor.firstValue.topic).isEqualTo("topic-a")
+        assertThat(captor.firstValue.messageKey).isEqualTo("key-a")
+        assertThat(captor.firstValue.eventType).isEqualTo("EVENT_A")
+        assertThat(captor.firstValue.schemaVersion).isEqualTo(1)
+        assertThat(captor.firstValue.eventPayloadJson).isEqualTo("""{"eventId":"event-1"}""")
+    }
+
+    private fun request(
+        schemaVersion: Int = 1,
+        processingPermit: Semaphore = Semaphore(1),
+        process: () -> Unit = {},
+    ) = ChunkConsumerRequest(
+        logPrefix = "Test",
+        log = LoggerFactory.getLogger(ChunkConsumerTemplateTest::class.java),
+        identity = identity,
+        topic = "topic-a",
+        messageKey = "key-a",
+        eventType = "EVENT_A",
+        schemaVersion = schemaVersion,
+        eventPayloadJson = """{"eventId":"event-1"}""",
+        objectKey = "object-key",
+        acknowledgment = acknowledgment,
+        processingPermit = processingPermit,
+        executor = executor,
+        processContext = TaskContext.of("Test", "Process", "chunk-1"),
+        lifecycleContext = TaskContext.of("Test", "Lifecycle", "chunk-1"),
+        process = process,
+    )
+
+    private fun state(
+        status: ChunkExecutionStatus,
+        nextRetryAt: Instant? = null,
+        leaseUntil: Instant? = null,
+    ) = ChunkExecutionState(
+        status = status,
+        nextRetryAt = nextRetryAt,
+        leaseUntil = leaseUntil,
+        attemptCount = 0,
+    )
+
+    private class ImmediateLogicExecutor : LogicExecutor {
+        override fun <T> execute(task: ThrowingSupplier<T>, context: TaskContext): T = task.get()
+
+        override fun executeVoid(task: ThrowingRunnable, context: TaskContext) = task.run()
+
+        override fun executeVoidJava(task: Runnable, context: TaskContext) = task.run()
+
+        override fun <T> executeWithFinally(
+            task: ThrowingSupplier<T>,
+            finallyBlock: Runnable,
+            context: TaskContext,
+        ): T {
+            val result = task.get()
+            finallyBlock.run()
+            return result
+        }
+
+        override fun <T> executeOrDefault(task: ThrowingSupplier<T>, defaultValue: T, context: TaskContext): T =
+            runCatching { task.get() }.getOrDefault(defaultValue)
+
+        override fun <T> executeWithTranslation(
+            task: ThrowingSupplier<T>,
+            customTranslator: ExceptionTranslator,
+            context: TaskContext,
+        ): T = task.get()
+
+        override fun <T> executeWithFallback(
+            task: ThrowingSupplier<T>,
+            fallback: (Throwable) -> T,
+            context: TaskContext,
+        ): T = runCatching { task.get() }.getOrElse(fallback)
+
+        override fun <T> executeWithFallback(
+            task: ThrowingSupplier<T>,
+            fallback: ExceptionTranslator,
+            context: TaskContext,
+        ): T = task.get()
+
+        override fun <T> executeOrCatch(
+            task: ThrowingSupplier<T>,
+            recovery: (Throwable) -> T,
+            context: TaskContext,
+        ): T = runCatching { task.get() }.getOrElse(recovery)
+
+        override fun <T> executeOrCatch(
+            task: ThrowingSupplier<T>,
+            recovery: ExceptionTranslator,
+            context: TaskContext,
+        ): T = task.get()
+    }
+
+    private companion object {
+        private val identity = ChunkExecutionIdentity(
+            executionType = ChunkExecutionType.SYNCHRONIZER_RESULT_CHUNK,
+            runId = "run-1",
+            endpoint = "result",
+            chunkId = "chunk-1",
+        )
+    }
+}

--- a/module-synchronizer/src/test/kotlin/maple/synchronizer/repository/ChunkExecutionRepositoryTest.kt
+++ b/module-synchronizer/src/test/kotlin/maple/synchronizer/repository/ChunkExecutionRepositoryTest.kt
@@ -1,0 +1,376 @@
+package maple.synchronizer.repository
+
+import maple.expectation.common.event.ChunkExecutionIdentity
+import maple.expectation.common.event.ChunkExecutionStatus
+import maple.expectation.common.event.ChunkExecutionType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.core.io.ClassPathResource
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.jdbc.datasource.DriverManagerDataSource
+import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.utility.DockerImageName
+import java.sql.Timestamp
+import java.time.Duration
+import java.time.Instant
+import javax.sql.DataSource
+
+class ChunkExecutionRepositoryTest {
+
+    @BeforeEach
+    fun resetTable() {
+        jdbcTemplate.execute("TRUNCATE TABLE chunk_execution RESTART IDENTITY")
+    }
+
+    @Test
+    fun `duplicate insert same identity returns true then false and keeps one row`() {
+        val first = repository.insertPendingIfAbsent(command())
+        val second = repository.insertPendingIfAbsent(command())
+
+        assertThat(first).isTrue()
+        assertThat(second).isFalse()
+        assertThat(rowCount()).isEqualTo(1)
+        assertThat(repository.findStatus(identity)).isEqualTo(ChunkExecutionStatus.PENDING)
+    }
+
+    @Test
+    fun `find execution state returns status retry lease and attempt count`() {
+        val nextRetryAt = Instant.parse("2026-05-18T10:00:00Z")
+        repository.insertPendingIfAbsent(command())
+        val claim = requireNotNull(repository.claimProcessing(identity, Duration.ofMinutes(10)))
+        repository.markFailedRetryable(identity, claim.attemptCount, "temporary failure", nextRetryAt)
+
+        val state = repository.findExecutionState(identity)
+
+        assertThat(state?.status).isEqualTo(ChunkExecutionStatus.FAILED_RETRYABLE)
+        assertThat(state?.nextRetryAt).isEqualTo(nextRetryAt)
+        assertThat(state?.leaseUntil).isNull()
+        assertThat(state?.attemptCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `claim PENDING changes status to PROCESSING with first attempt and lease`() {
+        repository.insertPendingIfAbsent(command())
+
+        val claimed = repository.claimProcessing(identity, Duration.ofMinutes(10))
+
+        val row = row()
+        assertThat(claimed?.attemptCount).isEqualTo(1)
+        assertThat(row.status).isEqualTo("PROCESSING")
+        assertThat(row.attemptCount).isEqualTo(1)
+        assertThat(row.leaseUntil).isNotNull()
+    }
+
+    @Test
+    fun `non-expired PROCESSING claim returns false`() {
+        repository.insertPendingIfAbsent(command())
+        repository.claimProcessing(identity, Duration.ofMinutes(10))
+
+        val claimed = repository.claimProcessing(identity, Duration.ofMinutes(10))
+
+        val row = row()
+        assertThat(claimed).isNull()
+        assertThat(row.status).isEqualTo("PROCESSING")
+        assertThat(row.attemptCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `expired PROCESSING reclaims and increments attempt count`() {
+        repository.insertPendingIfAbsent(command())
+        repository.claimProcessing(identity, Duration.ofMinutes(10))
+        expireLease()
+
+        val claimed = repository.claimProcessing(identity, Duration.ofMinutes(10))
+
+        val row = row()
+        assertThat(claimed?.attemptCount).isEqualTo(2)
+        assertThat(row.status).isEqualTo("PROCESSING")
+        assertThat(row.attemptCount).isEqualTo(2)
+        assertThat(row.leaseUntil).isNotNull()
+    }
+
+    @Test
+    fun `retryable failure with null retry time remains claimable`() {
+        repository.insertPendingIfAbsent(command())
+        val firstClaim = requireNotNull(repository.claimProcessing(identity, Duration.ofMinutes(10)))
+        repository.markFailedRetryable(identity, firstClaim.attemptCount, "temporary failure", Instant.now().minusSeconds(60))
+        clearNextRetryAt()
+
+        val claimed = repository.claimProcessing(identity, Duration.ofMinutes(10))
+
+        val row = row()
+        assertThat(claimed?.attemptCount).isEqualTo(2)
+        assertThat(row.status).isEqualTo("PROCESSING")
+        assertThat(row.attemptCount).isEqualTo(2)
+    }
+
+    @Test
+    fun `mark success changes PROCESSING to SUCCEEDED and clears lease`() {
+        repository.insertPendingIfAbsent(command())
+        val claim = requireNotNull(repository.claimProcessing(identity, Duration.ofMinutes(10)))
+
+        val updated = repository.markSucceeded(identity, claim.attemptCount)
+
+        val row = row()
+        assertThat(updated).isTrue()
+        assertThat(row.status).isEqualTo("SUCCEEDED")
+        assertThat(row.nextRetryAt).isNull()
+        assertThat(row.lastError).isNull()
+        assertThat(row.terminalReason).isNull()
+        assertThat(row.leaseUntil).isNull()
+    }
+
+    @Test
+    fun `mark retryable failure populates failure timestamps retry time and error`() {
+        val nextRetryAt = Instant.parse("2026-05-18T10:00:00Z")
+        repository.insertPendingIfAbsent(command())
+        val claim = requireNotNull(repository.claimProcessing(identity, Duration.ofMinutes(10)))
+
+        val updated = repository.markFailedRetryable(identity, claim.attemptCount, "temporary failure", nextRetryAt)
+
+        val row = row()
+        assertThat(updated).isTrue()
+        assertThat(row.status).isEqualTo("FAILED_RETRYABLE")
+        assertThat(row.firstFailedAt).isNotNull()
+        assertThat(row.lastFailedAt).isNotNull()
+        assertThat(row.nextRetryAt).isEqualTo(Timestamp.from(nextRetryAt))
+        assertThat(row.lastError).isEqualTo("temporary failure")
+        assertThat(row.terminalReason).isNull()
+        assertThat(row.leaseUntil).isNull()
+    }
+
+    @Test
+    fun `mark terminal failure populates terminal reason and clears retry time`() {
+        repository.insertPendingIfAbsent(command())
+        val claim = requireNotNull(repository.claimProcessing(identity, Duration.ofMinutes(10)))
+
+        val updated = repository.markFailedTerminal(identity, claim.attemptCount, "bad schema", "UNSUPPORTED_SCHEMA")
+
+        val row = row()
+        assertThat(updated).isTrue()
+        assertThat(row.status).isEqualTo("FAILED_TERMINAL")
+        assertThat(row.firstFailedAt).isNotNull()
+        assertThat(row.lastFailedAt).isNotNull()
+        assertThat(row.lastError).isEqualTo("bad schema")
+        assertThat(row.terminalReason).isEqualTo("UNSUPPORTED_SCHEMA")
+        assertThat(row.nextRetryAt).isNull()
+        assertThat(row.leaseUntil).isNull()
+    }
+
+    @Test
+    fun `stale expired claim cannot mark success or failure after reclaim`() {
+        val nextRetryAt = Instant.parse("2026-05-18T10:00:00Z")
+        repository.insertPendingIfAbsent(command())
+        val staleClaim = requireNotNull(repository.claimProcessing(identity, Duration.ofMinutes(10)))
+        expireLease()
+        val currentClaim = requireNotNull(repository.claimProcessing(identity, Duration.ofMinutes(10)))
+
+        val staleSuccess = repository.markSucceeded(identity, staleClaim.attemptCount)
+        val staleRetryableFailure = repository.markFailedRetryable(
+            identity,
+            staleClaim.attemptCount,
+            "stale retryable failure",
+            nextRetryAt,
+        )
+        val staleTerminalFailure = repository.markFailedTerminal(
+            identity,
+            staleClaim.attemptCount,
+            "stale terminal failure",
+            "STALE",
+        )
+
+        val row = row()
+        assertThat(currentClaim.attemptCount).isEqualTo(2)
+        assertThat(staleSuccess).isFalse()
+        assertThat(staleRetryableFailure).isFalse()
+        assertThat(staleTerminalFailure).isFalse()
+        assertThat(row.status).isEqualTo("PROCESSING")
+        assertThat(row.attemptCount).isEqualTo(2)
+        assertThat(row.nextRetryAt).isNull()
+        assertThat(row.lastError).isNull()
+        assertThat(row.terminalReason).isNull()
+        assertThat(row.leaseUntil).isNotNull()
+    }
+
+    private fun command() = InsertChunkExecutionCommand(
+        identity = identity,
+        topic = "result-topic",
+        messageKey = "message-key",
+        eventType = "CalculatorResultChunkReadyEvent",
+        schemaVersion = 1,
+        eventPayloadJson = """{"runId":"run-1"}""",
+    )
+
+    private fun rowCount(): Int =
+        jdbcTemplate.queryForObject("SELECT COUNT(*) FROM chunk_execution", Int::class.java) ?: 0
+
+    private fun row(): ChunkExecutionRow =
+        namedJdbc.query(
+            """
+            SELECT
+                status,
+                attempt_count,
+                next_retry_at,
+                first_failed_at,
+                last_failed_at,
+                last_error,
+                terminal_reason,
+                lease_until
+            FROM chunk_execution
+            WHERE execution_type = :executionType
+              AND run_id = :runId
+              AND endpoint = :endpoint
+              AND chunk_id = :chunkId
+            """.trimIndent(),
+            identityParams(),
+        ) { rs, _ ->
+            ChunkExecutionRow(
+                status = rs.getString("status"),
+                attemptCount = rs.getInt("attempt_count"),
+                nextRetryAt = rs.getTimestamp("next_retry_at"),
+                firstFailedAt = rs.getTimestamp("first_failed_at"),
+                lastFailedAt = rs.getTimestamp("last_failed_at"),
+                lastError = rs.getString("last_error"),
+                terminalReason = rs.getString("terminal_reason"),
+                leaseUntil = rs.getTimestamp("lease_until"),
+            )
+        }.first()
+
+    private fun expireLease() {
+        namedJdbc.update(
+            """
+            UPDATE chunk_execution
+            SET lease_until = now() - interval '1 second'
+            WHERE execution_type = :executionType
+              AND run_id = :runId
+              AND endpoint = :endpoint
+              AND chunk_id = :chunkId
+            """.trimIndent(),
+            identityParams(),
+        )
+    }
+
+    private fun clearNextRetryAt() {
+        namedJdbc.update(
+            """
+            UPDATE chunk_execution
+            SET next_retry_at = NULL
+            WHERE execution_type = :executionType
+              AND run_id = :runId
+              AND endpoint = :endpoint
+              AND chunk_id = :chunkId
+            """.trimIndent(),
+            identityParams(),
+        )
+    }
+
+    private fun identityParams(): MapSqlParameterSource =
+        MapSqlParameterSource()
+            .addValue("executionType", identity.executionType.name)
+            .addValue("runId", identity.runId)
+            .addValue("endpoint", identity.endpoint)
+            .addValue("chunkId", identity.chunkId)
+
+    private data class ChunkExecutionRow(
+        val status: String,
+        val attemptCount: Int,
+        val nextRetryAt: Timestamp?,
+        val firstFailedAt: Timestamp?,
+        val lastFailedAt: Timestamp?,
+        val lastError: String?,
+        val terminalReason: String?,
+        val leaseUntil: Timestamp?,
+    )
+
+    private class PostgresTestContainer :
+        GenericContainer<PostgresTestContainer>(DockerImageName.parse("postgres:17-alpine"))
+
+    private companion object {
+        private val identity = ChunkExecutionIdentity(
+            executionType = ChunkExecutionType.SYNCHRONIZER_RESULT_CHUNK,
+            runId = "run-1",
+            endpoint = "equipment",
+            chunkId = "chunk-1",
+        )
+
+        private const val TEST_SCHEMA = "chunk_execution_repository_test"
+
+        private lateinit var jdbcTemplate: JdbcTemplate
+        private lateinit var namedJdbc: NamedParameterJdbcTemplate
+        private lateinit var repository: ChunkExecutionRepository
+        private var postgres: PostgresTestContainer? = null
+
+        @BeforeAll
+        @JvmStatic
+        fun setUpDatabase() {
+            val dataSource = testDataSource()
+            ResourceDatabasePopulator(ClassPathResource("db/migration/V128__chunk_execution.sql"))
+                .execute(dataSource)
+            jdbcTemplate = JdbcTemplate(dataSource)
+            namedJdbc = NamedParameterJdbcTemplate(dataSource)
+            repository = ChunkExecutionRepository(namedJdbc)
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun stopContainer() {
+            postgres?.stop()
+        }
+
+        private fun testDataSource(): DataSource {
+            val containerDataSource = tryContainerDataSource()
+            if (containerDataSource != null) {
+                return containerDataSource
+            }
+            return localDataSource()
+        }
+
+        private fun tryContainerDataSource(): DataSource? {
+            return runCatching {
+                val container = PostgresTestContainer()
+                    .withEnv("POSTGRES_DB", "testdb")
+                    .withEnv("POSTGRES_USER", "test")
+                    .withEnv("POSTGRES_PASSWORD", "test")
+                    .withExposedPorts(5432)
+                    .waitingFor(Wait.forListeningPort())
+                container.start()
+                postgres = container
+                schemaDataSource(
+                    baseUrl = "jdbc:postgresql://${container.host}:${container.getMappedPort(5432)}/testdb",
+                    username = "test",
+                    password = "test",
+                )
+            }.getOrNull()
+        }
+
+        private fun localDataSource(): DataSource =
+            schemaDataSource(
+                baseUrl = "jdbc:postgresql://${env("PGHOST", "localhost")}:${env("PGPORT", "5432")}/${env("PGDATABASE", "postgres")}",
+                username = env("PGUSER", System.getProperty("user.name")),
+                password = env("PGPASSWORD", ""),
+            )
+
+        private fun schemaDataSource(baseUrl: String, username: String, password: String): DataSource {
+            val baseDataSource = driverManagerDataSource(baseUrl, username, password)
+            JdbcTemplate(baseDataSource).execute("CREATE SCHEMA IF NOT EXISTS $TEST_SCHEMA")
+            return driverManagerDataSource("$baseUrl?currentSchema=$TEST_SCHEMA", username, password)
+        }
+
+        private fun driverManagerDataSource(url: String, username: String, password: String): DataSource =
+            DriverManagerDataSource().apply {
+                setDriverClassName("org.postgresql.Driver")
+                this.url = url
+                this.username = username
+                this.password = password
+            }
+
+        private fun env(name: String, fallback: String): String = System.getenv(name) ?: fallback
+    }
+}


### PR DESCRIPTION
## Summary
- add chunk_execution migration and common execution identity/status types
- persist synchronizer chunk execution state before Kafka ack with claim fencing
- add consumer/repository tests and chunk execution metrics

## Test Plan
- ./gradlew --console=plain :module-common:compileKotlin :module-infra:compileKotlin :module-synchronizer:compileKotlin :module-synchronizer:test --tests '*ChunkConsumer*' --tests '*KafkaResultChunkConsumer*' --tests '*BasicSnapshotChunkConsumer*' --tests 'maple.synchronizer.repository.ChunkExecutionRepositoryTest' --rerun-tasks
- ./gradlew --console=plain :module-synchronizer:test --tests 'maple.synchronizer.processor.DefaultChunkProcessorTest' --rerun-tasks
- ./gradlew --console=plain :module-synchronizer:test --rerun-tasks