### PR TITLE
fix: Blocking-in-async — Discord subscribe, TieredCache/SingleFlight/AuthClient timeout

### DIFF
--- a/docs/01_ADR/ADR-blocking-in-async-timeout.md
+++ b/docs/01_ADR/ADR-blocking-in-async-timeout.md
@@ -1,0 +1,90 @@
+# ADR: Blocking-in-async 타임아웃 및 비동기 전환
+
+- Status: Accepted
+- Date: 2026-06-04
+- Owner: zbnerd
+
+---
+
+## 1. Background / Problem
+
+### Background
+
+- 비동기 코드 4곳에서 동기 blocking 발생 (.join(), .block())
+- 무한 대기로 인한 스레드 고갈 위험
+- 에러 핸들링 경로 블로킹으로 알림 지연
+
+### Problem
+
+- TieredCache: `buffer.submit(key).join()` 무한 대기
+- PostgresSingleFlightStrategy: `executeAsync(...).join()` 무한 대기
+- RealNexonAuthClient: WebClient `.block()` 무한 대기
+- DiscordAlertChannel: WebClient `.block()` 동기 대기
+
+### Goal
+
+- 각 위치에 적절한 타임아웃 또는 비동기 전환으로 무한 대기 방지
+
+---
+
+## 2. Decision
+
+> Discord: fire-and-forget subscribe(). 나머지: 타임아웃 추가.
+
+```text
+DiscordAlertChannel: .block() → .subscribe() (fire-and-forget)
+PostgresSingleFlightStrategy: .join() → .orTimeout(10s).join()
+RealNexonAuthClient: .block() → .block(Duration(5s))
+TieredCache: .join() → .orTimeout(5s).join() + fallback
+```
+
+---
+
+## 3. Trade-offs
+
+### Sensitivity
+
+* 외부 API 응답 시간 (Nexon, Discord webhook)
+* L2 캐시 batch buffer flush 주기
+* SingleFlight 리더 실행 시간
+
+### Trade-off
+
+| 선택 | 얻는 것 | 포기한 것 |
+| -- | ---- | ----- |
+| Discord subscribe() | non-blocking, 스레드 해제 | 전송 성공/실패 즉시 확인 불가 |
+| TieredCache orTimeout | 무한 대기 방지 + fallback | 타임아웃 내 미처리 시 direct L2 조회 |
+| SingleFlight orTimeout | 무한 대기 방지 | 타임아웃 시 예외 전파 |
+| RealNexonAuthClient block(Duration) | 무한 대기 방지 | 여전히 blocking (호출자 동기 제약) |
+
+### Risk
+
+* TieredCache fallback 시 batch 이점 상실 (개별 L2 조회)
+* SingleFlight 타임아웃 10초가 짧을 수 있음 (외부 API 지연 시)
+
+### Non-Risk
+
+* Discord subscribe() 콜백 기반 에러 로깅으로 관측성 유지
+* Spring Cache/SingleFlight 인터페이스 변경 없음
+
+---
+
+## 4. Result / Evidence
+
+### Metrics
+
+| Metric | Value | Notes |
+| ------ | ----: | ----- |
+| TieredCache timeout | 5s | batch buffer 타임아웃 |
+| SingleFlight timeout | 10s | DEFAULT_TIMEOUT 정렬 |
+| RealNexonAuthClient timeout | 5s | WebClient block 타임아웃 |
+
+### Observed Result
+
+* 컴파일 통과, 기존 테스트 통과 확인
+
+---
+
+## 5. Summary
+
+> Discord fire-and-forget + 나머지 3곳 타임아웃으로 무한 대기 방지. Spring Cache/SingleFlight 동기 API 제약으로 .join() 잔존 — ADR 정당화.

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/alert/channel/DiscordAlertChannel.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/alert/channel/DiscordAlertChannel.kt
@@ -3,13 +3,10 @@ package maple.expectation.infrastructure.alert.channel
 import maple.expectation.infrastructure.alert.factory.MessageFactory
 import maple.expectation.infrastructure.alert.message.AlertMessage
 import maple.expectation.infrastructure.config.AlertFeatureProperties
