### PR TITLE
fix: TieredCache keyVersions memory leak + PgmqWorker shutdown drain

### DIFF
--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/cache/TieredCache.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/cache/TieredCache.kt
@@ -4,7 +4,7 @@ import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.MeterRegistry
 import java.util.Optional
 import java.util.concurrent.Callable
-import java.util.concurrent.ConcurrentHashMap
+import com.github.benmanes.caffeine.cache.Caffeine
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.locks.LockSupport
@@ -51,7 +51,10 @@ class TieredCache(
     }
 
     private val versionCounter = AtomicLong(0)
-    private val keyVersions = ConcurrentHashMap<Any, Long>()
+    private val keyVersions = Caffeine.newBuilder()
+        .expireAfterAccess(10, TimeUnit.MINUTES)
+        .maximumSize(10_000)
+        .build<Any, Long>()
 
     private val l1HitCounter: Counter
     private val l2HitCounter: Counter
@@ -119,7 +122,7 @@ class TieredCache(
         if (buffer != null) {
             val value = buffer.submit(key).join()
             return if (value != null) {
-                keyVersions[key] = versionCounter.incrementAndGet()
+                keyVersions.put(key, versionCounter.incrementAndGet())
                 l2HitCounter.increment()
                 SimpleValueWrapper(value)
             } else {
@@ -129,7 +132,7 @@ class TieredCache(
         return Optional.ofNullable(l2.get(key))
             .map { w ->
                 l1.put(key, w.get())
-                keyVersions[key] = versionCounter.incrementAndGet()
+                keyVersions.put(key, versionCounter.incrementAndGet())
                 tapCacheHit(w, "L2")
             }
             .orElseGet { null }
@@ -146,7 +149,7 @@ class TieredCache(
         if (buffer != null) {
             buffer.submit(key, value)
             val ver = versionCounter.incrementAndGet()
-            keyVersions[key] = ver
+            keyVersions.put(key, ver)
             publishEvictEvent(key, ver)
             return
         }
@@ -157,7 +160,7 @@ class TieredCache(
         if (l2Success) {
             executor.executeVoid({ l1.put(key, value) }, context)
             val ver = versionCounter.incrementAndGet()
-            keyVersions[key] = ver
+            keyVersions.put(key, ver)
             publishEvictEvent(key, ver)
         } else {
             log.warn("[TieredCache] L2 put failed, skipping L1 for consistency: key={}", key)
@@ -181,7 +184,7 @@ class TieredCache(
             l2FailureCounter.increment()
         }
         executor.executeVoid({ l1.evict(key) }, context)
-        keyVersions.remove(key)
+        keyVersions.invalidate(key)
         publishEvictEvent(key, versionCounter.incrementAndGet())
     }
 
@@ -201,7 +204,7 @@ class TieredCache(
             l2FailureCounter.increment()
         }
         executor.executeVoid({ l1.clear() }, context)
-        keyVersions.clear()
+        keyVersions.invalidateAll()
         publishClearAllEvent()
     }
 
@@ -274,14 +277,14 @@ class TieredCache(
     }
 
     fun clearKeyVersions() {
-        keyVersions.clear()
+        keyVersions.invalidateAll()
     }
 
     fun clearKeyVersion(key: Any) {
-        keyVersions.remove(key)
+        keyVersions.invalidate(key)
     }
 
-    fun getKeyVersion(key: Any): Long? = keyVersions[key]
+    fun getKeyVersion(key: Any): Long? = keyVersions.getIfPresent(key)
 
     fun getCurrentVersion(): Long = versionCounter.get()
 

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/PgmqWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/PgmqWorker.kt
@@ -474,6 +474,18 @@ abstract class PgmqWorker<T : Any>(
             log.warn("[{}] Shutdown with {} messages in buffer, forcing flush", queueName, accumulationBuffer.size())
             flushSequentialBatch()
         }
+
+        // Drain pipeline buffer — Phase 1 results that are buffered but not yet persisted
+        val remaining = pipelineBuffer.drain(pipelineBuffer.size())
+        if (remaining.isNotEmpty()) {
+            log.warn("[{}] Shutdown with {} items in pipeline buffer, draining", queueName, remaining.size)
+            executor.executeOrDefault(
+                { batchWrite(remaining); true },
+                false,
+                TaskContext.of(queueName, "PipelineBufferDrain"),
+            )
+        }
+
         log.info("[{}] Shutting down worker pool", queueName)
         workerPool.shutdown()
         if (!workerPool.awaitTermination(5, TimeUnit.SECONDS)) {


### PR DESCRIPTION
## Summary

Fix TieredCache `keyVersions` unbounded memory leak and PgmqWorker shutdown data loss.

### Part A: TieredCache keyVersions leak
**Problem:** `keyVersions: ConcurrentHashMap<Any, Long>()` grows without bound. Entries added on every `put()` and `getFromL2WithBackfill()` but only removed on explicit `evict()`.

**Fix:** Replace `ConcurrentHashMap` with Caffeine cache (`expireAfterAccess(10min)`, `maximumSize(10k)`). Auto-evicts stale entries.

### Part B: PgmqWorker shutdown drain
**Problem:** `@PreDestroy` flushes `accumulationBuffer` but not `pipelineBuffer`. In-flight Phase 1 results in the pipeline buffer are lost on shutdown.

**Fix:** Drain `pipelineBuffer` before `workerPool.shutdown()` and persist via `batchWrite()` through `LogicExecutor`.

## Files Changed
- `TieredCache.kt` — ConcurrentHashMap → Caffeine cache
- `PgmqWorker.kt` — pipelineBuffer drain on shutdown

## Test Plan
- [x] `./gradlew :module-infra:compileKotlin` passes
- [ ] Runtime verification on server

Closes #877

🤖 Generated with [Claude Code](https://claude.com/claude-code)