### PR TITLE
fix(airflow): handle 409 CONFLICT in DAG response checks

### DIFF
--- a/docker/airflow/dags/daily_cleanup_pipeline.py
+++ b/docker/airflow/dags/daily_cleanup_pipeline.py
@@ -14,6 +14,19 @@ from airflow import DAG
 from airflow.providers.http.operators.http import HttpOperator
 from airflow.providers.http.sensors.http import HttpSensor
 
+
+def is_accepted_response(response):
+    """Check if HTTP response indicates success or already-accepted state.
+    Handles 409 CONFLICT (already running/started) as acceptance.
+    """
+    if response.status_code == 409:
+        return True
+    try:
+        return response.json().get("status") in ("UP", "STARTED")
+    except (ValueError, AttributeError):
+        return False
+
+
 default_args = {
     "owner": "maple-pipeline",
     "retries": 1,
@@ -34,7 +47,7 @@ with DAG(
         http_conn_id="external_api",
         endpoint="actuator/health",
         request_params={},
-        response_check=lambda r: r.json().get("status") == "UP",
+        response_check=is_accepted_response,
         poke_interval=30,
         timeout=120,
     )
@@ -45,7 +58,7 @@ with DAG(
         endpoint="api/internal/trigger/artifact-cleanup",
         method="POST",
         execution_timeout=timedelta(seconds=30),
-        response_check=lambda r: r.json().get("status") == "STARTED",
+        response_check=is_accepted_response,
     )
 
     trigger_consumed_cleanup = HttpOperator(
@@ -54,7 +67,7 @@ with DAG(
         endpoint="api/internal/trigger/consumed-cleanup",
         method="POST",
         execution_timeout=timedelta(seconds=30),
-        response_check=lambda r: r.json().get("status") == "STARTED",
+        response_check=is_accepted_response,
     )
 
     trigger_result_cleanup = HttpOperator(
@@ -63,7 +76,7 @@ with DAG(
         endpoint="api/internal/trigger/result-cleanup",
         method="POST",
         execution_timeout=timedelta(seconds=30),
-        response_check=lambda r: r.json().get("status") == "STARTED",
+        response_check=is_accepted_response,
     )
 
     check_external_api >> [trigger_artifact_cleanup, trigger_consumed_cleanup, trigger_result_cleanup]

--- a/docker/airflow/dags/daily_collection_pipeline.py
+++ b/docker/airflow/dags/daily_collection_pipeline.py
@@ -19,6 +19,18 @@ from airflow.providers.http.operators.http import HttpOperator
 from airflow.providers.http.sensors.http import HttpSensor
 
 
+def is_accepted_response(response):
+    """Check if HTTP response indicates success or already-accepted state.
+    Handles 409 CONFLICT (already running/started) as acceptance.
+    """
+    if response.status_code == 409:
+        return True
+    try:
+        return response.json().get("status") in ("UP", "STARTED")
+    except (ValueError, AttributeError):
+        return False
+
+
 def poll_run_completion(**context):
     """Poll run-status, return True when triggered run reaches terminal state."""
     trigger_response = context["ti"].xcom_pull(task_ids="trigger_daily_collection")
@@ -27,6 +39,11 @@ def poll_run_completion(**context):
     run_id = trigger_response["runId"]
 
     resp = requests.get("http://host.docker.internal:8081/api/internal/run-status", timeout=10)
+
+    # 409 CONFLICT means a run is already active — treat as in-progress, not error
+    if resp.status_code == 409:
+        raise RuntimeError(f"Run {run_id} still in progress (409 CONFLICT - another run active)")
+
     resp.raise_for_status()
     data = resp.json()
 
@@ -96,7 +113,7 @@ with DAG(
         http_conn_id="external_api",
         endpoint="actuator/health",
         request_params={},
-        response_check=lambda r: r.json().get("status") == "UP",
+        response_check=is_accepted_response,
         poke_interval=30,
         timeout=120,
     )
@@ -106,7 +123,7 @@ with DAG(
         http_conn_id="external_api",
         endpoint="api/internal/trigger/daily",
         method="POST",
-        response_check=lambda r: r.json().get("status") == "STARTED",
+        response_check=is_accepted_response,
     )
 
     wait_for_completion = PythonOperator(


### PR DESCRIPTION
Fixes #868

## Changes
- Add `is_accepted_response()` helper to both DAGs — treats 409 CONFLICT as success
- `poll_run_completion`: 409 → raise RuntimeError (Airflow retries), not crash
- 6 `response_check` lambdas → use shared helper

## Files Changed (2)
- docker/airflow/dags/daily_collection_pipeline.py
- docker/airflow/dags/daily_cleanup_pipeline.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)