### PR TITLE
fix(cleanup): remove @ConditionalOnProperty from migrated schedulers

### DIFF
--- a/module-calculator/src/main/kotlin/maple/calculator/cleanup/CalculatorResultCleanupScheduler.kt
+++ b/module-calculator/src/main/kotlin/maple/calculator/cleanup/CalculatorResultCleanupScheduler.kt
@@ -6,8 +6,6 @@ import maple.common.cleanup.RunCleanupResult
 import maple.common.cleanup.RunInfo
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
-
 import org.springframework.stereotype.Component
 import java.nio.file.Files
 import java.nio.file.Paths
@@ -15,7 +13,6 @@ import java.nio.file.attribute.BasicFileAttributes
 import java.time.Instant
 
 @Component
-@ConditionalOnProperty(name = ["calculator.cleanup.enabled"], havingValue = "true")
 class CalculatorResultCleanupScheduler(
     private val objectStorage: ObjectStorage,
     @Value("\${calculator.cleanup.dry-run:true}")

--- a/module-external-api/src/main/kotlin/maple/externalapi/cleanup/ArtifactCleanupScheduler.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/cleanup/ArtifactCleanupScheduler.kt
@@ -7,14 +7,12 @@ import maple.externalapi.metrics.CleanupMetrics
 import maple.externalapi.port.out.ExternalApiArtifactStorePort
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
 @Component
-@ConditionalOnProperty(name = ["external-api.cleanup.enabled"], havingValue = "true")
 class ArtifactCleanupScheduler(
     private val artifactStore: ExternalApiArtifactStorePort,
     private val metrics: CleanupMetrics,


### PR DESCRIPTION
## Summary
- Remove `@ConditionalOnProperty` from `ArtifactCleanupScheduler` and `CalculatorResultCleanupScheduler`
- These schedulers were migrated from `@Scheduled` to Airflow trigger endpoints, but the conditional annotation was left in place
- With `cleanup.enabled=false` in YAML, beans were never created → trigger endpoints returned DISABLED

## Test plan
- [x] `./gradlew compileKotlin compileJava --continue` — BUILD SUCCESSFUL
- [x] `./gradlew test` — 67 tasks, all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)