### PR TITLE
feat(external-api): ranking fetch pipeline with daily cron scheduler

### DIFF
--- a/docs/superpowers/plans/2026-05-20-ranking-fetch-pipeline.md
+++ b/docs/superpowers/plans/2026-05-20-ranking-fetch-pipeline.md
@@ -1,0 +1,578 @@
+# Ranking Fetch Pipeline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Daily fetch of Nexon overall ranking (pages 1..300), store as chunked gzip JSONL, extract character_names to CSV for downstream OCID lookup.
+
+**Architecture:** New `RankingFetchPhase` prepended to `ExternalApiScheduler` daily pipeline. Ranking API pages fetched sequentially with rate limiting. Each page response flattened into individual ranking entry JSONL records → `ChunkedSnapshotSink` for gzip storage. character_names collected during streaming → CSV overwrite after completion. Ranking failure does NOT block downstream OCID lookup (error isolation via `.handle`).
+
+**Tech Stack:** Kotlin, Spring Boot, WebClient, Virtual Threads, CompletableFuture chaining, Bucket4j, Jackson, gzip JSONL
+
+**Pipeline flow:**
+```
+RankingFetchPhase (gzip + CSV) → [error isolation] → OcidLookupPhase (reads CSV) → SnapshotFetchPhase
+```
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Modify | `module-external-api/.../domain/ExternalApiFetchCommand.kt` | Add `RANKING_OVERALL` endpoint + `KeyType.DATE_PAGE` |
+| Modify | `module-external-api/.../infra/nexon/NexonExternalApiClientAdapter.kt` | Handle `DATE_PAGE` → `date` + `page` query params |
+| Modify | `module-external-api/.../snapshot/SnapshotChunkingProperties.kt` | Add `rankingOverall` chunk config + `configFor` branch |
+| Modify | `module-external-api/.../snapshot/event/SnapshotEventPublisherConfig.kt` | Add `rankingSnapshotPublisher` qualified beans |
+| Modify | `module-external-api/.../metrics/ExternalApiMetrics.kt` | Add ranking fetched/failed counters |
+| Create | `module-external-api/.../scheduler/phase/RankingFetchPhase.kt` | Core phase: page iteration, entry flattening, gzip sink, CSV overwrite |
+| Modify | `module-external-api/.../scheduler/ExternalApiScheduler.kt` | Inject via `ObjectProvider`, chain ranking before OCID lookup with error isolation |
+| Modify | `module-external-api/src/main/resources/application.yml` | Add ranking config block |
+
+---
+
+### Task 1: Add RANKING_OVERALL endpoint + KeyType.DATE_PAGE
+
+**Files:**
+- Modify: `module-external-api/src/main/kotlin/maple/externalapi/domain/ExternalApiFetchCommand.kt`
+
+- [ ] **Step 1: Add `DATE_PAGE` to KeyType and `RANKING_OVERALL` to ExternalApiEndpoint**
+
+```kotlin
+enum class ExternalApiEndpoint(
+    val path: String,
+    val keyType: KeyType,
+) {
+    OCID_LOOKUP("/maplestory/v1/id", KeyType.USER_IGN),
+    CHARACTER_BASIC("/maplestory/v1/character/basic", KeyType.OCID),
+    ITEM_EQUIPMENT("/maplestory/v1/character/item-equipment", KeyType.OCID),
+    RANKING_OVERALL("/maplestory/v1/ranking/overall", KeyType.DATE_PAGE),
+    ;
+
+    fun storageSubDir(): String = name.lowercase().replace('_', '-')
+}
+
+enum class KeyType {
+    USER_IGN,
+    OCID,
+    DATE_PAGE,
+}
+```
+
+- [ ] **Step 2: Compile to verify**
+
+Run: `./gradlew :module-external-api:compileKotlin --continue 2>&1 | tail -5`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add module-external-api/src/main/kotlin/maple/externalapi/domain/ExternalApiFetchCommand.kt
+git commit -m "feat(external-api): add RANKING_OVERALL endpoint and DATE_PAGE key type"
+```
+
+---
+
+### Task 2: Handle DATE_PAGE in NexonExternalApiClientAdapter
+
+**Files:**
+- Modify: `module-external-api/src/main/kotlin/maple/externalapi/infra/nexon/NexonExternalApiClientAdapter.kt`
+
+The `fetch()` method currently has a `val queryParam = when(endpoint.keyType)` block (line 76-79) that only handles `USER_IGN` and `OCID`. Need to add `DATE_PAGE` handling that splits the requestKey by `:` into `date` + `page` params.
+
+- [ ] **Step 1: Update fetch() method**
+
+Replace lines 76-88 (from `val queryParam = when(...)` through `.build()` in the uri lambda):
+
+```kotlin
+    override fun fetch(
+        provider: ExternalApiProvider,
+        endpoint: ExternalApiEndpoint,
+        requestKey: String,
+    ): CompletableFuture<ByteArray> {
+        val startedAt = Instant.now()
+        return webClient.get()
+            .uri { builder ->
+                val pathBuilder = builder.path(endpoint.path)
+                when (endpoint.keyType) {
+                    KeyType.USER_IGN -> pathBuilder.queryParam("character_name", requestKey)
+                    KeyType.OCID -> pathBuilder.queryParam("ocid", requestKey)
+                    KeyType.DATE_PAGE -> {
+                        val parts = requestKey.split(":", limit = 2)
+                        pathBuilder
+                            .queryParam("date", parts[0])
+                            .queryParam("page", parts.getOrElse(1) { "1" })
+                    }
+                }.build()
+            }
+```
+
+Rest of the method (`.header`, `.retrieve()`, `.bodyToMono`, metrics, error handling, `.timeout`, `.toFuture`) stays unchanged.
+
+- [ ] **Step 2: Compile to verify**
+
+Run: `./gradlew :module-external-api:compileKotlin --continue 2>&1 | tail -5`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add module-external-api/src/main/kotlin/maple/externalapi/infra/nexon/NexonExternalApiClientAdapter.kt
+git commit -m "feat(external-api): handle DATE_PAGE key type in Nexon adapter"
+```
+
+---
+
+### Task 3: Add ranking chunk config + YAML properties
+
+**Files:**
+- Modify: `module-external-api/src/main/kotlin/maple/externalapi/snapshot/SnapshotChunkingProperties.kt`
+- Modify: `module-external-api/src/main/resources/application.yml`
+
+- [ ] **Step 1: Add `rankingOverall` to ChunkConfig and `configFor` branch**
+
+```kotlin
+@ConfigurationProperties(prefix = "external-api.snapshot")
+data class SnapshotChunkingProperties(
+    val chunk: ChunkConfig = ChunkConfig(),
+    val queueCapacity: Int = 1000,
+) {
+    data class ChunkConfig(
+        val characterBasic: EndpointChunkConfig = EndpointChunkConfig(maxRecords = 2000),
+        val itemEquipment: EndpointChunkConfig = EndpointChunkConfig(maxRecords = 500),
+        val rankingOverall: EndpointChunkConfig = EndpointChunkConfig(maxRecords = 5000),
+    )
+
+    data class EndpointChunkConfig(
+        val maxRecords: Int = 1000,
+        val maxUncompressedBytes: Long = 134217728L,
+    )
+
+    fun configFor(endpoint: String): EndpointChunkConfig = when (endpoint) {
+        "character-basic" -> chunk.characterBasic
+        "item-equipment" -> chunk.itemEquipment
+        "ranking-overall" -> chunk.rankingOverall
+        else -> EndpointChunkConfig()
+    }
+}
+```
+
+- [ ] **Step 2: Add ranking config to application.yml**
+
+Add under the existing `external-api:` block, after `snapshot:` section (line 77), before `management:`:
+
+```yaml
+  ranking:
+    enabled: true
+    max-pages: 300
+    permits-per-second: 50
+```
+
+The full ranking config sits at `external-api.ranking.*`. Insert at the same indentation level as `schedule:`, `urgent:`, `snapshot:`.
+
+- [ ] **Step 3: Compile to verify**
+
+Run: `./gradlew :module-external-api:compileKotlin --continue 2>&1 | tail -5`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add module-external-api/src/main/kotlin/maple/externalapi/snapshot/SnapshotChunkingProperties.kt module-external-api/src/main/resources/application.yml
+git commit -m "feat(external-api): add ranking chunk config and YAML properties"
+```
+
+---
+
+### Task 4: Add ranking publisher bean + ranking metrics
+
+**Files:**
+- Modify: `module-external-api/src/main/kotlin/maple/externalapi/snapshot/event/SnapshotEventPublisherConfig.kt`
+- Modify: `module-external-api/src/main/kotlin/maple/externalapi/metrics/ExternalApiMetrics.kt`
+
+- [ ] **Step 1: Add `rankingSnapshotPublisher` qualified beans**
+
+Add two new bean methods inside `SnapshotEventPublisherConfig` class, after the existing `characterBasicSnapshotPublisher` beans:
+
+```kotlin
+    @Bean
+    @Qualifier("rankingSnapshotPublisher")
+    @ConditionalOnProperty(
+        prefix = "external-api.snapshot.events.kafka",
+        name = ["enabled"],
+        havingValue = "false",
+        matchIfMissing = true,
+    )
+    fun noOpRankingSnapshotPublisher(): SnapshotChunkEventPublisher =
+        NoOpSnapshotChunkEventPublisher()
+
+    @Bean
+    @Qualifier("rankingSnapshotPublisher")
+    @ConditionalOnProperty(
+        prefix = "external-api.snapshot.events.kafka",
+        name = ["enabled"],
+        havingValue = "true",
+    )
+    fun kafkaRankingSnapshotPublisher(
+        kafkaTemplate: KafkaTemplate<String, String>,
+        objectMapper: ObjectMapper,
+        properties: SnapshotEventProperties,
+    ): SnapshotChunkEventPublisher =
+        KafkaSnapshotChunkEventPublisher(
+            kafkaTemplate = kafkaTemplate,
+            objectMapper = objectMapper,
+            chunkReadyTopic = properties.kafka.chunkReadyTopic,
+            runCompletedTopic = properties.kafka.runCompletedTopic,
+            runFailedTopic = properties.kafka.runFailedTopic,
+        )
+```
+
+- [ ] **Step 2: Add ranking metrics to ExternalApiMetrics**
+
+Add two counter fields and two methods to `ExternalApiMetrics`:
+
+```kotlin
+    private val rankingFetched = registry.counter("external_api_ranking_fetched_total")
+    private val rankingFailed = registry.counter("external_api_ranking_failed_total")
+
+    fun recordRankingFetched(count: Int = 1) {
+        rankingFetched.increment(count.toDouble())
+    }
+
+    fun recordRankingFailed(count: Int = 1) {
+        rankingFailed.increment(count.toDouble())
+    }
+```
+
+- [ ] **Step 3: Compile to verify**
+
+Run: `./gradlew :module-external-api:compileKotlin --continue 2>&1 | tail -5`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add module-external-api/src/main/kotlin/maple/externalapi/snapshot/event/SnapshotEventPublisherConfig.kt module-external-api/src/main/kotlin/maple/externalapi/metrics/ExternalApiMetrics.kt
+git commit -m "feat(external-api): add ranking snapshot publisher bean and metrics"
+```
+
+---
+
+### Task 5: Create RankingFetchPhase
+
+**Files:**
+- Create: `module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/RankingFetchPhase.kt`
+
+This is the core new class. Follows `SnapshotFetchPhase` patterns:
+- `runDir = Paths.get(storeBasePath, "runs", runId)` — sink creates endpoint subdirectory internally
+- `ChunkedSnapshotSink(runDir = runDir: Path, ...)` — no `runId` parameter
+- Sequential page processing via recursive `thenCompose` CF chaining
+- Rate limited via Bucket4j
+- CSV overwrite with collected character_names after all pages complete
+
+- [ ] **Step 1: Create RankingFetchPhase**
+
+```kotlin
+package maple.externalapi.scheduler.phase
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import maple.externalapi.domain.ExternalApiEndpoint
+import maple.externalapi.domain.ExternalApiProvider
+import maple.externalapi.domain.KeyType
+import maple.externalapi.metrics.ExternalApiMetrics
+import maple.externalapi.metrics.SnapshotVolumeMetrics
+import maple.externalapi.port.out.ExternalApiClientPort
+import maple.externalapi.snapshot.ChunkedSnapshotSink
+import maple.externalapi.snapshot.SnapshotChunkRecord
+import maple.externalapi.snapshot.SnapshotChunkingProperties
+import maple.externalapi.snapshot.event.SnapshotChunkEventPublisher
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.atomic.AtomicInteger
+
+@Component
+@ConditionalOnProperty(name = ["external-api.ranking.enabled"], havingValue = "true", matchIfMissing = false)
+class RankingFetchPhase(
+    private val clientPort: ExternalApiClientPort,
+    private val objectMapper: ObjectMapper,
+    private val chunkingProperties: SnapshotChunkingProperties,
+    private val volumeMetrics: SnapshotVolumeMetrics,
+    private val metrics: ExternalApiMetrics,
+    @Qualifier("rankingSnapshotPublisher")
+    private val rankingPublisher: SnapshotChunkEventPublisher,
+    @Value("\${external-api.ranking.max-pages:300}")
+    private val maxPages: Int,
+    @Value("\${external-api.ranking.permits-per-second:50}")
+    private val permitsPerSecond: Int,
+    @Value("\${external-api.store.base-path:/data/external-api}")
+    private val storeBasePath: String,
+    @Value("\${external-api.csv.path:userIgn_List.csv}")
+    private val csvPath: String,
+) {
+    private val log = LoggerFactory.getLogger(RankingFetchPhase::class.java)
+
+    fun execute(workerExecutor: ExecutorService): CompletableFuture<Void> {
+        val runId = SchedulerPhaseUtils.newRunId()
+        val date = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE)
+        val runDir: Path = Paths.get(storeBasePath, "runs", runId)
+        val endpointConfig = chunkingProperties.configFor("ranking-overall")
+
+        SchedulerPhaseUtils.writeRunningMarker(runDir)
+
+        val sink = ChunkedSnapshotSink(
+            runDir = runDir,
+            endpoint = "ranking-overall",
+            maxRecords = endpointConfig.maxRecords,
+            maxUncompressedBytes = endpointConfig.maxUncompressedBytes,
+            queueCapacity = chunkingProperties.queueCapacity,
+            objectMapper = objectMapper,
+            eventPublisher = rankingPublisher,
+            volumeMetrics = volumeMetrics,
+        )
+
+        val rateLimiter = SchedulerPhaseUtils.newRateLimiter(permitsPerSecond)
+        val fetched = AtomicInteger(0)
+        val failed = AtomicInteger(0)
+        val characterNames = mutableListOf<String>()
+
+        log.info("[RankingFetch] starting: runId={}, date={}, maxPages={}, permitsPerSecond={}", runId, date, maxPages, permitsPerSecond)
+        val start = Instant.now()
+
+        return processPages(workerExecutor, sink, rateLimiter, date, 1, fetched, failed, characterNames)
+            .whenComplete { _, ex ->
+                sink.close()
+                if (ex != null) {
+                    log.error("[RankingFetch] failed: runId={}, fetched={}, failed={}", runId, fetched.get(), failed.get(), ex)
+                } else {
+                    writeCsv(characterNames)
+                    SchedulerPhaseUtils.logSummary("RankingFetch", fetched.get(), fetched.get(), fetched.get(), failed.get(), start)
+                }
+            }
+    }
+
+    private fun processPages(
+        workerExecutor: ExecutorService,
+        sink: ChunkedSnapshotSink,
+        rateLimiter: io.github.bucket4j.Bucket,
+        date: String,
+        currentPage: Int,
+        fetched: AtomicInteger,
+        failed: AtomicInteger,
+        characterNames: MutableList<String>,
+    ): CompletableFuture<Void> {
+        if (currentPage > maxPages) {
+            return CompletableFuture.completedFuture(null)
+        }
+
+        SchedulerPhaseUtils.acquirePermits(rateLimiter, 1, 1)
+
+        val requestKey = "$date:$currentPage"
+        return clientPort.fetch(ExternalApiProvider.NEXON, ExternalApiEndpoint.RANKING_OVERALL, requestKey)
+            .thenAcceptAsync({ bodyBytes ->
+                val count = submitRankingEntries(sink, bodyBytes, currentPage, characterNames)
+                fetched.addAndGet(count)
+                metrics.recordRankingFetched(count)
+                if (fetched.get() % 10000 == 0) {
+                    log.info("[RankingFetch] progress: fetched={}, failed={}, page={}/{}", fetched.get(), failed.get(), currentPage, maxPages)
+                }
+            }, workerExecutor)
+            .handle { _, ex ->
+                if (ex != null) {
+                    failed.incrementAndGet()
+                    metrics.recordRankingFailed()
+                    val status = SchedulerPhaseUtils.extractHttpStatus(ex)
+                    sink.submit(SnapshotChunkRecord.Failure(
+                        key = requestKey,
+                        endpoint = "ranking-overall",
+                        keyType = KeyType.DATE_PAGE.name,
+                        httpStatus = status,
+                        fetchedAt = Instant.now(),
+                        errorMessage = ex.message ?: "unknown",
+                    ))
+                    log.warn("[RankingFetch] page failed: page={}, status={}, error={}", currentPage, status, ex.message)
+                }
+                null
+            }
+            .thenCompose { processPages(workerExecutor, sink, rateLimiter, date, currentPage + 1, fetched, failed, characterNames) }
+    }
+
+    private fun submitRankingEntries(
+        sink: ChunkedSnapshotSink,
+        bodyBytes: ByteArray,
+        page: Int,
+        characterNames: MutableList<String>,
+    ): Int {
+        val root = objectMapper.readTree(bodyBytes)
+        val rankingArray = root.get("ranking")
+        if (rankingArray == null || !rankingArray.isArray) {
+            log.warn("[RankingFetch] no ranking array in response: page={}", page)
+            return 0
+        }
+
+        var count = 0
+        for (node in rankingArray) {
+            val entryBytes = objectMapper.writeValueAsBytes(node)
+            val name = node.get("character_name")?.asText() ?: continue
+            characterNames.add(name)
+            sink.submit(SnapshotChunkRecord.Success(
+                bodyBytes = entryBytes,
+                key = name,
+                endpoint = "ranking-overall",
+                keyType = KeyType.DATE_PAGE.name,
+                httpStatus = 200,
+                fetchedAt = Instant.now(),
+            ))
+            count++
+        }
+        return count
+    }
+
+    private fun writeCsv(characterNames: List<String>) {
+        val path = Paths.get(csvPath)
+        val content = characterNames.joinToString("\n", postfix = "\n")
+        Files.writeString(path, content)
+        log.info("[RankingFetch] CSV overwritten: path={}, count={}", path.toAbsolutePath(), characterNames.size)
+    }
+}
+```
+
+- [ ] **Step 2: Compile to verify**
+
+Run: `./gradlew :module-external-api:compileKotlin --continue 2>&1 | tail -5`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/RankingFetchPhase.kt
+git commit -m "feat(external-api): create RankingFetchPhase with gzip sink and CSV overwrite"
+```
+
+---
+
+### Task 6: Wire RankingFetchPhase into ExternalApiScheduler
+
+**Files:**
+- Modify: `module-external-api/src/main/kotlin/maple/externalapi/scheduler/ExternalApiScheduler.kt`
+
+Key changes:
+- Inject `ObjectProvider<RankingFetchPhase>` for conditional bean (not nullable constructor param)
+- Chain ranking before OCID lookup
+- Error isolation: `.handle { _, _ -> null }` so ranking failure does NOT block downstream
+
+- [ ] **Step 1: Update scheduler constructor and triggerDailyRefresh**
+
+Add import:
+```kotlin
+import maple.externalapi.scheduler.phase.RankingFetchPhase
+import org.springframework.beans.factory.ObjectProvider
+```
+
+Update constructor to add `rankingFetchPhaseProvider`:
+```kotlin
+class ExternalApiScheduler(
+    private val ocidLookupPhase: OcidLookupPhase,
+    private val snapshotFetchPhase: SnapshotFetchPhase,
+    private val ocidCacheProvider: OcidCacheProvider,
+    private val rankingFetchPhaseProvider: ObjectProvider<RankingFetchPhase>,
+    @Value("\${external-api.schedule.run-on-startup:false}")
+    private val runOnStartup: Boolean,
+    @Value("\${external-api.schedule.skip-character-basic:false}")
+    private val skipCharacterBasic: Boolean,
+) : ManagedLifecycle {
+```
+
+Update `triggerDailyRefresh()` — replace lines 62-72 (the `ocidLookupPhase.execute(executor)...` block):
+
+```kotlin
+        val rankingPhase = rankingFetchPhaseProvider.ifAvailable
+        val rankingFuture = if (rankingPhase != null) {
+            log.info("[Scheduler] starting ranking fetch phase")
+            rankingPhase.execute(executor)
+                .handle { _, ex ->
+                    if (ex != null) {
+                        log.error("[Scheduler] ranking fetch failed, continuing with OCID lookup", ex)
+                    }
+                    null
+                }
+        } else {
+            log.info("[Scheduler] ranking fetch phase disabled, skipping")
+            CompletableFuture.completedFuture(null)
+        }
+
+        rankingFuture
+            .thenCompose {
+                ocidLookupPhase.execute(executor)
+            }
+            .thenCompose {
+                val cache = ocidCacheProvider.refresh()
+                snapshotFetchPhase.executeCharacterBasic(executor, cache)
+            }
+            .whenComplete { _, ex ->
+                if (ex != null) {
+                    log.error("[Scheduler] daily refresh failed", ex)
+                }
+                running.set(false)
+            }
+```
+
+- [ ] **Step 2: Compile to verify**
+
+Run: `./gradlew :module-external-api:compileKotlin --continue 2>&1 | tail -5`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add module-external-api/src/main/kotlin/maple/externalapi/scheduler/ExternalApiScheduler.kt
+git commit -m "feat(external-api): wire RankingFetchPhase into daily scheduler with error isolation"
+```
+
+---
+
+### Task 7: Full compile + test verification
+
+- [ ] **Step 1: Full project compile**
+
+Run: `./gradlew compileKotlin compileJava --continue 2>&1 | tail -5`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 2: Run module-external-api tests**
+
+Run: `./gradlew :module-external-api:test 2>&1 | tail -10`
+Expected: All existing tests pass (new phase is conditional, no tests break)
+
+- [ ] **Step 3: Verify YAML property keys match code**
+
+Check all `@Value` and `@ConditionalOnProperty` references:
+- `external-api.ranking.enabled` → `@ConditionalOnProperty` in RankingFetchPhase
+- `external-api.ranking.max-pages` → `@Value` in RankingFetchPhase
+- `external-api.ranking.permits-per-second` → `@Value` in RankingFetchPhase
+- `external-api.csv.path` → `@Value` in RankingFetchPhase
+- `external-api.store.base-path` → existing, reused
+
+- [ ] **Step 4: Final commit if any fixes needed**
+
+---
+
+## Self-Review Checklist
+
+- [x] Spec coverage: Daily cron, page 1..N, YAML config, gzip JSONL via ChunkedSnapshotSink, CSV overwrite, error isolation
+- [x] Placeholder scan: No TBD/TODO/placeholders
+- [x] Type consistency: `SnapshotChunkRecord.Success` params match sealed interface (key, endpoint, keyType, httpStatus, fetchedAt, bodyBytes); `KeyType.DATE_PAGE` used consistently; `runDir: Path` not String
+- [x] No duplicate logic: Reuses ExternalApiClientPort, ChunkedSnapshotSink, GzipJsonlChunkWriter, SnapshotChunkEventPublisher, SchedulerPhaseUtils, Bucket4j
+- [x] Project rules: No try-catch (CF chaining + .handle), no join/get, no System.out, no `!!`, logging via LoggerFactory, LogicExecutor not needed (no try-catch used)
+- [x] Module boundaries: All changes within module-external-api, port interfaces unchanged
+- [x] Async safety: Sequential CF chaining via recursive `thenCompose`, no blocking, `.handle` for error isolation
+- [x] CSV format: One IGN per line, matches `UserIgnCsvReader.readAll()` expectations (trim + blank filter)

--- a/module-external-api/src/main/kotlin/maple/externalapi/domain/ExternalApiFetchCommand.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/domain/ExternalApiFetchCommand.kt
@@ -16,6 +16,7 @@ enum class ExternalApiEndpoint(
     OCID_LOOKUP("/maplestory/v1/id", KeyType.USER_IGN),
     CHARACTER_BASIC("/maplestory/v1/character/basic", KeyType.OCID),
     ITEM_EQUIPMENT("/maplestory/v1/character/item-equipment", KeyType.OCID),
+    RANKING_OVERALL("/maplestory/v1/ranking/overall", KeyType.DATE_PAGE),
     ;
 
     fun storageSubDir(): String = name.lowercase().replace('_', '-')
@@ -24,4 +25,5 @@ enum class ExternalApiEndpoint(
 enum class KeyType {
     USER_IGN,
     OCID,
+    DATE_PAGE,
 }

--- a/module-external-api/src/main/kotlin/maple/externalapi/infra/nexon/NexonExternalApiClientAdapter.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/infra/nexon/NexonExternalApiClientAdapter.kt
@@ -73,18 +73,20 @@ class NexonExternalApiClientAdapter(
         endpoint: ExternalApiEndpoint,
         requestKey: String,
     ): CompletableFuture<ByteArray> {
-        val queryParam = when (endpoint.keyType) {
-            KeyType.USER_IGN -> "character_name"
-            KeyType.OCID -> "ocid"
-        }
-
         val startedAt = Instant.now()
         return webClient.get()
             .uri { builder ->
-                builder
-                    .path(endpoint.path)
-                    .queryParam(queryParam, requestKey)
-                    .build()
+                val pathBuilder = builder.path(endpoint.path)
+                when (endpoint.keyType) {
+                    KeyType.USER_IGN -> pathBuilder.queryParam("character_name", requestKey)
+                    KeyType.OCID -> pathBuilder.queryParam("ocid", requestKey)
+                    KeyType.DATE_PAGE -> {
+                        val parts = requestKey.split(":", limit = 2)
+                        pathBuilder
+                            .queryParam("date", parts[0])
+                            .queryParam("page", parts.getOrElse(1) { "1" })
+                    }
+                }.build()
             }
             .header("x-nxopen-api-key", apiKey)
             .retrieve()

--- a/module-external-api/src/main/kotlin/maple/externalapi/metrics/ExternalApiMetrics.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/metrics/ExternalApiMetrics.kt
@@ -16,6 +16,9 @@ class ExternalApiMetrics(registry: MeterRegistry) {
     private val itemEquipmentFailed = registry.counter("external_api_item_equipment_failed_total")
     private val chunksCreated = registry.counter("external_api_chunks_created_total")
 
+    private val rankingFetched = registry.counter("external_api_ranking_fetched_total")
+    private val rankingFailed = registry.counter("external_api_ranking_failed_total")
+
     private val lookupTimer = Timer.builder("external_api_lookup_duration_seconds")
         .description("Time for a full endpoint lookup run")
         .register(registry)
@@ -56,4 +59,12 @@ class ExternalApiMetrics(registry: MeterRegistry) {
     fun lookupTimer(): Timer = lookupTimer
     fun characterBasicTimer(): Timer = characterBasicTimer
     fun itemEquipmentTimer(): Timer = itemEquipmentTimer
+
+    fun recordRankingFetched(count: Int = 1) {
+        rankingFetched.increment(count.toDouble())
+    }
+
+    fun recordRankingFailed(count: Int = 1) {
+        rankingFailed.increment(count.toDouble())
+    }
 }

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/ExternalApiScheduler.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/ExternalApiScheduler.kt
@@ -2,9 +2,11 @@ package maple.externalapi.scheduler
 
 import maple.externalapi.cache.OcidCacheProvider
 import maple.externalapi.scheduler.phase.OcidLookupPhase
+import maple.externalapi.scheduler.phase.RankingFetchPhase
 import maple.externalapi.scheduler.phase.SnapshotFetchPhase
 import maple.expectation.infrastructure.lifecycle.ManagedLifecycle
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.ObjectProvider
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.event.ApplicationReadyEvent
@@ -22,6 +24,7 @@ class ExternalApiScheduler(
     private val ocidLookupPhase: OcidLookupPhase,
     private val snapshotFetchPhase: SnapshotFetchPhase,
     private val ocidCacheProvider: OcidCacheProvider,
+    private val rankingFetchPhaseProvider: ObjectProvider<RankingFetchPhase>,
     @Value("\${external-api.schedule.run-on-startup:false}")
     private val runOnStartup: Boolean,
     @Value("\${external-api.schedule.skip-character-basic:false}")
@@ -59,7 +62,25 @@ class ExternalApiScheduler(
             return
         }
 
-        ocidLookupPhase.execute(executor)
+        val rankingPhase = rankingFetchPhaseProvider.ifAvailable
+        val rankingFuture = if (rankingPhase != null) {
+            log.info("[Scheduler] starting ranking fetch phase")
+            rankingPhase.execute(executor)
+                .handle { _, ex ->
+                    if (ex != null) {
+                        log.error("[Scheduler] ranking fetch failed, continuing with OCID lookup", ex)
+                    }
+                    null
+                }
+        } else {
+            log.info("[Scheduler] ranking fetch phase disabled, skipping")
+            CompletableFuture.completedFuture(null)
+        }
+
+        rankingFuture
+            .thenCompose {
+                ocidLookupPhase.execute(executor)
+            }
             .thenCompose {
                 val cache = ocidCacheProvider.refresh()
                 snapshotFetchPhase.executeCharacterBasic(executor, cache)

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/ExternalApiScheduler.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/ExternalApiScheduler.kt
@@ -13,10 +13,10 @@ import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.context.event.EventListener
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
-import java.time.Duration
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.locks.ReentrantLock
 
 @Component
 @ConditionalOnProperty(name = ["external-api.schedule.enabled"], havingValue = "true")
@@ -34,6 +34,8 @@ class ExternalApiScheduler(
     private val running = AtomicBoolean(false)
     private val shutdown = AtomicBoolean(false)
     private val executor = Executors.newVirtualThreadPerTaskExecutor()
+    private val lock = ReentrantLock()
+    private val idle = lock.newCondition()
 
     @EventListener(ApplicationReadyEvent::class)
     fun onStartup() {
@@ -51,14 +53,14 @@ class ExternalApiScheduler(
     }
 
     fun triggerDailyRefresh() {
-        if (!acquireLock(120_000)) {
+        if (!acquireLock(3_600_000)) {
             log.warn("[Scheduler] could not acquire lock for daily refresh, skipping")
             return
         }
         if (skipCharacterBasic) {
             log.info("[Scheduler] skip-character-basic enabled, loading OCID cache from existing data")
             ocidCacheProvider.refresh()
-            running.set(false)
+            releaseLock()
             return
         }
 
@@ -89,7 +91,7 @@ class ExternalApiScheduler(
                 if (ex != null) {
                     log.error("[Scheduler] daily refresh failed", ex)
                 }
-                running.set(false)
+                releaseLock()
             }
     }
 
@@ -108,7 +110,7 @@ class ExternalApiScheduler(
         if (entries.isEmpty()) {
             log.warn("[Scheduler] OCID cache empty, waiting 30s")
             executor.submit {
-                Thread.sleep(Duration.ofSeconds(30))
+                Thread.sleep(java.time.Duration.ofSeconds(30))
                 ocidCacheProvider.refresh()
                 runItemEquipmentCycle()
             }
@@ -117,7 +119,7 @@ class ExternalApiScheduler(
 
         if (!acquireLock(120_000)) {
             executor.submit {
-                Thread.sleep(Duration.ofSeconds(5))
+                Thread.sleep(java.time.Duration.ofSeconds(5))
                 runItemEquipmentCycle()
             }
             return
@@ -129,18 +131,29 @@ class ExternalApiScheduler(
                 if (ex != null) {
                     log.error("[Scheduler] ITEM_EQUIPMENT cycle failed", ex)
                 }
-                running.set(false)
+                releaseLock()
                 executor.submit { runItemEquipmentCycle() }
             }
     }
 
     private fun acquireLock(timeoutMs: Long): Boolean {
-        val deadline = System.currentTimeMillis() + timeoutMs
-        while (System.currentTimeMillis() < deadline) {
-            if (running.compareAndSet(false, true)) return true
-            Thread.sleep(Duration.ofMillis(500))
+        lock.lock()
+        try {
+            var remainingNanos = timeoutMs * 1_000_000L
+            while (!running.compareAndSet(false, true)) {
+                if (remainingNanos <= 0) return false
+                remainingNanos = idle.awaitNanos(remainingNanos)
+            }
+            return true
+        } finally {
+            lock.unlock()
         }
-        return false
+    }
+
+    private fun releaseLock() {
+        running.set(false)
+        lock.lock()
+        try { idle.signalAll() } finally { lock.unlock() }
     }
 
     override val lifecyclePhase: Int = 100

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/RankingFetchPhase.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/RankingFetchPhase.kt
@@ -1,0 +1,173 @@
+package maple.externalapi.scheduler.phase
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import maple.externalapi.domain.ExternalApiEndpoint
+import maple.externalapi.domain.ExternalApiProvider
+import maple.externalapi.domain.KeyType
+import maple.externalapi.metrics.ExternalApiMetrics
+import maple.externalapi.metrics.SnapshotVolumeMetrics
+import maple.externalapi.port.out.ExternalApiClientPort
+import maple.externalapi.snapshot.ChunkedSnapshotSink
+import maple.externalapi.snapshot.SnapshotChunkRecord
+import maple.externalapi.snapshot.SnapshotChunkingProperties
+import maple.externalapi.snapshot.event.SnapshotChunkEventPublisher
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.atomic.AtomicInteger
+
+@Component
+@ConditionalOnProperty(name = ["external-api.ranking.enabled"], havingValue = "true", matchIfMissing = false)
+class RankingFetchPhase(
+    private val clientPort: ExternalApiClientPort,
+    private val objectMapper: ObjectMapper,
+    private val chunkingProperties: SnapshotChunkingProperties,
+    private val volumeMetrics: SnapshotVolumeMetrics,
+    private val metrics: ExternalApiMetrics,
+    @Qualifier("rankingSnapshotPublisher")
+    private val rankingPublisher: SnapshotChunkEventPublisher,
+    @Value("\${external-api.ranking.max-pages:300}")
+    private val maxPages: Int,
+    @Value("\${external-api.ranking.permits-per-second:50}")
+    private val permitsPerSecond: Int,
+    @Value("\${external-api.store.base-path:/data/external-api}")
+    private val storeBasePath: String,
+    @Value("\${external-api.csv.path:userIgn_List.csv}")
+    private val csvPath: String,
+) {
+    private val log = LoggerFactory.getLogger(RankingFetchPhase::class.java)
+
+    fun execute(workerExecutor: ExecutorService): CompletableFuture<Void> {
+        val runId = SchedulerPhaseUtils.newRunId()
+        val date = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE)
+        val runDir: Path = Paths.get(storeBasePath, "runs", runId)
+        val endpointConfig = chunkingProperties.configFor("ranking-overall")
+
+        SchedulerPhaseUtils.writeRunningMarker(runDir)
+
+        val sink = ChunkedSnapshotSink(
+            runDir = runDir,
+            endpoint = "ranking-overall",
+            maxRecords = endpointConfig.maxRecords,
+            maxUncompressedBytes = endpointConfig.maxUncompressedBytes,
+            queueCapacity = chunkingProperties.queueCapacity,
+            objectMapper = objectMapper,
+            eventPublisher = rankingPublisher,
+            volumeMetrics = volumeMetrics,
+        )
+
+        val rateLimiter = SchedulerPhaseUtils.newRateLimiter(permitsPerSecond)
+        val fetched = AtomicInteger(0)
+        val failed = AtomicInteger(0)
+        val characterNames = mutableListOf<String>()
+
+        log.info("[RankingFetch] starting: runId={}, date={}, maxPages={}, permitsPerSecond={}", runId, date, maxPages, permitsPerSecond)
+        val start = Instant.now()
+
+        return processPages(workerExecutor, sink, rateLimiter, date, 1, fetched, failed, characterNames)
+            .whenComplete { _, ex ->
+                sink.close()
+                if (ex != null) {
+                    log.error("[RankingFetch] failed: runId={}, fetched={}, failed={}", runId, fetched.get(), failed.get(), ex)
+                } else {
+                    writeCsv(characterNames)
+                    SchedulerPhaseUtils.logSummary("RankingFetch", fetched.get(), fetched.get(), fetched.get(), failed.get(), start)
+                }
+            }
+    }
+
+    private fun processPages(
+        workerExecutor: ExecutorService,
+        sink: ChunkedSnapshotSink,
+        rateLimiter: io.github.bucket4j.Bucket,
+        date: String,
+        currentPage: Int,
+        fetched: AtomicInteger,
+        failed: AtomicInteger,
+        characterNames: MutableList<String>,
+    ): CompletableFuture<Void> {
+        if (currentPage > maxPages) {
+            return CompletableFuture.completedFuture(null)
+        }
+
+        SchedulerPhaseUtils.acquirePermits(rateLimiter, 1, 1)
+
+        val requestKey = "$date:$currentPage"
+        return clientPort.fetch(ExternalApiProvider.NEXON, ExternalApiEndpoint.RANKING_OVERALL, requestKey)
+            .thenAcceptAsync({ bodyBytes ->
+                val count = submitRankingEntries(sink, bodyBytes, currentPage, characterNames)
+                fetched.addAndGet(count)
+                metrics.recordRankingFetched(count)
+                if (fetched.get() % 10000 == 0) {
+                    log.info("[RankingFetch] progress: fetched={}, failed={}, page={}/{}", fetched.get(), failed.get(), currentPage, maxPages)
+                }
+            }, workerExecutor)
+            .handle { _, ex ->
+                if (ex != null) {
+                    failed.incrementAndGet()
+                    metrics.recordRankingFailed()
+                    val status = SchedulerPhaseUtils.extractHttpStatus(ex)
+                    sink.submit(SnapshotChunkRecord.Failure(
+                        key = requestKey,
+                        endpoint = "ranking-overall",
+                        keyType = KeyType.DATE_PAGE.name,
+                        httpStatus = status,
+                        fetchedAt = Instant.now(),
+                        errorMessage = ex.message ?: "unknown",
+                    ))
+                    log.warn("[RankingFetch] page failed: page={}, status={}, error={}", currentPage, status, ex.message)
+                }
+                null
+            }
+            .thenCompose { processPages(workerExecutor, sink, rateLimiter, date, currentPage + 1, fetched, failed, characterNames) }
+    }
+
+    private fun submitRankingEntries(
+        sink: ChunkedSnapshotSink,
+        bodyBytes: ByteArray,
+        page: Int,
+        characterNames: MutableList<String>,
+    ): Int {
+        val root = objectMapper.readTree(bodyBytes)
+        val rankingArray = root.get("ranking")
+        if (rankingArray == null || !rankingArray.isArray) {
+            log.warn("[RankingFetch] no ranking array in response: page={}", page)
+            return 0
+        }
+
+        var count = 0
+        for (node in rankingArray) {
+            val name = node.get("character_name")?.asText() ?: continue
+            val entryBytes = objectMapper.writeValueAsBytes(node)
+            characterNames.add(name)
+            sink.submit(SnapshotChunkRecord.Success(
+                bodyBytes = entryBytes,
+                key = name,
+                endpoint = "ranking-overall",
+                keyType = KeyType.DATE_PAGE.name,
+                httpStatus = 200,
+                fetchedAt = Instant.now(),
+            ))
+            count++
+        }
+        return count
+    }
+
+    private fun writeCsv(characterNames: List<String>) {
+        val path = Paths.get(csvPath)
+        val content = characterNames.joinToString("\n", postfix = "\n")
+        Files.writeString(path, content)
+        log.info("[RankingFetch] CSV overwritten: path={}, count={}", path.toAbsolutePath(), characterNames.size)
+    }
+}

--- a/module-external-api/src/main/kotlin/maple/externalapi/snapshot/SnapshotChunkingProperties.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/snapshot/SnapshotChunkingProperties.kt
@@ -10,6 +10,7 @@ data class SnapshotChunkingProperties(
     data class ChunkConfig(
         val characterBasic: EndpointChunkConfig = EndpointChunkConfig(maxRecords = 2000),
         val itemEquipment: EndpointChunkConfig = EndpointChunkConfig(maxRecords = 500),
+        val rankingOverall: EndpointChunkConfig = EndpointChunkConfig(maxRecords = 5000),
     )
 
     data class EndpointChunkConfig(
@@ -20,6 +21,7 @@ data class SnapshotChunkingProperties(
     fun configFor(endpoint: String): EndpointChunkConfig = when (endpoint) {
         "character-basic" -> chunk.characterBasic
         "item-equipment" -> chunk.itemEquipment
+        "ranking-overall" -> chunk.rankingOverall
         else -> EndpointChunkConfig()
     }
 }

--- a/module-external-api/src/main/kotlin/maple/externalapi/snapshot/event/SnapshotEventPublisherConfig.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/snapshot/event/SnapshotEventPublisherConfig.kt
@@ -72,4 +72,35 @@ class SnapshotEventPublisherConfig {
             runCompletedTopic = properties.kafka.runCompletedTopic,
             runFailedTopic = properties.kafka.runFailedTopic,
         )
+
+    @Bean
+    @Qualifier("rankingSnapshotPublisher")
+    @ConditionalOnProperty(
+        prefix = "external-api.snapshot.events.kafka",
+        name = ["enabled"],
+        havingValue = "false",
+        matchIfMissing = true,
+    )
+    fun noOpRankingSnapshotPublisher(): SnapshotChunkEventPublisher =
+        NoOpSnapshotChunkEventPublisher()
+
+    @Bean
+    @Qualifier("rankingSnapshotPublisher")
+    @ConditionalOnProperty(
+        prefix = "external-api.snapshot.events.kafka",
+        name = ["enabled"],
+        havingValue = "true",
+    )
+    fun kafkaRankingSnapshotPublisher(
+        kafkaTemplate: KafkaTemplate<String, String>,
+        objectMapper: ObjectMapper,
+        properties: SnapshotEventProperties,
+    ): SnapshotChunkEventPublisher =
+        KafkaSnapshotChunkEventPublisher(
+            kafkaTemplate = kafkaTemplate,
+            objectMapper = objectMapper,
+            chunkReadyTopic = properties.kafka.chunkReadyTopic,
+            runCompletedTopic = properties.kafka.runCompletedTopic,
+            runFailedTopic = properties.kafka.runFailedTopic,
+        )
 }

--- a/module-external-api/src/main/resources/application-local.yml
+++ b/module-external-api/src/main/resources/application-local.yml
@@ -1,0 +1,16 @@
+spring:
+  datasource:
+    url: ${DB_URL}
+    driver-class-name: org.postgresql.Driver
+    hikari:
+      maximum-pool-size: 10
+      minimum-idle: 2
+      connection-timeout: 5000
+      keepalive-time: 30000
+      max-lifetime: 600000
+      connection-test-query: SELECT 1
+  jpa:
+    open-in-view: false
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+    hibernate:
+      ddl-auto: none

--- a/module-external-api/src/main/resources/application.yml
+++ b/module-external-api/src/main/resources/application.yml
@@ -75,6 +75,10 @@ external-api:
         chunk-ready-topic: external-api.snapshot.chunk-ready
         run-completed-topic: external-api.snapshot.run-completed
         run-failed-topic: external-api.snapshot.run-failed
+  ranking:
+    enabled: true
+    max-pages: 300
+    permits-per-second: 50
 
 management:
   endpoints:

--- a/module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/RankingFetchPhaseTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/RankingFetchPhaseTest.kt
@@ -1,0 +1,139 @@
+package maple.externalapi.scheduler.phase
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import maple.externalapi.domain.ExternalApiEndpoint
+import maple.externalapi.domain.ExternalApiProvider
+import maple.externalapi.metrics.ExternalApiMetrics
+import maple.externalapi.metrics.SnapshotVolumeMetrics
+import maple.externalapi.port.out.ExternalApiClientPort
+import maple.externalapi.snapshot.SnapshotChunkingProperties
+import maple.externalapi.snapshot.event.NoOpSnapshotChunkEventPublisher
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executors
+
+class RankingFetchPhaseTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    private lateinit var clientPort: ExternalApiClientPort
+    private lateinit var objectMapper: ObjectMapper
+    private lateinit var phase: RankingFetchPhase
+    private lateinit var csvPath: Path
+    private lateinit var executor: java.util.concurrent.ExecutorService
+
+    @BeforeEach
+    fun setUp() {
+        clientPort = mock()
+        objectMapper = ObjectMapper().registerKotlinModule().registerModule(JavaTimeModule())
+        csvPath = tempDir.resolve("userIgn_List.csv")
+        val storeBasePath = tempDir.resolve("store").toString()
+
+        val registry = SimpleMeterRegistry()
+        phase = RankingFetchPhase(
+            clientPort = clientPort,
+            objectMapper = objectMapper,
+            chunkingProperties = SnapshotChunkingProperties(),
+            volumeMetrics = SnapshotVolumeMetrics(registry),
+            metrics = ExternalApiMetrics(registry),
+            rankingPublisher = NoOpSnapshotChunkEventPublisher(),
+            maxPages = 3,
+            permitsPerSecond = 100,
+            storeBasePath = storeBasePath,
+            csvPath = csvPath.toString(),
+        )
+        executor = Executors.newVirtualThreadPerTaskExecutor()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        executor.close()
+    }
+
+    private fun rankingJson(vararg names: String): ByteArray {
+        val entries = names.mapIndexed { i, name ->
+            """{"ranking":${i + 1},"character_name":"$name","world_name":"크로아","class_name":"전사"}"""
+        }.joinToString(",", prefix = """{"ranking":[""", postfix = "]}")
+        return entries.toByteArray()
+    }
+
+    @Test
+    fun `execute fetches all pages and writes character names to CSV`() {
+        // Given - 3 pages with different character names
+        whenever(clientPort.fetch(ExternalApiProvider.NEXON, ExternalApiEndpoint.RANKING_OVERALL, "2026-05-20:1"))
+            .thenReturn(CompletableFuture.completedFuture(rankingJson("PlayerA", "PlayerB")))
+        whenever(clientPort.fetch(ExternalApiProvider.NEXON, ExternalApiEndpoint.RANKING_OVERALL, "2026-05-20:2"))
+            .thenReturn(CompletableFuture.completedFuture(rankingJson("PlayerC", "PlayerD")))
+        whenever(clientPort.fetch(ExternalApiProvider.NEXON, ExternalApiEndpoint.RANKING_OVERALL, "2026-05-20:3"))
+            .thenReturn(CompletableFuture.completedFuture(rankingJson("PlayerE")))
+
+        // When
+        val future = phase.execute(executor)
+        future.join()
+
+        // Then - CSV contains all character names
+        val csvLines = Files.readAllLines(csvPath).filter { it.isNotBlank() }
+        assertThat(csvLines).containsExactly("PlayerA", "PlayerB", "PlayerC", "PlayerD", "PlayerE")
+
+        // And - gzip chunk files created in store
+        val chunksDir = tempDir.resolve("store").resolve("runs")
+        val gzFiles = Files.walk(chunksDir).filter { it.toString().endsWith(".gz") }.toList()
+        assertThat(gzFiles).isNotEmpty
+
+        // And - _SUCCESS marker exists
+        val successMarkers = Files.walk(chunksDir).filter { it.fileName.toString() == "_SUCCESS" }.toList()
+        assertThat(successMarkers).hasSize(1)
+    }
+
+    @Test
+    fun `execute continues on page failure and writes successful names to CSV`() {
+        // Given - page 1 succeeds, page 2 fails, page 3 succeeds
+        whenever(clientPort.fetch(ExternalApiProvider.NEXON, ExternalApiEndpoint.RANKING_OVERALL, "2026-05-20:1"))
+            .thenReturn(CompletableFuture.completedFuture(rankingJson("PlayerA")))
+        whenever(clientPort.fetch(ExternalApiProvider.NEXON, ExternalApiEndpoint.RANKING_OVERALL, "2026-05-20:2"))
+            .thenReturn(CompletableFuture.failedFuture(RuntimeException("API error")))
+        whenever(clientPort.fetch(ExternalApiProvider.NEXON, ExternalApiEndpoint.RANKING_OVERALL, "2026-05-20:3"))
+            .thenReturn(CompletableFuture.completedFuture(rankingJson("PlayerC")))
+
+        // When
+        val future = phase.execute(executor)
+        future.join()
+
+        // Then - CSV contains only names from successful pages
+        val csvLines = Files.readAllLines(csvPath).filter { it.isNotBlank() }
+        assertThat(csvLines).containsExactly("PlayerA", "PlayerC")
+    }
+
+    @Test
+    fun `execute skips entries without character_name`() {
+        // Given - page with entries where one has no character_name
+        val json = """{"ranking":[{"ranking":1,"character_name":"ValidName","world_name":"크로아"},{"ranking":2,"world_name":"크로아"}]}""".toByteArray()
+        whenever(clientPort.fetch(ExternalApiProvider.NEXON, ExternalApiEndpoint.RANKING_OVERALL, "2026-05-20:1"))
+            .thenReturn(CompletableFuture.completedFuture(json))
+        // Return empty for remaining pages to end quickly
+        whenever(clientPort.fetch(ExternalApiProvider.NEXON, ExternalApiEndpoint.RANKING_OVERALL, "2026-05-20:2"))
+            .thenReturn(CompletableFuture.completedFuture("""{"ranking":[]}""".toByteArray()))
+        whenever(clientPort.fetch(ExternalApiProvider.NEXON, ExternalApiEndpoint.RANKING_OVERALL, "2026-05-20:3"))
+            .thenReturn(CompletableFuture.completedFuture("""{"ranking":[]}""".toByteArray()))
+
+        // When
+        val future = phase.execute(executor)
+        future.join()
+
+        // Then - only valid entry in CSV
+        val csvLines = Files.readAllLines(csvPath).filter { it.isNotBlank() }
+        assertThat(csvLines).containsExactly("ValidName")
+    }
+}


### PR DESCRIPTION
## Summary

- **RankingFetchPhase**: Nexon 전체 랭킹 API (page 1~N) 비동기 호출 → JSONL gzip 청크 저장 + character_name CSV 덮어쓰기
- **ExternalApiScheduler 개선**: daily cron → ranking fetch → OCID lookup → character basic 순차 파이프라인 체이닝
- **락 메커니즘 교체**: AtomicBoolean 500ms spin-wait → ReentrantLock + Condition.awaitNanos() (CPU 낭비 제거, item equipment 완료까지 대기 후 daily refresh 실행)
- **application-local.yml**: module-external-api PostgreSQL datasource 설정 추가

## Pipeline Flow

```
Cron (daily-cron) → RankingFetchPhase (gzip + CSV)
                   → OcidLookupPhase (reads CSV)
                   → OcidCacheProvider.refresh()
                   → SnapshotFetchPhase.executeCharacterBasic()
                   → releaseLock()
                   → ItemEquipment loop resumes
```

## Runtime Test 결과 (KST)

| 단계 | 시간 | 소요 |
|------|------|------|
| Ranking fetch | 11:25:00 | 3s (400 records, 113 files/s) |
| OCID lookup | 11:25:03 | 스킵 (288,422 존재) |
| OcidCache refresh | 11:25~11:27 | ~2m |
| Character basic | 11:27~11:46 | 19m (288,422건) |
| Item equipment | 11:46~ | 자동 재시작 |

## Changes

- `ExternalApiEndpoint.RANKING_OVERALL` + `KeyType.DATE_PAGE` 추가
- `NexonExternalApiClientAdapter`: DATE_PAGE 요청 key 파싱 (date:page)
- `RankingFetchPhase`: recursive CF chain, ChunkedSnapshotSink, CSV overwrite
- `ExternalApiScheduler`: ObjectProvider<RankingFetchPhase> 주입, ReentrantLock+Condition
- `SnapshotChunkingProperties`: ranking-overall 설정 추가
- `ExternalApiMetrics`: rankingFetched/rankingFailed 카운터 추가
- `SnapshotEventPublisherConfig`: rankingSnapshotPublisher 빈 추가

## Test plan

- [x] `RankingFetchPhaseTest` 3개 단위테스트 통과
- [x] 런타임 테스트: cron trigger → ranking → OCID → character basic → item equipment 재개
- [x] ReentrantLock 대기/해제 동작 확인 (item equipment 실행 중 daily cron 발화 시 대기 후 실행)

🤖 Generated with [Claude Code](https://claude.com/claude-code)