### PR TITLE
refactor: extract VirtualThreadExecutorManager for VT executor lifecycle (PAT-1)

### DIFF
--- a/module-calculator/src/main/kotlin/maple/calculator/cleanup/InternalApiController.kt
+++ b/module-calculator/src/main/kotlin/maple/calculator/cleanup/InternalApiController.kt
@@ -4,7 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
-import java.util.concurrent.Executors
+import maple.expectation.infrastructure.lifecycle.VirtualThreadExecutorManager
 import java.util.concurrent.atomic.AtomicBoolean
 
 @RestController
@@ -12,7 +12,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 class InternalApiController(
     @Autowired(required = false) private val resultCleanup: CalculatorResultCleanupScheduler?,
 ) {
-    private val triggerExecutor = Executors.newVirtualThreadPerTaskExecutor()
+    private val exec = VirtualThreadExecutorManager("CalculatorInternalApi")
     private val resultCleanupRunning = AtomicBoolean(false)
 
     @PostMapping("/trigger/result-cleanup")
@@ -25,7 +25,7 @@ class InternalApiController(
             return ResponseEntity.status(HttpStatus.CONFLICT)
                 .body(mapOf("status" to "ALREADY_RUNNING"))
         }
-        triggerExecutor.submit {
+        exec.executor.submit {
             try {
                 resultCleanup.cleanup()
             } finally {
@@ -37,6 +37,6 @@ class InternalApiController(
 
     @jakarta.annotation.PreDestroy
     fun shutdown() {
-        triggerExecutor.close()
+        exec.shutdown()
     }
 }

--- a/module-external-api/src/main/kotlin/maple/externalapi/auth/AuthCharacterFetchConsumer.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/auth/AuthCharacterFetchConsumer.kt
@@ -12,8 +12,8 @@ import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.kafka.support.Acknowledgment
 import org.springframework.kafka.support.KafkaHeaders
 import org.springframework.messaging.handler.annotation.Header
+import maple.expectation.infrastructure.lifecycle.VirtualThreadExecutorManager
 import org.springframework.stereotype.Component
-import java.util.concurrent.Executors
 
 @Component
 class AuthCharacterFetchConsumer(
@@ -22,16 +22,11 @@ class AuthCharacterFetchConsumer(
     private val objectMapper: ObjectMapper,
     @Value("\${auth.kafka.character-fetch-response-topic}") private val responseTopic: String,
 ) {
-    private val vtExecutor = Executors.newVirtualThreadPerTaskExecutor()
+    private val exec = VirtualThreadExecutorManager("AuthCharacterFetchConsumer")
 
     @PreDestroy
     fun shutdown() {
-        vtExecutor.shutdown()
-        if (!vtExecutor.awaitTermination(5, java.util.concurrent.TimeUnit.SECONDS)) {
-            log.warn("[AuthFetch] VT executor did not terminate in 5s")
-            vtExecutor.shutdownNow()
-        }
-        log.info("[AuthFetch] VT executor shut down")
+        exec.shutdown()
     }
 
     @KafkaListener(
@@ -46,7 +41,7 @@ class AuthCharacterFetchConsumer(
         val request = objectMapper.readValue(message, CharacterFetchRequest::class.java)
         log.info("[AuthFetch] processing: eventId={}, userIgn={}", request.eventId, request.userIgn)
 
-        vtExecutor.submit {
+        exec.executor.submit {
             runCatching {
                 val characterListOpt = nexonAuthClient.getCharacterList(request.apiKey)
 

--- a/module-external-api/src/main/kotlin/maple/externalapi/runstatus/InternalApiController.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/runstatus/InternalApiController.kt
@@ -7,8 +7,8 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
+import maple.expectation.infrastructure.lifecycle.VirtualThreadExecutorManager
 import java.util.UUID
-import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicBoolean
 
 @RestController
@@ -19,7 +19,7 @@ class InternalApiController(
     @Autowired(required = false) private val artifactCleanup: ArtifactCleanupScheduler?,
     @Autowired(required = false) private val consumedCleanup: ConsumedChunkCleanupScheduler?,
 ) {
-    private val triggerExecutor = Executors.newVirtualThreadPerTaskExecutor()
+    private val exec = VirtualThreadExecutorManager("InternalApiController")
     private val artifactCleanupRunning = AtomicBoolean(false)
     private val consumedCleanupRunning = AtomicBoolean(false)
 
@@ -43,7 +43,7 @@ class InternalApiController(
         }
 
         val runId = airflowRunId ?: UUID.randomUUID().toString()
-        triggerExecutor.submit { scheduler.triggerDailyRefresh(runId) }
+        exec.executor.submit { scheduler.triggerDailyRefresh(runId) }
         return ResponseEntity.accepted().body(mapOf("status" to "STARTED", "runId" to runId))
     }
 
@@ -57,7 +57,7 @@ class InternalApiController(
             return ResponseEntity.status(HttpStatus.CONFLICT)
                 .body(mapOf("status" to "ALREADY_RUNNING"))
         }
-        triggerExecutor.submit {
+        exec.executor.submit {
             try { artifactCleanup.cleanup() } finally { artifactCleanupRunning.set(false) }
         }
         return ResponseEntity.accepted().body(mapOf("status" to "STARTED"))
@@ -73,7 +73,7 @@ class InternalApiController(
             return ResponseEntity.status(HttpStatus.CONFLICT)
                 .body(mapOf("status" to "ALREADY_RUNNING"))
         }
-        triggerExecutor.submit {
+        exec.executor.submit {
             try { consumedCleanup.cleanup() } finally { consumedCleanupRunning.set(false) }
         }
         return ResponseEntity.accepted().body(mapOf("status" to "STARTED"))
@@ -81,7 +81,7 @@ class InternalApiController(
 
     @jakarta.annotation.PreDestroy
     fun shutdown() {
-        triggerExecutor.close()
+        exec.shutdown()
     }
 }
 

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/ExternalApiScheduler.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/ExternalApiScheduler.kt
@@ -14,9 +14,9 @@ import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.context.event.EventListener
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
+import maple.expectation.infrastructure.lifecycle.VirtualThreadExecutorManager
 import java.util.UUID
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.locks.ReentrantLock
 
@@ -38,7 +38,7 @@ class ExternalApiScheduler(
     private val running = AtomicBoolean(false)
     private val shutdown = AtomicBoolean(false)
     private val itemEquipmentStarted = AtomicBoolean(false)
-    private val executor = Executors.newVirtualThreadPerTaskExecutor()
+    private val exec = VirtualThreadExecutorManager("ExternalApiScheduler")
     private val lock = ReentrantLock()
     private val idle = lock.newCondition()
 
@@ -84,7 +84,7 @@ class ExternalApiScheduler(
 
         log.info("[Scheduler] starting ranking fetch phase, runId={}", runId)
         runStatusTracker.transitionPhase(PipelinePhase.RANKING_FETCH)
-        rankingPhase.execute(executor)
+        rankingPhase.execute(exec.executor)
             .handle { runDir, ex ->
                 if (ex != null) {
                     log.error("[Scheduler] ranking fetch failed, cannot proceed with OCID lookup", ex)
@@ -96,13 +96,13 @@ class ExternalApiScheduler(
                     CompletableFuture.completedFuture(null)
                 } else {
                     runStatusTracker.transitionPhase(PipelinePhase.OCID_LOOKUP)
-                    ocidLookupPhase.execute(executor, runDir)
+                    ocidLookupPhase.execute(exec.executor, runDir)
                 }
             }
             .thenCompose {
                 val cache = ocidCacheProvider.refresh()
                 runStatusTracker.transitionPhase(PipelinePhase.CHARACTER_BASIC)
-                snapshotFetchPhase.executeCharacterBasic(executor, cache)
+                snapshotFetchPhase.executeCharacterBasic(exec.executor, cache)
             }
             .whenComplete { _, ex ->
                 if (ex != null) {
@@ -120,7 +120,7 @@ class ExternalApiScheduler(
 
     private fun startItemEquipmentLoopOnce() {
         if (itemEquipmentStarted.compareAndSet(false, true)) {
-            executor.submit { runItemEquipmentLoop() }
+            exec.executor.submit { runItemEquipmentLoop() }
         }
     }
 
@@ -138,7 +138,7 @@ class ExternalApiScheduler(
         val entries = ocidCacheProvider.current().entries.toList()
         if (entries.isEmpty()) {
             log.warn("[Scheduler] OCID cache empty, waiting 30s")
-            executor.submit {
+            exec.executor.submit {
                 Thread.sleep(java.time.Duration.ofSeconds(30))
                 ocidCacheProvider.refresh()
                 runItemEquipmentCycle()
@@ -147,7 +147,7 @@ class ExternalApiScheduler(
         }
 
         if (!acquireLock(120_000)) {
-            executor.submit {
+            exec.executor.submit {
                 Thread.sleep(java.time.Duration.ofSeconds(5))
                 runItemEquipmentCycle()
             }
@@ -155,13 +155,13 @@ class ExternalApiScheduler(
         }
 
         CompletableFuture.completedFuture(null)
-            .thenCompose { snapshotFetchPhase.executeItemEquipment(executor, entries) }
+            .thenCompose { snapshotFetchPhase.executeItemEquipment(exec.executor, entries) }
             .whenComplete { _, ex ->
                 if (ex != null) {
                     log.error("[Scheduler] ITEM_EQUIPMENT cycle failed", ex)
                 }
                 releaseLock()
-                executor.submit { runItemEquipmentCycle() }
+                exec.executor.submit { runItemEquipmentCycle() }
             }
     }
 
@@ -190,6 +190,6 @@ class ExternalApiScheduler(
     override fun stopLifecycle() {
         log.info("[Scheduler] shutdown requested")
         shutdown.set(true)
-        executor.close()
+        exec.shutdown()
     }
 }

--- a/module-external-api/src/main/kotlin/maple/externalapi/urgent/UrgentCharacterRequestConsumer.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/urgent/UrgentCharacterRequestConsumer.kt
@@ -19,9 +19,9 @@ import org.springframework.stereotype.Component
 import java.nio.file.Files
 import java.nio.file.Path
 import java.time.Instant
+import maple.expectation.infrastructure.lifecycle.VirtualThreadExecutorManager
 import java.util.UUID
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.Executors
 
 @Component
 @ConditionalOnProperty(
@@ -41,7 +41,7 @@ class UrgentCharacterRequestConsumer(
     private val storeBasePath: String,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
-    private val workerExecutor = Executors.newVirtualThreadPerTaskExecutor()
+    private val exec = VirtualThreadExecutorManager("UrgentCharacterRequestConsumer")
 
     @KafkaListener(
         topics = ["\${external-api.urgent.request-topic}"],
@@ -97,8 +97,8 @@ class UrgentCharacterRequestConsumer(
                         basicData = basicFuture.resultNow(),
                         equipmentData = equipmentFuture.resultNow(),
                     )
-                }, workerExecutor)
-        }, workerExecutor)
+                }, exec.executor)
+        }, exec.executor)
 
     private fun publishUrgentChunksAsync(
         request: UrgentCharacterRequest,
@@ -159,7 +159,7 @@ class UrgentCharacterRequestConsumer(
                 compressedBytes = stats.compressedBytes,
                 createdAt = Instant.now(),
             )
-        }, workerExecutor).thenCompose { event ->
+        }, exec.executor).thenCompose { event ->
             val eventJson = objectMapper.writeValueAsString(event)
             kafkaTemplate.send(urgentChunkReadyTopic, event.kafkaKey(), eventJson).thenAccept {
                 log.info(
@@ -186,7 +186,7 @@ class UrgentCharacterRequestConsumer(
 
     @PreDestroy
     fun close() {
-        workerExecutor.close()
+        exec.shutdown()
     }
 }
 

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/event/EventDispatcher.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/event/EventDispatcher.kt
@@ -5,15 +5,13 @@ import java.lang.reflect.Method
 import java.util.ArrayList
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executor
-import java.util.concurrent.ExecutorService
-import java.util.concurrent.Executors
-import java.util.concurrent.TimeUnit
 import maple.expectation.core.domain.event.IntegrationEvent
 import maple.expectation.error.CommonErrorCode
 import maple.expectation.error.exception.EventProcessingException
 import maple.expectation.event.EventHandler
 import maple.expectation.infrastructure.executor.LogicExecutor
 import maple.expectation.infrastructure.executor.TaskContext
+import maple.expectation.infrastructure.lifecycle.VirtualThreadExecutorManager
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
@@ -24,7 +22,8 @@ class EventDispatcher(
     @Value("\${app.event.dispatcher.async:true}") private val enableAsync: Boolean,
 ) {
     private val logger = LoggerFactory.getLogger(EventDispatcher::class.java)
-    private val virtualThreadExecutor: Executor = if (enableAsync) Executors.newVirtualThreadPerTaskExecutor() else Executor { it.run() }
+    private val exec = if (enableAsync) VirtualThreadExecutorManager("EventDispatcher") else null
+    private val virtualThreadExecutor: Executor = exec?.executor ?: Executor { it.run() }
     private val handlers: MutableMap<Class<*>, MutableList<HandlerMethod>> = ConcurrentHashMap()
 
     init {
@@ -177,14 +176,5 @@ class EventDispatcher(
     }
 
     @PreDestroy
-    fun shutdown() {
-        (virtualThreadExecutor as? ExecutorService)?.let { es ->
-            es.shutdown()
-            if (!es.awaitTermination(5, TimeUnit.SECONDS)) {
-                logger.warn("[EventDispatcher] VT executor did not terminate in 5s")
-                es.shutdownNow()
-            }
-            logger.info("[EventDispatcher] Virtual thread executor shut down")
-        }
-    }
+    fun shutdown() = exec?.shutdown()
 }

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/event/IntegrationEventConsumer.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/event/IntegrationEventConsumer.kt
@@ -2,14 +2,13 @@ package maple.expectation.infrastructure.event
 
 import io.micrometer.core.instrument.MeterRegistry
 import jakarta.annotation.PreDestroy
-import java.util.concurrent.ExecutorService
-import java.util.concurrent.Executors
 import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.Semaphore
 import java.util.concurrent.TimeUnit
 import maple.expectation.core.domain.event.IntegrationEvent
 import maple.expectation.infrastructure.executor.LogicExecutor
 import maple.expectation.infrastructure.executor.TaskContext
+import maple.expectation.infrastructure.lifecycle.VirtualThreadExecutorManager
 import org.slf4j.LoggerFactory
 
 /**
@@ -26,7 +25,7 @@ open class IntegrationEventConsumer(
 ) {
     private val logPrefix = "${priority.replaceFirstChar { it.uppercase() }}PriorityConsumer"
     private val logger = LoggerFactory.getLogger(IntegrationEventConsumer::class.java)
-    private val executor: ExecutorService = Executors.newVirtualThreadPerTaskExecutor()
+    private val exec = VirtualThreadExecutorManager("IntegrationEventConsumer")
     private val semaphore = Semaphore(maxConcurrent)
 
     fun <T> processAsync(event: IntegrationEvent<T>, handler: EventHandler<T>) {
@@ -42,7 +41,7 @@ open class IntegrationEventConsumer(
                 throw RejectedExecutionException("$priority priority event semaphore timeout")
             }
 
-            executor.execute {
+            exec.executor.execute {
                 val start = System.nanoTime()
                 logicExecutor.executeWithFinally(
                     {
@@ -73,12 +72,5 @@ open class IntegrationEventConsumer(
     }
 
     @PreDestroy
-    fun shutdown() {
-        executor.shutdown()
-        if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
-            logger.warn("[$logPrefix] VT executor did not terminate in 5s")
-            executor.shutdownNow()
-        }
-        logger.info("[$logPrefix] Executor shut down")
-    }
+    fun shutdown() = exec.shutdown()
 }

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/lifecycle/VirtualThreadExecutorManager.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/lifecycle/VirtualThreadExecutorManager.kt
@@ -1,0 +1,35 @@
+package maple.expectation.infrastructure.lifecycle
+
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import org.slf4j.LoggerFactory
+
+/**
+ * Manages virtual thread executor lifecycle with standardized shutdown.
+ *
+ * Usage:
+ * ```
+ * private val exec = VirtualThreadExecutorManager("MyComponent")
+ * // use exec.executor for task submission
+ *
+ * @PreDestroy fun shutdown() = exec.shutdown()
+ * ```
+ */
+class VirtualThreadExecutorManager(private val componentName: String) {
+    val executor: ExecutorService = Executors.newVirtualThreadPerTaskExecutor()
+
+    fun shutdown() {
+        executor.shutdown()
+        if (!executor.awaitTermination(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+            log.warn("[{}] VT executor did not terminate in {}s", componentName, SHUTDOWN_TIMEOUT_SECONDS)
+            executor.shutdownNow()
+        }
+        log.info("[{}] VT executor shut down", componentName)
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(VirtualThreadExecutorManager::class.java)
+        private const val SHUTDOWN_TIMEOUT_SECONDS = 5L
+    }
+}

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/ExternalApiWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/ExternalApiWorker.kt
@@ -7,8 +7,6 @@ import java.time.Instant
 import java.time.ZoneOffset
 import java.util.UUID
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.ExecutorService
-import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -35,6 +33,7 @@ import maple.expectation.infrastructure.external.dto.v2.EquipmentResponse
 import maple.expectation.infrastructure.job.CalculationExecutionService
 import maple.expectation.infrastructure.job.CalculationJobService
 import maple.expectation.infrastructure.lifecycle.ScheduledTaskLifecycleWrapper
+import maple.expectation.infrastructure.lifecycle.VirtualThreadExecutorManager
 import maple.expectation.infrastructure.persistence.entity.CalculationSnapshotEntity
 import maple.expectation.infrastructure.pgmq.CalculationRequestedPayload
 import maple.expectation.infrastructure.pgmq.ExternalApiJobPayload
@@ -88,16 +87,13 @@ class ExternalApiWorker(
     @Value("\${app.slow-task.step-trace.threshold-ms:500}") private val stepTraceThresholdMs: Long,
 ) : PgmqWorker<ExternalApiJobPayload>(pgmqClient, executor, workerConfig, meterRegistry, queueMetrics, lifecycleWrapper) {
 
-    private val snapshotWriter: ExecutorService = Executors.newVirtualThreadPerTaskExecutor()
-
-    private val apiCallPool: ExecutorService = Executors.newVirtualThreadPerTaskExecutor()
+    private val snapshotExec = VirtualThreadExecutorManager("ExternalApiWorker-snapshot")
+    private val apiCallExec = VirtualThreadExecutorManager("ExternalApiWorker-apiCall")
 
     @PreDestroy
     fun shutdownExecutors() {
-        snapshotWriter.shutdown()
-        apiCallPool.shutdown()
-        snapshotWriter.awaitTermination(5, TimeUnit.SECONDS)
-        apiCallPool.awaitTermination(5, TimeUnit.SECONDS)
+        snapshotExec.shutdown()
+        apiCallExec.shutdown()
     }
 
     override val queueName: String = QueueNames.EXTERNAL_API
@@ -204,7 +200,7 @@ class ExternalApiWorker(
                 stage("SnapshotPut", jobId.toString()) {
                     snapshotStore.put(snapshot, snapshotData)
                 }
-            }, snapshotWriter)
+            }, snapshotExec.executor)
 
             // Step 4: Build and persist calculation input
             val inputItems = stage("BuildCalculationInput", payload.userIgn) {
@@ -390,7 +386,7 @@ class ExternalApiWorker(
                 CompletableFuture.supplyAsync({
                     log.debug("[VT] API call on virtual thread: isVirtual={}", Thread.currentThread().isVirtual)
                     Pair(ocid, equipmentFetchProvider.fetchWithCache(ocid))
-                }, apiCallPool)
+                }, apiCallExec.executor)
             }
             .orTimeout(15, TimeUnit.SECONDS)
             .join()

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/BasicSnapshotChunkConsumer.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/BasicSnapshotChunkConsumer.kt
@@ -19,7 +19,7 @@ import org.springframework.kafka.support.Acknowledgment
 import org.springframework.kafka.support.KafkaHeaders
 import org.springframework.messaging.handler.annotation.Header
 import org.springframework.stereotype.Component
-import java.util.concurrent.Executors
+import maple.expectation.infrastructure.lifecycle.VirtualThreadExecutorManager
 import java.util.concurrent.Semaphore
 
 @Component
@@ -32,7 +32,7 @@ class BasicSnapshotChunkConsumer(
     private val consumedEventPublisher: KafkaChunkConsumedEventPublisher,
 ) : ManagedLifecycle {
     private val log = LoggerFactory.getLogger(javaClass)
-    private val vtExecutor = Executors.newVirtualThreadPerTaskExecutor()
+    private val exec = VirtualThreadExecutorManager("BasicSnapshotChunkConsumer")
     private val processingPermit = Semaphore(2)
 
     @KafkaListener(
@@ -118,7 +118,7 @@ class BasicSnapshotChunkConsumer(
                 objectKey = event.objectKey,
                 acknowledgment = acknowledgment,
                 processingPermit = processingPermit,
-                executor = vtExecutor,
+                executor = exec.executor,
                 processContext = TaskContext.of("BasicSync", "${operation}Process", chunkId),
                 lifecycleContext = TaskContext.of("BasicSync", "${operation}Lifecycle", chunkId),
                 process = {
@@ -168,6 +168,6 @@ class BasicSnapshotChunkConsumer(
     override val lifecyclePhase: Int = 100
 
     override fun stopLifecycle() {
-        vtExecutor.close()
+        exec.shutdown()
     }
 }

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/KafkaResultChunkConsumer.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/KafkaResultChunkConsumer.kt
@@ -18,7 +18,7 @@ import org.springframework.kafka.support.Acknowledgment
 import org.springframework.kafka.support.KafkaHeaders
 import org.springframework.messaging.handler.annotation.Header
 import org.springframework.stereotype.Component
-import java.util.concurrent.Executors
+import maple.expectation.infrastructure.lifecycle.VirtualThreadExecutorManager
 import java.util.concurrent.Semaphore
 
 @Component
@@ -30,7 +30,7 @@ class KafkaResultChunkConsumer(
     private val consumedEventPublisher: KafkaChunkConsumedEventPublisher,
 ) : ManagedLifecycle {
     private val log = LoggerFactory.getLogger(KafkaResultChunkConsumer::class.java)
-    private val vtExecutor = Executors.newVirtualThreadPerTaskExecutor()
+    private val exec = VirtualThreadExecutorManager("KafkaResultChunkConsumer")
     private val processingPermit = Semaphore(2)
 
     @KafkaListener(
@@ -70,7 +70,7 @@ class KafkaResultChunkConsumer(
                 objectKey = event.objectKey,
                 acknowledgment = acknowledgment,
                 processingPermit = processingPermit,
-                executor = vtExecutor,
+                executor = exec.executor,
                 processContext = TaskContext.of("Synchronizer", "ChunkProcess", chunkId),
                 lifecycleContext = TaskContext.of("Synchronizer", "ChunkLifecycle", chunkId),
                 mdcValues = mapOf("kafkaTopic" to (topic ?: event.eventType)),
@@ -129,6 +129,6 @@ class KafkaResultChunkConsumer(
     override val lifecyclePhase: Int = 100
 
     override fun stopLifecycle() {
-        vtExecutor.close()
+        exec.shutdown()
     }
 }


### PR DESCRIPTION
## Summary
- New `VirtualThreadExecutorManager` utility — creates VT executor + standardized shutdown (5s timeout, shutdownNow fallback, logging)
- Applied to 10 files across 4 modules: `module-infra`, `module-external-api`, `module-calculator`, `module-synchronizer`
- Future shutdown behavior changes only need one file edit instead of 10+

## Files changed
- `IntegrationEventConsumer` (infra)
- `EventDispatcher` (infra)
- `ExternalApiWorker` (infra — 2 executors)
- `InternalApiController` (external-api)
- `ExternalApiScheduler` (external-api)
- `UrgentCharacterRequestConsumer` (external-api)
- `AuthCharacterFetchConsumer` (external-api)
- `InternalApiController` (calculator)
- `BasicSnapshotChunkConsumer` (synchronizer)
- `KafkaResultChunkConsumer` (synchronizer)

## Test plan
- [x] `./gradlew compileKotlin compileJava --continue` passes
- [x] `./gradlew test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)