### PR TITLE
refactor: config binding consolidation + metrics event listener extraction

### DIFF
--- a/module-calculator/src/main/kotlin/maple/calculator/CalculatorChunkProcessingCoordinator.kt
+++ b/module-calculator/src/main/kotlin/maple/calculator/CalculatorChunkProcessingCoordinator.kt
@@ -6,23 +6,21 @@ import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
 import maple.expectation.common.event.CalculatorResultChunkReadyEvent
 import maple.expectation.common.event.SnapshotChunkReadyEvent
+import maple.calculator.event.ChunkProcessingEvent
 import maple.calculator.event.KafkaResultEventPublisher
-import maple.calculator.metrics.CalculatorMetrics
+import maple.calculator.metrics.CalculatorMetricsListener
 import maple.calculator.model.ChunkResult
-import maple.calculator.metrics.CalculatorVolumeMetrics
 import maple.calculator.processor.SnapshotChunkProcessor
 import maple.calculator.storage.ObjectStorage
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
-import java.time.Duration
 
 @Component
 class CalculatorChunkProcessingCoordinator(
     private val chunkProcessor: SnapshotChunkProcessor,
     private val resultEventPublisher: KafkaResultEventPublisher,
     private val objectStorage: ObjectStorage,
-    private val metrics: CalculatorMetrics,
-    private val volumeMetrics: CalculatorVolumeMetrics,
+    private val metricsListener: CalculatorMetricsListener,
 ) {
     private val log = LoggerFactory.getLogger(CalculatorChunkProcessingCoordinator::class.java)
     private val concurrency = Semaphore(2)
@@ -30,16 +28,15 @@ class CalculatorChunkProcessingCoordinator(
     suspend fun handle(event: SnapshotChunkReadyEvent) {
         if (event.endpoint != "item-equipment") {
             log.info("[Coordinator] skipping non-item-equipment endpoint: {}", event.endpoint)
-            metrics.recordChunkSkippedEndpoint()
+            metricsListener.onEvent(ChunkProcessingEvent.Skipped(event.runId, event.chunkId, "endpoint_mismatch"))
             return
         }
 
         withMdc(event) {
             concurrency.withPermit {
-                // All checks inside semaphore — eliminates TOCTOU race
                 if (!objectStorage.exists(event.objectKey)) {
                     log.error("[Coordinator] source chunk not found: runId={} chunkId={} objectKey={}", event.runId, event.chunkId, event.objectKey)
-                    metrics.recordChunkSkippedNotFound()
+                    metricsListener.onEvent(ChunkProcessingEvent.Skipped(event.runId, event.chunkId, "source_not_found"))
                     return@withPermit
                 }
 
@@ -59,7 +56,7 @@ class CalculatorChunkProcessingCoordinator(
 
     private suspend fun republishExistingResult(event: SnapshotChunkReadyEvent, resultObjectKey: String) {
         log.info("[Coordinator] result already exists, republishing: runId={} chunkId={} objectKey={}", event.runId, event.chunkId, resultObjectKey)
-        metrics.recordChunkSkippedIdempotent()
+        metricsListener.onEvent(ChunkProcessingEvent.Skipped(event.runId, event.chunkId, "result_exists"))
         resultEventPublisher.publishChunkReady(
             CalculatorResultChunkReadyEvent(
                 sourceRunId = event.runId,
@@ -79,11 +76,10 @@ class CalculatorChunkProcessingCoordinator(
         val start = System.nanoTime()
         runCatching {
             val result = chunkProcessor.process(event, resultObjectKey)
-            metrics.timer().record(Duration.ofNanos(System.nanoTime() - start))
             onChunkProcessed(event, result, start)
         }.onFailure { ex ->
             log.error("[Coordinator] chunk processing failed: runId={} chunkId={}: {}", event.runId, event.chunkId, ex.message, ex)
-            metrics.recordChunkFailed()
+            metricsListener.onEvent(ChunkProcessingEvent.Failed(event.runId, event.chunkId))
             throw ex
         }
     }
@@ -111,21 +107,25 @@ class CalculatorChunkProcessingCoordinator(
             event.runId, event.chunkId,
             result.recordCount, result.successCount, result.totalItems, result.resultCount, result.errorCount,
         )
-        volumeMetrics.recordInput(event.compressedBytes, event.uncompressedBytes)
-        volumeMetrics.recordResult(result.resultCompressedBytes, result.resultUncompressedBytes, result.resultCount.toLong())
         val ratio = if (result.resultCompressedBytes > 0) "%.2f".format(result.resultUncompressedBytes.toDouble() / result.resultCompressedBytes.toDouble()) else "N/A"
         log.info(
             "[calculatorArtifactVolume] runId={} chunkId={} inputCompressedBytes={} inputUncompressedBytes={} resultCompressedBytes={} resultUncompressedBytes={} resultJsonRows={} resultCompressionRatio={}",
             event.runId, event.chunkId, event.compressedBytes, event.uncompressedBytes,
             result.resultCompressedBytes, result.resultUncompressedBytes, result.resultCount, ratio,
         )
-        metrics.recordChunkProcessed()
-        metrics.recordUsers(result.recordCount)
-        metrics.recordItems(result.totalItems)
-        metrics.recordCalculated(result.resultCount)
-        metrics.recordErrors(result.errorCount)
-        val durationSec = (System.nanoTime() - startNanos) / 1_000_000_000.0
-        metrics.recordChunkRates(result.recordCount, result.totalItems, durationSec)
+        metricsListener.onEvent(ChunkProcessingEvent.Completed(
+            runId = event.runId,
+            chunkId = event.chunkId,
+            recordCount = result.recordCount,
+            totalItems = result.totalItems,
+            resultCount = result.resultCount,
+            errorCount = result.errorCount,
+            inputCompressedBytes = event.compressedBytes,
+            inputUncompressedBytes = event.uncompressedBytes,
+            resultCompressedBytes = result.resultCompressedBytes,
+            resultUncompressedBytes = result.resultUncompressedBytes,
+            durationNanos = System.nanoTime() - startNanos,
+        ))
     }
 
     private suspend fun <T> withMdc(event: SnapshotChunkReadyEvent, block: suspend () -> T): T =

--- a/module-calculator/src/main/kotlin/maple/calculator/event/ChunkProcessingEvent.kt
+++ b/module-calculator/src/main/kotlin/maple/calculator/event/ChunkProcessingEvent.kt
@@ -1,0 +1,33 @@
+package maple.calculator.event
+
+import maple.calculator.model.ChunkResult
+
+sealed interface ChunkProcessingEvent {
+    val runId: String
+    val chunkId: String
+
+    data class Skipped(
+        override val runId: String,
+        override val chunkId: String,
+        val reason: String,
+    ) : ChunkProcessingEvent
+
+    data class Failed(
+        override val runId: String,
+        override val chunkId: String,
+    ) : ChunkProcessingEvent
+
+    data class Completed(
+        override val runId: String,
+        override val chunkId: String,
+        val recordCount: Int,
+        val totalItems: Int,
+        val resultCount: Int,
+        val errorCount: Int,
+        val inputCompressedBytes: Long,
+        val inputUncompressedBytes: Long,
+        val resultCompressedBytes: Long,
+        val resultUncompressedBytes: Long,
+        val durationNanos: Long,
+    ) : ChunkProcessingEvent
+}

--- a/module-calculator/src/main/kotlin/maple/calculator/metrics/CalculatorMetricsListener.kt
+++ b/module-calculator/src/main/kotlin/maple/calculator/metrics/CalculatorMetricsListener.kt
@@ -1,0 +1,44 @@
+package maple.calculator.metrics
+
+import maple.calculator.event.ChunkProcessingEvent
+import org.springframework.stereotype.Component
+import java.time.Duration
+
+@Component
+class CalculatorMetricsListener(
+    private val metrics: CalculatorMetrics,
+    private val volumeMetrics: CalculatorVolumeMetrics,
+) {
+    fun onEvent(event: ChunkProcessingEvent) {
+        when (event) {
+            is ChunkProcessingEvent.Skipped -> onSkipped(event)
+            is ChunkProcessingEvent.Failed -> onFailed(event)
+            is ChunkProcessingEvent.Completed -> onCompleted(event)
+        }
+    }
+
+    private fun onSkipped(event: ChunkProcessingEvent.Skipped) {
+        when (event.reason) {
+            "endpoint_mismatch" -> metrics.recordChunkSkippedEndpoint()
+            "source_not_found" -> metrics.recordChunkSkippedNotFound()
+            "result_exists" -> metrics.recordChunkSkippedIdempotent()
+        }
+    }
+
+    private fun onFailed(event: ChunkProcessingEvent.Failed) {
+        metrics.recordChunkFailed()
+    }
+
+    private fun onCompleted(event: ChunkProcessingEvent.Completed) {
+        metrics.timer().record(Duration.ofNanos(event.durationNanos))
+        metrics.recordChunkProcessed()
+        metrics.recordUsers(event.recordCount)
+        metrics.recordItems(event.totalItems)
+        metrics.recordCalculated(event.resultCount)
+        metrics.recordErrors(event.errorCount)
+        val durationSec = event.durationNanos / 1_000_000_000.0
+        metrics.recordChunkRates(event.recordCount, event.totalItems, durationSec)
+        volumeMetrics.recordInput(event.inputCompressedBytes, event.inputUncompressedBytes)
+        volumeMetrics.recordResult(event.resultCompressedBytes, event.resultUncompressedBytes, event.resultCount.toLong())
+    }
+}

--- a/module-calculator/src/test/kotlin/maple/calculator/CalculatorChunkProcessingCoordinatorTest.kt
+++ b/module-calculator/src/test/kotlin/maple/calculator/CalculatorChunkProcessingCoordinatorTest.kt
@@ -1,12 +1,10 @@
 package maple.calculator
 
-import io.micrometer.core.instrument.Timer
 import kotlinx.coroutines.runBlocking
-import maple.expectation.common.event.CalculatorResultChunkReadyEvent
 import maple.expectation.common.event.SnapshotChunkReadyEvent
+import maple.calculator.event.ChunkProcessingEvent
 import maple.calculator.event.KafkaResultEventPublisher
-import maple.calculator.metrics.CalculatorMetrics
-import maple.calculator.metrics.CalculatorVolumeMetrics
+import maple.calculator.metrics.CalculatorMetricsListener
 import maple.calculator.model.ChunkResult
 import maple.calculator.processor.SnapshotChunkProcessor
 import maple.calculator.storage.ObjectStorage
@@ -18,12 +16,12 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.check
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import java.time.Duration
 import java.time.Instant
 
 @ExtendWith(MockitoExtension::class)
@@ -39,20 +37,14 @@ class CalculatorChunkProcessingCoordinatorTest {
     private lateinit var objectStorage: ObjectStorage
 
     @Mock
-    private lateinit var metrics: CalculatorMetrics
-
-    @Mock
-    private lateinit var volumeMetrics: CalculatorVolumeMetrics
-
-    @Mock
-    private lateinit var chunkTimer: Timer
+    private lateinit var metricsListener: CalculatorMetricsListener
 
     private lateinit var coordinator: CalculatorChunkProcessingCoordinator
 
     @BeforeEach
     fun setUp() {
         coordinator = CalculatorChunkProcessingCoordinator(
-            chunkProcessor, resultEventPublisher, objectStorage, metrics, volumeMetrics,
+            chunkProcessor, resultEventPublisher, objectStorage, metricsListener,
         )
     }
 
@@ -88,7 +80,6 @@ class CalculatorChunkProcessingCoordinatorTest {
         whenever(objectStorage.exists(event.objectKey)).thenReturn(true)
         whenever(objectStorage.exists(coordinator.resultObjectKeyFor(event))).thenReturn(false)
         whenever(chunkProcessor.process(any(), any())).thenReturn(chunkResult())
-        whenever(metrics.timer()).thenReturn(chunkTimer)
     }
 
     @Test
@@ -98,7 +89,10 @@ class CalculatorChunkProcessingCoordinatorTest {
         coordinator.handle(event)
 
         verify(chunkProcessor, never()).process(any(), any())
-        verify(metrics).recordChunkSkippedEndpoint()
+        val captor = argumentCaptor<ChunkProcessingEvent>()
+        verify(metricsListener).onEvent(captor.capture())
+        assertThat(captor.firstValue).isInstanceOf(ChunkProcessingEvent.Skipped::class.java)
+        assertThat((captor.firstValue as ChunkProcessingEvent.Skipped).reason).isEqualTo("endpoint_mismatch")
     }
 
     @Test
@@ -109,7 +103,10 @@ class CalculatorChunkProcessingCoordinatorTest {
         coordinator.handle(event)
 
         verify(chunkProcessor, never()).process(any(), any())
-        verify(metrics).recordChunkSkippedNotFound()
+        val captor = argumentCaptor<ChunkProcessingEvent>()
+        verify(metricsListener).onEvent(captor.capture())
+        assertThat(captor.firstValue).isInstanceOf(ChunkProcessingEvent.Skipped::class.java)
+        assertThat((captor.firstValue as ChunkProcessingEvent.Skipped).reason).isEqualTo("source_not_found")
     }
 
     @Test
@@ -121,7 +118,10 @@ class CalculatorChunkProcessingCoordinatorTest {
         coordinator.handle(event)
 
         verify(chunkProcessor, never()).process(any(), any())
-        verify(metrics).recordChunkSkippedIdempotent()
+        val captor = argumentCaptor<ChunkProcessingEvent>()
+        verify(metricsListener).onEvent(captor.capture())
+        assertThat(captor.firstValue).isInstanceOf(ChunkProcessingEvent.Skipped::class.java)
+        assertThat((captor.firstValue as ChunkProcessingEvent.Skipped).reason).isEqualTo("result_exists")
         verify(resultEventPublisher).publishChunkReady(any())
     }
 
@@ -134,39 +134,34 @@ class CalculatorChunkProcessingCoordinatorTest {
 
         verify(chunkProcessor).process(any(), any())
         verify(resultEventPublisher).publishChunkReady(any())
-        verify(metrics).recordChunkProcessed()
-        verify(chunkTimer).record(any<Duration>())
+        val captor = argumentCaptor<ChunkProcessingEvent>()
+        verify(metricsListener).onEvent(captor.capture())
+        assertThat(captor.firstValue).isInstanceOf(ChunkProcessingEvent.Completed::class.java)
     }
 
     @Test
-    fun `records volume metrics on success`() = runBlocking {
+    fun `completed event contains correct volume and processing data`() = runBlocking {
         val event = testEvent()
         val result = chunkResult()
         setupHappyPath(event)
 
         coordinator.handle(event)
 
-        verify(volumeMetrics).recordInput(event.compressedBytes, event.uncompressedBytes)
-        verify(volumeMetrics).recordResult(result.resultCompressedBytes, result.resultUncompressedBytes, result.resultCount.toLong())
+        val captor = argumentCaptor<ChunkProcessingEvent>()
+        verify(metricsListener).onEvent(captor.capture())
+        val completed = captor.firstValue as ChunkProcessingEvent.Completed
+        assertThat(completed.recordCount).isEqualTo(100)
+        assertThat(completed.totalItems).isEqualTo(500)
+        assertThat(completed.resultCount).isEqualTo(480)
+        assertThat(completed.errorCount).isEqualTo(20)
+        assertThat(completed.inputCompressedBytes).isEqualTo(1000L)
+        assertThat(completed.inputUncompressedBytes).isEqualTo(5000L)
+        assertThat(completed.resultCompressedBytes).isEqualTo(2000L)
+        assertThat(completed.resultUncompressedBytes).isEqualTo(10000L)
     }
 
     @Test
-    fun `records chunk-level metrics on success`() = runBlocking {
-        val event = testEvent()
-        setupHappyPath(event)
-
-        coordinator.handle(event)
-
-        verify(metrics).recordChunkProcessed()
-        verify(metrics).recordUsers(100)
-        verify(metrics).recordItems(500)
-        verify(metrics).recordCalculated(480)
-        verify(metrics).recordErrors(20)
-        verify(metrics).recordChunkRates(any(), any(), any())
-    }
-
-    @Test
-    fun `records failure metric when processor throws`() = runBlocking {
+    fun `records failure event when processor throws`() = runBlocking {
         val event = testEvent()
         whenever(objectStorage.exists(event.objectKey)).thenReturn(true)
         whenever(objectStorage.exists(coordinator.resultObjectKeyFor(event))).thenReturn(false)
@@ -177,9 +172,10 @@ class CalculatorChunkProcessingCoordinatorTest {
         }.isInstanceOf(RuntimeException::class.java)
             .hasMessage("boom")
 
-        verify(metrics).recordChunkFailed()
+        val captor = argumentCaptor<ChunkProcessingEvent>()
+        verify(metricsListener).onEvent(captor.capture())
+        assertThat(captor.firstValue).isInstanceOf(ChunkProcessingEvent.Failed::class.java)
         verify(resultEventPublisher, never()).publishChunkReady(any())
-        verify(metrics, never()).recordChunkProcessed()
     }
 
     @Test

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/SynchronizerApplication.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/SynchronizerApplication.kt
@@ -1,6 +1,7 @@
 package maple.synchronizer
 
 import maple.expectation.infrastructure.lifecycle.ManagedLifecycleCoordinator
+import maple.synchronizer.consumer.ChunkExecutionProperties
 import maple.synchronizer.ranking.EquipmentRankingProperties
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.EnableConfigurationProperties
@@ -11,7 +12,7 @@ import org.springframework.context.annotation.Import
     "maple.synchronizer",
     "maple.expectation.infrastructure.executor",
 ])
-@EnableConfigurationProperties(EquipmentRankingProperties::class)
+@EnableConfigurationProperties(EquipmentRankingProperties::class, ChunkExecutionProperties::class)
 @Import(
     maple.expectation.infrastructure.config.ExecutorConfig::class,
     ManagedLifecycleCoordinator::class,

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/ChunkConsumerTemplate.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/ChunkConsumerTemplate.kt
@@ -11,10 +11,8 @@ import maple.synchronizer.repository.ChunkExecutionRepository
 import maple.synchronizer.repository.InsertChunkExecutionCommand
 import org.slf4j.Logger
 import org.slf4j.MDC
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.kafka.support.Acknowledgment
 import org.springframework.stereotype.Component
-import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.Executor
 import java.util.concurrent.Semaphore
@@ -24,14 +22,7 @@ class ChunkConsumerTemplate(
     private val logicExecutor: LogicExecutor,
     private val chunkExecutionRepository: ChunkExecutionRepository,
     private val metrics: SynchronizerMetrics,
-    @Value("#{T(java.time.Duration).ofSeconds(\${chunk-execution.processing-timeout-seconds:600})}")
-    private val processingTimeout: Duration = Duration.ofSeconds(600),
-    @Value("#{T(java.time.Duration).ofSeconds(\${chunk-execution.retry.base-backoff-seconds:60})}")
-    private val retryBaseBackoff: Duration = Duration.ofSeconds(60),
-    @Value("\${chunk-execution.retry.max-attempts:5}")
-    private val maxAttempts: Int = 5,
-    @Value("\${chunk-execution.retry.artifact-missing-max-attempts:2}")
-    private val artifactMissingMaxAttempts: Int = 2,
+    private val properties: ChunkExecutionProperties,
 ) {
     fun submit(request: ChunkConsumerRequest) {
         if (chunkExecutionRepository.insertPendingIfAbsent(request.toInsertCommand())) {
@@ -72,7 +63,7 @@ class ChunkConsumerTemplate(
             return
         }
 
-        val claim = chunkExecutionRepository.claimProcessing(request.identity, processingTimeout)
+        val claim = chunkExecutionRepository.claimProcessing(request.identity, properties.processingTimeout)
         if (claim == null) {
             request.processingPermit.release()
             if (state.shouldPreserveKafkaRedelivery()) {
@@ -207,7 +198,7 @@ class ChunkConsumerTemplate(
                 request.identity,
                 claim.attemptCount,
                 error,
-                Instant.now().plus(retryBaseBackoff.multipliedBy(claim.attemptCount.toLong())),
+                Instant.now().plus(properties.retryBaseBackoff.multipliedBy(claim.attemptCount.toLong())),
             )
         } else {
             chunkExecutionRepository.markFailedTerminal(
@@ -252,10 +243,10 @@ class ChunkConsumerTemplate(
         claim: ChunkExecutionClaim,
     ): FailureDecision {
         val artifactMissing = ex.message?.contains("file not found", ignoreCase = true) == true
-        if (artifactMissing && claim.attemptCount >= artifactMissingMaxAttempts) {
+        if (artifactMissing && claim.attemptCount >= properties.retry.artifactMissingMaxAttempts) {
             return FailureDecision(ARTIFACT_MISSING_MAX_ATTEMPTS)
         }
-        if (!artifactMissing && claim.attemptCount >= maxAttempts) {
+        if (!artifactMissing && claim.attemptCount >= properties.retry.maxAttempts) {
             return FailureDecision(MAX_ATTEMPTS_EXCEEDED)
         }
         return FailureDecision(terminalReason = null)

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/ChunkExecutionProperties.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/ChunkExecutionProperties.kt
@@ -1,0 +1,19 @@
+package maple.synchronizer.consumer
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import java.time.Duration
+
+@ConfigurationProperties("chunk-execution")
+data class ChunkExecutionProperties(
+    val processingTimeoutSeconds: Long = 600,
+    val retry: Retry = Retry(),
+) {
+    data class Retry(
+        val baseBackoffSeconds: Long = 60,
+        val maxAttempts: Int = 5,
+        val artifactMissingMaxAttempts: Int = 2,
+    )
+
+    val processingTimeout: Duration get() = Duration.ofSeconds(processingTimeoutSeconds)
+    val retryBaseBackoff: Duration get() = Duration.ofSeconds(retry.baseBackoffSeconds)
+}

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/ChunkLifecycleEvent.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/ChunkLifecycleEvent.kt
@@ -1,0 +1,27 @@
+package maple.synchronizer.consumer
+
+sealed interface ChunkLifecycleEvent {
+    data class Accepted(
+        val runId: String,
+        val chunkId: String,
+    ) : ChunkLifecycleEvent
+
+    data class Succeeded(
+        val runId: String,
+        val chunkId: String,
+        val compressedBytes: Long,
+        val uncompressedBytes: Long,
+        val resultCount: Long,
+        val durationNanos: Long,
+    ) : ChunkLifecycleEvent
+
+    data class Failed(
+        val runId: String,
+        val chunkId: String,
+    ) : ChunkLifecycleEvent
+
+    data class Finally(
+        val runId: String,
+        val chunkId: String,
+    ) : ChunkLifecycleEvent
+}

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/KafkaResultChunkConsumer.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/KafkaResultChunkConsumer.kt
@@ -1,17 +1,17 @@
 package maple.synchronizer.consumer
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import io.micrometer.core.instrument.Timer
 import maple.expectation.common.event.CalculatorResultChunkReadyEvent
+import maple.expectation.common.event.ChunkConsumedEvent
 import maple.expectation.common.event.ChunkExecutionIdentity
 import maple.expectation.common.event.ChunkExecutionType
 import maple.expectation.infrastructure.executor.TaskContext
 import maple.expectation.infrastructure.lifecycle.ManagedLifecycle
 import maple.synchronizer.event.KafkaChunkConsumedEventPublisher
+import maple.synchronizer.metrics.SynchronizerChunkMetricsListener
 import maple.synchronizer.metrics.SynchronizerMetrics
 import maple.synchronizer.processor.ChunkProcessInput
 import maple.synchronizer.processor.ChunkProcessor
-import maple.expectation.common.event.ChunkConsumedEvent
 import org.slf4j.LoggerFactory
 import org.springframework.kafka.annotation.KafkaListener
 import org.springframework.kafka.support.Acknowledgment
@@ -25,7 +25,7 @@ import java.util.concurrent.Semaphore
 class KafkaResultChunkConsumer(
     private val objectMapper: ObjectMapper,
     private val chunkProcessor: ChunkProcessor,
-    private val metrics: SynchronizerMetrics,
+    private val chunkMetricsListener: SynchronizerChunkMetricsListener,
     private val chunkConsumerTemplate: ChunkConsumerTemplate,
     private val consumedEventPublisher: KafkaChunkConsumedEventPublisher,
 ) : ManagedLifecycle {
@@ -56,7 +56,7 @@ class KafkaResultChunkConsumer(
         log.info("[Synchronizer] received: runId={} chunkId={} objectKey={} results={}",
             runId, chunkId, event.objectKey, event.resultCount)
 
-        var chunkSample: Timer.Sample? = null
+        var startNanos: Long = 0
         chunkConsumerTemplate.submit(
             ChunkConsumerRequest(
                 logPrefix = "Synchronizer",
@@ -83,16 +83,19 @@ class KafkaResultChunkConsumer(
                     ))
                 },
                 onAccepted = {
-                    chunkSample = Timer.start()
-                    metrics.incrementReceived()
-                    metrics.incrementProcessing()
+                    startNanos = System.nanoTime()
+                    chunkMetricsListener.onEvent(ChunkLifecycleEvent.Accepted(runId, chunkId))
                 },
                 onSuccess = {
-                    metrics.incrementProcessed()
-                    metrics.recordStatusTransition("SUCCESS")
-                    chunkSample?.stop(metrics.chunkTimer())
-                    metrics.recordChunkBytes(event.compressedBytes)
-                    recordPreUpsertVolume(event)
+                    chunkMetricsListener.onEvent(ChunkLifecycleEvent.Succeeded(
+                        runId = runId,
+                        chunkId = chunkId,
+                        compressedBytes = event.compressedBytes,
+                        uncompressedBytes = event.uncompressedBytes,
+                        resultCount = event.resultCount.toLong(),
+                        durationNanos = System.nanoTime() - startNanos,
+                    ))
+                    logPreUpsertVolume(event)
                     consumedEventPublisher.publish(ChunkConsumedEvent(
                         runId = runId,
                         endpoint = event.sourceEndpoint.ifBlank { "result" },
@@ -102,17 +105,17 @@ class KafkaResultChunkConsumer(
                     ))
                 },
                 onFailure = { ex ->
-                    metrics.incrementFailed()
-                    metrics.recordStatusTransition("FAILED")
+                    chunkMetricsListener.onEvent(ChunkLifecycleEvent.Failed(runId, chunkId))
                     log.error("[Synchronizer] chunk processing failed: runId={} chunkId={}", runId, chunkId, ex)
                 },
-                onFinally = { metrics.decrementProcessing() },
+                onFinally = {
+                    chunkMetricsListener.onEvent(ChunkLifecycleEvent.Finally(runId, chunkId))
+                },
             ),
         )
     }
 
-    private fun recordPreUpsertVolume(event: CalculatorResultChunkReadyEvent) {
-        metrics.recordPreUpsertVolume(event.compressedBytes, event.uncompressedBytes, event.resultCount.toLong())
+    private fun logPreUpsertVolume(event: CalculatorResultChunkReadyEvent) {
         val ratio = if (event.compressedBytes > 0)
             "%.2f".format(event.uncompressedBytes.toDouble() / event.compressedBytes.toDouble())
         else "N/A"

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/metrics/SynchronizerChunkMetricsListener.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/metrics/SynchronizerChunkMetricsListener.kt
@@ -1,0 +1,40 @@
+package maple.synchronizer.metrics
+
+import maple.synchronizer.consumer.ChunkLifecycleEvent
+import org.springframework.stereotype.Component
+
+@Component
+class SynchronizerChunkMetricsListener(
+    private val metrics: SynchronizerMetrics,
+) {
+    fun onEvent(event: ChunkLifecycleEvent) {
+        when (event) {
+            is ChunkLifecycleEvent.Accepted -> onAccepted(event)
+            is ChunkLifecycleEvent.Succeeded -> onSucceeded(event)
+            is ChunkLifecycleEvent.Failed -> onFailed(event)
+            is ChunkLifecycleEvent.Finally -> onFinally(event)
+        }
+    }
+
+    private fun onAccepted(event: ChunkLifecycleEvent.Accepted) {
+        metrics.incrementReceived()
+        metrics.incrementProcessing()
+    }
+
+    private fun onSucceeded(event: ChunkLifecycleEvent.Succeeded) {
+        metrics.incrementProcessed()
+        metrics.recordStatusTransition("SUCCESS")
+        metrics.chunkTimer().record(java.time.Duration.ofNanos(event.durationNanos))
+        metrics.recordChunkBytes(event.compressedBytes)
+        metrics.recordPreUpsertVolume(event.compressedBytes, event.uncompressedBytes, event.resultCount)
+    }
+
+    private fun onFailed(event: ChunkLifecycleEvent.Failed) {
+        metrics.incrementFailed()
+        metrics.recordStatusTransition("FAILED")
+    }
+
+    private fun onFinally(event: ChunkLifecycleEvent.Finally) {
+        metrics.decrementProcessing()
+    }
+}

--- a/module-synchronizer/src/test/kotlin/maple/synchronizer/consumer/ChunkConsumerMappingTest.kt
+++ b/module-synchronizer/src/test/kotlin/maple/synchronizer/consumer/ChunkConsumerMappingTest.kt
@@ -3,7 +3,7 @@ package maple.synchronizer.consumer
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import maple.expectation.common.event.ChunkExecutionType
 import maple.synchronizer.event.KafkaChunkConsumedEventPublisher
-import maple.synchronizer.metrics.SynchronizerMetrics
+import maple.synchronizer.metrics.SynchronizerChunkMetricsListener
 import maple.synchronizer.processor.ChunkProcessor
 import maple.synchronizer.repository.CharacterBasicRepository
 import maple.synchronizer.storage.BasicChunkFileReader
@@ -53,7 +53,7 @@ class ChunkConsumerMappingTest {
         val consumer = KafkaResultChunkConsumer(
             objectMapper = objectMapper,
             chunkProcessor = mock<ChunkProcessor>(),
-            metrics = mock<SynchronizerMetrics>(),
+            chunkMetricsListener = mock<SynchronizerChunkMetricsListener>(),
             chunkConsumerTemplate = template,
             consumedEventPublisher = mock<KafkaChunkConsumedEventPublisher>(),
         )

--- a/module-synchronizer/src/test/kotlin/maple/synchronizer/consumer/ChunkConsumerTemplateTest.kt
+++ b/module-synchronizer/src/test/kotlin/maple/synchronizer/consumer/ChunkConsumerTemplateTest.kt
@@ -40,10 +40,7 @@ class ChunkConsumerTemplateTest {
         logicExecutor = ImmediateLogicExecutor(),
         chunkExecutionRepository = repository,
         metrics = metrics,
-        processingTimeout = Duration.ofSeconds(600),
-        retryBaseBackoff = Duration.ofSeconds(60),
-        maxAttempts = 5,
-        artifactMissingMaxAttempts = 2,
+        properties = ChunkExecutionProperties(),
     )
 
     @Test


### PR DESCRIPTION
## Summary
- **#893**: `ChunkConsumerTemplate` 4 `@Value` → `ChunkExecutionProperties` data class (synchronizer)
- **#894**: `CalculatorChunkProcessingCoordinator` metrics → `CalculatorMetricsListener` via `ChunkProcessingEvent` sealed interface (calculator)
- **#895**: `KafkaResultChunkConsumer` metrics → `SynchronizerChunkMetricsListener` via `ChunkLifecycleEvent` sealed interface (synchronizer)

## Changes
- `ChunkExecutionProperties` — replaces 4 SpEL `@Value` with type-safe `@ConfigurationProperties`
- `ChunkProcessingEvent` — sealed interface: Skipped, Failed, Completed
- `CalculatorMetricsListener` — handles all calculator metrics via events, coordinator only orchestrates
- `ChunkLifecycleEvent` — sealed interface: Accepted, Succeeded, Failed, Finally
- `SynchronizerChunkMetricsListener` — handles all synchronizer consumer metrics via events

## Test plan
- [x] `./gradlew compileKotlin compileJava --continue` passes
- [x] `./gradlew :module-calculator:test` passes (31/31)
- [x] All non-synchronizer modules pass (`./gradlew test` excluding pre-existing broken test)
- [ ] `./gradlew :module-calculator:bootRun` runtime verification
- [ ] `./gradlew :module-synchronizer:bootRun` runtime verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)