### PR TITLE
fix(pipeline): address review feedback

### DIFF
--- a/module-app/src/main/java/maple/expectation/application/service/expectation/queue/ExpectationCalculationQueue.java
+++ b/module-app/src/main/java/maple/expectation/application/service/expectation/queue/ExpectationCalculationQueue.java
@@ -124,7 +124,7 @@ public class ExpectationCalculationQueue {
         jobPort.createOrFindActiveJob(null, task.getUserIgn(), task.getPresetNo());
     CalculationJob job = claim.getJob();
 
-    if (claim.getCreated() && job.getStatus() == CalculationJobStatus.REQUESTED) {
+    if (job.getStatus() == CalculationJobStatus.REQUESTED) {
       boolean transitioned =
           jobPort.transitionStatus(
               job.getJobId(), CalculationJobStatus.REQUESTED, CalculationJobStatus.OCID_RESOLVING);

--- a/module-calculator/src/main/kotlin/maple/calculator/CalculatorChunkProcessingCoordinator.kt
+++ b/module-calculator/src/main/kotlin/maple/calculator/CalculatorChunkProcessingCoordinator.kt
@@ -83,6 +83,7 @@ class CalculatorChunkProcessingCoordinator(
         }.onFailure { ex ->
             log.error("[Coordinator] chunk processing failed: runId={} chunkId={}: {}", event.runId, event.chunkId, ex.message, ex)
             metrics.recordChunkFailed()
+            throw ex
         }
     }
 

--- a/module-calculator/src/main/kotlin/maple/calculator/processor/SnapshotChunkProcessor.kt
+++ b/module-calculator/src/main/kotlin/maple/calculator/processor/SnapshotChunkProcessor.kt
@@ -34,6 +34,9 @@ class SnapshotChunkProcessor(
 ) {
     private val log = LoggerFactory.getLogger(SnapshotChunkProcessor::class.java)
     private val sampleCount = AtomicInteger(0)
+    private val workerCount: Int = requireNotNull(properties.workerCount.takeIf { it > 0 }) {
+        "calculator.pipeline.worker-count must be positive: ${properties.workerCount}"
+    }
 
     data class FlatItem(
         val ocid: String,
@@ -55,7 +58,7 @@ class SnapshotChunkProcessor(
 
         launch {
             coroutineScope {
-                repeat(properties.workerCount) {
+                repeat(workerCount) {
                     launch(Dispatchers.Default) {
                         parseLines(lineChannel, itemChannel, recordCount, successCount, totalItems)
                     }
@@ -66,7 +69,7 @@ class SnapshotChunkProcessor(
 
         launch {
             coroutineScope {
-                repeat(properties.workerCount) {
+                repeat(workerCount) {
                     launch(Dispatchers.Default) {
                         processItems(itemChannel, resultChannel, calculatedCount, errorCount)
                     }
@@ -159,7 +162,6 @@ class SnapshotChunkProcessor(
     }
 
     private fun calculateComponentCosts(cubeInput: CubeCalculationInput, presetNo: Int): CalculationCache.ComponentCosts {
-        if (!cubeInput.isReady()) return CalculationCache.ComponentCosts.empty()
         val input = EquipmentCalculationInputConverter.toCalculationInput(cubeInput, presetNo)
         return calculationCache.calculate(input)
     }

--- a/module-common/src/main/kotlin/maple/common/cleanup/RunRetentionPolicy.kt
+++ b/module-common/src/main/kotlin/maple/common/cleanup/RunRetentionPolicy.kt
@@ -12,6 +12,8 @@ object RunRetentionPolicy {
         now: Instant,
     ): List<RunInfo> {
         if (runs.isEmpty()) return emptyList()
+        require(keepRecentCount >= 0) { "keepRecentCount must be non-negative: $keepRecentCount" }
+        require(keepWithinHours >= 0) { "keepWithinHours must be non-negative: $keepWithinHours" }
 
         val cutoff = now.minus(Duration.ofHours(keepWithinHours))
         val recentRunIds = runs.sortedByDescending { it.createdAt }

--- a/module-external-api/src/main/kotlin/maple/externalapi/infra/storage/LocalExternalApiArtifactStoreAdapter.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/infra/storage/LocalExternalApiArtifactStoreAdapter.kt
@@ -9,6 +9,7 @@ import java.nio.file.SimpleFileVisitor
 import java.nio.file.StandardCopyOption
 import java.nio.file.attribute.BasicFileAttributes
 import java.security.MessageDigest
+import java.util.UUID
 import java.util.stream.Collectors
 import java.util.zip.GZIPInputStream
 import java.util.zip.GZIPOutputStream
@@ -37,7 +38,7 @@ class LocalExternalApiArtifactStoreAdapter(
         val filePath = resolvePath(endpoint, key)
 
         filePath.parent.toFile().mkdirs()
-        val tempFile = filePath.resolveSibling(filePath.fileName.toString() + ".tmp")
+        val tempFile = filePath.resolveSibling("${filePath.fileName}.${UUID.randomUUID()}.tmp")
         Files.write(tempFile, compressed)
         Files.move(tempFile, filePath, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
 

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/ExternalApiScheduler.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/ExternalApiScheduler.kt
@@ -12,6 +12,7 @@ import org.springframework.context.event.EventListener
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import java.time.Duration
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -101,7 +102,8 @@ class ExternalApiScheduler(
             return
         }
 
-        snapshotFetchPhase.executeItemEquipment(executor, entries)
+        CompletableFuture.completedFuture(null)
+            .thenCompose { snapshotFetchPhase.executeItemEquipment(executor, entries) }
             .whenComplete { _, ex ->
                 if (ex != null) {
                     log.error("[Scheduler] ITEM_EQUIPMENT cycle failed", ex)

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/SchedulerPhaseUtils.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/SchedulerPhaseUtils.kt
@@ -30,8 +30,9 @@ internal object SchedulerPhaseUtils {
     }
 
     fun newRunId(): String {
+        val now = Instant.now()
         val formatter = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss").withZone(ZoneId.systemDefault())
-        return formatter.format(Instant.now())
+        return "${formatter.format(now)}-${now.nano}"
     }
 
     fun writeRunningMarker(runDir: Path) {

--- a/module-external-api/src/main/kotlin/maple/externalapi/snapshot/ChunkedSnapshotSink.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/snapshot/ChunkedSnapshotSink.kt
@@ -12,6 +12,7 @@ import java.nio.file.Path
 import java.time.Instant
 import java.util.UUID
 import java.util.concurrent.ArrayBlockingQueue
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 
@@ -64,7 +65,19 @@ class ChunkedSnapshotSink(
             }
             throw IllegalStateException("sink is closed, cannot submit")
         }
-        if (!queue.offer(record, 30, java.util.concurrent.TimeUnit.SECONDS)) {
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(30)
+        while (System.nanoTime() < deadline) {
+            writerError.get()?.let { err ->
+                throw IllegalStateException("sink closed due to writer error: ${err.message}", err)
+            }
+            if (!writerThread.isAlive) {
+                throw IllegalStateException("sink writer thread is not alive")
+            }
+            if (queue.offer(record, 100, TimeUnit.MILLISECONDS)) {
+                return
+            }
+        }
+        if (!queue.offer(record)) {
             throw IllegalStateException("sink queue full after 30s, likely writer thread stuck")
         }
     }

--- a/module-external-api/src/main/kotlin/maple/externalapi/urgent/UrgentCharacterRequestConsumer.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/urgent/UrgentCharacterRequestConsumer.kt
@@ -92,6 +92,7 @@ class UrgentCharacterRequestConsumer(
                 .thenComposeAsync({
                     publishUrgentChunksAsync(
                         request = request,
+                        ocid = ocid,
                         basicData = basicFuture.resultNow(),
                         equipmentData = equipmentFuture.resultNow(),
                     )
@@ -100,14 +101,15 @@ class UrgentCharacterRequestConsumer(
 
     private fun publishUrgentChunksAsync(
         request: UrgentCharacterRequest,
+        ocid: String,
         basicData: ByteArray,
         equipmentData: ByteArray,
     ): CompletableFuture<Void> {
         val runId = "urgent-${UUID.randomUUID()}"
 
-        return publishUrgentChunkAsync(runId, ExternalApiEndpoint.CHARACTER_BASIC, request.userIgn, basicData, "OCID")
+        return publishUrgentChunkAsync(runId, ExternalApiEndpoint.CHARACTER_BASIC, request.userIgn, ocid, basicData, "OCID")
             .thenCompose {
-                publishUrgentChunkAsync(runId, ExternalApiEndpoint.ITEM_EQUIPMENT, request.userIgn, equipmentData, "OCID")
+                publishUrgentChunkAsync(runId, ExternalApiEndpoint.ITEM_EQUIPMENT, request.userIgn, ocid, equipmentData, "OCID")
             }
             .thenAccept {
                 log.info(
@@ -122,6 +124,7 @@ class UrgentCharacterRequestConsumer(
         runId: String,
         endpoint: ExternalApiEndpoint,
         userIgn: String,
+        key: String,
         data: ByteArray,
         keyType: String,
     ): CompletableFuture<Void> =
@@ -133,7 +136,7 @@ class UrgentCharacterRequestConsumer(
             val writer = GzipJsonlChunkWriter(chunksDir, 1, 1, Long.MAX_VALUE, objectMapper)
             writer.append(
                 SnapshotChunkRecord.Success(
-                    key = userIgn,
+                    key = key,
                     endpoint = endpointDir,
                     keyType = keyType,
                     httpStatus = 200,
@@ -148,7 +151,7 @@ class UrgentCharacterRequestConsumer(
                 eventId = UUID.randomUUID().toString(),
                 runId = runId,
                 endpoint = endpointDir,
-                chunkId = "part-000001",
+                chunkId = "$endpointDir-part-000001",
                 objectKey = objectKey,
                 recordCount = stats.recordCount,
                 uncompressedBytes = stats.uncompressedBytes,

--- a/module-external-api/src/main/resources/application.yml
+++ b/module-external-api/src/main/resources/application.yml
@@ -8,6 +8,8 @@ spring:
     banner-mode: off
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    listener:
+      ack-mode: manual
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.apache.kafka.common.serialization.StringSerializer

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/admission/GlobalAdmissionControl.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/admission/GlobalAdmissionControl.kt
@@ -267,17 +267,28 @@ class GlobalAdmissionControl(
     }
 
     private fun <T> executeRequest(request: AdmissionRequest<T>) {
+        val context = TaskContext.of("AdmissionControl", "Execute", request.key)
         logicExecutor.executeWithFinally(
             {
-                val result = request.task.call()
-                @Suppress("UNCHECKED_CAST")
-                (request.future as CompletableFuture<Any>).complete(result)
+                logicExecutor.executeWithFallback(
+                    {
+                        val result = request.task.call()
+                        @Suppress("UNCHECKED_CAST")
+                        (request.future as CompletableFuture<Any>).complete(result)
+                        Unit
+                    },
+                    { e ->
+                        request.future.completeExceptionally(e)
+                        Unit
+                    },
+                    context,
+                )
             },
             {
                 semaphore.release()
                 inFlightCount.decrementAndGet()
             },
-            TaskContext.of("AdmissionControl", "Execute", request.key),
+            context,
         )
     }
 

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/event/EventDispatcher.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/event/EventDispatcher.kt
@@ -117,17 +117,29 @@ class EventDispatcher(
     private fun executeHandler(handler: HandlerMethod, event: IntegrationEvent<*>) {
         if (handler.async) {
             virtualThreadExecutor.execute {
-                executor.executeVoidJava(
+                executor.executeOrCatch(
                     { invokeHandler(handler, event) },
+                    { e -> logHandlerFailure(handler, event, e) },
                     TaskContext.of("EventDispatcher", "InvokeAsync", handler.method.name),
                 )
             }
         } else {
-            executor.executeVoidJava(
+            executor.executeOrCatch(
                 { invokeHandler(handler, event) },
+                { e -> logHandlerFailure(handler, event, e) },
                 TaskContext.of("EventDispatcher", "InvokeSync", handler.method.name),
             )
         }
+    }
+
+    private fun logHandlerFailure(handler: HandlerMethod, event: IntegrationEvent<*>, error: Throwable) {
+        logger.error(
+            "[EventDispatcher] Handler failed: eventId={}, eventType={}, handler={}",
+            event.eventId,
+            event.eventType,
+            handler.method.name,
+            error,
+        )
     }
 
     @Throws(Exception::class)

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/jdbc/JdbcBatchUpsertRepository.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/jdbc/JdbcBatchUpsertRepository.kt
@@ -228,19 +228,19 @@ class JdbcBatchUpsertRepository(
                     doBatchUpsert(equipments, batchSize)
                 },
                 { e ->
-                    val dataEx = if (e is DataAccessException) e else null
-                    if (dataEx != null) {
-                        lastException = dataEx
-                        attempt++
-                        if (attempt > retryConfig.maxRetries) {
-                            log.error("Batch upsert failed after {} attempts", attempt, dataEx)
-                            throw IllegalStateException(
-                                "JDBC batch upsert failed after $attempt attempts: ${dataEx.message}",
-                                dataEx,
-                            )
-                        }
-                        log.warn("Batch upsert attempt {} failed: {}", attempt, dataEx.message)
+                    if (e !is DataAccessException) {
+                        throw e
                     }
+                    lastException = e
+                    attempt++
+                    if (attempt > retryConfig.maxRetries) {
+                        log.error("Batch upsert failed after {} attempts", attempt, e)
+                        throw IllegalStateException(
+                            "JDBC batch upsert failed after $attempt attempts: ${e.message}",
+                            e,
+                        )
+                    }
+                    log.warn("Batch upsert attempt {} failed: {}", attempt, e.message)
                     intArrayOf()
                 },
                 TaskContext.of("JdbcBatchUpsert", "RetryAttempt", "$attempt"),

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/lock/PostgresAdvisoryLockStrategy.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/lock/PostgresAdvisoryLockStrategy.kt
@@ -82,7 +82,7 @@ class PostgresAdvisoryLockStrategy(
                 @Suppress("UNCHECKED_CAST")
                 return result as T
             }
-            LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(POLL_INTERVAL_MS))
+            parkForPollOrThrow(key)
         }
 
         lockMetrics.recordFailure("postgres")
@@ -137,7 +137,7 @@ class PostgresAdvisoryLockStrategy(
                 log.info("✅ [Follower] Leader completed, proceeding: key={}", key)
                 break
             }
-            LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(POLL_INTERVAL_MS))
+            parkForPollOrThrow(key)
         }
 
         return executor.execute({ followerTask.get() }, context)
@@ -207,6 +207,17 @@ class PostgresAdvisoryLockStrategy(
         Long::class.java,
         "latch:char:$key",
     ) ?: key.hashCode().toLong()
+
+    private fun parkForPollOrThrow(key: String) {
+        if (Thread.currentThread().isInterrupted) {
+            throw DistributedLockException("Interrupted while waiting for lock: $key")
+        }
+        LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(POLL_INTERVAL_MS))
+        if (Thread.interrupted()) {
+            Thread.currentThread().interrupt()
+            throw DistributedLockException("Interrupted while waiting for lock: $key")
+        }
+    }
 
     companion object {
         private val log = LoggerFactory.getLogger(PostgresAdvisoryLockStrategy::class.java)

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/CharacterViewQueryServicePostgres.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/CharacterViewQueryServicePostgres.kt
@@ -143,8 +143,10 @@ class CharacterViewQueryServicePostgres(
     private fun performUpsert(entity: CharacterValuationViewEntity) {
         if (entity.messageId != null) {
             val presetsJson = entity.presets?.let { objectMapper.writeValueAsString(it) }
-            upsertNative(entity, presetsJson)
-            asyncExecutor.submit { saveToReadModel(entity) }
+            val applied = upsertNative(entity, presetsJson)
+            if (applied > 0) {
+                asyncExecutor.submit { saveToReadModel(entity) }
+            }
         } else {
             val existing = findExistingEntity(entity)
             val saved = if (existing != null) {
@@ -159,10 +161,10 @@ class CharacterViewQueryServicePostgres(
         }
     }
 
-    private fun upsertNative(entity: CharacterValuationViewEntity, presetsJson: String?) {
+    private fun upsertNative(entity: CharacterValuationViewEntity, presetsJson: String?): Int {
         val params = mapOf(
             "userIgn" to entity.userIgn,
-            "messageId" to (entity.messageId ?: return),
+            "messageId" to (entity.messageId ?: return 0),
             "characterOcid" to entity.characterOcid,
             "characterClass" to entity.characterClass,
             "characterLevel" to entity.characterLevel,
@@ -176,7 +178,7 @@ class CharacterViewQueryServicePostgres(
             "presets" to presetsJson?.toJsonb(),
             "fromCache" to entity.fromCache,
         )
-        jdbc.update(
+        return jdbc.update(
             """
             INSERT INTO character_valuation_views (
                 user_ign, message_id, jpa_version, character_ocid, character_class, character_level,
@@ -202,6 +204,7 @@ class CharacterViewQueryServicePostgres(
                 preset_no = EXCLUDED.preset_no,
                 presets = EXCLUDED.presets,
                 from_cache = EXCLUDED.from_cache
+            WHERE COALESCE(character_valuation_views.last_applied_version, 0) < EXCLUDED.last_applied_version
             """,
             params,
         )
@@ -274,11 +277,17 @@ class CharacterViewQueryServicePostgres(
                 preset_no = EXCLUDED.preset_no,
                 presets = EXCLUDED.presets,
                 from_cache = EXCLUDED.from_cache
+            WHERE COALESCE(character_valuation_views.last_applied_version, 0) < EXCLUDED.last_applied_version
             """,
                 rows.map { it.second }.toTypedArray(),
             )
             timer.mark("executeValuationViewUpsert")
-            asyncExecutor.submit { saveToReadModelBatch(rows.map { it.first }) }
+            val appliedRows = rows.zip(counts.toList())
+                .filter { (_, count) -> count > 0 }
+                .map { (row, _) -> row.first }
+            if (appliedRows.isNotEmpty()) {
+                asyncExecutor.submit { saveToReadModelBatch(appliedRows) }
+            }
             return counts.sumOf { if (it > 0) it else 0 }
         } finally {
             timer.close(log)

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/repository/CalculationSnapshotInputRepository.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/repository/CalculationSnapshotInputRepository.kt
@@ -6,11 +6,13 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
+import org.springframework.transaction.annotation.Transactional
 
 interface CalculationSnapshotInputRepository : JpaRepository<CalculationSnapshotInputEntity, UUID> {
     fun findByJobId(jobId: UUID): CalculationSnapshotInputEntity?
 
     @Modifying
+    @Transactional("transactionManager")
     @Query(
         value = """
             INSERT INTO calculation_snapshot_inputs (input_id, job_id, schema_version, payload, created_at)

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/PgmqWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/PgmqWorker.kt
@@ -3,6 +3,7 @@ package maple.expectation.infrastructure.pgmq
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics
 import jakarta.annotation.PreDestroy
+import java.util.concurrent.Callable
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
@@ -310,36 +311,29 @@ abstract class PgmqWorker<T : Any>(
         )
     }
 
-    @Volatile
-    private var pendingBatchFuture: CompletableFuture<*>? = null
-
     private fun processBatchSinglePhase(messages: List<PgmqMessage<T>>) {
         val archiveIds = java.util.concurrent.ConcurrentLinkedQueue<Long>()
-        val futures = messages.map { message ->
-            CompletableFuture.supplyAsync({
+        val tasks = messages.map { message ->
+            Callable {
                 val needsArchive = processSingleMessage(message)
                 if (needsArchive) archiveIds.add(message.messageId)
                 needsArchive
-            }, workerPool)
+            }
         }
-        pendingBatchFuture = CompletableFuture.allOf(*futures.toTypedArray())
-            .exceptionally { ex ->
-                log.warn("[{}] Batch completion error: {}", queueName, ex.message)
-                null
-            }
-            .thenAccept {
-                if (archiveIds.isNotEmpty()) {
-                    executor.executeOrDefault(
-                        {
-                            val archived = pgmqClient.archiveBatch(queueName, archiveIds.toList())
-                            log.debug("[{}] Batch archived {}/{} messages", queueName, archived, archiveIds.size)
-                        },
-                        Unit,
-                        TaskContext.of("PgmqWorker", "BatchArchive", queueName),
-                    )
-                }
-                log.debug("[{}] Batch of {} messages completed", queueName, messages.size)
-            }
+        val visibilityTimeout = config.common.visibilityTimeoutSec.toLong()
+        workerPool.invokeAll(tasks, visibilityTimeout, TimeUnit.SECONDS)
+
+        if (archiveIds.isNotEmpty()) {
+            executor.executeOrDefault(
+                {
+                    val archived = pgmqClient.archiveBatch(queueName, archiveIds.toList())
+                    log.debug("[{}] Batch archived {}/{} messages", queueName, archived, archiveIds.size)
+                },
+                Unit,
+                TaskContext.of("PgmqWorker", "BatchArchive", queueName),
+            )
+        }
+        log.debug("[{}] Batch of {} messages completed", queueName, messages.size)
     }
 
     /**
@@ -449,20 +443,21 @@ abstract class PgmqWorker<T : Any>(
                 when {
                     success -> {
                         metrics.success.increment()
+                        true
                     }
                     message.isRetryable(maxRetries) -> {
                         onProcessingFailed(message)
                         metrics.failure.increment()
                         log.warn("[{}] Message will be retried: msgId={}, readCount={}", queueName, message.messageId, message.readCount)
+                        false
                     }
                     else -> {
                         metrics.failure.increment()
                         metrics.dlq.increment()
                         log.error("[{}] Max retries exceeded: msgId={}, readCount={}", queueName, message.messageId, message.readCount)
+                        true
                     }
                 }
-
-                success
             },
             finallyBlock = {
                 metrics.concurrentDecrement()
@@ -480,7 +475,6 @@ abstract class PgmqWorker<T : Any>(
             flushSequentialBatch()
         }
         log.info("[{}] Shutting down worker pool", queueName)
-        pendingBatchFuture?.join()
         workerPool.shutdown()
         if (!workerPool.awaitTermination(5, TimeUnit.SECONDS)) {
             log.warn("[{}] Worker pool did not terminate in 5s, forcing", queueName)

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/CalculationRequestedWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/CalculationRequestedWorker.kt
@@ -3,10 +3,6 @@ package maple.expectation.infrastructure.worker
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.micrometer.core.instrument.MeterRegistry
 import java.util.UUID
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withContext
 import maple.expectation.core.model.job.CalculationJobStatus
 import maple.expectation.core.port.out.CalculationInputPort
 import maple.expectation.core.port.out.CalculationJobPort
@@ -27,7 +23,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
 
-@OptIn(ExperimentalCoroutinesApi::class)
 @Component
 @ConditionalOnProperty(name = ["app.pipeline.consolidated.enabled"], havingValue = "false")
 class CalculationRequestedWorker(
@@ -47,10 +42,6 @@ class CalculationRequestedWorker(
     override val queueName: String = QueueNames.CALCULATION_REQUESTED
     override val payloadClass: Class<CalculationRequestedPayload> = CalculationRequestedPayload::class.java
     override val workerSettings: PgmqWorkerConfig.WorkerSettings = workerConfig.calculationRequested
-
-    private val cpuDispatcher = Dispatchers.Default.limitedParallelism(
-        Runtime.getRuntime().availableProcessors().coerceAtLeast(1),
-    )
 
     override fun process(message: PgmqMessage<CalculationRequestedPayload>): Boolean {
         val payload = message.payload
@@ -95,11 +86,7 @@ class CalculationRequestedWorker(
             calculationInputPort.findByJobId(jobId) ?: error("Calculation input missing: $jobId")
         }
         val calcResult = stage("PureCalculate", payload.userIgn) {
-            runBlocking(cpuDispatcher) {
-                withContext(cpuDispatcher) {
-                    pureCalculationPort.calculate(input)
-                }
-            }
+            pureCalculationPort.calculate(input)
         }
         val resultBytes = stage("SerializeResult", payload.userIgn) {
             objectMapper.writeValueAsString(calcResult).toByteArray()

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/ExternalApiWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/ExternalApiWorker.kt
@@ -15,7 +15,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withContext
 import maple.expectation.core.dto.v4.CalculationInput
 import maple.expectation.core.dto.v4.EquipmentItem
 import maple.expectation.core.model.job.CalculationJobStatus
@@ -90,10 +89,6 @@ class ExternalApiWorker(
     private val snapshotWriter: ExecutorService = Executors.newVirtualThreadPerTaskExecutor()
 
     private val apiCallPool: ExecutorService = Executors.newVirtualThreadPerTaskExecutor()
-
-    private val cpuDispatcher = Dispatchers.Default.limitedParallelism(
-        Runtime.getRuntime().availableProcessors().coerceAtLeast(1),
-    )
 
     @PreDestroy
     fun shutdownExecutors() {
@@ -296,11 +291,7 @@ class ExternalApiWorker(
 
             // CPU-bound calculation [no TX]
             val calcResult = stage("PureCalculate", payload.userIgn) {
-                runBlocking(cpuDispatcher) {
-                    withContext(cpuDispatcher) {
-                        pureCalculationPort.calculate(input)
-                    }
-                }
+                pureCalculationPort.calculate(input)
             }
             timer.mark("pureCalculate")
 

--- a/module-infra/src/main/resources/db/migration/V120__calculation_job_request_key_dedup.sql
+++ b/module-infra/src/main/resources/db/migration/V120__calculation_job_request_key_dedup.sql
@@ -10,6 +10,26 @@ UPDATE calculation_jobs
 SET request_key = 'calc:v1:ign:' || lower(btrim(user_ign)) || ':preset:' || preset_no || ':schema:1'
 WHERE request_key IS NULL;
 
+WITH ranked AS (
+    SELECT
+        job_id,
+        row_number() OVER (
+            PARTITION BY request_key
+            ORDER BY created_at DESC, updated_at DESC, job_id DESC
+        ) AS rn
+    FROM calculation_jobs
+    WHERE status IN ('REQUESTED', 'OCID_RESOLVING', 'API_REQUESTED', 'SNAPSHOT_READY', 'CALCULATING', 'RETRYING')
+)
+UPDATE calculation_jobs cj
+SET
+    status = 'FAILED',
+    last_error_code = 'DUPLICATE_ACTIVE_REQUEST_KEY',
+    error_message = 'Superseded during request_key dedup migration',
+    updated_at = now()
+FROM ranked r
+WHERE cj.job_id = r.job_id
+  AND r.rn > 1;
+
 CREATE UNIQUE INDEX IF NOT EXISTS ux_calc_jobs_active_request_key
     ON calculation_jobs (request_key)
     WHERE status IN ('REQUESTED', 'OCID_RESOLVING', 'API_REQUESTED', 'SNAPSHOT_READY', 'CALCULATING', 'RETRYING');

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/advice/RestControllerExceptionHandler.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/advice/RestControllerExceptionHandler.kt
@@ -1,9 +1,11 @@
 package maple.restcontroller.advice
 
+import jakarta.validation.ConstraintViolationException
 import maple.expectation.error.dto.ErrorResponse
 import maple.expectation.error.exception.base.BaseException
 import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 
@@ -18,6 +20,17 @@ class RestControllerExceptionHandler {
         return ResponseEntity
             .status(ex.errorCode.statusCode)
             .body(ErrorResponse.from(ex))
+    }
+
+    @ExceptionHandler(
+        ConstraintViolationException::class,
+        MethodArgumentNotValidException::class,
+    )
+    fun handleValidation(ex: Exception): ResponseEntity<ErrorResponse> {
+        log.warn("Validation exception: {}", ex.message)
+        return ResponseEntity
+            .badRequest()
+            .body(ErrorResponse.from(400, "C001", "Invalid request"))
     }
 
     @ExceptionHandler(Exception::class)

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/config/V6ReadConfig.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/config/V6ReadConfig.kt
@@ -3,6 +3,7 @@ package maple.restcontroller.config
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.micrometer.core.instrument.MeterRegistry
 import maple.restcontroller.metrics.V6ReadMetrics
+import maple.restcontroller.popular.PopularCharacterService
 import maple.restcontroller.ranking.EquipmentRankingCacheService
 import maple.restcontroller.ranking.EquipmentRankingQueryService
 import maple.restcontroller.ranking.EquipmentRankingService
@@ -71,12 +72,25 @@ class V6ReadConfig(
     ): EquipmentRankingService = EquipmentRankingService(cacheService, queryService, properties)
 
     @Bean
+    fun popularCharacterService(
+        redisTemplate: StringRedisTemplate
+    ): PopularCharacterService = PopularCharacterService(redisTemplate, properties)
+
+    @Bean
     fun expectationReadFacade(
         registry: InflightRequestRegistry,
         buffer: LocalRequestBuffer,
         metrics: V6ReadMetrics,
-        cacheService: ReadModelCacheService
-    ): ExpectationReadFacade = ExpectationReadFacade(registry, buffer, metrics, cacheService, properties)
+        cacheService: ReadModelCacheService,
+        popularCharacterService: PopularCharacterService
+    ): ExpectationReadFacade = ExpectationReadFacade(
+        registry,
+        buffer,
+        metrics,
+        cacheService,
+        popularCharacterService,
+        properties,
+    )
 
     @Bean
     fun batchReadScheduler(

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/config/V6ReadProperties.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/config/V6ReadProperties.kt
@@ -11,6 +11,7 @@ class V6ReadProperties {
     var queueCapacity: Int = 5000
     var shutdownDrainTimeoutSeconds: Long = 5
     var cacheTtlSeconds: Long = 300
+    var readModelFreshnessSeconds: Long = 1800
     var urgentPendingTtlSeconds: Long = 30
     var statusRetryAfterSeconds: Long = 3
     var statusEstimatedThroughputPerSecond: Double = 5.0

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/config/V6ReadProperties.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/config/V6ReadProperties.kt
@@ -15,9 +15,19 @@ class V6ReadProperties {
     var statusRetryAfterSeconds: Long = 3
     var statusEstimatedThroughputPerSecond: Double = 5.0
     var ranking: Ranking = Ranking()
+    var popular: Popular = Popular()
 
     class Ranking {
         var redisKeyPrefix: String = "ranking:equipment:total-cost"
         var topSize: Int = 10
+    }
+
+    class Popular {
+        var redisKeyPrefix: String = "popular:characters:v6"
+        var topSize: Int = 10
+        var defaultWindowHours: Int = 3
+        var maxWindowHours: Int = 24
+        var bucketTtlHours: Long = 48
+        var rollingTtlSeconds: Long = 60
     }
 }

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/controller/ExpectationV6Controller.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/controller/ExpectationV6Controller.kt
@@ -8,6 +8,7 @@ import maple.restcontroller.read.ReadModelQueryService
 import maple.restcontroller.read.UrgentReadState
 import maple.restcontroller.validation.ValidUserIgn
 import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
@@ -20,6 +21,7 @@ import org.springframework.web.context.request.async.DeferredResult
 @RestController
 @RequestMapping("/api/v6/characters")
 @Validated
+@ConditionalOnProperty(name = ["expectation.v6.enabled"], havingValue = "true")
 class ExpectationV6Controller(
     private val facade: ExpectationReadFacade,
     private val properties: V6ReadProperties,

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/controller/ExpectationV6Controller.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/controller/ExpectationV6Controller.kt
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.context.request.async.DeferredResult
+import java.time.Duration
 
 @RestController
 @RequestMapping("/api/v6/characters")
@@ -48,7 +49,10 @@ class ExpectationV6Controller(
     ): ResponseEntity<*> {
         val current = cacheService.status(userIgn, presetNo)
         val status = if (current.state == UrgentReadState.PENDING || current.state == UrgentReadState.UNKNOWN) {
-            val dbResult = queryService.batchQuery(mapOf(userIgn to presetNo))
+            val dbResult = queryService.batchQuery(
+                mapOf(userIgn to presetNo),
+                Duration.ofSeconds(properties.readModelFreshnessSeconds),
+            )
             if (dbResult.isNotEmpty()) {
                 cacheService.multiPut(dbResult)
                 cacheService.status(userIgn, presetNo)

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/controller/PopularCharacterController.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/controller/PopularCharacterController.kt
@@ -1,0 +1,22 @@
+package maple.restcontroller.controller
+
+import maple.restcontroller.popular.PopularCharacterService
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v6/characters/popular")
+@ConditionalOnProperty(name = ["expectation.v6.enabled"], havingValue = "true")
+class PopularCharacterController(
+    private val popularCharacterService: PopularCharacterService,
+) {
+    @GetMapping("/top10")
+    fun top10(
+        @RequestParam(required = false) windowHours: Int?,
+    ): ResponseEntity<*> =
+        ResponseEntity.ok(popularCharacterService.top(windowHours))
+}

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/popular/PopularCharacterModels.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/popular/PopularCharacterModels.kt
@@ -1,0 +1,19 @@
+package maple.restcontroller.popular
+
+data class PopularCharacterEntry(
+    val rank: Int,
+    val userIgn: String,
+    val requestCount: Long,
+)
+
+data class PopularCharacterResponse(
+    val windowHours: Int,
+    val source: PopularCharacterSource,
+    val degraded: Boolean,
+    val characters: List<PopularCharacterEntry>,
+)
+
+enum class PopularCharacterSource {
+    REDIS,
+    DEGRADED,
+}

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/popular/PopularCharacterService.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/popular/PopularCharacterService.kt
@@ -1,0 +1,101 @@
+package maple.restcontroller.popular
+
+import maple.expectation.util.StringMaskingUtils.maskIgn
+import maple.restcontroller.config.V6ReadProperties
+import org.slf4j.LoggerFactory
+import org.springframework.data.redis.core.StringRedisTemplate
+import java.time.Duration
+import java.time.Instant
+
+class PopularCharacterService(
+    private val redisTemplate: StringRedisTemplate,
+    private val properties: V6ReadProperties,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun recordV6ExpectationRequest(userIgn: String) {
+        val normalizedIgn = userIgn.trim()
+        if (normalizedIgn.isBlank()) return
+
+        runCatching {
+            val key = bucketKey(currentEpochHour())
+            redisTemplate.opsForZSet().incrementScore(key, normalizedIgn, 1.0)
+            redisTemplate.expire(key, Duration.ofHours(properties.popular.bucketTtlHours))
+        }.onFailure { error ->
+            log.warn(
+                "Popular character Redis write failed: userIgn={} error={}",
+                maskIgn(normalizedIgn),
+                error.javaClass.simpleName,
+            )
+        }
+    }
+
+    fun top(windowHours: Int? = null): PopularCharacterResponse {
+        val effectiveWindowHours = effectiveWindowHours(windowHours)
+        val limit = properties.popular.topSize.coerceAtLeast(1)
+
+        return runCatching {
+            val readKey = rollingReadKey(effectiveWindowHours)
+            val entries = redisTemplate.opsForZSet()
+                .reverseRangeWithScores(readKey, 0, (limit - 1).toLong())
+                ?.mapIndexedNotNull { index, tuple ->
+                    val userIgn = tuple.value ?: return@mapIndexedNotNull null
+                    val score = tuple.score ?: return@mapIndexedNotNull null
+                    PopularCharacterEntry(
+                        rank = index + 1,
+                        userIgn = userIgn,
+                        requestCount = score.toLong(),
+                    )
+                }
+                .orEmpty()
+
+            PopularCharacterResponse(
+                windowHours = effectiveWindowHours,
+                source = PopularCharacterSource.REDIS,
+                degraded = false,
+                characters = entries,
+            )
+        }.getOrElse { error ->
+            log.warn(
+                "Popular character Redis read failed: windowHours={} error={}",
+                effectiveWindowHours,
+                error.javaClass.simpleName,
+            )
+            PopularCharacterResponse(
+                windowHours = effectiveWindowHours,
+                source = PopularCharacterSource.DEGRADED,
+                degraded = true,
+                characters = emptyList(),
+            )
+        }
+    }
+
+    private fun rollingReadKey(windowHours: Int): String {
+        val currentHour = currentEpochHour()
+        if (windowHours == 1) return bucketKey(currentHour)
+
+        val keys = (0 until windowHours).map { offset -> bucketKey(currentHour - offset) }
+        val destinationKey = rollingKey(currentHour, windowHours)
+        redisTemplate.opsForZSet().unionAndStore(keys.first(), keys.drop(1), destinationKey)
+        redisTemplate.expire(destinationKey, Duration.ofSeconds(properties.popular.rollingTtlSeconds))
+        return destinationKey
+    }
+
+    private fun effectiveWindowHours(windowHours: Int?): Int =
+        (windowHours ?: properties.popular.defaultWindowHours)
+            .coerceAtLeast(1)
+            .coerceAtMost(properties.popular.maxWindowHours.coerceAtLeast(1))
+
+    private fun currentEpochHour(): Long =
+        Instant.now().epochSecond / SECONDS_PER_HOUR
+
+    private fun bucketKey(epochHour: Long): String =
+        "${properties.popular.redisKeyPrefix}:hour:$epochHour"
+
+    private fun rollingKey(epochHour: Long, windowHours: Int): String =
+        "${properties.popular.redisKeyPrefix}:rolling:${windowHours}h:$epochHour"
+
+    private companion object {
+        const val SECONDS_PER_HOUR = 3600L
+    }
+}

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/ranking/EquipmentRankingService.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/ranking/EquipmentRankingService.kt
@@ -10,7 +10,7 @@ class EquipmentRankingService(
     fun topByTotalCost(presetNo: Int): EquipmentRankingResponse {
         val limit = properties.ranking.topSize.coerceAtLeast(1)
         val cached = cacheService.topByTotalCost(presetNo, limit)
-        if (cached != null) {
+        if (!cached.isNullOrEmpty()) {
             return EquipmentRankingResponse(presetNo, EquipmentRankingSource.REDIS, cached)
         }
 

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/read/BatchReadScheduler.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/read/BatchReadScheduler.kt
@@ -85,31 +85,24 @@ class BatchReadScheduler(
 
         // 2. Resolve cache hits directly
         cacheHits.forEach { (userIgn, response) ->
-            val deferreds = registry.getAndRemove(userIgn)
+            val deferreds = registry.getAndRemove(userIgn, response.presetNo)
             metrics.recordHit()
             metrics.recordRedisHit()
             deferreds.forEach { it.setResult(ResponseEntity.ok(response)) }
             resolved++
         }
 
-        // 3. DB batch query for cache misses only (skip characters with urgent pending)
+        // 3. DB batch query for cache misses, including urgent-pending keys.
         if (cacheMisses.isNotEmpty()) {
-            val dbLookupCandidates = cacheMisses.filterKeys { userIgn ->
-                !cacheService.isUrgentPending(userIgn)
-            }
-
-            val dbResults = if (dbLookupCandidates.isNotEmpty()) {
-                queryService.batchQuery(dbLookupCandidates)
-            } else {
-                emptyMap()
-            }
+            val dbResults = queryService.batchQuery(cacheMisses)
 
             // 4. Write DB results to Redis cache
             cacheService.multiPut(dbResults)
 
             // 5. Resolve miss deferreds
             cacheMisses.keys.forEach { userIgn ->
-                val deferreds = registry.getAndRemove(userIgn)
+                val presetNo = cacheMisses[userIgn] ?: 1
+                val deferreds = registry.getAndRemove(userIgn, presetNo)
                 val response = dbResults[userIgn]
 
                 if (response != null) {
@@ -132,7 +125,6 @@ class BatchReadScheduler(
 
                     // Trigger urgent pipeline (with dedup via Redis SETNX)
                     if (urgentPublisher != null && cacheService.tryMarkUrgentPending(userIgn)) {
-                        val presetNo = cacheMisses[userIgn] ?: 1
                         urgentPublisher.publish(UrgentCharacterRequest(userIgn = userIgn, presetNo = presetNo))
                         metrics.urgentTriggerTotal.increment()
                         log.info("Triggered urgent pipeline: userIgn={}", maskIgn(userIgn))

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/read/BatchReadScheduler.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/read/BatchReadScheduler.kt
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.context.SmartLifecycle
 import org.springframework.http.ResponseEntity
 import org.springframework.scheduling.annotation.Scheduled
+import java.time.Duration
 import java.util.concurrent.TimeUnit
 
 class BatchReadScheduler(
@@ -94,7 +95,10 @@ class BatchReadScheduler(
 
         // 3. DB batch query for cache misses, including urgent-pending keys.
         if (cacheMisses.isNotEmpty()) {
-            val dbResults = queryService.batchQuery(cacheMisses)
+            val dbResults = queryService.batchQuery(
+                cacheMisses,
+                Duration.ofSeconds(properties.readModelFreshnessSeconds),
+            )
 
             // 4. Write DB results to Redis cache
             cacheService.multiPut(dbResults)

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/read/ExpectationReadFacade.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/read/ExpectationReadFacade.kt
@@ -18,12 +18,12 @@ class ExpectationReadFacade(
 
     fun enqueue(userIgn: String, presetNo: Int, deferred: DeferredResult<ResponseEntity<*>>) {
         metrics.requestTotal.increment()
-        val firstRequest = registry.register(userIgn, deferred)
+        val firstRequest = registry.register(userIgn, presetNo, deferred)
         if (firstRequest) {
             metrics.dedupMissTotal.increment()
             if (!buffer.offer(ReadRequest(userIgn = userIgn, presetNo = presetNo))) {
                 metrics.bufferRejectedTotal.increment()
-                registry.cleanup(userIgn, deferred)
+                registry.cleanup(userIgn, presetNo, deferred)
                 log.warn("Buffer full, rejecting request userIgn={}", maskIgn(userIgn))
                 deferred.setErrorResult(
                     ResponseEntity.status(503)
@@ -48,7 +48,7 @@ class ExpectationReadFacade(
             )
         }
         deferred.onCompletion {
-            registry.cleanup(userIgn, deferred)
+            registry.cleanup(userIgn, presetNo, deferred)
         }
     }
 }

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/read/ExpectationReadFacade.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/read/ExpectationReadFacade.kt
@@ -3,6 +3,7 @@ package maple.restcontroller.read
 import maple.expectation.util.StringMaskingUtils.maskIgn
 import maple.restcontroller.config.V6ReadProperties
 import maple.restcontroller.metrics.V6ReadMetrics
+import maple.restcontroller.popular.PopularCharacterService
 import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.web.context.request.async.DeferredResult
@@ -12,11 +13,13 @@ class ExpectationReadFacade(
     private val buffer: RequestBuffer,
     private val metrics: V6ReadMetrics,
     private val cacheService: ReadModelCacheService,
+    private val popularCharacterService: PopularCharacterService,
     private val properties: V6ReadProperties,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
     fun enqueue(userIgn: String, presetNo: Int, deferred: DeferredResult<ResponseEntity<*>>) {
+        popularCharacterService.recordV6ExpectationRequest(userIgn)
         metrics.requestTotal.increment()
         val firstRequest = registry.register(userIgn, presetNo, deferred)
         if (firstRequest) {

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/read/InflightRequestRegistry.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/read/InflightRequestRegistry.kt
@@ -9,18 +9,18 @@ class InflightRequestRegistry {
 
     private val registry = ConcurrentHashMap<String, CopyOnWriteArrayList<DeferredResult<ResponseEntity<*>>>>()
 
-    fun register(userIgn: String, deferred: DeferredResult<ResponseEntity<*>>): Boolean {
-        val list = registry.computeIfAbsent(userIgn) { CopyOnWriteArrayList() }
+    fun register(userIgn: String, presetNo: Int, deferred: DeferredResult<ResponseEntity<*>>): Boolean {
+        val list = registry.computeIfAbsent(key(userIgn, presetNo)) { CopyOnWriteArrayList() }
         list.add(deferred)
         return list.size == 1
     }
 
-    fun getAndRemove(userIgn: String): List<DeferredResult<ResponseEntity<*>>> {
-        return registry.remove(userIgn) ?: emptyList()
+    fun getAndRemove(userIgn: String, presetNo: Int): List<DeferredResult<ResponseEntity<*>>> {
+        return registry.remove(key(userIgn, presetNo)) ?: emptyList()
     }
 
-    fun cleanup(userIgn: String, deferred: DeferredResult<ResponseEntity<*>>) {
-        registry.computeIfPresent(userIgn) { _, list ->
+    fun cleanup(userIgn: String, presetNo: Int, deferred: DeferredResult<ResponseEntity<*>>) {
+        registry.computeIfPresent(key(userIgn, presetNo)) { _, list ->
             list.remove(deferred)
             if (list.isEmpty()) null else list
         }
@@ -36,4 +36,6 @@ class InflightRequestRegistry {
             }
         }
     }
+
+    private fun key(userIgn: String, presetNo: Int): String = "$userIgn:$presetNo"
 }

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelQueryService.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelQueryService.kt
@@ -6,6 +6,8 @@ import org.slf4j.LoggerFactory
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import java.math.BigDecimal
+import java.sql.Timestamp
+import java.time.Duration
 import java.time.Instant
 
 class ReadModelQueryService(
@@ -18,7 +20,10 @@ class ReadModelQueryService(
      * @param requests userIgn -> presetNo mapping
      * @return userIgn -> V6ExpectationResponse for hits only
      */
-    fun batchQuery(requests: Map<String, Int>): Map<String, V6ExpectationResponse> {
+    fun batchQuery(
+        requests: Map<String, Int>,
+        maxAge: Duration? = null,
+    ): Map<String, V6ExpectationResponse> {
         if (requests.isEmpty()) return emptyMap()
 
         val params = MapSqlParameterSource()
@@ -30,7 +35,7 @@ class ReadModelQueryService(
         }.joinToString(" OR ")
 
         val sql = """
-            SELECT user_ign, preset_no, document, total_cost, equipment_count, calculated_at
+            SELECT user_ign, preset_no, document, total_cost, equipment_count, calculated_at, updated_at
             FROM character_equipment_read_model
             WHERE ($pairPredicates)
               AND user_ign IS NOT NULL
@@ -38,7 +43,15 @@ class ReadModelQueryService(
 
         val rows = jdbc.queryForList(sql, params)
         val result = LinkedHashMap<String, V6ExpectationResponse>()
+        val minimumUpdatedAt = maxAge?.let { Instant.now().minus(it) }
+        var stale = 0
         rows.forEach { row ->
+            val updatedAt = (row["updated_at"] as? Timestamp)?.toInstant() ?: Instant.EPOCH
+            if (minimumUpdatedAt != null && updatedAt.isBefore(minimumUpdatedAt)) {
+                stale++
+                return@forEach
+            }
+
             val userIgn = row["user_ign"].toString()
             val compressed = row["document"] as ByteArray
             val json = GzipUtils.decompress(compressed)
@@ -65,11 +78,11 @@ class ReadModelQueryService(
                     ?: 0,
                 equipment = equipment,
                 calculatedAt = tree["metadata"]?.get("calculatedAt")?.asText()?.let(Instant::parse)
-                    ?: (row["calculated_at"] as? java.sql.Timestamp)?.toInstant()
+                    ?: (row["calculated_at"] as? Timestamp)?.toInstant()
                     ?: Instant.now(),
             )
         }
-        log.debug("Read model query: requested={}, hits={}", requests.size, result.size)
+        log.debug("Read model query: requested={}, hits={}, stale={}", requests.size, result.size, stale)
         return result
     }
 }

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelQueryService.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelQueryService.kt
@@ -21,20 +21,20 @@ class ReadModelQueryService(
     fun batchQuery(requests: Map<String, Int>): Map<String, V6ExpectationResponse> {
         if (requests.isEmpty()) return emptyMap()
 
-        val userIgns = requests.keys.toList()
-        val presetNos = requests.values.distinct()
+        val params = MapSqlParameterSource()
+        val pairPredicates = requests.entries.mapIndexed { index, (userIgn, presetNo) ->
+            params
+                .addValue("userIgn$index", userIgn)
+                .addValue("presetNo$index", presetNo)
+            "(user_ign = :userIgn$index AND preset_no = :presetNo$index)"
+        }.joinToString(" OR ")
 
         val sql = """
             SELECT user_ign, preset_no, document, total_cost, equipment_count, calculated_at
             FROM character_equipment_read_model
-            WHERE user_ign IN (:userIgns)
-              AND preset_no IN (:presetNos)
+            WHERE ($pairPredicates)
               AND user_ign IS NOT NULL
         """.trimIndent()
-
-        val params = MapSqlParameterSource()
-            .addValue("userIgns", userIgns)
-            .addValue("presetNos", presetNos)
 
         val rows = jdbc.queryForList(sql, params)
         val result = LinkedHashMap<String, V6ExpectationResponse>()

--- a/module-rest-controller/src/main/resources/application.yml
+++ b/module-rest-controller/src/main/resources/application.yml
@@ -43,6 +43,7 @@ expectation:
     max-batch-size: 200               # scheduler batch size (Phase 2)
     queue-capacity: 5000              # RequestBuffer max capacity
     shutdown-drain-timeout-seconds: 5 # graceful shutdown deadline
+    read-model-freshness-seconds: 1800 # DB read model TTL before urgent refresh
     status-retry-after-seconds: 3     # frontend polling hint after 202/status
     status-estimated-throughput-per-second: 5.0 # approximate urgent pipeline throughput
     ranking:

--- a/module-rest-controller/src/main/resources/application.yml
+++ b/module-rest-controller/src/main/resources/application.yml
@@ -48,6 +48,13 @@ expectation:
     ranking:
       redis-key-prefix: ranking:equipment:total-cost
       top-size: 10
+    popular:
+      redis-key-prefix: popular:characters:v6
+      top-size: 10
+      default-window-hours: 3
+      max-window-hours: 24
+      bucket-ttl-hours: 48
+      rolling-ttl-seconds: 60
     urgent:
       enabled: false                              # feature flag
       request-topic: urgent-character-request

--- a/module-rest-controller/src/test/kotlin/maple/restcontroller/controller/ExpectationV6ControllerTest.kt
+++ b/module-rest-controller/src/test/kotlin/maple/restcontroller/controller/ExpectationV6ControllerTest.kt
@@ -4,6 +4,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import maple.restcontroller.advice.RestControllerExceptionHandler
 import maple.restcontroller.config.V6ReadProperties
 import maple.restcontroller.metrics.V6ReadMetrics
+import maple.restcontroller.popular.PopularCharacterService
 import maple.restcontroller.read.*
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -21,6 +22,7 @@ class ExpectationV6ControllerTest {
     private lateinit var registry: InflightRequestRegistry
     private lateinit var facade: ExpectationReadFacade
     private lateinit var cacheService: ReadModelCacheService
+    private lateinit var popularCharacterService: PopularCharacterService
     private lateinit var queryService: ReadModelQueryService
     private val properties = V6ReadProperties().apply {
         requestTimeoutMs = 100
@@ -36,8 +38,9 @@ class ExpectationV6ControllerTest {
         registry = InflightRequestRegistry()
         val metrics = V6ReadMetrics(SimpleMeterRegistry(), buffer, registry)
         cacheService = mock()
+        popularCharacterService = mock()
         queryService = mock()
-        facade = ExpectationReadFacade(registry, buffer, metrics, cacheService, properties)
+        facade = ExpectationReadFacade(registry, buffer, metrics, cacheService, popularCharacterService, properties)
 
         mockMvc = MockMvcBuilders
             .standaloneSetup(ExpectationV6Controller(facade, properties, cacheService, queryService))

--- a/module-rest-controller/src/test/kotlin/maple/restcontroller/read/ExpectationReadFacadeTest.kt
+++ b/module-rest-controller/src/test/kotlin/maple/restcontroller/read/ExpectationReadFacadeTest.kt
@@ -3,6 +3,7 @@ package maple.restcontroller.read
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import maple.restcontroller.metrics.V6ReadMetrics
 import maple.restcontroller.config.V6ReadProperties
+import maple.restcontroller.popular.PopularCharacterService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -18,6 +19,7 @@ class ExpectationReadFacadeTest {
     private lateinit var metrics: V6ReadMetrics
     private lateinit var facade: ExpectationReadFacade
     private lateinit var cacheService: ReadModelCacheService
+    private lateinit var popularCharacterService: PopularCharacterService
     private lateinit var properties: V6ReadProperties
 
     @BeforeEach
@@ -26,8 +28,9 @@ class ExpectationReadFacadeTest {
         registry = InflightRequestRegistry()
         metrics = V6ReadMetrics(meterRegistry, buffer, registry)
         cacheService = mock()
+        popularCharacterService = mock()
         properties = V6ReadProperties()
-        facade = ExpectationReadFacade(registry, buffer, metrics, cacheService, properties)
+        facade = ExpectationReadFacade(registry, buffer, metrics, cacheService, popularCharacterService, properties)
     }
 
     private fun enqueue(ign: String, presetNo: Int = 1): DeferredResult<ResponseEntity<*>> {
@@ -60,7 +63,14 @@ class ExpectationReadFacadeTest {
     fun `enqueue sets 503 error when buffer is full`() {
         val smallBuffer = LocalRequestBuffer(1)
         val smallMetrics = V6ReadMetrics(SimpleMeterRegistry(), smallBuffer, registry)
-        val fullFacade = ExpectationReadFacade(registry, smallBuffer, smallMetrics, cacheService, properties)
+        val fullFacade = ExpectationReadFacade(
+            registry,
+            smallBuffer,
+            smallMetrics,
+            cacheService,
+            popularCharacterService,
+            properties,
+        )
 
         val d1 = DeferredResult<ResponseEntity<*>>()
         fullFacade.enqueue("a", 1, d1)

--- a/module-rest-controller/src/test/kotlin/maple/restcontroller/read/InflightRequestRegistryTest.kt
+++ b/module-rest-controller/src/test/kotlin/maple/restcontroller/read/InflightRequestRegistryTest.kt
@@ -14,22 +14,30 @@ class InflightRequestRegistryTest {
 
     @Test
     fun `register returns true for first request (dedup miss)`() {
-        val result = registry.register("진격캐넌", deferred())
+        val result = registry.register("진격캐넌", 1, deferred())
         assertThat(result).isTrue
     }
 
     @Test
-    fun `register returns false for duplicate userIgn (dedup hit)`() {
-        registry.register("진격캐넌", deferred())
-        val result = registry.register("진격캐넌", deferred())
+    fun `register returns false for duplicate userIgn and presetNo (dedup hit)`() {
+        registry.register("진격캐넌", 1, deferred())
+        val result = registry.register("진격캐넌", 1, deferred())
         assertThat(result).isFalse
     }
 
     @Test
-    fun `size returns unique userIgn count`() {
-        registry.register("a", deferred())
-        registry.register("b", deferred())
-        registry.register("a", deferred())
+    fun `register treats different presetNo as separate inflight request`() {
+        registry.register("진격캐넌", 1, deferred())
+        val result = registry.register("진격캐넌", 2, deferred())
+        assertThat(result).isTrue
+        assertThat(registry.size()).isEqualTo(2)
+    }
+
+    @Test
+    fun `size returns unique userIgn and presetNo count`() {
+        registry.register("a", 1, deferred())
+        registry.register("b", 1, deferred())
+        registry.register("a", 1, deferred())
         assertThat(registry.size()).isEqualTo(2)
     }
 
@@ -37,37 +45,37 @@ class InflightRequestRegistryTest {
     fun `getAndRemove returns all deferreds for userIgn`() {
         val d1 = deferred()
         val d2 = deferred()
-        registry.register("진격캐넌", d1)
-        registry.register("진격캐넌", d2)
+        registry.register("진격캐넌", 1, d1)
+        registry.register("진격캐넌", 1, d2)
 
-        val removed = registry.getAndRemove("진격캐넌")
+        val removed = registry.getAndRemove("진격캐넌", 1)
         assertThat(removed).containsExactly(d1, d2)
         assertThat(registry.size()).isZero
     }
 
     @Test
     fun `getAndRemove for non-existent key returns empty list`() {
-        assertThat(registry.getAndRemove("none")).isEmpty()
+        assertThat(registry.getAndRemove("none", 1)).isEmpty()
     }
 
     @Test
     fun `cleanup removes specific deferred from list`() {
         val d1 = deferred()
         val d2 = deferred()
-        registry.register("진격캐넌", d1)
-        registry.register("진격캐넌", d2)
+        registry.register("진격캐넌", 1, d1)
+        registry.register("진격캐넌", 1, d2)
 
-        registry.cleanup("진격캐넌", d1)
+        registry.cleanup("진격캐넌", 1, d1)
 
-        val remaining = registry.getAndRemove("진격캐넌")
+        val remaining = registry.getAndRemove("진격캐넌", 1)
         assertThat(remaining).containsExactly(d2)
     }
 
     @Test
     fun `cleanup removes entry when list becomes empty`() {
         val d = deferred()
-        registry.register("진격캐넌", d)
-        registry.cleanup("진격캐넌", d)
+        registry.register("진격캐넌", 1, d)
+        registry.cleanup("진격캐넌", 1, d)
         assertThat(registry.size()).isZero
     }
 
@@ -75,8 +83,8 @@ class InflightRequestRegistryTest {
     fun `failAll sets error on all pending deferreds and clears registry`() {
         val d1 = deferred()
         val d2 = deferred()
-        registry.register("a", d1)
-        registry.register("b", d2)
+        registry.register("a", 1, d1)
+        registry.register("b", 1, d2)
 
         val errorResponse = ResponseEntity.status(503).header("Retry-After", "1").build<Any>()
         registry.failAll(errorResponse)

--- a/module-rest-controller/src/test/kotlin/maple/restcontroller/read/ReadModelQueryServiceTest.kt
+++ b/module-rest-controller/src/test/kotlin/maple/restcontroller/read/ReadModelQueryServiceTest.kt
@@ -9,6 +9,7 @@ import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import java.math.BigDecimal
 import java.sql.Timestamp
+import java.time.Duration
 import java.time.Instant
 
 class ReadModelQueryServiceTest {
@@ -42,7 +43,8 @@ class ReadModelQueryServiceTest {
                     "document" to compressed,
                     "total_cost" to BigDecimal(1000),
                     "equipment_count" to 5,
-                    "calculated_at" to Timestamp.from(now)
+                    "calculated_at" to Timestamp.from(now),
+                    "updated_at" to Timestamp.from(now),
                 )
             ))
 
@@ -96,7 +98,8 @@ class ReadModelQueryServiceTest {
                     "document" to GzipUtils.compress(String(doc1)),
                     "total_cost" to BigDecimal(1000),
                     "equipment_count" to 3,
-                    "calculated_at" to Timestamp.from(now)
+                    "calculated_at" to Timestamp.from(now),
+                    "updated_at" to Timestamp.from(now),
                 ),
                 mapOf<String, Any>(
                     "user_ign" to "진격캐넌",
@@ -104,7 +107,8 @@ class ReadModelQueryServiceTest {
                     "document" to GzipUtils.compress(String(doc2)),
                     "total_cost" to BigDecimal(2000),
                     "equipment_count" to 6,
-                    "calculated_at" to Timestamp.from(now)
+                    "calculated_at" to Timestamp.from(now),
+                    "updated_at" to Timestamp.from(now),
                 )
             ))
 
@@ -115,5 +119,33 @@ class ReadModelQueryServiceTest {
         assertThat(result["아델"]!!.presetNo).isEqualTo(1)
         assertThat(result["진격캐넌"]!!.presetNo).isEqualTo(2)
         assertThat(result["진격캐넌"]!!.totalCost).isEqualByComparingTo(BigDecimal(2000))
+    }
+
+    @Test
+    fun `should treat stale updatedAt as cache miss`() {
+        val now = Instant.now()
+        val docJson = objectMapper.writeValueAsBytes(mapOf(
+            "presetNo" to 1,
+            "summary" to mapOf("totalCost" to 1000, "equipmentCount" to 5),
+            "equipment" to emptyList<Any>(),
+            "metadata" to mapOf("calculatedAt" to now.toString())
+        ))
+
+        whenever(jdbc.queryForList(any<String>(), any<MapSqlParameterSource>()))
+            .thenReturn(listOf(
+                mapOf<String, Any>(
+                    "user_ign" to "아델",
+                    "preset_no" to 1,
+                    "document" to GzipUtils.compress(String(docJson)),
+                    "total_cost" to BigDecimal(1000),
+                    "equipment_count" to 5,
+                    "calculated_at" to Timestamp.from(now),
+                    "updated_at" to Timestamp.from(now.minus(Duration.ofMinutes(31))),
+                )
+            ))
+
+        val result = service.batchQuery(mapOf("아델" to 1), Duration.ofMinutes(30))
+
+        assertThat(result).isEmpty()
     }
 }

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/ChunkConsumerTemplate.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/ChunkConsumerTemplate.kt
@@ -75,6 +75,16 @@ class ChunkConsumerTemplate(
         val claim = chunkExecutionRepository.claimProcessing(request.identity, processingTimeout)
         if (claim == null) {
             request.processingPermit.release()
+            if (state.shouldPreserveKafkaRedelivery()) {
+                request.log.info(
+                    "[{}] retryable chunk not due, leaving unacked for Kafka redelivery: runId={} chunkId={} nextRetryAt={}",
+                    request.logPrefix,
+                    request.runId,
+                    request.chunkId,
+                    state.nextRetryAt,
+                )
+                return
+            }
             request.log.info(
                 "[{}] skip - chunk not eligible for claim: runId={} chunkId={} status={}",
                 request.logPrefix,
@@ -92,13 +102,13 @@ class ChunkConsumerTemplate(
         }
 
         request.onAccepted()
-        MDC.put("runId", request.runId)
-        MDC.put("chunkId", request.chunkId)
-        request.mdcValues.forEach { (key, value) -> MDC.put(key, value) }
 
         request.executor.execute {
             logicExecutor.executeWithFinally(
                 task = {
+                    MDC.put("runId", request.runId)
+                    MDC.put("chunkId", request.chunkId)
+                    request.mdcValues.forEach { (key, value) -> MDC.put(key, value) }
                     processClaimed(request, claim)
                 },
                 finallyBlock = {
@@ -220,6 +230,16 @@ class ChunkConsumerTemplate(
                 failure.terminalReason ?: RETRYABLE_FAILURE,
             )
             request.onFailure(ex)
+            if (failure.terminalReason == null) {
+                request.log.warn(
+                    "[{}] retryable chunk failure recorded, leaving unacked for Kafka redelivery: runId={} chunkId={} attempt={}",
+                    request.logPrefix,
+                    request.runId,
+                    request.chunkId,
+                    claim.attemptCount,
+                )
+                return
+            }
             request.acknowledgment.acknowledge()
             return
         }
@@ -263,13 +283,16 @@ class ChunkConsumerTemplate(
             return true
         }
         if (status == ChunkExecutionStatus.FAILED_RETRYABLE && nextRetryAt?.isAfter(now) == true) {
-            return true
+            return false
         }
         if (status == ChunkExecutionStatus.PROCESSING && leaseUntil?.isAfter(now) == true) {
             return true
         }
         return false
     }
+
+    private fun ChunkExecutionState.shouldPreserveKafkaRedelivery(): Boolean =
+        status == ChunkExecutionStatus.FAILED_RETRYABLE && nextRetryAt?.isAfter(Instant.now()) == true
 
     private fun ChunkConsumerRequest.toInsertCommand(): InsertChunkExecutionCommand =
         InsertChunkExecutionCommand(

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/storage/ResultFileReader.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/storage/ResultFileReader.kt
@@ -35,9 +35,8 @@ class ResultFileReader(
                     require(rowCount <= maxRowsPerChunk) {
                         "Chunk row limit exceeded: objectKey=$objectKey, maxRows=$maxRowsPerChunk, current=$rowCount"
                     }
-                    parseItem(line)?.let { item ->
-                        grouped.getOrPut("${item.ocid}:${item.presetNo}") { mutableListOf() }.add(item)
-                    }
+                    val item = parseItem(line)
+                    grouped.getOrPut("${item.ocid}:${item.presetNo}") { mutableListOf() }.add(item)
                 }
 
             return grouped.map { (readKey, group) ->
@@ -51,31 +50,29 @@ class ResultFileReader(
         }
     }
 
-    fun parseItem(line: String): CalculatedEquipmentItem? {
-        return runCatching {
-            val node = objectMapper.readTree(line)
-            val ocid = node.get("ocid")?.asText() ?: return null
-            val presetNo = node.get("presetNo")?.asInt() ?: return null
-            CalculatedEquipmentItem(
-                ocid = ocid,
-                presetNo = presetNo,
-                itemName = node.get("itemName")?.asText() ?: "",
-                itemLevel = node.get("itemLevel")?.asInt() ?: 0,
-                itemPart = node.get("itemPart")?.asText() ?: "",
-                itemEquipmentPart = node.get("itemEquipmentPart")?.asText(),
-                potentialGrade = node.get("potentialGrade")?.asText(),
-                potentialOptions = node.get("potentialOptions")?.map { it.asText() },
-                additionalGrade = node.get("additionalGrade")?.asText(),
-                additionalOptions = node.get("additionalOptions")?.map { it.asText() },
-                currentStar = node.get("currentStar")?.asInt() ?: 0,
-                targetStar = node.get("targetStar")?.asInt() ?: 0,
-                status = node.get("status")?.asText() ?: "UNKNOWN",
-                totalCost = node.get("totalCost")?.decimalValue() ?: BigDecimal.ZERO,
-                blackCubeCost = node.get("blackCubeCost")?.decimalValue() ?: BigDecimal.ZERO,
-                additionalCubeCost = node.get("additionalCubeCost")?.decimalValue() ?: BigDecimal.ZERO,
-                starforceCost = node.get("starforceCost")?.decimalValue() ?: BigDecimal.ZERO,
-                errorMessage = node.get("errorMessage")?.asText(),
-            )
-        }.getOrNull()
+    fun parseItem(line: String): CalculatedEquipmentItem {
+        val node = objectMapper.readTree(line)
+        val ocid = requireNotNull(node.get("ocid")?.asText()) { "Missing required field: ocid" }
+        val presetNo = requireNotNull(node.get("presetNo")?.asInt()) { "Missing required field: presetNo" }
+        return CalculatedEquipmentItem(
+            ocid = ocid,
+            presetNo = presetNo,
+            itemName = node.get("itemName")?.asText() ?: "",
+            itemLevel = node.get("itemLevel")?.asInt() ?: 0,
+            itemPart = node.get("itemPart")?.asText() ?: "",
+            itemEquipmentPart = node.get("itemEquipmentPart")?.asText(),
+            potentialGrade = node.get("potentialGrade")?.asText(),
+            potentialOptions = node.get("potentialOptions")?.map { it.asText() },
+            additionalGrade = node.get("additionalGrade")?.asText(),
+            additionalOptions = node.get("additionalOptions")?.map { it.asText() },
+            currentStar = node.get("currentStar")?.asInt() ?: 0,
+            targetStar = node.get("targetStar")?.asInt() ?: 0,
+            status = node.get("status")?.asText() ?: "UNKNOWN",
+            totalCost = node.get("totalCost")?.decimalValue() ?: BigDecimal.ZERO,
+            blackCubeCost = node.get("blackCubeCost")?.decimalValue() ?: BigDecimal.ZERO,
+            additionalCubeCost = node.get("additionalCubeCost")?.decimalValue() ?: BigDecimal.ZERO,
+            starforceCost = node.get("starforceCost")?.decimalValue() ?: BigDecimal.ZERO,
+            errorMessage = node.get("errorMessage")?.asText(),
+        )
     }
 }

--- a/module-synchronizer/src/test/kotlin/maple/synchronizer/consumer/ChunkConsumerTemplateTest.kt
+++ b/module-synchronizer/src/test/kotlin/maple/synchronizer/consumer/ChunkConsumerTemplateTest.kt
@@ -89,7 +89,7 @@ class ChunkConsumerTemplateTest {
     }
 
     @Test
-    fun `retryable failure not due acks without permit or claim`() {
+    fun `retryable failure not due does not ack without permit or claim`() {
         val permit = Semaphore(0)
         whenever(repository.findExecutionState(identity)).thenReturn(
             state(ChunkExecutionStatus.FAILED_RETRYABLE, nextRetryAt = Instant.now().plusSeconds(60)),
@@ -98,7 +98,7 @@ class ChunkConsumerTemplateTest {
         template.submit(request(processingPermit = permit, process = { error("must not process") }))
 
         verify(repository, never()).claimProcessing(any(), any())
-        verify(acknowledgment).acknowledge()
+        verify(acknowledgment, never()).acknowledge()
     }
 
     @Test
@@ -126,16 +126,15 @@ class ChunkConsumerTemplateTest {
     }
 
     @Test
-    fun `business failure writes retryable failure before ack`() {
+    fun `business failure writes retryable failure and preserves Kafka redelivery`() {
         whenever(repository.findExecutionState(identity)).thenReturn(state(ChunkExecutionStatus.PENDING))
         whenever(repository.claimProcessing(eq(identity), any())).thenReturn(ChunkExecutionClaim(attemptCount = 1))
         whenever(repository.markFailedRetryable(eq(identity), eq(1), any(), any())).thenReturn(true)
 
         template.submit(request(process = { error("boom") }))
 
-        val order = inOrder(repository, acknowledgment)
-        order.verify(repository).markFailedRetryable(eq(identity), eq(1), any(), any())
-        order.verify(acknowledgment).acknowledge()
+        verify(repository).markFailedRetryable(eq(identity), eq(1), any(), any())
+        verify(acknowledgment, never()).acknowledge()
         verify(repository, never()).markSucceeded(any(), any())
     }
 

--- a/module-synchronizer/src/test/kotlin/maple/synchronizer/storage/ResultFileReaderTest.kt
+++ b/module-synchronizer/src/test/kotlin/maple/synchronizer/storage/ResultFileReaderTest.kt
@@ -28,30 +28,29 @@ class ResultFileReaderTest {
     }
 
     @Test
-    fun `parseItem - missing ocid returns null`() {
+    fun `parseItem - missing ocid throws`() {
         val line = """{"presetNo":1,"itemName":"Sword"}"""
 
-        val item = reader.parseItem(line)
-
-        assertThat(item).isNull()
+        assertThatThrownBy { reader.parseItem(line) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Missing required field: ocid")
     }
 
     @Test
-    fun `parseItem - missing presetNo returns null`() {
+    fun `parseItem - missing presetNo throws`() {
         val line = """{"ocid":"oc1","itemName":"Sword"}"""
 
-        val item = reader.parseItem(line)
-
-        assertThat(item).isNull()
+        assertThatThrownBy { reader.parseItem(line) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Missing required field: presetNo")
     }
 
     @Test
-    fun `parseItem - invalid JSON returns null`() {
+    fun `parseItem - invalid JSON throws`() {
         val line = "not json at all"
 
-        val item = reader.parseItem(line)
-
-        assertThat(item).isNull()
+        assertThatThrownBy { reader.parseItem(line) }
+            .isInstanceOf(Exception::class.java)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Apply PR 774-840 review feedback across external-api, calculator, synchronizer, rest-controller, infra, and app queue paths.
- Harden Kafka/PGMQ ack behavior, retryable chunk state handling, stale read-model guards, exact V6 read matching, and batch/archive failure handling.
- Improve startup safety, artifact writing, urgent chunk identity/keying, Redis ranking fallback, and local duplicate request-key migration handling.

## Verification
- ./gradlew :module-infra:compileKotlin :module-synchronizer:test :module-rest-controller:compileKotlin :module-external-api:compileKotlin :module-calculator:compileKotlin --no-daemon
- ./gradlew :module-rest-controller:test --tests "*InflightRequestRegistryTest" :module-app:test --tests "*ExpectationCalculationQueueTest" --no-daemon
- ./gradlew :module-infra:compileKotlin :module-external-api:test --tests "*UrgentCharacterRequestConsumerTest" :module-rest-controller:test --tests "*InflightRequestRegistryTest" :module-app:test --tests "*ExpectationCalculationQueueTest" :module-calculator:compileKotlin --no-daemon
- ./gradlew :module-external-api:compileKotlin --no-daemon
- Boot check: external-api, calculator, synchronizer started on ports 8081/8082/8083 with --spring.kafka.listener.auto-startup=false.

## Notes
- Full listener-enabled synchronizer boot consumed existing local Kafka backlog and failed because local PostgreSQL did not have chunk_execution applied yet: relation "chunk_execution" does not exist. Listener-disabled boot verified application startup without consuming stale backlog.