### PR TITLE
fix(synchronizer): resolve user_ign from character_basic_read_model

### DIFF
--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/resolver/OcidUserIgnResolver.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/resolver/OcidUserIgnResolver.kt
@@ -15,7 +15,7 @@ class OcidUserIgnResolver(
         if (ocids.isEmpty()) return emptyMap()
 
         val sql = """
-            SELECT ocid, user_ign FROM game_character WHERE ocid IN (:ocids)
+            SELECT ocid, user_ign FROM character_basic_read_model WHERE ocid IN (:ocids)
         """.trimIndent()
 
         val params = MapSqlParameterSource("ocids", ocids.toList())


### PR DESCRIPTION
## Summary
- `OcidUserIgnResolver`가 `game_character`(2 rows) 대신 `character_basic_read_model`(288K rows)에서 user_ign을 조회하도록 수정
- 이 변경으로 equipment read model의 user_ign 컬럼이 정상 populate됨
- 쿼리플랜 분석 중 발견한 pipeline mapping bug (#1)

## Root Cause
EXPLAIN ANALYZE 분석 중 `user_ign`이 99.999% NULL인 것을 발견.
`character_basic_read_model`에는 288K ocid→user_ign 매핑이 존재하나,
`OcidUserIgnResolver`가 `game_character`(2 rows only)를 조회하고 있었음.

## Impact
- user_ign 기반 read path 복구 (`WHERE user_ign = ? AND preset_no = ?`)
- `idx_equipment_read_model_user_ign_preset` 인덱스 활성화
- next sync cycle에서 user_ign 자동 backfill

## Test plan
- [x] `OcidUserIgnResolverTest` 3/3 통과
- [x] `./gradlew :module-synchronizer:compileKotlin` 성공
- [ ] 서버 구동 후 Synchronizer 동작 확인 (user_ign populate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)