### PR TITLE
arch(#1068): VT ExecutorManager inline → @Bean injection

### DIFF
--- a/module-external-api/src/main/kotlin/maple/externalapi/ExternalApiApplication.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/ExternalApiApplication.kt
@@ -29,6 +29,7 @@ import org.springframework.scheduling.annotation.EnableScheduling
 )
 @Import(
     maple.expectation.infrastructure.config.CoreExecutorConfig::class,
+    maple.expectation.infrastructure.config.VtExecutorConfig::class,
     MaplestoryApiConfig::class,
     ExternalApiMetricsFilter::class,
     RealNexonAuthClient::class,

--- a/module-external-api/src/main/kotlin/maple/externalapi/auth/AuthCharacterFetchConsumer.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/auth/AuthCharacterFetchConsumer.kt
@@ -1,19 +1,19 @@
 package maple.externalapi.auth
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import jakarta.annotation.PreDestroy
 import maple.expectation.core.auth.event.CharacterFetchResponse
 import maple.expectation.core.auth.event.CharacterFetchRequest
 import maple.expectation.infrastructure.external.NexonAuthClient
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.kafka.annotation.KafkaListener
 import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.kafka.support.Acknowledgment
 import org.springframework.kafka.support.KafkaHeaders
 import org.springframework.messaging.handler.annotation.Header
-import maple.expectation.infrastructure.lifecycle.VirtualThreadExecutorManager
 import org.springframework.stereotype.Component
+import java.util.concurrent.ExecutorService
 
 @Component
 class AuthCharacterFetchConsumer(
@@ -21,13 +21,8 @@ class AuthCharacterFetchConsumer(
     private val kafkaTemplate: KafkaTemplate<String, String>,
     private val objectMapper: ObjectMapper,
     @Value("\${auth.kafka.character-fetch-response-topic}") private val responseTopic: String,
+    @Qualifier("authCharacterFetchExecutor") private val executor: ExecutorService,
 ) {
-    private val exec = VirtualThreadExecutorManager("AuthCharacterFetchConsumer")
-
-    @PreDestroy
-    fun shutdown() {
-        exec.shutdown()
-    }
 
     @KafkaListener(
         topics = ["\${auth.kafka.character-fetch-request-topic}"],
@@ -41,7 +36,7 @@ class AuthCharacterFetchConsumer(
         val request = objectMapper.readValue(message, CharacterFetchRequest::class.java)
         log.info("[AuthFetch] processing: eventId={}, userIgn={}", request.eventId, request.userIgn)
 
-        exec.executor.submit {
+        executor.submit {
             runCatching {
                 val characterListOpt = nexonAuthClient.getCharacterList(request.apiKey)
 

--- a/module-external-api/src/main/kotlin/maple/externalapi/runstatus/InternalApiController.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/runstatus/InternalApiController.kt
@@ -4,11 +4,12 @@ import maple.externalapi.cleanup.ArtifactCleanupScheduler
 import maple.externalapi.cleanup.ConsumedChunkCleanupScheduler
 import maple.externalapi.scheduler.ExternalApiScheduler
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
-import maple.expectation.infrastructure.lifecycle.VirtualThreadExecutorManager
 import java.util.UUID
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.atomic.AtomicBoolean
 
 @RestController
@@ -18,8 +19,8 @@ class InternalApiController(
     private val scheduler: ExternalApiScheduler,
     @Autowired(required = false) private val artifactCleanup: ArtifactCleanupScheduler?,
     @Autowired(required = false) private val consumedCleanup: ConsumedChunkCleanupScheduler?,
+    @Qualifier("internalApiExecutor") private val executor: ExecutorService,
 ) {
-    private val exec = VirtualThreadExecutorManager("InternalApiController")
     private val artifactCleanupRunning = AtomicBoolean(false)
     private val consumedCleanupRunning = AtomicBoolean(false)
 
@@ -43,7 +44,7 @@ class InternalApiController(
         }
 
         val runId = airflowRunId ?: UUID.randomUUID().toString()
-        exec.executor.submit { scheduler.triggerDailyRefresh(runId) }
+        executor.submit { scheduler.triggerDailyRefresh(runId) }
         return ResponseEntity.accepted().body(mapOf("status" to "STARTED", "runId" to runId))
     }
 
@@ -57,7 +58,7 @@ class InternalApiController(
             return ResponseEntity.status(HttpStatus.CONFLICT)
                 .body(mapOf("status" to "ALREADY_RUNNING"))
         }
-        exec.executor.submit {
+        executor.submit {
             try { artifactCleanup.cleanup() } finally { artifactCleanupRunning.set(false) }
         }
         return ResponseEntity.accepted().body(mapOf("status" to "STARTED"))
@@ -73,16 +74,12 @@ class InternalApiController(
             return ResponseEntity.status(HttpStatus.CONFLICT)
                 .body(mapOf("status" to "ALREADY_RUNNING"))
         }
-        exec.executor.submit {
+        executor.submit {
             try { consumedCleanup.cleanup() } finally { consumedCleanupRunning.set(false) }
         }
         return ResponseEntity.accepted().body(mapOf("status" to "STARTED"))
     }
 
-    @jakarta.annotation.PreDestroy
-    fun shutdown() {
-        exec.shutdown()
-    }
 }
 
 data class RunStatusResponse(

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/ExternalApiScheduler.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/ExternalApiScheduler.kt
@@ -14,9 +14,10 @@ import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.context.event.EventListener
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
-import maple.expectation.infrastructure.lifecycle.VirtualThreadExecutorManager
+import org.springframework.beans.factory.annotation.Qualifier
 import java.util.UUID
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.locks.ReentrantLock
 
@@ -33,12 +34,12 @@ class ExternalApiScheduler(
     private val runOnStartup: Boolean,
     @Value("\${external-api.schedule.skip-character-basic:false}")
     private val skipCharacterBasic: Boolean,
+    @Qualifier("externalApiSchedulerExecutor") private val executor: ExecutorService,
 ) : ManagedLifecycle {
     private val log = LoggerFactory.getLogger(ExternalApiScheduler::class.java)
     private val running = AtomicBoolean(false)
     private val shutdown = AtomicBoolean(false)
     private val itemEquipmentStarted = AtomicBoolean(false)
-    private val exec = VirtualThreadExecutorManager("ExternalApiScheduler")
     private val lock = ReentrantLock()
     private val idle = lock.newCondition()
 
@@ -84,7 +85,7 @@ class ExternalApiScheduler(
 
         log.info("[Scheduler] starting ranking fetch phase, runId={}", runId)
         runStatusTracker.transitionPhase(PipelinePhase.RANKING_FETCH)
-        rankingPhase.execute(exec.executor)
+        rankingPhase.execute(executor)
             .handle { runDir, ex ->
                 if (ex != null) {
                     log.error("[Scheduler] ranking fetch failed, cannot proceed with OCID lookup", ex)
@@ -96,13 +97,13 @@ class ExternalApiScheduler(
                     CompletableFuture.completedFuture(null)
                 } else {
                     runStatusTracker.transitionPhase(PipelinePhase.OCID_LOOKUP)
-                    ocidLookupPhase.execute(exec.executor, runDir)
+                    ocidLookupPhase.execute(executor, runDir)
                 }
             }
             .thenCompose {
                 val cache = ocidCacheProvider.refresh()
                 runStatusTracker.transitionPhase(PipelinePhase.CHARACTER_BASIC)
-                snapshotFetchPhase.executeCharacterBasic(exec.executor, cache)
+                snapshotFetchPhase.executeCharacterBasic(executor, cache)
             }
             .whenComplete { _, ex ->
                 if (ex != null) {
@@ -120,7 +121,7 @@ class ExternalApiScheduler(
 
     private fun startItemEquipmentLoopOnce() {
         if (itemEquipmentStarted.compareAndSet(false, true)) {
-            exec.executor.submit { runItemEquipmentLoop() }
+            executor.submit { runItemEquipmentLoop() }
         }
     }
 
@@ -138,7 +139,7 @@ class ExternalApiScheduler(
         val entries = ocidCacheProvider.current().entries.toList()
         if (entries.isEmpty()) {
             log.warn("[Scheduler] OCID cache empty, waiting 30s")
-            exec.executor.submit {
+            executor.submit {
                 Thread.sleep(java.time.Duration.ofSeconds(30))
                 ocidCacheProvider.refresh()
                 runItemEquipmentCycle()
@@ -147,7 +148,7 @@ class ExternalApiScheduler(
         }
 
         if (!acquireLock(120_000)) {
-            exec.executor.submit {
+            executor.submit {
                 Thread.sleep(java.time.Duration.ofSeconds(5))
                 runItemEquipmentCycle()
             }
@@ -155,13 +156,13 @@ class ExternalApiScheduler(
         }
 
         CompletableFuture.completedFuture(null)
-            .thenCompose { snapshotFetchPhase.executeItemEquipment(exec.executor, entries) }
+            .thenCompose { snapshotFetchPhase.executeItemEquipment(executor, entries) }
             .whenComplete { _, ex ->
                 if (ex != null) {
                     log.error("[Scheduler] ITEM_EQUIPMENT cycle failed", ex)
                 }
                 releaseLock()
-                exec.executor.submit { runItemEquipmentCycle() }
+                executor.submit { runItemEquipmentCycle() }
             }
     }
 
@@ -190,6 +191,5 @@ class ExternalApiScheduler(
     override fun stopLifecycle() {
         log.info("[Scheduler] shutdown requested")
         shutdown.set(true)
-        exec.shutdown()
     }
 }

--- a/module-external-api/src/main/kotlin/maple/externalapi/urgent/UrgentCharacterRequestConsumer.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/urgent/UrgentCharacterRequestConsumer.kt
@@ -1,7 +1,6 @@
 package maple.externalapi.urgent
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import jakarta.annotation.PreDestroy
 import maple.externalapi.domain.ExternalApiEndpoint
 import maple.externalapi.domain.ExternalApiProvider
 import maple.externalapi.port.out.ExternalApiClientPort
@@ -10,6 +9,7 @@ import maple.externalapi.snapshot.SnapshotChunkRecord
 import maple.expectation.common.event.SnapshotChunkReadyEvent
 import maple.expectation.util.StringMaskingUtils.maskIgn
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.kafka.annotation.KafkaListener
@@ -19,9 +19,9 @@ import org.springframework.stereotype.Component
 import java.nio.file.Files
 import java.nio.file.Path
 import java.time.Instant
-import maple.expectation.infrastructure.lifecycle.VirtualThreadExecutorManager
 import java.util.UUID
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.Semaphore
 
 @Component
@@ -42,9 +42,9 @@ class UrgentCharacterRequestConsumer(
     private val storeBasePath: String,
     @Value("\${external-api.concurrency.urgent-max-concurrent:30}")
     maxConcurrent: Int,
+    @Qualifier("urgentCharacterRequestExecutor") private val executor: ExecutorService,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
-    private val exec = VirtualThreadExecutorManager("UrgentCharacterRequestConsumer")
     private val semaphore = Semaphore(maxConcurrent)
 
     @KafkaListener(
@@ -108,8 +108,8 @@ class UrgentCharacterRequestConsumer(
                         basicData = basicFuture.resultNow(),
                         equipmentData = equipmentFuture.resultNow(),
                     )
-                }, exec.executor)
-        }, exec.executor)
+                }, executor)
+        }, executor)
 
     private fun publishUrgentChunksAsync(
         request: UrgentCharacterRequest,
@@ -170,7 +170,7 @@ class UrgentCharacterRequestConsumer(
                 compressedBytes = stats.compressedBytes,
                 createdAt = Instant.now(),
             )
-        }, exec.executor).thenCompose { event ->
+        }, executor).thenCompose { event ->
             val eventJson = objectMapper.writeValueAsString(event)
             kafkaTemplate.send(urgentChunkReadyTopic, event.kafkaKey(), eventJson).thenAccept {
                 log.info(
@@ -193,11 +193,6 @@ class UrgentCharacterRequestConsumer(
             .thenAccept {
                 log.info("[Urgent] published not-found: userIgn={}", maskIgn(userIgn))
             }
-    }
-
-    @PreDestroy
-    fun close() {
-        exec.shutdown()
     }
 }
 

--- a/module-external-api/src/test/kotlin/maple/externalapi/runstatus/InternalApiControllerTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/runstatus/InternalApiControllerTest.kt
@@ -30,7 +30,7 @@ class InternalApiControllerTest {
         scheduler = org.mockito.kotlin.mock()
         val artifactCleanup = org.mockito.kotlin.mock<maple.externalapi.cleanup.ArtifactCleanupScheduler>()
         val consumedCleanup = org.mockito.kotlin.mock<maple.externalapi.cleanup.ConsumedChunkCleanupScheduler>()
-        val controller = InternalApiController(runStatusTracker, scheduler, artifactCleanup, consumedCleanup)
+        val controller = InternalApiController(runStatusTracker, scheduler, artifactCleanup, consumedCleanup, java.util.concurrent.Executors.newVirtualThreadPerTaskExecutor())
         mockMvc = standaloneSetup(controller)
             .setMessageConverters(MappingJackson2HttpMessageConverter(objectMapper))
             .build()
@@ -135,7 +135,7 @@ class InternalApiControllerTest {
             Unit
         }
         val consumedCleanup = org.mockito.kotlin.mock<maple.externalapi.cleanup.ConsumedChunkCleanupScheduler>()
-        val controller = InternalApiController(runStatusTracker, scheduler, artifactCleanup, consumedCleanup)
+        val controller = InternalApiController(runStatusTracker, scheduler, artifactCleanup, consumedCleanup, java.util.concurrent.Executors.newVirtualThreadPerTaskExecutor())
         mockMvc = standaloneSetup(controller)
             .setMessageConverters(MappingJackson2HttpMessageConverter(objectMapper))
             .build()

--- a/module-external-api/src/test/kotlin/maple/externalapi/urgent/UrgentCharacterRequestConsumerTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/urgent/UrgentCharacterRequestConsumerTest.kt
@@ -54,12 +54,13 @@ class UrgentCharacterRequestConsumerTest {
             urgentChunkReadyTopic = "external-api.urgent.snapshot.chunk-ready",
             storeBasePath = tempDir.toString(),
             maxConcurrent = 30,
+            executor = java.util.concurrent.Executors.newVirtualThreadPerTaskExecutor(),
         )
     }
 
     @AfterEach
     fun tearDown() {
-        consumer.close()
+        // executor lifecycle managed by VtExecutorConfig
     }
 
     private fun stubSendResult(): CompletableFuture<SendResult<String, String>> {

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/config/VtExecutorConfig.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/config/VtExecutorConfig.kt
@@ -1,0 +1,85 @@
+package maple.expectation.infrastructure.config
+
+import jakarta.annotation.PreDestroy
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * VT Executor Configuration — external-api, synchronizer 전용 named virtual thread executors
+ *
+ * <p>각 컴포넌트가 inline으로 VirtualThreadExecutorManager를 생성하던 패턴을
+ * 중앙 집중식 @Bean 관리로 전환.
+ *
+ * <p>포함 Bean:
+ * <ul>
+ *   <li>externalApiSchedulerExecutor
+ *   <li>authCharacterFetchExecutor
+ *   <li>internalApiExecutor
+ *   <li>urgentCharacterRequestExecutor
+ *   <li>kafkaResultChunkExecutor
+ *   <li>basicSnapshotChunkExecutor
+ * </ul>
+ *
+ * @see CoreExecutorConfig
+ */
+@Configuration
+class VtExecutorConfig {
+
+    private val log = LoggerFactory.getLogger(VtExecutorConfig::class.java)
+    private val executors = mutableListOf<ExecutorService>()
+
+    @Bean(name = ["externalApiSchedulerExecutor"])
+    @ConditionalOnMissingBean(name = ["externalApiSchedulerExecutor"])
+    fun externalApiSchedulerExecutor(): ExecutorService =
+        createTrackedExecutor("ExternalApiScheduler")
+
+    @Bean(name = ["authCharacterFetchExecutor"])
+    @ConditionalOnMissingBean(name = ["authCharacterFetchExecutor"])
+    fun authCharacterFetchExecutor(): ExecutorService =
+        createTrackedExecutor("AuthCharacterFetchConsumer")
+
+    @Bean(name = ["internalApiExecutor"])
+    @ConditionalOnMissingBean(name = ["internalApiExecutor"])
+    fun internalApiExecutor(): ExecutorService =
+        createTrackedExecutor("InternalApiController")
+
+    @Bean(name = ["urgentCharacterRequestExecutor"])
+    @ConditionalOnMissingBean(name = ["urgentCharacterRequestExecutor"])
+    fun urgentCharacterRequestExecutor(): ExecutorService =
+        createTrackedExecutor("UrgentCharacterRequestConsumer")
+
+    @Bean(name = ["kafkaResultChunkExecutor"])
+    @ConditionalOnMissingBean(name = ["kafkaResultChunkExecutor"])
+    fun kafkaResultChunkExecutor(): ExecutorService =
+        createTrackedExecutor("KafkaResultChunkConsumer")
+
+    @Bean(name = ["basicSnapshotChunkExecutor"])
+    @ConditionalOnMissingBean(name = ["basicSnapshotChunkExecutor"])
+    fun basicSnapshotChunkExecutor(): ExecutorService =
+        createTrackedExecutor("BasicSnapshotChunkConsumer")
+
+    private fun createTrackedExecutor(name: String): ExecutorService {
+        val es = Executors.newVirtualThreadPerTaskExecutor()
+        synchronized(executors) { executors.add(es) }
+        return es
+    }
+
+    @PreDestroy
+    fun shutdownAll() {
+        synchronized(executors) {
+            executors.forEach { es ->
+                es.shutdown()
+                if (!es.awaitTermination(5, TimeUnit.SECONDS)) {
+                    log.warn("[VtExecutorConfig] executor did not terminate in 5s, forcing shutdown")
+                    es.shutdownNow()
+                }
+            }
+            log.info("[VtExecutorConfig] {} VT executors shut down", executors.size)
+        }
+    }
+}

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/SynchronizerApplication.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/SynchronizerApplication.kt
@@ -15,6 +15,7 @@ import org.springframework.context.annotation.Import
 @EnableConfigurationProperties(EquipmentRankingProperties::class, ChunkExecutionProperties::class)
 @Import(
     maple.expectation.infrastructure.config.CoreExecutorConfig::class,
+    maple.expectation.infrastructure.config.VtExecutorConfig::class,
     ManagedLifecycleCoordinator::class,
 )
 class SynchronizerApplication

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/BasicSnapshotChunkConsumer.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/BasicSnapshotChunkConsumer.kt
@@ -6,7 +6,6 @@ import maple.expectation.common.event.ChunkExecutionIdentity
 import maple.expectation.common.event.ChunkExecutionType
 import maple.expectation.common.event.SnapshotChunkReadyEvent
 import maple.expectation.infrastructure.executor.TaskContext
-import maple.expectation.infrastructure.lifecycle.ManagedLifecycle
 import maple.synchronizer.event.KafkaChunkConsumedEventPublisher
 import maple.synchronizer.repository.CharacterBasicRepository
 import maple.synchronizer.repository.OcidMappingRepository
@@ -19,7 +18,8 @@ import org.springframework.kafka.support.Acknowledgment
 import org.springframework.kafka.support.KafkaHeaders
 import org.springframework.messaging.handler.annotation.Header
 import org.springframework.stereotype.Component
-import maple.expectation.infrastructure.lifecycle.VirtualThreadExecutorManager
+import org.springframework.beans.factory.annotation.Qualifier
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.Semaphore
 
 @Component
@@ -30,9 +30,9 @@ class BasicSnapshotChunkConsumer(
     private val ocidMappingRepository: OcidMappingRepository,
     private val chunkConsumerTemplate: ChunkConsumerTemplate,
     private val consumedEventPublisher: KafkaChunkConsumedEventPublisher,
-) : ManagedLifecycle {
+    @Qualifier("basicSnapshotChunkExecutor") private val executor: ExecutorService,
+) {
     private val log = LoggerFactory.getLogger(javaClass)
-    private val exec = VirtualThreadExecutorManager("BasicSnapshotChunkConsumer")
     private val processingPermit = Semaphore(2)
 
     @KafkaListener(
@@ -118,7 +118,7 @@ class BasicSnapshotChunkConsumer(
                 objectKey = event.objectKey,
                 acknowledgment = acknowledgment,
                 processingPermit = processingPermit,
-                executor = exec.executor,
+                executor = executor,
                 processContext = TaskContext.of("BasicSync", "${operation}Process", chunkId),
                 lifecycleContext = TaskContext.of("BasicSync", "${operation}Lifecycle", chunkId),
                 process = {
@@ -165,9 +165,4 @@ class BasicSnapshotChunkConsumer(
         log.info("[BasicSync] batch upserted OCID mappings: count={}", mappings.size)
     }
 
-    override val lifecyclePhase: Int = 100
-
-    override fun stopLifecycle() {
-        exec.shutdown()
-    }
 }

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/KafkaResultChunkConsumer.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/KafkaResultChunkConsumer.kt
@@ -6,7 +6,6 @@ import maple.expectation.common.event.ChunkConsumedEvent
 import maple.expectation.common.event.ChunkExecutionIdentity
 import maple.expectation.common.event.ChunkExecutionType
 import maple.expectation.infrastructure.executor.TaskContext
-import maple.expectation.infrastructure.lifecycle.ManagedLifecycle
 import maple.synchronizer.event.KafkaChunkConsumedEventPublisher
 import maple.synchronizer.metrics.SynchronizerChunkMetricsListener
 import maple.synchronizer.metrics.SynchronizerMetrics
@@ -18,7 +17,8 @@ import org.springframework.kafka.support.Acknowledgment
 import org.springframework.kafka.support.KafkaHeaders
 import org.springframework.messaging.handler.annotation.Header
 import org.springframework.stereotype.Component
-import maple.expectation.infrastructure.lifecycle.VirtualThreadExecutorManager
+import org.springframework.beans.factory.annotation.Qualifier
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.Semaphore
 
 @Component
@@ -28,9 +28,9 @@ class KafkaResultChunkConsumer(
     private val chunkMetricsListener: SynchronizerChunkMetricsListener,
     private val chunkConsumerTemplate: ChunkConsumerTemplate,
     private val consumedEventPublisher: KafkaChunkConsumedEventPublisher,
-) : ManagedLifecycle {
+    @Qualifier("kafkaResultChunkExecutor") private val executor: ExecutorService,
+) {
     private val log = LoggerFactory.getLogger(KafkaResultChunkConsumer::class.java)
-    private val exec = VirtualThreadExecutorManager("KafkaResultChunkConsumer")
     private val processingPermit = Semaphore(2)
 
     @KafkaListener(
@@ -70,7 +70,7 @@ class KafkaResultChunkConsumer(
                 objectKey = event.objectKey,
                 acknowledgment = acknowledgment,
                 processingPermit = processingPermit,
-                executor = exec.executor,
+                executor = executor,
                 processContext = TaskContext.of("Synchronizer", "ChunkProcess", chunkId),
                 lifecycleContext = TaskContext.of("Synchronizer", "ChunkLifecycle", chunkId),
                 mdcValues = mapOf("kafkaTopic" to (topic ?: event.eventType)),
@@ -124,11 +124,5 @@ class KafkaResultChunkConsumer(
             event.sourceRunId, event.sourceChunkId, event.compressedBytes, event.uncompressedBytes,
             event.resultCount, ratio,
         )
-    }
-
-    override val lifecyclePhase: Int = 100
-
-    override fun stopLifecycle() {
-        exec.shutdown()
     }
 }

--- a/module-synchronizer/src/test/kotlin/maple/synchronizer/consumer/ChunkConsumerMappingTest.kt
+++ b/module-synchronizer/src/test/kotlin/maple/synchronizer/consumer/ChunkConsumerMappingTest.kt
@@ -29,6 +29,7 @@ class ChunkConsumerMappingTest {
             ocidMappingRepository = mock<OcidMappingRepository>(),
             chunkConsumerTemplate = template,
             consumedEventPublisher = mock<KafkaChunkConsumedEventPublisher>(),
+            executor = java.util.concurrent.Executors.newVirtualThreadPerTaskExecutor(),
         )
 
         consumer.consume(basicMessage, mock<Acknowledgment>(), "basic-topic", null)
@@ -56,6 +57,7 @@ class ChunkConsumerMappingTest {
             chunkMetricsListener = mock<SynchronizerChunkMetricsListener>(),
             chunkConsumerTemplate = template,
             consumedEventPublisher = mock<KafkaChunkConsumedEventPublisher>(),
+            executor = java.util.concurrent.Executors.newVirtualThreadPerTaskExecutor(),
         )
 
         consumer.consume(resultMessage, mock<Acknowledgment>(), "result-topic", "result-key")


### PR DESCRIPTION
#1068, Closes #1041

## Changes

- **VtExecutorConfig** — 6 named VT `ExecutorService` beans with `@PreDestroy` centralized shutdown
- 6 consumers/workers converted from inline `VirtualThreadExecutorManager("name")` to `@Qualifier` constructor injection
- Zero inline VTEM in `module-external-api` and `module-synchronizer`
- Removed `ManagedLifecycle` / `@PreDestroy` where only `exec.shutdown()` remained

### Components converted
| Component | Bean name |
|-----------|-----------|
| ExternalApiScheduler | `externalApiSchedulerExecutor` |
| AuthCharacterFetchConsumer | `authCharacterFetchExecutor` |
| InternalApiController | `internalApiExecutor` |
| UrgentCharacterRequestConsumer | `urgentCharacterRequestExecutor` |
| KafkaResultChunkConsumer | `kafkaResultChunkExecutor` |
| BasicSnapshotChunkConsumer | `basicSnapshotChunkExecutor` |

## Test

- `./gradlew compileKotlin compileJava --continue` ✅
- `./gradlew test` ✅

## Dependencies

- Requires #1063 (PR #1119) — CoreExecutorConfig split

🤖 Generated with [Claude Code](https://claude.com/claude-code)