### PR TITLE
fix: add @PreDestroy executor lifecycle to 5 components

### DIFF
--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/admission/AdaptiveAdmissionControl.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/admission/AdaptiveAdmissionControl.kt
@@ -12,6 +12,7 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Semaphore
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
+import jakarta.annotation.PreDestroy
 import maple.expectation.infrastructure.config.GlobalAdmissionProperties
 import maple.expectation.infrastructure.executor.LogicExecutor
 import maple.expectation.infrastructure.executor.TaskContext
@@ -56,6 +57,9 @@ class AdaptiveAdmissionControl(
     // 🔥 REAL BOUNDED QUEUE
     private val admissionQueue: BlockingQueue<AdmissionRequest<*>> =
         ArrayBlockingQueue(properties.maxQueueSize)
+
+    // CPU monitor executor (promoted from local for lifecycle management)
+    private var cpuMonitorExecutor: java.util.concurrent.ScheduledExecutorService? = null
 
     // Metrics
     private val queueTimeoutCounter: Counter
@@ -177,13 +181,14 @@ class AdaptiveAdmissionControl(
      * 🔥 CPU MONITOR: Adjust admission limits based on CPU load
      */
     private fun startCpuMonitor() {
-        val cpuMonitorExecutor = java.util.concurrent.Executors.newSingleThreadScheduledExecutor { runnable ->
+        val executor = java.util.concurrent.Executors.newSingleThreadScheduledExecutor { runnable ->
             Thread.ofVirtual().name("adaptive-admission-cpu-monitor").unstarted(runnable)
         }
+        cpuMonitorExecutor = executor
 
-        cpuMonitorExecutor.scheduleAtFixedRate(
+        executor.scheduleAtFixedRate(
             {
-                executor.executeVoid(
+                this.executor.executeVoid(
                     { adjustLimitsBasedOnCpu() },
                     TaskContext.of("AdaptiveAdmissionControl", "CpuMonitor"),
                 )
@@ -320,6 +325,18 @@ class AdaptiveAdmissionControl(
             },
             TaskContext.of("AdaptiveAdmissionControl", "Execute", request.key),
         )
+    }
+
+    @PreDestroy
+    fun shutdown() {
+        cpuMonitorExecutor?.let { executor ->
+            log.info("[AdaptiveAdmissionControl] Shutting down CPU monitor")
+            executor.shutdown()
+            if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+                log.warn("[AdaptiveAdmissionControl] CPU monitor did not terminate in 5s, forcing")
+                executor.shutdownNow()
+            }
+        }
     }
 
     data class AdmissionRequest<T>(

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/admission/SimpleAdmissionControl.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/admission/SimpleAdmissionControl.kt
@@ -10,6 +10,7 @@ import java.util.concurrent.Executors
 import java.util.concurrent.Semaphore
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
+import jakarta.annotation.PreDestroy
 import maple.expectation.infrastructure.executor.LogicExecutor
 import maple.expectation.infrastructure.executor.TaskContext
 import org.slf4j.LoggerFactory
@@ -168,6 +169,7 @@ class SimpleAdmissionControl(
     /**
      * 🔥 SHUTDOWN: Graceful shutdown
      */
+    @PreDestroy
     fun shutdown() {
         log.info("[SimpleAdmissionControl] Shutting down...")
         workerPool.shutdown()

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/bulk/BulkLoaderService.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/bulk/BulkLoaderService.kt
@@ -17,6 +17,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.locks.LockSupport
+import jakarta.annotation.PreDestroy
 import maple.expectation.core.port.out.CacheWarmupPort
 import maple.expectation.infrastructure.buffer.ExpectationWriteBackBuffer
 import maple.expectation.infrastructure.cache.tiered.PostgresL2CacheStrategy
@@ -69,10 +70,11 @@ class BulkLoaderService(
         private const val BACKPRESSURE_THRESHOLD = 1000
         private const val PROGRESS_LOG_INTERVAL = 100
         private const val CHECKPOINT_INTERVAL = 500
+    }
 
-        // Bounded executor for bulk loading - prevents ForkJoinPool exhaustion
-        // 10 threads: matches semaphore permits to avoid Nexon API rate limiting
-        private val BULK_EXECUTOR: ExecutorService = Executors.newFixedThreadPool(10)
+    // Bounded executor for bulk loading - prevents ForkJoinPool exhaustion
+    private val bulkExecutor: ExecutorService = Executors.newFixedThreadPool(10) { runnable ->
+        Thread.ofVirtual().name("bulk-loader").unstarted(runnable)
     }
 
     // State
@@ -271,7 +273,7 @@ class BulkLoaderService(
                 } finally {
                     semaphore.release()
                 }
-            }, BULK_EXECUTOR) // Use bounded executor instead of ForkJoinPool
+            }, bulkExecutor) // Use bounded executor instead of ForkJoinPool
             futures.add(future)
         }
 
@@ -489,6 +491,16 @@ class BulkLoaderService(
                 0
             },
         )
+    }
+
+    @PreDestroy
+    fun shutdown() {
+        log.info("[BulkLoaderService] Shutting down bulk executor")
+        bulkExecutor.shutdown()
+        if (!bulkExecutor.awaitTermination(5, TimeUnit.SECONDS)) {
+            log.warn("[BulkLoaderService] Executor did not terminate in 5s, forcing")
+            bulkExecutor.shutdownNow()
+        }
     }
 
     fun stop() {

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/cache/TieredCache.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/cache/TieredCache.kt
@@ -285,6 +285,12 @@ class TieredCache(
 
     fun getCurrentVersion(): Long = versionCounter.get()
 
+    /** Shutdown batch buffers (called by TieredCacheManager @PreDestroy) */
+    fun shutdown() {
+        batchBuffer?.let { BatchL2LookupBuffer.shutdown() }
+        writeBuffer?.let { BatchL2WriteBuffer.shutdown() }
+    }
+
     override fun <T : Any?> get(key: Any, type: Class<T>?): T? {
         val wrapper = get(key)
         @Suppress("UNCHECKED_CAST")

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/cache/TieredCacheManager.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/cache/TieredCacheManager.kt
@@ -3,6 +3,7 @@ package maple.expectation.infrastructure.cache
 import io.micrometer.core.instrument.MeterRegistry
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicReference
+import jakarta.annotation.PreDestroy
 import java.util.function.Consumer
 import maple.expectation.infrastructure.cache.invalidation.CacheInvalidationEvent
 import maple.expectation.infrastructure.executor.LogicExecutor
@@ -180,5 +181,13 @@ class TieredCacheManager(
 
     fun clearKeyVersion(cacheName: String, key: Any) {
         (getCache(cacheName) as? TieredCache)?.clearKeyVersion(key)
+    }
+
+    @PreDestroy
+    fun shutdown() {
+        log.info("[TieredCacheManager] Shutting down batch buffers for {} caches", cachePool.size)
+        cachePool.values.forEach { cache ->
+            (cache as? TieredCache)?.shutdown()
+        }
     }
 }

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/cache/tiered/BatchL2LookupBuffer.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/cache/tiered/BatchL2LookupBuffer.kt
@@ -42,6 +42,13 @@ class BatchL2LookupBuffer(
     companion object {
         private val log = LoggerFactory.getLogger(BatchL2LookupBuffer::class.java)
         private val sharedScheduler = Executors.newSingleThreadScheduledExecutor { Thread(it, "batch-l2-flush") }
+
+        fun shutdown() {
+            sharedScheduler.shutdown()
+            if (!sharedScheduler.awaitTermination(5, TimeUnit.SECONDS)) {
+                sharedScheduler.shutdownNow()
+            }
+        }
     }
 
     private data class PendingRequest(

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/cache/tiered/BatchL2WriteBuffer.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/cache/tiered/BatchL2WriteBuffer.kt
@@ -44,6 +44,13 @@ class BatchL2WriteBuffer(
     companion object {
         private val log = LoggerFactory.getLogger(BatchL2WriteBuffer::class.java)
         private val sharedScheduler = Executors.newSingleThreadScheduledExecutor { Thread(it, "batch-l2-write") }
+
+        fun shutdown() {
+            sharedScheduler.shutdown()
+            if (!sharedScheduler.awaitTermination(5, TimeUnit.SECONDS)) {
+                sharedScheduler.shutdownNow()
+            }
+        }
     }
 
     private data class PendingWrite(


### PR DESCRIPTION
## Summary

Add `@PreDestroy` shutdown lifecycle to 5 components that create inline executors without cleanup.

**Problem:** 5 components create `ExecutorService`/`ScheduledExecutorService` inline but never shut them down. On Spring context teardown, threads leak.

**Fix:**
1. `BulkLoaderService` — companion static → instance field + `@PreDestroy`
2. `SimpleAdmissionControl` — `@PreDestroy` on existing `shutdown()`
3. `AdaptiveAdmissionControl` — promote local `cpuMonitorExecutor` to instance field + `@PreDestroy`
4. `BatchL2LookupBuffer` — companion `sharedScheduler` shutdown via `TieredCacheManager`
5. `BatchL2WriteBuffer` — companion `sharedScheduler` shutdown via `TieredCacheManager`

**Verified (no changes):**
- `CharacterCreationListener` — `@PreDestroy` already correct
- `PostgresNotifySubscriber` — `@PreDestroy` already correct

## Files Changed
- 7 files in `module-infra`

## Test Plan
- [x] `./gradlew :module-infra:compileKotlin` passes
- [ ] Runtime verification on server

Closes #1097

🤖 Generated with [Claude Code](https://claude.com/claude-code)