### PR TITLE
feat(observability): AI trace logging hooks for agent audit trail

### DIFF
--- a/.claude/hooks/trace-lib.sh
+++ b/.claude/hooks/trace-lib.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# trace-lib.sh — Shared functions for AI trace logging
+set -euo pipefail
+
+TRACE_BASE="${CLAUDE_PROJECT_DIR:-$(pwd)}/docs/ai-traces"
+SESSION_MARKER="$TRACE_BASE/.current-session"
+
+# Get or create stable session ID
+_ensure_session() {
+    if [ -f "$SESSION_MARKER" ]; then
+        # Existing session — reuse
+        cat "$SESSION_MARKER"
+    else
+        # New session
+        local sid
+        sid="$(date +%Y%m%d/%Y%m%d-%H%M%S)-$$"
+        echo "$sid" > "$SESSION_MARKER"
+        echo "$sid"
+    fi
+}
+
+TRACE_SESSION_ID="$(_ensure_session)"
+TRACE_DIR="${TRACE_BASE}/${TRACE_SESSION_ID}"
+
+# Ensure trace directory exists
+mkdir -p "$TRACE_DIR"
+
+# Append JSONL entry to a trace file
+# Usage: trace_append "filename.jsonl" '{"key":"value"}'
+trace_append() {
+    local file="$TRACE_DIR/$1"
+    local entry="$2"
+    echo "$entry" >> "$file"
+}
+
+# Current ISO timestamp
+trace_ts() {
+    date -u +%Y-%m-%dT%H:%M:%SZ
+}

--- a/.claude/hooks/trace-prompt.sh
+++ b/.claude/hooks/trace-prompt.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# trace-prompt.sh — UserPromptSubmit hook: logs user prompts
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/trace-lib.sh"
+
+INPUT=$(cat)
+
+PROMPT=$(echo "$INPUT" | jq -r '.prompt // ""' | head -c 2000)
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // ""')
+TS=$(trace_ts)
+
+ENTRY=$(jq -n \
+    --arg ts "$TS" \
+    --arg prompt "$PROMPT" \
+    --arg session_id "$SESSION_ID" \
+    '{timestamp: $ts, role: "user", content: $prompt, session_id: $session_id}')
+
+trace_append "prompts.jsonl" "$ENTRY"

--- a/.claude/hooks/trace-session-init.sh
+++ b/.claude/hooks/trace-session-init.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# trace-session-init.sh — SessionStart hook: initializes session marker
+set -euo pipefail
+
+TRACE_BASE="${CLAUDE_PROJECT_DIR:-$(pwd)}/docs/ai-traces"
+SESSION_MARKER="$TRACE_BASE/.current-session"
+
+# Create new session marker
+SESSION_ID="$(date +%Y%m%d/%Y%m%d-%H%M%S)-$$"
+mkdir -p "$(dirname "$SESSION_MARKER")"
+echo "$SESSION_ID" > "$SESSION_MARKER"
+
+# Create session directory
+SESSION_DIR="${TRACE_BASE}/${SESSION_ID}"
+mkdir -p "$SESSION_DIR"
+
+# Log session start
+TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+ENTRY=$(jq -n \
+    --arg ts "$TS" \
+    --arg session_id "$SESSION_ID" \
+    '{timestamp: $ts, event: "session_start", session_id: $session_id}')
+
+echo "$ENTRY" >> "$SESSION_DIR/session.jsonl"
+echo "AI trace session: $SESSION_ID"

