### PR TITLE
refactor(calculator): consolidate @Value into CleanupProperties, extract @Import into EngineConfiguration

### DIFF
--- a/module-calculator/src/main/kotlin/maple/calculator/CalculatorApplication.kt
+++ b/module-calculator/src/main/kotlin/maple/calculator/CalculatorApplication.kt
@@ -1,24 +1,8 @@
 package maple.calculator
 
+import maple.calculator.config.CalculatorCleanupProperties
+import maple.calculator.config.CalculatorEngineConfiguration
 import maple.calculator.config.PipelineProperties
-import maple.expectation.application.service.calculator.v4.EquipmentExpectationCalculatorFactory
-import maple.expectation.application.service.cube.CubeServiceImpl
-import maple.expectation.application.service.cube.component.CubeComputeBuffer
-import maple.expectation.application.service.cube.component.CubeDpCalculator
-import maple.expectation.application.service.cube.component.CubeSlotCountResolver
-import maple.expectation.application.service.cube.component.DpModeInferrer
-import maple.expectation.application.service.cube.component.SlotDistributionBuilder
-import maple.expectation.application.service.cube.component.StatValueExtractor
-import maple.expectation.application.service.cube.policy.CubeCostPolicy
-import maple.expectation.application.service.starforce.StarforceLookupAdapter
-import maple.expectation.config.CubeEngineFeatureFlag
-import maple.expectation.config.TableMassConfig
-import maple.expectation.infrastructure.adapter.policy.PolicyAdapter
-import maple.expectation.infrastructure.config.CalculationPortConfig
-import maple.expectation.infrastructure.config.ExecutorConfig
-import maple.expectation.infrastructure.executor.DefaultLogicExecutor
-import maple.expectation.infrastructure.executor.classifier.DefaultExceptionClassifier
-import maple.expectation.infrastructure.persistence.repository.CubeProbabilityRepositoryImpl
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
 import org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration
@@ -29,27 +13,8 @@ import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication(exclude = [SecurityAutoConfiguration::class, ManagementWebSecurityAutoConfiguration::class])
 @EnableScheduling
