### PR TITLE
fix(cleanup): run ID parsing bug and tighten retention policy

### DIFF
--- a/docker/airflow/dags/daily_cleanup_pipeline.py
+++ b/docker/airflow/dags/daily_cleanup_pipeline.py
@@ -24,7 +24,7 @@ with DAG(
     dag_id="daily_cleanup_pipeline",
     default_args=default_args,
     start_date=datetime(2026, 5, 29),
-    schedule=None,
+    schedule="0 */6 * * *",  # every 6 hours + triggered after collection
     catchup=False,
     tags=["pipeline", "cleanup"],
 ) as dag:

--- a/module-external-api/src/main/kotlin/maple/externalapi/cleanup/ArtifactCleanupScheduler.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/cleanup/ArtifactCleanupScheduler.kt
@@ -110,7 +110,8 @@ class ArtifactCleanupScheduler(
     }
 
     private fun parseRunIdTimestamp(runId: String): Instant? {
-        return runIdPattern.parse(runId) { Instant.from(it) }
+        val timestamp = runId.substringBeforeLast("-")
+        return runCatching { runIdPattern.parse(timestamp) { Instant.from(it) } }.getOrNull()
     }
 
     private fun updateStorageMetrics() {

--- a/module-external-api/src/main/resources/application.yml
+++ b/module-external-api/src/main/resources/application.yml
@@ -39,15 +39,15 @@ external-api:
   store:
     base-path: ../data
   cleanup:
-    enabled: false                    # enable to activate cleanup scheduler
+    enabled: true                     # enable to activate cleanup scheduler
     dry-run: false                    # true = log candidates without deleting
     interval-ms: 21600000             # 6 hours between cleanup cycles
     max-delete-runs-per-cycle: 10     # max runs deleted per cycle
     max-delete-bytes-per-cycle: 53687091200  # 50GB max deleted per cycle
     max-runtime-seconds: 300          # hard wall-clock limit per cycle
     runs:
-      keep-recent: 5                  # always keep the 5 most recent runs
-      keep-within-hours: 12           # keep runs newer than 12 hours
+      keep-recent: 2                  # always keep the 2 most recent runs
+      keep-within-hours: 3            # keep runs newer than 3 hours
     consumed:
       enabled: true                   # enable consumed-chunk auto-deletion
       interval-ms: 3600000            # 1 hour between batch deletes


### PR DESCRIPTION
## Summary
- Fix `parseRunIdTimestamp` to handle run IDs with random suffix (`yyyyMMdd-HHmmss-XXXXXXXXX`) using `substringBeforeLast("-")`
- Enable cleanup scheduler (`cleanup.enabled: true`)
- Tighten retention policy: keep-recent 2, keep-within-hours 3 (was 5/12h)
- Add 6h cron schedule to `daily_cleanup_pipeline` DAG (was manual-only)

## Test plan
- [x] Triggered cleanup via `POST /api/internal/trigger/artifact-cleanup` — 13 runs deleted, 0 errors
- [x] Verified log: `[Cleanup] completed: runsDeleted=10, bytesDeleted=158480822`
- [x] Second pass cleaned remaining 3 throttled runs
- [ ] Verify 6h cron fires on next cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)