-import maple.expectation.infrastructure.executor.LogicExecutor
-import maple.expectation.infrastructure.executor.TaskContext
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.http.MediaType
-import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientRequestException
@@ -49,7 +46,6 @@ import org.springframework.web.reactive.function.client.WebClientRequestExceptio
 )
 class DiscordAlertChannel(
     @Qualifier("alertWebClient") private val alertWebClient: WebClient,
-    private val executor: LogicExecutor,
     private val alertFeatureProperties: AlertFeatureProperties,
     private val messageFactory: MessageFactory,
 ) : AlertChannel {
@@ -63,63 +59,45 @@ class DiscordAlertChannel(
             return false
         }
 
-        return executor.executeWithFallback(
-            { sendToDiscord(message) },
-            { e -> handleWebClientException(message, e) },
-            TaskContext.of("AlertChannel", "Discord", message.getTitle()),
-        )
+        sendToDiscord(message)
+        return true // fire-and-forget
     }
 
     /**
-     * Send alert to Discord webhook.
+     * Send alert to Discord webhook (fire-and-forget).
      *
-     * <p>Wrapped by LogicExecutor.executeWithFallback() which handles WebClientRequestException with
-     * logging and returns false.
-     *
-     * <p>ADR-039 Fix: Added {@code ContentType.APPLICATION_JSON} to match Discord webhook wire
-     * format.
+     * Uses .subscribe() for non-blocking async publish.
+     * Success/failure handled via subscribe callbacks.
      */
