### PR TITLE
fix: unify storage paths, ocid dedup, ranking yesterday date

### DIFF
--- a/module-external-api/src/main/kotlin/maple/externalapi/infra/storage/LocalExternalApiArtifactStoreAdapter.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/infra/storage/LocalExternalApiArtifactStoreAdapter.kt
@@ -22,7 +22,7 @@ import org.springframework.stereotype.Component
 
 @Component
 class LocalExternalApiArtifactStoreAdapter(
-    @Value("\${external-api.store.base-path:/data/external-api}")
+    @Value("\${external-api.store.base-path:../data}")
     private val basePath: String,
 ) : ExternalApiArtifactStorePort {
 

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/RankingFetchPhase.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/RankingFetchPhase.kt
@@ -39,14 +39,14 @@ class RankingFetchPhase(
     private val maxPages: Int,
     @Value("\${external-api.ranking.permits-per-second:50}")
     private val permitsPerSecond: Int,
-    @Value("\${external-api.store.base-path:/data/external-api}")
+    @Value("\${external-api.store.base-path:../data}")
     private val storeBasePath: String,
 ) {
     private val log = LoggerFactory.getLogger(RankingFetchPhase::class.java)
 
     fun execute(workerExecutor: ExecutorService): CompletableFuture<Path> {
         val runId = SchedulerPhaseUtils.newRunId()
-        val date = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE)
+        val date = LocalDate.now().minusDays(1).format(DateTimeFormatter.ISO_LOCAL_DATE)
         val runDir: Path = Paths.get(storeBasePath, "runs", runId)
         val endpointConfig = chunkingProperties.configFor("ranking-overall")
 

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/SnapshotFetchPhase.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/SnapshotFetchPhase.kt
@@ -51,7 +51,7 @@ class SnapshotFetchPhase(
     private val permitsPerSecond: Int,
     @Value("\${external-api.batch-size:1000}")
     private val batchSize: Int,
-    @Value("\${external-api.store.base-path:/data/external-api}")
+    @Value("\${external-api.store.base-path:../data}")
     private val storeBasePath: String,
 ) {
     private val log = LoggerFactory.getLogger(SnapshotFetchPhase::class.java)

--- a/module-external-api/src/main/kotlin/maple/externalapi/urgent/UrgentCharacterRequestConsumer.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/urgent/UrgentCharacterRequestConsumer.kt
@@ -37,7 +37,7 @@ class UrgentCharacterRequestConsumer(
     private val notFoundTopic: String,
     @Value("\${external-api.urgent.chunk-ready-topic}")
     private val urgentChunkReadyTopic: String,
-    @Value("\${external-api.store.base-path}")
+    @Value("\${external-api.store.base-path:../data}")
     private val storeBasePath: String,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)

--- a/module-synchronizer/build.gradle
+++ b/module-synchronizer/build.gradle
@@ -22,7 +22,7 @@ dependencies {
 	implementation(libs.spring.boot)
 	implementation(libs.spring.boot.starter.web)
 	implementation(libs.spring.boot.starter.data.jpa)
-	runtimeOnly(libs.postgresql)
+	implementation(libs.postgresql)
 
 	// Metrics
 	implementation(libs.spring.boot.starter.actuator)

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/BasicSnapshotChunkConsumer.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/BasicSnapshotChunkConsumer.kt
@@ -152,8 +152,8 @@ class BasicSnapshotChunkConsumer(
     private fun upsertOcidFromBasicRecords(records: List<BasicRecord>) {
         records.forEach { record ->
             jdbc.update(
-                """INSERT INTO game_character (user_ign, ocid, created_at, updated_at)
-                   VALUES (:userIgn, :ocid, NOW(), NOW())
+                """INSERT INTO game_character (user_ign, ocid, updated_at)
+                   VALUES (:userIgn, :ocid, NOW())
                    ON CONFLICT (user_ign) DO UPDATE SET ocid = EXCLUDED.ocid, updated_at = NOW()""",
                 MapSqlParameterSource()
                     .addValue("userIgn", record.userIgn)

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/BasicSnapshotChunkConsumer.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/BasicSnapshotChunkConsumer.kt
@@ -11,7 +11,6 @@ import maple.synchronizer.repository.CharacterBasicRepository
 import maple.synchronizer.storage.BasicChunkFileReader
 import maple.synchronizer.storage.BasicRecord
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.kafka.annotation.KafkaListener
@@ -29,8 +28,6 @@ class BasicSnapshotChunkConsumer(
     private val repository: CharacterBasicRepository,
     private val chunkConsumerTemplate: ChunkConsumerTemplate,
     private val jdbc: NamedParameterJdbcTemplate,
-    @Value("\${synchronizer.store.base-path:../data}")
-    private val basePath: String,
 ) : ManagedLifecycle {
     private val log = LoggerFactory.getLogger(javaClass)
     private val vtExecutor = Executors.newVirtualThreadPerTaskExecutor()

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/repository/CharacterBasicRepository.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/repository/CharacterBasicRepository.kt
@@ -15,18 +15,32 @@ class CharacterBasicRepository(
     }
 
     fun bulkUpsert(runId: String, chunkId: String, records: List<BasicRecord>) {
+        val deduped = records
+            .groupBy { it.ocid }
+            .map { it.value.first() }
+
         batchExecutor.execute(
             label = "CharacterBasic",
             itemLabel = "records",
             runId = runId,
             chunkId = chunkId,
-            items = records,
+            items = deduped,
             batchSize = SUB_BATCH_SIZE,
             upsertBatch = { batch -> upsertBatch(runId, chunkId, batch) },
         )
     }
 
     private fun upsertBatch(runId: String, chunkId: String, batch: List<BasicRecord>): Int {
+        val ocids = batch.map { it.ocid }.toTypedArray()
+        val userIgns = batch.map { it.userIgn }.toTypedArray()
+
+        jdbc.update(
+            "DELETE FROM character_basic_read_model WHERE ocid = ANY(:ocids) AND NOT (user_ign = ANY(:userIgns))",
+            MapSqlParameterSource()
+                .addValue("ocids", ocids)
+                .addValue("userIgns", userIgns),
+        )
+
         val sql = """
             INSERT INTO character_basic_read_model (
                 user_ign, ocid, world_name, character_class, character_level,
@@ -54,8 +68,8 @@ class CharacterBasicRepository(
         return jdbc.update(sql, MapSqlParameterSource()
             .addValue("runId", runId)
             .addValue("chunkId", chunkId)
-            .addValue("userIgns", batch.map { it.userIgn }.toTypedArray())
-            .addValue("ocids", batch.map { it.ocid }.toTypedArray())
+            .addValue("userIgns", userIgns)
+            .addValue("ocids", ocids)
             .addValue("worldNames", batch.map { it.worldName }.toTypedArray())
             .addValue("characterClasses", batch.map { it.characterClass }.toTypedArray())
             .addValue("characterLevels", batch.map { it.characterLevel }.toTypedArray())

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/repository/OcidMappingRepository.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/repository/OcidMappingRepository.kt
@@ -1,11 +1,14 @@
 package maple.synchronizer.repository
 
 import maple.synchronizer.storage.OcidMapping
+import org.postgresql.copy.CopyManager
+import org.postgresql.core.BaseConnection
 import org.slf4j.LoggerFactory
 import org.springframework.data.redis.core.StringRedisTemplate
-import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
+import org.springframework.jdbc.core.ConnectionCallback
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Repository
+import java.sql.Connection
 
 @Repository
 class OcidMappingRepository(
@@ -15,27 +18,46 @@ class OcidMappingRepository(
     private val log = LoggerFactory.getLogger(javaClass)
 
     companion object {
-        private const val BATCH_SIZE = 50000
         private const val REDIS_KEY = "ocid:mapping"
-        private const val MERGE_SQL = """
-            INSERT INTO game_character (user_ign, ocid, updated_at)
-            SELECT unnest(:userIgns::varchar[]), unnest(:ocids::varchar[]), now()
-            ON CONFLICT (user_ign) DO UPDATE SET
-                ocid = EXCLUDED.ocid,
-                updated_at = now()
-            WHERE game_character.ocid IS DISTINCT FROM EXCLUDED.ocid
-        """
     }
 
     fun batchUpsert(mappings: List<OcidMapping>) {
-        val batches = mappings.chunked(BATCH_SIZE)
-        batches.forEachIndexed { index, batch ->
-            jdbc.update(MERGE_SQL, MapSqlParameterSource()
-                .addValue("userIgns", batch.map { it.userIgn }.toTypedArray())
-                .addValue("ocids", batch.map { it.ocid }.toTypedArray())
-            )
-            log.info("[OcidMapping] DB upsert batch {}/{}: {} mappings", index + 1, batches.size, batch.size)
-        }
+        val affected: Int = jdbc.jdbcTemplate.execute(
+            ConnectionCallback { con: Connection ->
+                con.autoCommit = false
+
+                runCatching {
+                    con.createStatement().use { stmt ->
+                        stmt.execute("DROP TABLE IF EXISTS tmp_ocid_mapping")
+                        stmt.execute("CREATE TEMP TABLE tmp_ocid_mapping (user_ign text NOT NULL, ocid text NOT NULL) ON COMMIT DROP")
+                    }
+
+                    val copyManager = CopyManager(con.unwrap(BaseConnection::class.java))
+                    val data = mappings.joinToString("\n") { "${it.userIgn}\t${it.ocid}" }
+                    copyManager.copyIn("COPY tmp_ocid_mapping (user_ign, ocid) FROM STDIN", data.reader())
+
+                    val rows = con.createStatement().use { stmt ->
+                        stmt.executeUpdate("""
+                            INSERT INTO game_character (user_ign, ocid, updated_at)
+                            SELECT user_ign, ocid, now()
+                            FROM tmp_ocid_mapping
+                            ON CONFLICT (user_ign) DO UPDATE SET
+                                ocid = EXCLUDED.ocid,
+                                updated_at = now()
+                            WHERE game_character.ocid IS DISTINCT FROM EXCLUDED.ocid
+                        """.trimIndent())
+                    }
+
+                    con.commit()
+                    rows
+                }.getOrElse { ex ->
+                    runCatching { con.rollback() }
+                    throw ex
+                }
+            }
+        ) ?: 0
+
+        log.info("[OcidMapping] DB upserted via COPY→merge: {} mappings, {} affected", mappings.size, affected)
     }
 
     fun writeOcidToRedis(mappings: List<OcidMapping>) {

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/repository/OcidMappingRepository.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/repository/OcidMappingRepository.kt
@@ -15,29 +15,27 @@ class OcidMappingRepository(
     private val log = LoggerFactory.getLogger(javaClass)
 
     companion object {
-        private const val BATCH_SIZE = 1000
+        private const val BATCH_SIZE = 50000
         private const val REDIS_KEY = "ocid:mapping"
+        private const val MERGE_SQL = """
+            INSERT INTO game_character (user_ign, ocid, created_at, updated_at)
+            SELECT unnest(:userIgns::varchar[]), unnest(:ocids::varchar[]), now(), now()
+            ON CONFLICT (user_ign) DO UPDATE SET
+                ocid = EXCLUDED.ocid,
+                updated_at = now()
+            WHERE game_character.ocid IS DISTINCT FROM EXCLUDED.ocid
+        """
     }
 
     fun batchUpsert(mappings: List<OcidMapping>) {
-        var upserted = 0
-        mappings.chunked(BATCH_SIZE).forEach { batch ->
-            val sql = """
-                INSERT INTO game_character (user_ign, ocid, updated_at)
-                SELECT unnest(:userIgns::varchar[]), unnest(:ocids::varchar[]), now()
-                ON CONFLICT (user_ign) DO UPDATE SET
-                    ocid = EXCLUDED.ocid,
-                    updated_at = EXCLUDED.updated_at
-                WHERE game_character.ocid IS DISTINCT FROM EXCLUDED.ocid
-            """.trimIndent()
-
-            jdbc.update(sql, MapSqlParameterSource()
+        val batches = mappings.chunked(BATCH_SIZE)
+        batches.forEachIndexed { index, batch ->
+            jdbc.update(MERGE_SQL, MapSqlParameterSource()
                 .addValue("userIgns", batch.map { it.userIgn }.toTypedArray())
                 .addValue("ocids", batch.map { it.ocid }.toTypedArray())
             )
-            upserted += batch.size
+            log.info("[OcidMapping] DB upsert batch {}/{}: {} mappings", index + 1, batches.size, batch.size)
         }
-        log.info("[OcidMapping] DB upserted: {} mappings", upserted)
     }
 
     fun writeOcidToRedis(mappings: List<OcidMapping>) {

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/repository/OcidMappingRepository.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/repository/OcidMappingRepository.kt
@@ -18,8 +18,8 @@ class OcidMappingRepository(
         private const val BATCH_SIZE = 50000
         private const val REDIS_KEY = "ocid:mapping"
         private const val MERGE_SQL = """
-            INSERT INTO game_character (user_ign, ocid, created_at, updated_at)
-            SELECT unnest(:userIgns::varchar[]), unnest(:ocids::varchar[]), now(), now()
+            INSERT INTO game_character (user_ign, ocid, updated_at)
+            SELECT unnest(:userIgns::varchar[]), unnest(:ocids::varchar[]), now()
             ON CONFLICT (user_ign) DO UPDATE SET
                 ocid = EXCLUDED.ocid,
                 updated_at = now()

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/resolver/OcidUserIgnResolver.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/resolver/OcidUserIgnResolver.kt
@@ -20,12 +20,11 @@ class OcidUserIgnResolver(
 
         val params = MapSqlParameterSource("ocids", ocids.toList())
 
-        val rows = jdbc.queryForList(sql, params, Map::class.java)
-
-        val mapping = rows.mapNotNull { row ->
-            val ign = row["user_ign"]?.toString() ?: return@mapNotNull null
-            row["ocid"].toString() to ign
-        }.toMap()
+        val mapping = jdbc.queryForList(sql, params)
+            .associate { row ->
+                row["ocid"].toString() to (row["user_ign"]?.toString() ?: "")
+            }
+            .filterValues { it.isNotEmpty() }
         log.debug("Resolved {} of {} ocids to userIgn", mapping.size, ocids.size)
         return mapping
     }

--- a/module-synchronizer/src/test/kotlin/maple/synchronizer/resolver/OcidUserIgnResolverTest.kt
+++ b/module-synchronizer/src/test/kotlin/maple/synchronizer/resolver/OcidUserIgnResolverTest.kt
@@ -3,7 +3,6 @@ package maple.synchronizer.resolver
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
@@ -23,7 +22,7 @@ class OcidUserIgnResolverTest {
     @Test
     fun `should resolve ocids to userIgn map`() {
         @Suppress("UNCHECKED_CAST")
-        whenever(jdbc.queryForList(any<String>(), any<MapSqlParameterSource>(), eq(Map::class.java) as Class<Any>))
+        whenever(jdbc.queryForList(any<String>(), any<MapSqlParameterSource>()))
             .thenReturn(listOf(
                 mapOf("ocid" to "ocid1", "user_ign" to "아델"),
                 mapOf("ocid" to "ocid2", "user_ign" to "강은호")
@@ -38,7 +37,7 @@ class OcidUserIgnResolverTest {
     @Test
     fun `should handle partial miss — return only found mappings`() {
         @Suppress("UNCHECKED_CAST")
-        whenever(jdbc.queryForList(any<String>(), any<MapSqlParameterSource>(), eq(Map::class.java) as Class<Any>))
+        whenever(jdbc.queryForList(any<String>(), any<MapSqlParameterSource>()))
             .thenReturn(listOf(
                 mapOf("ocid" to "ocid1", "user_ign" to "아델")
             ))


### PR DESCRIPTION
## Summary
- Unify @Value defaults from `/data/external-api` to `../data` across external-api module (3 files)
- Fix `UrgentCharacterRequestConsumer` missing default basePath
- Remove unused `basePath` field in `BasicSnapshotChunkConsumer`
- Add ocid dedup in `CharacterBasicRepository` to prevent `uq_basic_read_model_ocid` unique constraint violation (character rename)
- Add stale row DELETE before INSERT for cross-batch character rename handling
- Use `LocalDate.now().minusDays(1)` for ranking fetch to avoid Nexon `OPENAPI00009` error

## Test plan
- [x] Pipeline test: external-api → calculator → synchronizer full run verified
- [x] character_basic_read_model: 645K rows synced without unique constraint errors
- [x] character_equipment_read_model: 1.7M rows synced
- [x] Ranking fetch: 594K OCID mappings resolved, OCID lookup ~400/s

🤖 Generated with [Claude Code](https://claude.com/claude-code)