### PR TITLE
perf(synchronizer): reduce transient memory allocations and fix bootJar mainClass

### DIFF
--- a/module-calculator/build.gradle
+++ b/module-calculator/build.gradle
@@ -51,7 +51,7 @@ dependencies {
 bootJar {
 	enabled = true
 	archiveClassifier = ""
-	mainClass.set("maple.calculator.CalculatorApplication")
+	mainClass.set("maple.calculator.CalculatorApplicationKt")
 }
 
 tasks.named("jar") {

--- a/module-common/src/main/kotlin/maple/expectation/util/GzipUtils.kt
+++ b/module-common/src/main/kotlin/maple/expectation/util/GzipUtils.kt
@@ -28,10 +28,20 @@ object GzipUtils {
             return ByteArray(0)
         }
 
-        val out = ByteArrayOutputStream()
-        val gzip = GZIPOutputStream(out)
-        gzip.write(str.toByteArray(StandardCharsets.UTF_8))
-        gzip.finish()
+        return compress(str.toByteArray(StandardCharsets.UTF_8))
+    }
+
+    @JvmStatic
+    @Throws(IOException::class)
+    fun compress(bytes: ByteArray): ByteArray {
+        if (bytes.isEmpty()) {
+            return ByteArray(0)
+        }
+
+        val out = ByteArrayOutputStream(bytes.size)
+        GZIPOutputStream(out).use { gzip ->
+            gzip.write(bytes)
+        }
         return out.toByteArray()
     }
 

--- a/module-external-api/build.gradle
+++ b/module-external-api/build.gradle
@@ -53,7 +53,7 @@ dependencies {
 bootJar {
 	enabled = true
 	archiveClassifier = ""
-	mainClass.set("maple.externalapi.ExternalApiApplication")
+	mainClass.set("maple.externalapi.ExternalApiApplicationKt")
 }
 
 tasks.named("jar") {

--- a/module-synchronizer/build.gradle
+++ b/module-synchronizer/build.gradle
@@ -50,7 +50,7 @@ dependencies {
 bootJar {
 	enabled = true
 	archiveClassifier = ""
-	mainClass.set("maple.synchronizer.SynchronizerApplication")
+	mainClass.set("maple.synchronizer.SynchronizerApplicationKt")
 }
 
 tasks.named("jar") {

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/preparer/EquipmentDocumentPreparer.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/preparer/EquipmentDocumentPreparer.kt
@@ -13,22 +13,22 @@ class EquipmentDocumentPreparer(private val objectMapper: ObjectMapper) {
     }
 
     private fun prepareOne(doc: EquipmentReadDocument): PreppedDocument {
-        val json = objectMapper.writeValueAsString(doc)
+        val bytes = objectMapper.writeValueAsBytes(doc)
         return PreppedDocument(
             readKey = "${doc.ocid}:${doc.presetNo}",
             ocid = doc.ocid,
             presetNo = doc.presetNo.toShort(),
             userIgn = doc.userIgn,
-            compressed = GzipUtils.compress(json),
-            documentHash = sha256Hex(json),
+            compressed = GzipUtils.compress(bytes),
+            documentHash = sha256Hex(bytes),
             totalCost = doc.summary.totalCost,
             equipmentCount = doc.summary.equipmentCount,
             calculatedAt = Timestamp.from(doc.metadata.calculatedAt),
         )
     }
 
-    private fun sha256Hex(input: String): String {
-        val digest = MessageDigest.getInstance("SHA-256").digest(input.toByteArray(Charsets.UTF_8))
+    private fun sha256Hex(input: ByteArray): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(input)
         return digest.joinToString("") { "%02x".format(it) }
     }
 }

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/storage/BasicChunkFileReader.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/storage/BasicChunkFileReader.kt
@@ -38,9 +38,13 @@ class BasicChunkFileReader(
 
         GZIPInputStream(Files.newInputStream(path)).bufferedReader().use { reader ->
             val records = mutableListOf<BasicRecord>()
-            reader.lineSequence()
-                .filter { it.isNotBlank() }
-                .forEach { line -> parseRecord(line)?.let { records.add(it) } }
+            var line: String? = reader.readLine()
+            while (line != null) {
+                if (line.isNotBlank()) {
+                    parseRecord(line)?.let { records.add(it) }
+                }
+                line = reader.readLine()
+            }
             log.info("[BasicChunkFileReader] parsed {} records from {}", records.size, objectKey)
             return records
         }
@@ -61,9 +65,9 @@ class BasicChunkFileReader(
             val characterLevel = body.get("character_level")?.asInt()
             val guildName = body.get("guild_name")?.asText()
 
-            val bodyJson = objectMapper.writeValueAsString(body)
-            val compressed = GzipUtils.compress(bodyJson)
-            val hash = sha256Hex(bodyJson.toByteArray(Charsets.UTF_8))
+            val bodyBytes = objectMapper.writeValueAsBytes(body)
+            val compressed = GzipUtils.compress(bodyBytes)
+            val hash = sha256Hex(bodyBytes)
 
             BasicRecord(
                 userIgn = userIgn,

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/storage/ResultFileReader.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/storage/ResultFileReader.kt
@@ -28,9 +28,9 @@ class ResultFileReader(
             var rowCount = 0
             val grouped = mutableMapOf<String, MutableList<CalculatedEquipmentItem>>()
 
-            reader.lineSequence()
-                .filter { it.isNotBlank() }
-                .forEach { line ->
+            var line: String? = reader.readLine()
+            while (line != null) {
+                if (line.isNotBlank()) {
                     rowCount++
                     require(rowCount <= maxRowsPerChunk) {
                         "Chunk row limit exceeded: objectKey=$objectKey, maxRows=$maxRowsPerChunk, current=$rowCount"
@@ -38,6 +38,8 @@ class ResultFileReader(
                     val item = parseItem(line)
                     grouped.getOrPut("${item.ocid}:${item.presetNo}") { mutableListOf() }.add(item)
                 }
+                line = reader.readLine()
+            }
 
             return grouped.map { (readKey, group) ->
                 GroupedEquipmentResult(


### PR DESCRIPTION
## Summary
- Add `GzipUtils.compress(ByteArray)` overload to skip unnecessary String→ByteArray conversion
- BasicChunkFileReader: `writeValueAsBytes()` for single byte array, `lineSequence` → `while-readLine`
- EquipmentDocumentPreparer: `writeValueAsBytes()` eliminates 3 intermediate copies (String → toByteArray → compress)
- ResultFileReader: `lineSequence` → `while-readLine` to avoid Sequence iterator allocation
- Fix bootJar mainClass for all 3 modules (Kotlin top-level `fun main` needs `Kt` suffix)

## Test plan
- [x] `./gradlew compileKotlin compileJava --continue` passes
- [ ] Pipeline test with `java -jar` + `-Xmx1g` + `MALLOC_ARENA_MAX=1`, verify RSS reduction
- [ ] Synchronizer processes basic + equipment chunks without OOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)