### PR TITLE
fix(airflow): Kafka networking and correctness fixes

### DIFF
--- a/docker/airflow/connections.sh
+++ b/docker/airflow/connections.sh
@@ -9,14 +9,14 @@ echo "Creating Airflow connections..."
 # External API (host.docker.internal → host port 8081)
 docker exec maple-airflow-scheduler airflow connections add external_api \
   --conn-type http \
-  --conn-host http://host.docker.internal \
+  --conn-host host.docker.internal \
   --conn-port 8081 \
   --conn-schema http
 
 # Calculator (host.docker.internal → host port 8082)
 docker exec maple-airflow-scheduler airflow connections add calculator \
   --conn-type http \
-  --conn-host http://host.docker.internal \
+  --conn-host host.docker.internal \
   --conn-port 8082 \
   --conn-schema http
 

--- a/docker/airflow/dags/daily_collection_pipeline.py
+++ b/docker/airflow/dags/daily_collection_pipeline.py
@@ -65,19 +65,24 @@ def poll_run_completion(**context):
 def wait_for_item_equipment_cycle(**context):
     """Wait for item-equipment chunk consumed event from synchronizer via Kafka.
 
-    Consumes from synchronizer.chunk.consumed topic. When the first
-    item-equipment consumed event arrives, synchronizer has finished
-    processing at least one chunk — safe to trigger cleanup.
+    Consumes from synchronizer.chunk.consumed topic. Filters by runId
+    to only accept events from the run triggered by this pipeline invocation.
+    Uses per-run group_id to avoid partition rebalancing on overlapping runs.
     """
     import json as _json
     from kafka import KafkaConsumer
+
+    trigger_response = context["ti"].xcom_pull(task_ids="trigger_daily_collection")
+    if isinstance(trigger_response, str):
+        trigger_response = _json.loads(trigger_response)
+    run_id = trigger_response["runId"]
 
     consumer = KafkaConsumer(
         "synchronizer.chunk.consumed",
         bootstrap_servers="host.docker.internal:9092",
         auto_offset_reset="latest",
         enable_auto_commit=False,
-        group_id="airflow-ie-cycle-waiter",
+        group_id=f"airflow-ie-cycle-waiter-{run_id[:8]}",
         value_deserializer=lambda m: _json.loads(m.decode("utf-8")),
         consumer_timeout_ms=120 * 60 * 1000,  # 2 hours
     )
@@ -85,7 +90,7 @@ def wait_for_item_equipment_cycle(**context):
     try:
         for message in consumer:
             event = message.value
-            if event.get("endpoint") == "item-equipment":
+            if event.get("endpoint") == "item-equipment" and event.get("runId") == run_id:
                 return True
     finally:
         consumer.close()


### PR DESCRIPTION
Fixes #878

## Changes
- **connections.sh**: Remove double http:// scheme in --conn-host (scheme already from --conn-schema)
- **runId filtering**: Kafka consumer now filters by runId to only accept events from the triggered run
- **group_id**: Per-run unique consumer group (airflow-ie-cycle-waiter-{runId[:8]}) prevents partition rebalancing

**Not changed:** Kafka bootstrap address (host.docker.internal:9092) — will be addressed when containerization strategy is decided.

## Files Changed (2)
- docker/airflow/connections.sh
- docker/airflow/dags/daily_collection_pipeline.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)