-    private fun sendToDiscord(message: AlertMessage): Boolean {
-        val response: ResponseEntity<Void>? = alertWebClient
+    private fun sendToDiscord(message: AlertMessage) {
+        alertWebClient
             .post()
             .uri(message.getWebhookUrl())
-            .contentType(MediaType.APPLICATION_JSON) // ADR-039 Fix
+            .contentType(MediaType.APPLICATION_JSON)
             .bodyValue(messageFactory.toDiscordPayload(message))
             .retrieve()
             .toBodilessEntity()
-            .block()
-
-        val success = response?.statusCode?.is2xxSuccessful == true
-
-        if (success && log.isInfoEnabled) {
-            log.info(
-                "[DiscordAlertChannel] Alert sent successfully to {}: {}",
-                message.getTitle(),
-                response.statusCode,
+            .subscribe(
+                { response ->
+                    if (response.statusCode.is2xxSuccessful) {
+                        log.info("[DiscordAlertChannel] Alert sent successfully to {}: {}", message.getTitle(), response.statusCode)
+                    } else {
+                        log.warn("[DiscordAlertChannel] Alert failed with status {}: {}", message.getTitle(), response.statusCode)
+                    }
+                },
+                { error -> handleWebClientException(message, error) },
             )
-        } else if (!success && log.isWarnEnabled) {
-            log.warn(
-                "[DiscordAlertChannel] Alert failed with status {}: {}",
-                message.getTitle(),
-                response?.statusCode,
-            )
-        }
-
-        return success
     }
 
     /**
-     * Recovery handler for WebClient exceptions.
-     *
-     * <p>Called by LogicExecutor.executeWithFallback() when an exception occurs.
+     * Error handler for Discord webhook failures.
      */
-    private fun handleWebClientException(message: AlertMessage, e: Throwable): Boolean {
+    private fun handleWebClientException(message: AlertMessage, e: Throwable) {
         if (e is WebClientRequestException) {
             log.warn("[DiscordAlertChannel] Discord webhook request failed: {}", e.message)
         } else {
             log.error("[DiscordAlertChannel] Unexpected error sending alert: {}", e.message, e)
         }
-        return false
     }
 
     override fun getChannelName(): String = "discord"

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/cache/TieredCache.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/cache/TieredCache.kt
@@ -120,7 +120,23 @@ class TieredCache(
     private fun getFromL2WithBackfill(key: Any): ValueWrapper? {
         val buffer = batchBuffer
         if (buffer != null) {
-            val value = buffer.submit(key).join()
+            val value = try {
+                buffer.submit(key)
+                    .orTimeout(5, java.util.concurrent.TimeUnit.SECONDS)
+                    .join()
+            } catch (ex: java.util.concurrent.CompletionException) {
+                if (ex.cause is java.util.concurrent.TimeoutException) {
+                    log.warn("[TieredCache] L2 buffer timeout, falling back to direct lookup: key={}", key)
+                    return Optional.ofNullable(l2.get(key))
+                        .map { w ->
+                            l1.put(key, w.get())
+                            keyVersions.put(key, versionCounter.incrementAndGet())
+                            tapCacheHit(w, "L2")
+                        }
+                        .orElseGet { null }
+                }
+                throw ex
+            }
             return if (value != null) {
                 keyVersions.put(key, versionCounter.incrementAndGet())
                 l2HitCounter.increment()

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/concurrency/PostgresSingleFlightStrategy.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/concurrency/PostgresSingleFlightStrategy.kt
@@ -2,6 +2,7 @@ package maple.expectation.infrastructure.concurrency
 
 import java.time.Duration
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executor
 import java.util.concurrent.TimeUnit
@@ -69,7 +70,19 @@ class PostgresSingleFlightStrategy(
     /** Completed result cache for followers (short-lived, ~30s). */
     private val resultCache = ConcurrentHashMap<String, CompletableFuture<Any>>()
 
-    override fun <T> execute(key: String, supplier: Supplier<T>): T = executeAsync(key) { CompletableFuture.supplyAsync(supplier, taskExecutor) }.join()
+    override fun <T> execute(key: String, supplier: Supplier<T>): T {
+        return try {
+            executeAsync(key) { CompletableFuture.supplyAsync(supplier, taskExecutor) }
+                .orTimeout(DEFAULT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)
+                .join()
+        } catch (ex: CompletionException) {
+            if (ex.cause is TimeoutException) {
+                log.warn("[SingleFlight] Timeout waiting for result: key={}", maskKey(key))
+                throw ex
+            }
+            throw ex
+        }
+    }
 
     override fun <T> executeAsync(key: String, asyncSupplier: Supplier<CompletableFuture<T>>): CompletableFuture<T> {
         val context = TaskContext.of("SingleFlight", "Execute", key)

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/external/impl/RealNexonAuthClient.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/external/impl/RealNexonAuthClient.kt
@@ -92,7 +92,7 @@ class RealNexonAuthClient(
                 Mono.error(ex)
             }
             .timeout(timeoutProperties.apiCall)
-            .block()
+            .block(java.time.Duration.ofSeconds(5))
 
         return Optional.ofNullable(response)
             .filter { r -> r.accountList != null && requireNotNull(r.accountList).isNotEmpty() }


### PR DESCRIPTION
## Summary

Closes #1109

4개 위치 blocking 패턴 수정:

| 위치 | 변경 | 타임아웃 |
|------|------|----------|
| DiscordAlertChannel | `.block()` → `.subscribe()` fire-and-forget | N/A |
| PostgresSingleFlightStrategy | `.join()` → `.orTimeout(10s).join()` | 10s |
| RealNexonAuthClient | `.block()` → `.block(Duration(5s))` | 5s |
| TieredCache | `.join()` → `.orTimeout(5s).join()` + fallback | 5s |

## 설계 결정

- **DiscordAlertChannel**: LogicExecutor 래핑 제거, `.subscribe()` 콜백으로 에러 핸들링 (fire-and-forget)
- **SingleFlight/TieredCache**: Spring Cache/SingleFlightStrategy 동기 API 제약으로 `.join()` 잔존 — `.orTimeout()` + ADR 정당화
- **RealNexonAuthClient**: 호출자 2곳 모두 동기 결과 필요하여 `.block()` 유지 — 타임아웃만 추가

## ADR

`docs/01_ADR/ADR-blocking-in-async-timeout.md`

## Test

- `./gradlew compileKotlin compileJava --continue` ✅
- `./gradlew test` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)