### PR TITLE
fix(#1102): remove ForkJoinPool.commonPool() — dedicated executor for all 8 sites

### DIFF
--- a/module-core/src/main/kotlin/maple/expectation/core/port/out/EventPublisher.kt
+++ b/module-core/src/main/kotlin/maple/expectation/core/port/out/EventPublisher.kt
@@ -85,5 +85,5 @@ interface EventPublisher {
      * @param event Event to publish
      * @return CompletableFuture that completes when published
      */
-    fun publishAsync(topic: String, event: IntegrationEvent<*>): CompletableFuture<Void> = CompletableFuture.runAsync { publish(topic, event) }
+    fun publishAsync(topic: String, event: IntegrationEvent<*>): CompletableFuture<Void>
 }

--- a/module-infra/src/main/java/maple/expectation/application/service/expectation/PresetCalculationHelper.java
+++ b/module-infra/src/main/java/maple/expectation/application/service/expectation/PresetCalculationHelper.java
@@ -95,17 +95,26 @@ public class PresetCalculationHelper {
           presetNo, 0.0, CostFormatter.format(0.0), CostBreakdownDto.empty(), List.of());
     }
 
-    // 장비별 독립 계산 — parallelStream으로 ForkJoinPool work-stening 활용
-    List<ItemExpectationV4> results =
-        cubeInputs.parallelStream()
+    // 장비별 독립 계산 — 전용 executor 기반 병렬 처리 (parallelStream/ForkJoinPool 제거)
+    List<CompletableFuture<ItemExpectationV4>> futures =
+        cubeInputs.stream()
             .map(
-                cubeInput -> {
-                  if (!cubeInput.isReady()) {
-                    return buildNoPotentialItem(cubeInput, presetNo, characterClass);
-                  }
-                  EquipmentCalculationInput input = buildInput(cubeInput, presetNo);
-                  return calculateSingleItem(input, cubeInput, characterClass);
-                })
+                cubeInput ->
+                    CompletableFuture.supplyAsync(
+                        () -> {
+                          if (!cubeInput.isReady()) {
+                            return buildNoPotentialItem(cubeInput, presetNo, characterClass);
+                          }
+                          EquipmentCalculationInput input = buildInput(cubeInput, presetNo);
+                          return calculateSingleItem(input, cubeInput, characterClass);
+                        },
+                        itemExecutor))
+            .collect(Collectors.toList());
+
+    // .join() justified: calculatePreset is sync, called from worker thread
+    List<ItemExpectationV4> results =
+        futures.stream()
+            .map(CompletableFuture::join)
             .collect(Collectors.toList());
 
     // 비용 누적은 순서 무관

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/messaging/KafkaEventPublisher.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/messaging/KafkaEventPublisher.kt
@@ -7,8 +7,10 @@ import maple.expectation.core.port.out.EventPublisher
 import maple.expectation.infrastructure.executor.LogicExecutor
 import maple.expectation.infrastructure.executor.TaskContext
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
+import java.util.concurrent.Executor
 
 @Component
 @ConditionalOnProperty(
@@ -20,6 +22,7 @@ import org.springframework.stereotype.Component
 class KafkaEventPublisher(
     private val objectMapper: ObjectMapper,
     private val executor: LogicExecutor,
+    @Qualifier("taskExecutor") private val taskExecutor: Executor,
 ) : EventPublisher {
 
     private val logger = LoggerFactory.getLogger(KafkaEventPublisher::class.java)
@@ -58,6 +61,6 @@ class KafkaEventPublisher(
             event.eventId,
         )
 
-        return CompletableFuture.runAsync { publish(topic, event) }
+        return CompletableFuture.runAsync({ publish(topic, event) }, taskExecutor)
     }
 }

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/messaging/PgmqEventPublisherAdapter.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/messaging/PgmqEventPublisherAdapter.kt
@@ -9,8 +9,10 @@ import maple.expectation.infrastructure.executor.LogicExecutor
 import maple.expectation.infrastructure.executor.TaskContext
 import maple.expectation.infrastructure.pgmq.PgmqClient
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
+import java.util.concurrent.Executor
 
 /**
  * PGMQ-based EventPublisher adapter.
@@ -30,6 +32,7 @@ class PgmqEventPublisherAdapter(
     private val pgmqClient: PgmqClient,
     private val executor: LogicExecutor,
     private val objectMapper: ObjectMapper,
+    @Qualifier("taskExecutor") private val taskExecutor: Executor,
 ) : EventPublisher {
 
     override fun publish(topic: String, event: IntegrationEvent<*>) {
@@ -55,7 +58,7 @@ class PgmqEventPublisherAdapter(
         }, context)
     }
 
-    override fun publishAsync(topic: String, event: IntegrationEvent<*>): CompletableFuture<Void> = CompletableFuture.runAsync { publish(topic, event) }
+    override fun publishAsync(topic: String, event: IntegrationEvent<*>): CompletableFuture<Void> = CompletableFuture.runAsync({ publish(topic, event) }, taskExecutor)
 
     /**
      * Data class for stream message.

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/provider/EquipmentDataProvider.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/provider/EquipmentDataProvider.kt
@@ -10,8 +10,10 @@ import maple.expectation.infrastructure.executor.strategy.ExceptionTranslator
 import maple.expectation.infrastructure.external.dto.v2.EquipmentResponse
 import maple.expectation.util.GzipUtils
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
+import java.util.concurrent.Executor
 
 @Component
 class EquipmentDataProvider(
@@ -19,6 +21,7 @@ class EquipmentDataProvider(
     private val objectMapper: ObjectMapper,
     private val executor: LogicExecutor,
     @Value("\${app.optimization.use-compression:true}") private val useCompression: Boolean,
+    @Qualifier("taskExecutor") private val taskExecutor: Executor,
 ) {
     private val logger = LoggerFactory.getLogger(EquipmentDataProvider::class.java)
 
@@ -27,9 +30,9 @@ class EquipmentDataProvider(
         val context = TaskContext.of("EquipmentProvider", "GetRawData", ocid)
 
         // supplyAsync 내부 로직을 executor로 보호하여 예외 및 지표 추적
-        return CompletableFuture.supplyAsync {
+        return CompletableFuture.supplyAsync({
             executor.execute({ fetchProvider.fetchWithCache(ocid) }, context)
-        }
+        }, taskExecutor)
             .thenApply { response -> serializeResponse(response, context) }
     }
 

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/provider/EquipmentFetchProvider.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/provider/EquipmentFetchProvider.kt
@@ -6,8 +6,10 @@ import maple.expectation.infrastructure.aop.annotation.NexonDataCache
 import maple.expectation.infrastructure.external.NexonApiClient
 import maple.expectation.infrastructure.external.dto.v2.CharacterBasicResponse
 import maple.expectation.infrastructure.external.dto.v2.EquipmentResponse
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Component
+import java.util.concurrent.Executor
 
 /**
  * 장비 데이터 Fetch Provider (캐시 적용)
@@ -46,6 +48,7 @@ import org.springframework.stereotype.Component
 @Component
 class EquipmentFetchProvider(
     private val nexonApiClient: NexonApiClient,
+    @Qualifier("taskExecutor") private val executor: Executor,
 ) {
     private val logger = org.slf4j.LoggerFactory.getLogger(EquipmentFetchProvider::class.java)
 
@@ -84,7 +87,7 @@ class EquipmentFetchProvider(
             .getCharacterBasic(ocid)
             .orTimeout(API_TIMEOUT_SECONDS, TimeUnit.SECONDS)
 
-        val itemFuture = CompletableFuture.supplyAsync { fetchWithCache(ocid) }
+        val itemFuture = CompletableFuture.supplyAsync({ fetchWithCache(ocid) }, executor)
 
         return basicFuture.thenCombine(itemFuture) { basic, item -> Pair(basic, item) }
     }

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/RestControllerApplication.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/RestControllerApplication.kt
@@ -9,5 +9,5 @@ import org.springframework.context.annotation.ComponentScan
 class RestControllerApplication
 
 fun main(args: Array<String>) {
-	runApplication<RestControllerApplication>(*args)
+    runApplication<RestControllerApplication>(*args)
 }

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/config/RestControllerExecutorConfig.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/config/RestControllerExecutorConfig.kt
@@ -1,0 +1,25 @@
+package maple.restcontroller.config
+
+import java.util.concurrent.Executor
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+
+@Configuration
+class RestControllerExecutorConfig {
+
+    @Bean(name = ["taskExecutor"])
+    fun taskExecutor(): Executor {
+        val executor = ThreadPoolTaskExecutor()
+        executor.corePoolSize = 4
+        executor.maxPoolSize = 8
+        executor.queueCapacity = 100
+        executor.setThreadNamePrefix("rest-api-")
+        executor.setAllowCoreThreadTimeOut(true)
+        executor.setKeepAliveSeconds(30)
+        executor.setWaitForTasksToCompleteOnShutdown(true)
+        executor.setAwaitTerminationSeconds(30)
+        executor.initialize()
+        return executor
+    }
+}

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/controller/v6/LikeController.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/controller/v6/LikeController.kt
@@ -3,23 +3,26 @@ package maple.restcontroller.controller.v6
 import maple.expectation.core.domain.model.security.AuthenticatedUser
 import maple.expectation.core.port.inbound.LikeTogglePort
 import maple.restcontroller.auth.JwtAuthInterceptor
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executor
 
 @RestController
 @RequestMapping("/api/v6/characters")
 @ConditionalOnProperty(name = ["expectation.v6.enabled"], havingValue = "true")
 class LikeController(
     private val likeTogglePort: LikeTogglePort,
+    @Qualifier("taskExecutor") private val executor: Executor,
 ) {
 
     @PostMapping("/{userIgn}/like")
     fun toggleLike(
         @PathVariable userIgn: String,
         @RequestAttribute(JwtAuthInterceptor.USER_ATTRIBUTE) user: AuthenticatedUser,
-    ): CompletableFuture<ResponseEntity<LikeToggleResponse>> = CompletableFuture.supplyAsync {
+    ): CompletableFuture<ResponseEntity<LikeToggleResponse>> = CompletableFuture.supplyAsync({
         val result = likeTogglePort.toggleLikeWithCount(userIgn, user.accountId, user.myOcids)
         ResponseEntity.ok(
             LikeToggleResponse(
@@ -28,17 +31,17 @@ class LikeController(
                 likeCount = result.likeCount,
             )
         )
-    }
+    }, executor)
 
     @GetMapping("/{userIgn}/like/status")
     fun getLikeStatus(
         @PathVariable userIgn: String,
         @RequestAttribute(JwtAuthInterceptor.USER_ATTRIBUTE) user: AuthenticatedUser,
-    ): CompletableFuture<ResponseEntity<LikeStatusResponse>> = CompletableFuture.supplyAsync {
+    ): CompletableFuture<ResponseEntity<LikeStatusResponse>> = CompletableFuture.supplyAsync({
         val liked = likeTogglePort.isLiked(userIgn, user.accountId)
         val count = likeTogglePort.getLikeCount(userIgn)
         ResponseEntity.ok(LikeStatusResponse(targetUserIgn = userIgn, liked = liked, likeCount = count))
-    }
+    }, executor)
 }
 
 data class LikeToggleResponse(


### PR DESCRIPTION
#1102, Closes #1046, Closes #1027

## Changes

| # | Component | Before | After |
|---|-----------|--------|-------|
| 1-2 | LikeController | `supplyAsync { }` (commonPool) | `supplyAsync({...}, taskExecutor)` |
| 3 | EquipmentFetchProvider | `supplyAsync { }` (commonPool) | `supplyAsync({...}, taskExecutor)` |
| 4 | EquipmentDataProvider | `supplyAsync { }` (commonPool) | `supplyAsync({...}, taskExecutor)` |
| 5 | EventPublisher (core) | default `runAsync { }` (commonPool) | Removed default, now abstract |
| 6 | KafkaEventPublisher | `runAsync { }` (commonPool) | `runAsync({...}, taskExecutor)` |
| 7 | PgmqEventPublisherAdapter | `runAsync { }` (commonPool) | `runAsync({...}, taskExecutor)` |
| 8 | PresetCalculationHelper | `parallelStream()` (commonPool) | `CompletableFuture.supplyAsync + itemExecutor` |

New: `RestControllerExecutorConfig` — bounded executor for module-rest-controller (core=4, max=8, queue=100)

## Test

- `./gradlew compileKotlin compileJava --continue` ✅
- `./gradlew test` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)