### PR TITLE
feat(observability): improve AI trace hooks

### DIFF
--- a/.claude/hooks/trace-session-init.sh
+++ b/.claude/hooks/trace-session-init.sh
@@ -23,3 +23,6 @@ ENTRY=$(jq -n \
 
 echo "$ENTRY" >> "$SESSION_DIR/session.jsonl"
 echo "AI trace session: $SESSION_ID"
+
+# Compress trace files older than 7 days
+find "$TRACE_BASE" -name "*.jsonl" -mtime +7 ! -name "*.gz" -exec gzip {} \; 2>/dev/null || true

--- a/.claude/hooks/trace-tool-use.sh
+++ b/.claude/hooks/trace-tool-use.sh
@@ -9,7 +9,9 @@ INPUT=$(cat)
 
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // "unknown"')
 TOOL_INPUT=$(echo "$INPUT" | jq -c '.tool_input // {}')
-RESULT=$(echo "$INPUT" | jq -r '.tool_result // ""' | head -c 500)
+
+# Capture result — try .tool_result, then .result, handle string/object
+RESULT=$(echo "$INPUT" | jq -c '(.tool_result // .result // "") | if type == "string" then .[0:500] else (tostring[0:500]) end' 2>/dev/null || echo '""')
 ERROR=$(echo "$INPUT" | jq -r '.error // null')
 TS=$(trace_ts)
 
@@ -18,7 +20,7 @@ ENTRY=$(jq -n \
     --arg ts "$TS" \
     --arg tool "$TOOL_NAME" \
     --argjson input "$TOOL_INPUT" \
-    --arg result "$RESULT" \
+    --argjson result "$RESULT" \
     --arg error "$ERROR" \
     '{timestamp: $ts, tool: $tool, input: $input, result_preview: $result, error: $error}')
 


### PR DESCRIPTION
## Summary
- Capture actual tool result in `result_preview` field (try `.tool_result`/`.result`, handle string/object types)
- Auto-gzip trace files older than 7 days on session init

## Test plan
- [x] Manual verification: `result_preview` now captures tool output
- [x] 7-day gzip compression logic added to session-init

🤖 Generated with [Claude Code](https://claude.com/claude-code)