### PR TITLE
fix(synchronizer): atomic Redis writes

### DIFF
--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/ranking/EquipmentRankingRedisWriter.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/ranking/EquipmentRankingRedisWriter.kt
@@ -38,9 +38,11 @@ class EquipmentRankingRedisWriter(
 
     private fun updatePreset(documents: List<PreppedDocument>): Int {
         var updated = 0
+        val key = rankingKey(documents.first().presetNo.toInt()).toByteArray(StandardCharsets.UTF_8)
+        val keepFrom = properties.topSize.coerceAtLeast(1).toLong()
+
         documents.chunked(properties.batchSize.coerceAtLeast(1)).forEach { batch ->
             redisTemplate.executePipelined { connection ->
-                val key = rankingKey(documents.first().presetNo.toInt()).toByteArray(StandardCharsets.UTF_8)
                 batch.forEach { document ->
                     val userIgn = document.userIgn ?: return@forEach
                     connection.zSetCommands().zAdd(
@@ -50,10 +52,16 @@ class EquipmentRankingRedisWriter(
                     )
                     updated += 1
                 }
-                connection.zSetCommands().zRemRange(key, 0, -properties.topSize.coerceAtLeast(1).toLong() - 1)
                 null
             }
         }
+
+        // Trim once after all batches — removes all members ranked below top N
+        redisTemplate.executePipelined { connection ->
+            connection.zSetCommands().zRemRange(key, 0, -(keepFrom + 1))
+            null
+        }
+
         return updated
     }
 

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/repository/OcidMappingRepository.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/repository/OcidMappingRepository.kt
@@ -68,17 +68,23 @@ class OcidMappingRepository(
     }
 
     fun writeOcidToRedis(mappings: List<OcidMapping>) {
-        redisTemplate.delete(REDIS_KEY)
+        if (mappings.isEmpty()) {
+            redisTemplate.delete(REDIS_KEY)
+            log.info("[OcidMapping] Redis cleared: empty mappings")
+            return
+        }
+        val tempKey = "$REDIS_KEY:tmp:${System.nanoTime()}"
         redisTemplate.executePipelined { connection ->
             for (mapping in mappings) {
                 connection.hashCommands().hSet(
-                    REDIS_KEY.toByteArray(),
+                    tempKey.toByteArray(),
                     mapping.userIgn.toByteArray(),
                     mapping.ocid.toByteArray(),
                 )
             }
             null
         }
-        log.info("[OcidMapping] Redis written: {} mappings to {}", mappings.size, REDIS_KEY)
+        redisTemplate.rename(tempKey, REDIS_KEY)
+        log.info("[OcidMapping] Redis written atomically via RENAME: {} mappings to {}", mappings.size, REDIS_KEY)
     }
 }


### PR DESCRIPTION
Fixes #875

## Changes
- **OcidMapping atomic writes**: Replace `delete + hSet` with `write-to-temp + RENAME` pattern. RENAME is atomic — readers never see empty/partial hash.
- **EquipmentRanking correct trim**: Move `zRemRange` outside batch loop. Trim once after all `zAdd` calls complete, preserving correct top-N.

## Files Changed (2)
- `module-synchronizer/.../repository/OcidMappingRepository.kt`
- `module-synchronizer/.../ranking/EquipmentRankingRedisWriter.kt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)