--- a/.claude/hooks/trace-stop.sh
+++ b/.claude/hooks/trace-stop.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# trace-stop.sh — Stop hook: generates session summary + git diff
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/trace-lib.sh"
+
+TS=$(trace_ts)
+
+# Record git diff if available
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    git diff --stat HEAD~5 2>/dev/null > "$TRACE_DIR/git-diff.patch" || true
+    git log --oneline -10 > "$TRACE_DIR/git-log.txt" || true
+fi
+
+# Count trace entries
+TOOL_COUNT=$(wc -l < "$TRACE_DIR/tool-use.jsonl" 2>/dev/null || echo 0)
+PROMPT_COUNT=$(wc -l < "$TRACE_DIR/prompts.jsonl" 2>/dev/null || echo 0)
+
+# Tool frequency
+TOOLS_USED=""
+if [ -f "$TRACE_DIR/tool-use.jsonl" ]; then
+    TOOLS_USED=$(jq -r '.tool' "$TRACE_DIR/tool-use.jsonl" | sort | uniq -c | sort -rn | head -10)
+fi
+
+# Generate summary
+cat > "$TRACE_DIR/summary.md" << SUMMARY
+# AI Session Summary
+
+**Session:** ${TRACE_SESSION_ID}
+**Date:** $(date +%Y-%m-%d)
+**Ended:** ${TS}
+
+## Stats
+- Prompts: ${PROMPT_COUNT}
+- Tool calls: ${TOOL_COUNT}
+
+## Tool Usage
+\`\`\`
+${TOOLS_USED}
+\`\`\`
+
+## Files Modified
+\`\`\`
+$(git diff --name-only HEAD~5 2>/dev/null || echo "N/A")
+\`\`\`
+
+## Recent Commits
+\`\`\`
+$(git log --oneline -5 2>/dev/null || echo "N/A")
+\`\`\`
+SUMMARY
+
+echo "Trace summary written to $TRACE_DIR/summary.md"

--- a/.claude/hooks/trace-tool-use.sh
+++ b/.claude/hooks/trace-tool-use.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# trace-tool-use.sh — PostToolUse hook: logs all tool invocations to JSONL
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/trace-lib.sh"
+
+INPUT=$(cat)
+
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // "unknown"')
+TOOL_INPUT=$(echo "$INPUT" | jq -c '.tool_input // {}')
+RESULT=$(echo "$INPUT" | jq -r '.tool_result // ""' | head -c 500)
+ERROR=$(echo "$INPUT" | jq -r '.error // null')
+TS=$(trace_ts)
+
+# Build JSONL entry
+ENTRY=$(jq -n \
+    --arg ts "$TS" \
+    --arg tool "$TOOL_NAME" \
+    --argjson input "$TOOL_INPUT" \
+    --arg result "$RESULT" \
+    --arg error "$ERROR" \
+    '{timestamp: $ts, tool: $tool, input: $input, result_preview: $result, error: $error}')
+
+# Extract file path if present (for Read/Edit/Write tools)
+FILE_PATH=$(echo "$TOOL_INPUT" | jq -r '.file_path // .path // ""')
+if [ -n "$FILE_PATH" ] && [ "$FILE_PATH" != "null" ]; then
+    ENTRY=$(echo "$ENTRY" | jq --arg fp "$FILE_PATH" '. + {file: $fp}')
+fi
+
+trace_append "tool-use.jsonl" "$ENTRY"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,49 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/trace-session-init.sh",
+            "timeout": 5,
+            "statusMessage": "Initializing AI trace session..."
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/trace-tool-use.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/trace-prompt.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/trace-stop.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/docs/ai-traces/.gitignore
+++ b/docs/ai-traces/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!README.md


### PR DESCRIPTION
## Summary
- Session-scoped JSONL trace logging for Claude Code agent observability
- 4 hooks: SessionStart, PostToolUse, UserPromptSubmit, Stop
- Trace files in `docs/ai-traces/{date}/{session-id}/` (gitignored)
- Stable session ID via `.current-session` marker file

## Trace files per session
| File | Content |
|------|---------|
| `session.jsonl` | Session start event |
| `tool-use.jsonl` | Every tool call: name, input, file path, result preview |
| `prompts.jsonl` | User prompts with timestamps |
| `summary.md` | Auto-generated on Stop: stats, tool frequency, git diff |

## Test plan
- [x] `trace-session-init.sh` creates stable session ID
- [x] `trace-tool-use.sh` logs tool invocations with file extraction
- [x] `trace-prompt.sh` logs user prompts
- [x] All hooks write to same session directory across invocations
- [x] `.gitignore` prevents trace logs from being committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)