-@EnableConfigurationProperties(PipelineProperties::class)
-@Import(
-    EquipmentExpectationCalculatorFactory::class,
-    CubeServiceImpl::class,
-    CubeDpCalculator::class,
-    CubeComputeBuffer::class,
-    CubeSlotCountResolver::class,
-    DpModeInferrer::class,
-    SlotDistributionBuilder::class,
-    StatValueExtractor::class,
-    CubeCostPolicy::class,
-    StarforceLookupAdapter::class,
-    PolicyAdapter::class,
-    DefaultLogicExecutor::class,
-    DefaultExceptionClassifier::class,
-    CubeProbabilityRepositoryImpl::class,
-    CubeEngineFeatureFlag::class,
-    TableMassConfig::class,
-    CalculationPortConfig::class,
-    ExecutorConfig::class,
-)
+@EnableConfigurationProperties(PipelineProperties::class, CalculatorCleanupProperties::class)
+@Import(CalculatorEngineConfiguration::class)
 class CalculatorApplication
 
 fun main(args: Array<String>) {

--- a/module-calculator/src/main/kotlin/maple/calculator/cleanup/CalculatorResultCleanupScheduler.kt
+++ b/module-calculator/src/main/kotlin/maple/calculator/cleanup/CalculatorResultCleanupScheduler.kt
@@ -1,5 +1,6 @@
 package maple.calculator.cleanup
 
+import maple.calculator.config.CalculatorCleanupProperties
 import maple.calculator.storage.ObjectStorage
 import maple.common.cleanup.RunCleanupExecutor
 import maple.common.cleanup.RunCleanupResult
@@ -15,18 +16,7 @@ import java.time.Instant
 @Component
 class CalculatorResultCleanupScheduler(
     private val objectStorage: ObjectStorage,
-    @Value("\${calculator.cleanup.dry-run:true}")
-    private val dryRun: Boolean,
-    @Value("\${calculator.cleanup.runs.keep-recent:5}")
-    private val keepRecent: Int,
-    @Value("\${calculator.cleanup.runs.keep-within-hours:48}")
-    private val keepWithinHours: Long,
-    @Value("\${calculator.cleanup.max-delete-runs-per-cycle:10}")
-    private val maxDeleteRunsPerCycle: Int,
-    @Value("\${calculator.cleanup.max-delete-bytes-per-cycle:5368709120}")
-    private val maxDeleteBytesPerCycle: Long,
-    @Value("\${calculator.cleanup.max-runtime-seconds:60}")
-    private val maxRuntimeSeconds: Long,
+    private val cleanupProperties: CalculatorCleanupProperties,
     @Value("\${calculator.store.input-base-path:../data}")
     private val basePath: String,
 ) {
@@ -35,7 +25,7 @@ class CalculatorResultCleanupScheduler(
 
     fun cleanup() {
         val start = Instant.now()
-        log.info("[CalculatorCleanup] started: dryRun={}", dryRun)
+        log.info("[CalculatorCleanup] started: dryRun={}", cleanupProperties.dryRun)
 
         val result = runCatching { cleanupRuns(start) }
 
@@ -45,7 +35,7 @@ class CalculatorResultCleanupScheduler(
             log.info(
                 "[CalculatorCleanup] completed: dryRun={}, deleted={}, bytes={}, " +
                     "errors={}, throttled={}, durationMs={}",
-                dryRun, res.runsDeleted, res.bytesDeleted, res.errors, res.throttled, durationMs,
+                cleanupProperties.dryRun, res.runsDeleted, res.bytesDeleted, res.errors, res.throttled, durationMs,
             )
         }.onFailure { ex ->
             log.error("[CalculatorCleanup] failed (pipeline NOT affected): {}", ex.message, ex)
@@ -64,13 +54,13 @@ class CalculatorResultCleanupScheduler(
 
         return cleanupExecutor.cleanup(
             runs = runInfos,
-            dryRun = dryRun,
-            keepRecent = keepRecent,
-            keepWithinHours = keepWithinHours,
+            dryRun = cleanupProperties.dryRun,
+            keepRecent = cleanupProperties.runs.keepRecent,
+            keepWithinHours = cleanupProperties.runs.keepWithinHours,
             now = Instant.now(),
-            maxDeleteRunsPerCycle = maxDeleteRunsPerCycle,
-            maxDeleteBytesPerCycle = maxDeleteBytesPerCycle,
-            maxRuntimeSeconds = maxRuntimeSeconds,
+            maxDeleteRunsPerCycle = cleanupProperties.maxDeleteRunsPerCycle,
+            maxDeleteBytesPerCycle = cleanupProperties.maxDeleteBytesPerCycle,
+            maxRuntimeSeconds = cleanupProperties.maxRuntimeSeconds,
             startedAt = startedAt,
             deleteRun = { run -> objectStorage.deleteDirectory("calculator/runs/${run.runId}") },
             onDryRunCandidate = { run ->

--- a/module-calculator/src/main/kotlin/maple/calculator/config/CalculatorCleanupProperties.kt
+++ b/module-calculator/src/main/kotlin/maple/calculator/config/CalculatorCleanupProperties.kt
@@ -1,0 +1,17 @@
+package maple.calculator.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties("calculator.cleanup")
+data class CalculatorCleanupProperties(
+    val dryRun: Boolean = true,
+    val runs: Runs = Runs(),
+    val maxDeleteRunsPerCycle: Int = 10,
+    val maxDeleteBytesPerCycle: Long = 5368709120,
+    val maxRuntimeSeconds: Long = 60,
+) {
+    data class Runs(
+        val keepRecent: Int = 5,
+        val keepWithinHours: Long = 48,
+    )
+}

--- a/module-calculator/src/main/kotlin/maple/calculator/config/CalculatorEngineConfiguration.kt
+++ b/module-calculator/src/main/kotlin/maple/calculator/config/CalculatorEngineConfiguration.kt
@@ -1,0 +1,45 @@
+package maple.calculator.config
+
+import maple.expectation.application.service.calculator.v4.EquipmentExpectationCalculatorFactory
+import maple.expectation.application.service.cube.CubeServiceImpl
+import maple.expectation.application.service.cube.component.CubeComputeBuffer
+import maple.expectation.application.service.cube.component.CubeDpCalculator
+import maple.expectation.application.service.cube.component.CubeSlotCountResolver
+import maple.expectation.application.service.cube.component.DpModeInferrer
+import maple.expectation.application.service.cube.component.SlotDistributionBuilder
+import maple.expectation.application.service.cube.component.StatValueExtractor
+import maple.expectation.application.service.cube.policy.CubeCostPolicy
+import maple.expectation.application.service.starforce.StarforceLookupAdapter
+import maple.expectation.config.CubeEngineFeatureFlag
+import maple.expectation.config.TableMassConfig
+import maple.expectation.infrastructure.adapter.policy.PolicyAdapter
+import maple.expectation.infrastructure.config.CalculationPortConfig
+import maple.expectation.infrastructure.config.ExecutorConfig
+import maple.expectation.infrastructure.executor.DefaultLogicExecutor
+import maple.expectation.infrastructure.executor.classifier.DefaultExceptionClassifier
+import maple.expectation.infrastructure.persistence.repository.CubeProbabilityRepositoryImpl
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
+
+@Configuration
+@Import(
+    EquipmentExpectationCalculatorFactory::class,
+    CubeServiceImpl::class,
+    CubeDpCalculator::class,
+    CubeComputeBuffer::class,
+    CubeSlotCountResolver::class,
+    DpModeInferrer::class,
+    SlotDistributionBuilder::class,
+    StatValueExtractor::class,
+    CubeCostPolicy::class,
+    StarforceLookupAdapter::class,
+    PolicyAdapter::class,
+    DefaultLogicExecutor::class,
+    DefaultExceptionClassifier::class,
+    CubeProbabilityRepositoryImpl::class,
+    CubeEngineFeatureFlag::class,
+    TableMassConfig::class,
+    CalculationPortConfig::class,
+    ExecutorConfig::class,
+)
+class CalculatorEngineConfiguration


### PR DESCRIPTION
## Summary
- **#890**: `CalculatorResultCleanupScheduler` 6 `@Value` → `CalculatorCleanupProperties` data class
- **#891**: `CalculatorApplication` 18-class `@Import` → `CalculatorEngineConfiguration` `@Configuration`
- YAML keys unchanged (backward compatible)
- `basePath` `@Value` retained (different prefix: `calculator.store.input-base-path`)

## Test plan
- [x] `./gradlew compileKotlin compileJava --continue` passes
- [x] `./gradlew test` passes
- [ ] `./gradlew :module-calculator:bootRun` runtime verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)