### PR TITLE
fix(kafka): add DLQ and DefaultErrorHandler for poison message prevention

### DIFF
--- a/module-calculator/src/main/kotlin/maple/calculator/config/KafkaConsumerConfig.kt
+++ b/module-calculator/src/main/kotlin/maple/calculator/config/KafkaConsumerConfig.kt
@@ -1,0 +1,34 @@
+package maple.calculator.config
+
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.common.TopicPartition
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory
+import org.springframework.kafka.core.ConsumerFactory
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer
+import org.springframework.kafka.listener.DefaultErrorHandler
+import org.springframework.util.backoff.FixedBackOff
+
+@Configuration
+class KafkaConsumerConfig {
+    private val log = LoggerFactory.getLogger(KafkaConsumerConfig::class.java)
+
+    @Bean
+    fun kafkaListenerContainerFactory(
+        consumerFactory: ConsumerFactory<String, String>,
+        kafkaTemplate: KafkaTemplate<String, String>,
+    ): ConcurrentKafkaListenerContainerFactory<String, String> {
+        val factory = ConcurrentKafkaListenerContainerFactory<String, String>()
+        factory.consumerFactory = consumerFactory
+
+        val recoverer = DeadLetterPublishingRecoverer(kafkaTemplate) { record: ConsumerRecord<*, *>, ex: Exception ->
+            log.error("[DLQ] topic={} key={} offset={} error={}", record.topic(), record.key(), record.offset(), ex.message)
+            TopicPartition("${record.topic()}.DLT", record.partition())
+        }
+        factory.setCommonErrorHandler(DefaultErrorHandler(recoverer, FixedBackOff(1000, 3)))
+        return factory
+    }
+}

--- a/module-external-api/src/main/kotlin/maple/externalapi/auth/AuthCharacterFetchConsumer.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/auth/AuthCharacterFetchConsumer.kt
@@ -63,9 +63,10 @@ class AuthCharacterFetchConsumer(
                 log.error("[AuthFetch] failed: eventId={}", request.eventId, ex)
                 publishError(request, "Internal error: ${ex.message}")
             }
-        }
 
-        acknowledgment.acknowledge()
+            runCatching { acknowledgment.acknowledge() }
+                .onFailure { log.warn("[AuthFetch] ACK failed: eventId={}", request.eventId) }
+        }
     }
 
     private fun publishSuccess(request: CharacterFetchRequest, accountId: String?, characterOcidMap: Map<String, String>) {

--- a/module-external-api/src/main/kotlin/maple/externalapi/config/KafkaConsumerConfig.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/config/KafkaConsumerConfig.kt
@@ -1,0 +1,34 @@
+package maple.externalapi.config
+
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.common.TopicPartition
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory
+import org.springframework.kafka.core.ConsumerFactory
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer
+import org.springframework.kafka.listener.DefaultErrorHandler
+import org.springframework.util.backoff.FixedBackOff
+
+@Configuration
+class KafkaConsumerConfig {
+    private val log = LoggerFactory.getLogger(KafkaConsumerConfig::class.java)
+
+    @Bean
+    fun kafkaListenerContainerFactory(
+        consumerFactory: ConsumerFactory<String, String>,
+        kafkaTemplate: KafkaTemplate<String, String>,
+    ): ConcurrentKafkaListenerContainerFactory<String, String> {
+        val factory = ConcurrentKafkaListenerContainerFactory<String, String>()
+        factory.consumerFactory = consumerFactory
+
+        val recoverer = DeadLetterPublishingRecoverer(kafkaTemplate) { record: ConsumerRecord<*, *>, ex: Exception ->
+            log.error("[DLQ] topic={} key={} offset={} error={}", record.topic(), record.key(), record.offset(), ex.message)
+            TopicPartition("${record.topic()}.DLT", record.partition())
+        }
+        factory.setCommonErrorHandler(DefaultErrorHandler(recoverer, FixedBackOff(1000, 3)))
+        return factory
+    }
+}

--- a/module-external-api/src/main/kotlin/maple/externalapi/urgent/UrgentCharacterRequestConsumer.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/urgent/UrgentCharacterRequestConsumer.kt
@@ -55,10 +55,11 @@ class UrgentCharacterRequestConsumer(
             .whenComplete { _, ex ->
                 if (ex != null) {
                     log.error("[Urgent] failed: userIgn={}", maskIgn(request.userIgn), ex)
-                    return@whenComplete
+                } else {
+                    log.info("[Urgent] completed: userIgn={}", maskIgn(request.userIgn))
                 }
-                acknowledgment.acknowledge()
-                log.info("[Urgent] completed: userIgn={}", maskIgn(request.userIgn))
+                runCatching { acknowledgment.acknowledge() }
+                    .onFailure { log.warn("[Urgent] ACK failed: userIgn={}", maskIgn(request.userIgn)) }
             }
     }
 

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/config/KafkaConsumerConfig.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/config/KafkaConsumerConfig.kt
@@ -1,0 +1,34 @@
+package maple.synchronizer.config
+
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.common.TopicPartition
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory
+import org.springframework.kafka.core.ConsumerFactory
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer
+import org.springframework.kafka.listener.DefaultErrorHandler
+import org.springframework.util.backoff.FixedBackOff
+
+@Configuration
+class KafkaConsumerConfig {
+    private val log = LoggerFactory.getLogger(KafkaConsumerConfig::class.java)
+
+    @Bean
+    fun kafkaListenerContainerFactory(
+        consumerFactory: ConsumerFactory<String, String>,
+        kafkaTemplate: KafkaTemplate<String, String>,
+    ): ConcurrentKafkaListenerContainerFactory<String, String> {
+        val factory = ConcurrentKafkaListenerContainerFactory<String, String>()
+        factory.consumerFactory = consumerFactory
+
+        val recoverer = DeadLetterPublishingRecoverer(kafkaTemplate) { record: ConsumerRecord<*, *>, ex: Exception ->
+            log.error("[DLQ] topic={} key={} offset={} error={}", record.topic(), record.key(), record.offset(), ex.message)
+            TopicPartition("${record.topic()}.DLT", record.partition())
+        }
+        factory.setCommonErrorHandler(DefaultErrorHandler(recoverer, FixedBackOff(1000, 3)))
+        return factory
+    }
+}


### PR DESCRIPTION
## Summary
- Add `KafkaConsumerConfig` with `DefaultErrorHandler` + `DeadLetterPublishingRecoverer` to calculator, external-api, synchronizer modules
- Malformed JSON / deserialization failures now retry 3x then forward to `{topic}.DLT` instead of infinite redelivery
- Fix `UrgentCharacterRequestConsumer`: ACK in async error path to prevent infinite redelivery loop
- Fix `AuthCharacterFetchConsumer`: move ACK from after `vtExecutor.submit` into async completion to prevent ACK-before-complete data loss

## Test plan
- [x] `./gradlew compileKotlin compileJava --continue` passes
- [x] `./gradlew test` passes
- [ ] Start modules, send malformed JSON to Kafka topic → verify 3 retries logged + message forwarded to `.DLT` topic
- [ ] Verify consumer continues processing next message (no infinite loop)

Closes #867

🤖 Generated with [Claude Code](https://claude.com/claude-code)