### PR TITLE
feat(rest-controller): add V6 like endpoints with JWT auth

### DIFF
--- a/module-rest-controller/build.gradle
+++ b/module-rest-controller/build.gradle
@@ -36,6 +36,11 @@ dependencies {
 	// Jackson
 	implementation(libs.jackson.module.kotlin)
 
+	// JWT parsing for like endpoint auth
+	implementation(libs.jjwt.api)
+	runtimeOnly(libs.jjwt.impl)
+	runtimeOnly(libs.jjwt.jackson)
+
 	// Testing
 	testImplementation(libs.spring.boot.starter.test)
 	testImplementation(libs.mockito.kotlin)

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/auth/JdbcOcidQueryAdapter.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/auth/JdbcOcidQueryAdapter.kt
@@ -1,0 +1,50 @@
+package maple.restcontroller.auth
+
+import maple.expectation.core.port.out.CharacterOcidPort
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+@Component
+class JdbcOcidQueryAdapter(
+    private val jdbc: NamedParameterJdbcTemplate,
+) : CharacterOcidPort {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    override fun resolveOcid(userIgn: String): String? =
+        jdbc.queryForList(
+            "SELECT ocid FROM game_character WHERE user_ign = :userIgn LIMIT 1",
+            mapOf("userIgn" to userIgn),
+            String::class.java,
+        ).firstOrNull()
+
+    override fun resolveOcids(userIgns: Set<String>): Map<String, String> =
+        jdbc.queryForList(
+            "SELECT user_ign, ocid FROM game_character WHERE user_ign IN (:userIgns) AND ocid IS NOT NULL",
+            mapOf("userIgns" to userIgns.toList()),
+        ).associate { row ->
+            row["user_ign"] as String to row["ocid"] as String
+        }
+
+    override fun resolveAllOcids(): Map<String, String> =
+        jdbc.queryForList(
+            "SELECT user_ign, ocid FROM game_character WHERE ocid IS NOT NULL",
+            emptyMap<String, Any>(),
+        ).associate { row ->
+            row["user_ign"] as String to row["ocid"] as String
+        }
+
+    override fun resolveOcidsByFingerprint(fingerprint: String): Set<String> =
+        jdbc.queryForList(
+            "SELECT ocid FROM game_character WHERE fingerprint = :fingerprint AND ocid IS NOT NULL",
+            mapOf("fingerprint" to fingerprint),
+            String::class.java,
+        ).toSet()
+
+    override fun updateFingerprint(ocid: String, fingerprint: String, accountId: String): Int =
+        jdbc.update(
+            "UPDATE game_character SET fingerprint = :fingerprint, account_id = :accountId WHERE ocid = :ocid",
+            mapOf("ocid" to ocid, "fingerprint" to fingerprint, "accountId" to accountId),
+        )
+}

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/auth/JwtAuthInterceptor.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/auth/JwtAuthInterceptor.kt
@@ -1,0 +1,71 @@
+package maple.restcontroller.auth
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import maple.expectation.core.auth.JwtParserPort
+import maple.expectation.core.domain.model.security.AuthenticatedUser
+import maple.expectation.core.port.out.CharacterOcidPort
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.servlet.HandlerInterceptor
+
+@Component
+class JwtAuthInterceptor(
+    private val jwtParserPort: JwtParserPort,
+    private val characterOcidPort: CharacterOcidPort,
+    private val objectMapper: ObjectMapper,
+) : HandlerInterceptor {
+
+    companion object {
+        private val log = LoggerFactory.getLogger(JwtAuthInterceptor::class.java)
+        const val USER_ATTRIBUTE = "authenticatedUser"
+    }
+
+    override fun preHandle(request: HttpServletRequest, response: HttpServletResponse, handler: Any): Boolean {
+        val token = extractBearerToken(request)
+        if (token == null) {
+            sendUnauthorized(response, "Missing Authorization header")
+            return false
+        }
+
+        val payload = jwtParserPort.parseToken(token)
+        if (payload.isEmpty) {
+            sendUnauthorized(response, "Invalid or expired token")
+            return false
+        }
+
+        val jwt = payload.get()
+        val myOcids = runCatching {
+            characterOcidPort.resolveOcidsByFingerprint(jwt.fingerprint)
+        }.getOrElse { emptySet() }
+
+        val user = AuthenticatedUser(
+            sessionId = jwt.sessionId,
+            fingerprint = jwt.fingerprint,
+            userIgn = jwt.userIgn,
+            accountId = jwt.fingerprint,
+            apiKey = "",
+            myOcids = myOcids,
+            role = jwt.role,
+        )
+
+        request.setAttribute(USER_ATTRIBUTE, user)
+        return true
+    }
+
+    private fun extractBearerToken(request: HttpServletRequest): String? {
+        val header = request.getHeader("Authorization") ?: return null
+        return if (header.startsWith("Bearer ", ignoreCase = true)) {
+            header.substring(7).trim().takeIf { it.isNotBlank() }
+        } else null
+    }
+
+    private fun sendUnauthorized(response: HttpServletResponse, message: String) {
+        response.status = HttpStatus.UNAUTHORIZED.value()
+        response.contentType = MediaType.APPLICATION_JSON_VALUE
+        response.writer.write("""{"error":"$message","status":401}""")
+    }
+}

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/auth/JwtParserAdapter.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/auth/JwtParserAdapter.kt
@@ -1,0 +1,57 @@
+package maple.restcontroller.auth
+
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.security.Keys
+import maple.expectation.core.auth.JwtParserPort
+import maple.expectation.core.auth.JwtPayload
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import java.nio.charset.StandardCharsets
+import java.time.Instant
+import java.util.Optional
+import javax.crypto.SecretKey
+
+@Component
+class JwtParserAdapter(
+    @Value("\${auth.jwt.secret}") private val secret: String,
+) : JwtParserPort {
+
+    private val secretKey: SecretKey = Keys.hmacShaKeyFor(secret.toByteArray(StandardCharsets.UTF_8))
+
+    companion object {
+        private val log = LoggerFactory.getLogger(JwtParserAdapter::class.java)
+        private const val CLAIM_FINGERPRINT = "fgp"
+        private const val CLAIM_ROLE = "role"
+        private const val CLAIM_USER_IGN = "userIgn"
+    }
+
+    override fun parseToken(token: String?): Optional<JwtPayload> = runCatching {
+        require(token != null && token.isNotBlank()) { "Token is blank" }
+
+        val jws = Jwts.parser()
+            .verifyWith(secretKey)
+            .build()
+            .parseSignedClaims(token)
+
+        val claims = jws.payload
+        val issuedAt = claims.issuedAt?.toInstant() ?: Instant.now()
+        val expiration = claims.expiration?.toInstant() ?: issuedAt.plusSeconds(3600)
+
+        Optional.of(
+            JwtPayload(
+                sessionId = claims.subject,
+                fingerprint = claims[CLAIM_FINGERPRINT, String::class.java],
+                role = claims[CLAIM_ROLE, String::class.java],
+                userIgn = claims[CLAIM_USER_IGN, String::class.java] ?: "",
+                issuedAt = issuedAt,
+                expiration = expiration,
+            )
+        )
+    }.getOrElse { ex ->
+        log.debug("JWT parse failed: {}", ex.message)
+        Optional.empty()
+    }
+
+    override fun validateToken(token: String?): Boolean = parseToken(token).isPresent
+}

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/config/WebMvcConfig.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/config/WebMvcConfig.kt
@@ -1,0 +1,17 @@
+package maple.restcontroller.config
+
+import maple.restcontroller.auth.JwtAuthInterceptor
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebMvcConfig(
+    private val jwtAuthInterceptor: JwtAuthInterceptor,
+) : WebMvcConfigurer {
+
+    override fun addInterceptors(registry: InterceptorRegistry) {
+        registry.addInterceptor(jwtAuthInterceptor)
+            .addPathPatterns("/api/v6/characters/*/like", "/api/v6/characters/*/like/status")
+    }
+}

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/controller/v6/LikeController.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/controller/v6/LikeController.kt
@@ -1,0 +1,54 @@
+package maple.restcontroller.controller.v6
+
+import maple.expectation.core.domain.model.security.AuthenticatedUser
+import maple.expectation.core.port.inbound.LikeTogglePort
+import maple.restcontroller.auth.JwtAuthInterceptor
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+import java.util.concurrent.CompletableFuture
+
+@RestController
+@RequestMapping("/api/v6/characters")
+@ConditionalOnProperty(name = ["expectation.v6.enabled"], havingValue = "true")
+class LikeController(
+    private val likeTogglePort: LikeTogglePort,
+) {
+
+    @PostMapping("/{userIgn}/like")
+    fun toggleLike(
+        @PathVariable userIgn: String,
+        @RequestAttribute(JwtAuthInterceptor.USER_ATTRIBUTE) user: AuthenticatedUser,
+    ): CompletableFuture<ResponseEntity<LikeToggleResponse>> = CompletableFuture.supplyAsync {
+        val result = likeTogglePort.toggleLikeWithCount(userIgn, user.accountId, user.myOcids)
+        ResponseEntity.ok(
+            LikeToggleResponse(
+                targetUserIgn = userIgn,
+                liked = result.result == maple.expectation.core.domain.model.like.LikeToggleResult.LIKED,
+                likeCount = result.likeCount,
+            )
+        )
+    }
+
+    @GetMapping("/{userIgn}/like/status")
+    fun getLikeStatus(
+        @PathVariable userIgn: String,
+        @RequestAttribute(JwtAuthInterceptor.USER_ATTRIBUTE) user: AuthenticatedUser,
+    ): CompletableFuture<ResponseEntity<LikeStatusResponse>> = CompletableFuture.supplyAsync {
+        val liked = likeTogglePort.isLiked(userIgn, user.accountId)
+        val count = likeTogglePort.getLikeCount(userIgn)
+        ResponseEntity.ok(LikeStatusResponse(targetUserIgn = userIgn, liked = liked, likeCount = count))
+    }
+}
+
+data class LikeToggleResponse(
+    val targetUserIgn: String,
+    val liked: Boolean,
+    val likeCount: Long,
+)
+
+data class LikeStatusResponse(
+    val targetUserIgn: String,
+    val liked: Boolean,
+    val likeCount: Long,
+)

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/like/JdbcLikeToggleService.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/like/JdbcLikeToggleService.kt
@@ -1,0 +1,88 @@
+package maple.restcontroller.like
+
+import maple.expectation.core.domain.model.like.LikeToggleResult
+import maple.expectation.core.domain.model.like.LikeToggleWithCount
+import maple.expectation.core.port.inbound.LikeTogglePort
+import maple.expectation.core.port.out.CharacterOcidPort
+import maple.expectation.error.exception.CharacterNotFoundException
+import org.slf4j.LoggerFactory
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class JdbcLikeToggleService(
+    private val jdbc: NamedParameterJdbcTemplate,
+    private val characterOcidPort: CharacterOcidPort,
+) : LikeTogglePort {
+
+    companion object {
+        private val log = LoggerFactory.getLogger(JdbcLikeToggleService::class.java)
+    }
+
+    override fun toggleLike(targetUserIgn: String, likerAccountId: String, myOcids: Set<String>): LikeToggleResult =
+        toggleLikeWithCount(targetUserIgn, likerAccountId, myOcids).result
+
+    @Transactional("transactionManager")
+    override fun toggleLikeWithCount(
+        targetUserIgn: String,
+        likerAccountId: String,
+        myOcids: Set<String>,
+    ): LikeToggleWithCount {
+        val targetOcid = characterOcidPort.resolveOcid(targetUserIgn)
+            ?: throw CharacterNotFoundException("Character not found: ${maskIgn(targetUserIgn)}")
+
+        require(targetOcid !in myOcids) { "Self-like not allowed" }
+
+        val existed = jdbc.queryForObject(
+            "SELECT EXISTS(SELECT 1 FROM character_like WHERE target_ocid = :ocid AND liker_account_id = :accountId)",
+            mapOf("ocid" to targetOcid, "accountId" to likerAccountId),
+            Boolean::class.java,
+        ) ?: false
+
+        val result = if (existed) {
+            jdbc.update(
+                "DELETE FROM character_like WHERE target_ocid = :ocid AND liker_account_id = :accountId",
+                mapOf("ocid" to targetOcid, "accountId" to likerAccountId),
+            )
+            LikeToggleResult.UNLIKED
+        } else {
+            jdbc.update(
+                "INSERT INTO character_like (target_ocid, liker_account_id, created_at) VALUES (:ocid, :accountId, now()) ON CONFLICT (target_ocid, liker_account_id) DO NOTHING",
+                mapOf("ocid" to targetOcid, "accountId" to likerAccountId),
+            )
+            LikeToggleResult.LIKED
+        }
+
+        val count = jdbc.queryForObject(
+            "SELECT COUNT(*) FROM character_like WHERE target_ocid = :ocid",
+            mapOf("ocid" to targetOcid),
+            Long::class.java,
+        ) ?: 0L
+
+        return LikeToggleWithCount(result, count)
+    }
+
+    @Transactional("transactionManager", readOnly = true)
+    override fun isLiked(targetUserIgn: String, likerAccountId: String): Boolean {
+        val targetOcid = characterOcidPort.resolveOcid(targetUserIgn) ?: return false
+        return jdbc.queryForObject(
+            "SELECT EXISTS(SELECT 1 FROM character_like WHERE target_ocid = :ocid AND liker_account_id = :accountId)",
+            mapOf("ocid" to targetOcid, "accountId" to likerAccountId),
+            Boolean::class.java,
+        ) ?: false
+    }
+
+    @Transactional("transactionManager", readOnly = true)
+    override fun getLikeCount(targetUserIgn: String): Long {
+        val targetOcid = characterOcidPort.resolveOcid(targetUserIgn) ?: return 0L
+        return jdbc.queryForObject(
+            "SELECT COUNT(*) FROM character_like WHERE target_ocid = :ocid",
+            mapOf("ocid" to targetOcid),
+            Long::class.java,
+        ) ?: 0L
+    }
+
+    private fun maskIgn(ign: String): String =
+        if (ign.length <= 2) "***" else "${ign.first()}***${ign.last()}"
+}

--- a/module-rest-controller/src/main/resources/application-local.yml
+++ b/module-rest-controller/src/main/resources/application-local.yml
@@ -10,6 +10,10 @@ spring:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
 
+auth:
+  jwt:
+    secret: ${JWT_SECRET}
+
 expectation:
   v6:
     enabled: true


### PR DESCRIPTION
## Summary
- Add `POST /api/v6/characters/{userIgn}/like` (toggle) and `GET /api/v6/characters/{userIgn}/like/status` endpoints
- JWT auth via `HandlerInterceptor` + JJWT (no Spring Security dependency)
- JDBC-only implementation: `JdbcLikeToggleService`, `JdbcOcidQueryAdapter`, `JwtParserAdapter`
- Self-like prevention via OCID cross-check
- `@ConditionalOnProperty(name = ["expectation.v6.enabled"])` gated

## Test plan
- [x] `./gradlew compileKotlin compileJava --continue` — BUILD SUCCESSFUL
- [x] `./gradlew test` — BUILD SUCCESSFUL
- [ ] Runtime: bootRun + curl with valid/invalid JWT tokens
- [ ] Verify 401 on missing token, 401 on expired token, 200 on valid token

🤖 Generated with [Claude Code](https://claude.com/claude-code)