### PR TITLE
fix(external-api): ConsumedChunkCleanup concurrency overhaul

### DIFF
--- a/module-external-api/src/main/kotlin/maple/externalapi/cleanup/ConsumedChunkCleanupScheduler.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/cleanup/ConsumedChunkCleanupScheduler.kt
@@ -1,6 +1,7 @@
 package maple.externalapi.cleanup
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import jakarta.annotation.PreDestroy
 import maple.expectation.common.event.ChunkConsumedEvent
 import maple.expectation.infrastructure.lifecycle.ManagedLifecycle
 import org.slf4j.LoggerFactory
@@ -10,22 +11,23 @@ import org.springframework.kafka.annotation.KafkaListener
 import org.springframework.kafka.support.Acknowledgment
 import org.springframework.kafka.support.KafkaHeaders
 import org.springframework.messaging.handler.annotation.Header
+import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.util.concurrent.ConcurrentLinkedQueue
-import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
 
 @Component
 @ConditionalOnProperty(name = ["external-api.cleanup.consumed.enabled"], havingValue = "true")
 class ConsumedChunkCleanupScheduler(
     private val objectMapper: ObjectMapper,
-    @Value("\${external-api.store.base-path:../data}")
-    private val basePath: String,
+    @Value("\${external-api.store.base-path:../data}") private val basePath: String,
+    @Value("\${external-api.cleanup.consumed.max-pending:10000}") private val maxPending: Int,
 ) : ManagedLifecycle {
     private val log = LoggerFactory.getLogger(javaClass)
     private val pendingDeletions = ConcurrentLinkedQueue<ChunkConsumedEvent>()
-    private val vtExecutor = Executors.newVirtualThreadPerTaskExecutor()
+    private val pendingCount = AtomicInteger(0)
 
     @KafkaListener(
         topics = ["\${external-api.kafka.chunk-consumed-topic}"],
@@ -36,20 +38,36 @@ class ConsumedChunkCleanupScheduler(
         acknowledgment: Acknowledgment,
         @Header(name = KafkaHeaders.RECEIVED_TOPIC, required = false) topic: String?,
     ) {
-        runCatching {
-            val event = objectMapper.readValue(message, ChunkConsumedEvent::class.java)
-            pendingDeletions.add(event)
-            log.debug("[ConsumedChunkCleanup] queued: runId={} chunkId={} objectKey={}", event.runId, event.chunkId, event.objectKey)
-        }.onFailure { ex ->
+        val event = runCatching {
+            objectMapper.readValue(message, ChunkConsumedEvent::class.java)
+        }.getOrElse { ex ->
             log.warn("[ConsumedChunkCleanup] failed to parse event: {}", ex.message)
+            acknowledgment.acknowledge()
+            return
         }
+
+        // O(1) bound check via AtomicInteger
+        if (pendingCount.incrementAndGet() > maxPending) {
+            pendingDeletions.poll()
+            pendingCount.decrementAndGet()
+            log.warn("[ConsumedChunkCleanup] pending queue at capacity ({}), dropped oldest", maxPending)
+        }
+        pendingDeletions.add(event)
+        log.debug("[ConsumedChunkCleanup] queued: runId={} chunkId={} objectKey={}", event.runId, event.chunkId, event.objectKey)
+
         acknowledgment.acknowledge()
+    }
+
+    @Scheduled(fixedDelayString = "\${external-api.cleanup.consumed.interval-ms:3600000}")
+    fun scheduledCleanup() {
+        cleanup()
     }
 
     fun cleanup() {
         val batch = mutableListOf<ChunkConsumedEvent>()
         while (true) {
             val event = pendingDeletions.poll() ?: break
+            pendingCount.decrementAndGet()
             batch.add(event)
         }
         if (batch.isEmpty()) return
@@ -59,16 +77,17 @@ class ConsumedChunkCleanupScheduler(
         var failedCount = 0
 
         batch.forEach { event ->
-            vtExecutor.submit {
-                if (deleteFile(event.objectKey)) deletedCount++ else failedCount++
-                event.sourceObjectKey?.let {
-                    if (deleteFile(it)) deletedCount++ else failedCount++
-                }
+            if (deleteFile(event.objectKey)) deletedCount++ else failedCount++
+            event.sourceObjectKey?.let {
+                if (deleteFile(it)) deletedCount++ else failedCount++
             }
         }
 
         val durationMs = (System.nanoTime() - start) / 1_000_000
-        log.info("[ConsumedChunkCleanup] batch complete: chunks={} deleted={} failed={} durationMs={}", batch.size, deletedCount, failedCount, durationMs)
+        log.info(
+            "[ConsumedChunkCleanup] batch complete: chunks={} deleted={} failed={} durationMs={}",
+            batch.size, deletedCount, failedCount, durationMs,
+        )
     }
 
     private fun deleteFile(objectKey: String): Boolean {
@@ -89,6 +108,11 @@ class ConsumedChunkCleanupScheduler(
     override val lifecyclePhase: Int = 200
 
     override fun stopLifecycle() {
-        vtExecutor.close()
+        // No executor to close — cleanup is synchronous
+    }
+
+    @PreDestroy
+    fun shutdown() {
+        cleanup()
     }
 }


### PR DESCRIPTION
Fixes #872, #871

Bounded queue (AtomicInteger O(1)), synchronous deletion, @Scheduled auto-cleanup, @PreDestroy drain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)