### PR TITLE
fix(external-api): atomic RunStatusTracker state transitions

### DIFF
--- a/module-external-api/src/main/kotlin/maple/externalapi/runstatus/RunStatusTracker.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/runstatus/RunStatusTracker.kt
@@ -29,10 +29,11 @@ class RunStatusTracker {
         log.info("[RunStatus] phase={}", phase)
     }
 
-    fun completeRun(chunksProcessed: Int, recordsProcessed: Long) {
+    fun completeRun(runId: String, chunksProcessed: Int, recordsProcessed: Long) {
         val now = Instant.now()
-        currentRun.updateAndGet { current ->
-            current?.copy(
+        val completed = currentRun.updateAndGet { current ->
+            if (current?.runId != runId) return@updateAndGet current
+            current.copy(
                 phase = PipelinePhase.COMPLETED,
                 updatedAt = now,
                 completedAt = now,
@@ -40,22 +41,23 @@ class RunStatusTracker {
                 recordsProcessed = recordsProcessed,
             )
         }
-        lastCompletedRun.set(currentRun.get())
-        log.info("[RunStatus] completed chunks={} records={}", chunksProcessed, recordsProcessed)
+        lastCompletedRun.set(completed)
+        log.info("[RunStatus] completed run={} chunks={} records={}", completed?.runId, chunksProcessed, recordsProcessed)
     }
 
-    fun failRun(errorMessage: String) {
+    fun failRun(runId: String, errorMessage: String) {
         val now = Instant.now()
-        currentRun.updateAndGet { current ->
-            current?.copy(
+        val failed = currentRun.updateAndGet { current ->
+            if (current?.runId != runId) return@updateAndGet current
+            current.copy(
                 phase = PipelinePhase.FAILED,
                 updatedAt = now,
                 completedAt = now,
                 errorMessage = errorMessage,
             )
         }
-        lastCompletedRun.set(currentRun.get())
-        log.error("[RunStatus] failed: {}", errorMessage)
+        lastCompletedRun.set(failed)
+        log.error("[RunStatus] failed run={}: {}", failed?.runId, errorMessage)
     }
 
     fun getCurrentStatus(): RunStatus? = currentRun.get()

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/ExternalApiScheduler.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/ExternalApiScheduler.kt
@@ -107,10 +107,10 @@ class ExternalApiScheduler(
             .whenComplete { _, ex ->
                 if (ex != null) {
                     val message = ex.cause?.message ?: ex.message ?: "unknown error"
-                    runStatusTracker.failRun(message)
+                    runStatusTracker.failRun(runId, message)
                     log.error("[Scheduler] daily refresh failed, runId={}", runId, ex)
                 } else {
-                    runStatusTracker.completeRun(0, 0)
+                    runStatusTracker.completeRun(runId, 0, 0)
                     log.info("[Scheduler] daily refresh completed, runId={}", runId)
                 }
                 releaseLock()

--- a/module-external-api/src/test/kotlin/maple/externalapi/runstatus/RunStatusTrackerTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/runstatus/RunStatusTrackerTest.kt
@@ -37,7 +37,7 @@ class RunStatusTrackerTest {
     fun `completeRun sets COMPLETED`() {
         tracker.startRun("run-1")
         tracker.transitionPhase(PipelinePhase.OCID_LOOKUP)
-        tracker.completeRun(100, 600000L)
+        tracker.completeRun("run-1", 100, 600000L)
 
         val status = tracker.getCurrentStatus()!!
         assertThat(status.phase).isEqualTo(PipelinePhase.COMPLETED)
@@ -50,7 +50,7 @@ class RunStatusTrackerTest {
     @Test
     fun `failRun sets FAILED with message`() {
         tracker.startRun("run-1")
-        tracker.failRun("Nexon API timeout")
+        tracker.failRun("run-1", "Nexon API timeout")
 
         val status = tracker.getCurrentStatus()!!
         assertThat(status.phase).isEqualTo(PipelinePhase.FAILED)
@@ -60,7 +60,7 @@ class RunStatusTrackerTest {
     @Test
     fun `getLastCompletedRun returns most recent completed`() {
         tracker.startRun("run-1")
-        tracker.completeRun(10, 1000L)
+        tracker.completeRun("run-1", 10, 1000L)
 
         Thread.sleep(10)
 


### PR DESCRIPTION
Fixes #873

Capture `updateAndGet` result in local variable + add `runId` parameter to `completeRun`/`failRun`. Guard: skip transition if runId mismatch prevents completing the wrong run during a race with `startRun`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)