### PR TITLE
fix(#905): concurrency antipatterns — semaphore leak, volatile, bounded buffer, init race

### DIFF
--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/admission/SimpleAdmissionControl.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/admission/SimpleAdmissionControl.kt
@@ -144,26 +144,29 @@ class SimpleAdmissionControl(
                 // 🔥 SEMAPHORE: Limit in-flight executions
                 semaphore.acquire()
                 inFlight.incrementAndGet()
-
-                executeTask(task)
+                try {
+                    executeTask(task)
+                } finally {
+                    semaphore.release()
+                    inFlight.decrementAndGet()
+                }
             }, TaskContext.of("SimpleAdmissionControl", "Worker"))
         }
     }
 
     private fun <T> executeTask(task: AdmissionTask<T>) {
-        executor.executeWithFinally(
-            {
+        executor.executeOrDefault({
+            try {
                 @Suppress("UNCHECKED_CAST")
                 val result = task.callable.call() as Any
                 @Suppress("UNCHECKED_CAST")
                 (task.future as CompletableFuture<Any>).complete(result)
-            },
-            {
-                semaphore.release()
-                inFlight.decrementAndGet()
-            },
-            TaskContext.of("SimpleAdmissionControl", "ExecuteTask"),
-        )
+            } catch (e: Throwable) {
+                @Suppress("UNCHECKED_CAST")
+                (task.future as CompletableFuture<Any>).completeExceptionally(e)
+            }
+            null
+        }, null, TaskContext.of("SimpleAdmissionControl", "ExecuteTask"))
     }
 
     /**

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/monitoring/copilot/pipeline/SignalDefinitionLoader.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/monitoring/copilot/pipeline/SignalDefinitionLoader.kt
@@ -10,6 +10,7 @@ import maple.expectation.infrastructure.executor.TaskContext
 import maple.expectation.infrastructure.monitoring.copilot.ingestor.GrafanaJsonIngestor
 import maple.expectation.infrastructure.monitoring.copilot.model.SignalDefinition
 import org.slf4j.LoggerFactory
+import jakarta.annotation.PostConstruct
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Service
@@ -31,11 +32,15 @@ class SignalDefinitionLoader(
     @Value("\${monitoring.copilot.cache-ttl-ms:300000}")
     private var cacheTtlMs: Long = 300000
 
-    private val signalCatalogCache: Cache<String, List<SignalDefinition>> =
-        Caffeine.newBuilder()
+    private lateinit var signalCatalogCache: Cache<String, List<SignalDefinition>>
+
+    @PostConstruct
+    fun initCache() {
+        signalCatalogCache = Caffeine.newBuilder()
             .expireAfterWrite(Duration.ofMillis(cacheTtlMs))
             .recordStats()
             .build()
+    }
 
     fun loadSignalDefinitions(): List<SignalDefinition> = signalCatalogCache.get(CACHE_KEY) { loadSignalDefinitionsFromDisk() }
 

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/AccumulationBuffer.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/AccumulationBuffer.kt
@@ -11,6 +11,7 @@ package maple.expectation.infrastructure.pgmq
  */
 class AccumulationBuffer<T>(
     private val bufferMs: Long,
+    private val maxSize: Int = 10_000,
 ) {
     private val messages = ArrayDeque<PgmqMessage<T>>()
     private var firstMessageTimeMs: Long = 0L
@@ -39,4 +40,6 @@ class AccumulationBuffer<T>(
     fun isEmpty(): Boolean = messages.isEmpty()
 
     fun size(): Int = messages.size
+
+    fun isFull(): Boolean = messages.size >= maxSize
 }

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/PgmqWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/PgmqWorker.kt
@@ -207,6 +207,10 @@ abstract class PgmqWorker<T : Any>(
 
                 // Phase C: Route to processing mode
                 if (sequentialBatchMs > 0 && supportsTwoPhase) {
+                    if (accumulationBuffer.isFull()) {
+                        log.warn("[{}] Accumulation buffer full ({}), flushing before adding", queueName, accumulationBuffer.size())
+                        flushSequentialBatch()
+                    }
                     accumulationBuffer.addAll(messages)
                     if (accumulationBuffer.shouldFlush()) {
                         flushSequentialBatch()

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/ratelimit/NexonRateLimiter.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/ratelimit/NexonRateLimiter.kt
@@ -28,7 +28,7 @@ class NexonRateLimiter(
 ) {
     private val lock = ReentrantLock()
     private val notFull = lock.newCondition()
-    private var permits = maxConcurrent
+    @Volatile private var permits = maxConcurrent
     private val maxPermits = maxConcurrent
 
     init {


### PR DESCRIPTION
#905

## Changes

| # | Component | Issue | Fix |
|---|-----------|-------|-----|
| 1 | SimpleAdmissionControl | Semaphore permit leak on exception | Move acquire/release to outer try-finally in workerLoop |
| 2 | NexonRateLimiter | `permits` stale read on virtual threads | Add `@Volatile` annotation |
| 3 | AccumulationBuffer / PgmqWorker | Unbounded buffer growth | Add `maxSize` (10,000) + `isFull()` + flush-before-add |
| 4 | SignalDefinitionLoader | `@Value` cacheTtlMs not applied to Caffeine cache | Move cache init to `@PostConstruct` |

## Test

- `./gradlew compileKotlin compileJava --continue` ✅
- `./gradlew test` ✅

Closes #905

🤖 Generated with [Claude Code](https://claude.com/claude-code)