### PR TITLE
refactor(#984): Recursive CF → suspend fun + while loop

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -82,6 +82,7 @@ kotlin-logging-jvm = { module = "io.github.oshai:kotlin-logging-jvm", version.re
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-jdk8 = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-slf4j = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-slf4j", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 
 # Lombok
 lombok = { module = "org.projectlombok:lombok", version.ref = "lombok" }

--- a/module-external-api/build.gradle
+++ b/module-external-api/build.gradle
@@ -48,6 +48,7 @@ dependencies {
 	testImplementation(libs.spring.boot.starter.test)
 	testImplementation(libs.mockito.kotlin)
 	testImplementation(libs.assertj.core)
+	testImplementation(libs.kotlinx.coroutines.test)
 }
 
 // bootJar enabled — standalone executable application

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/OcidLookupPhase.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/OcidLookupPhase.kt
@@ -1,11 +1,21 @@
 package maple.externalapi.scheduler.phase
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.future.await
+import kotlinx.coroutines.future.future
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+import kotlinx.coroutines.withTimeoutOrNull
 import maple.externalapi.domain.ExternalApiEndpoint
 import maple.externalapi.domain.ExternalApiProvider
 import maple.externalapi.port.out.ExternalApiClientPort
 import maple.externalapi.snapshot.event.SnapshotChunkEventPublisher
 import maple.expectation.common.event.SnapshotRunCompletedEvent
-import com.fasterxml.jackson.databind.ObjectMapper
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
@@ -16,12 +26,9 @@ import java.io.BufferedOutputStream
 import java.nio.file.Files
 import java.nio.file.Path
 import java.time.Instant
-import java.util.Collections
 import java.util.UUID
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutorService
-import java.util.concurrent.Semaphore
-import java.util.concurrent.atomic.AtomicInteger
 import java.util.zip.GZIPInputStream
 import java.util.zip.GZIPOutputStream
 
@@ -43,6 +50,7 @@ class OcidLookupPhase(
 ) {
     private val log = LoggerFactory.getLogger(OcidLookupPhase::class.java)
     private val semaphore = Semaphore(maxInFlight)
+    private val maxInFlight = maxInFlight
 
     fun execute(workerExecutor: ExecutorService, rankingRunDir: Path): CompletableFuture<Path?> {
         val mappingDir = Path.of(storeBasePath).resolve("ocid-mapping")
@@ -60,42 +68,97 @@ class OcidLookupPhase(
         log.info("[Scheduler] ========== OCID lookup start ==========")
         log.info(
             "[Scheduler] config: total={}, rate={}/s, batchSize={}, maxInFlight={}, store={}",
-            igns.size, ocidLookupPermitsPerSecond, batchSize, semaphore.availablePermits(), storeBasePath,
+            igns.size, ocidLookupPermitsPerSecond, batchSize, maxInFlight, storeBasePath,
         )
 
         val start = Instant.now()
-        val successCount = AtomicInteger(0)
-        val failCount = AtomicInteger(0)
-        val lastProgressLog = AtomicInteger(0)
-        val results: MutableList<String> = Collections.synchronizedList(mutableListOf())
+        val dispatcher = workerExecutor.asCoroutineDispatcher()
+        val results = mutableListOf<String>()
 
-        return processBatch(
-            workerExecutor = workerExecutor,
-            rateLimiter = rateLimiter,
-            igns = igns,
-            processed = 0,
-            successCount = successCount,
-            failCount = failCount,
-            lastProgressLog = lastProgressLog,
-            results = results,
-            start = start,
-        ).thenApply {
+        return CoroutineScope(dispatcher).future {
+            val (successCount, failCount) = processBatchSuspend(rateLimiter, igns, results)
+
             val runId = SchedulerPhaseUtils.newRunId()
             val outputPath = writeGzipJsonl(mappingDir, results, runId)
-            SchedulerPhaseUtils.logSummary("OCID lookup", igns.size, successCount.get(), successCount.get(), failCount.get(), start)
+            SchedulerPhaseUtils.logSummary("OCID lookup", igns.size, successCount, successCount, failCount, start)
             eventPublisher.publishRunCompleted(SnapshotRunCompletedEvent(
                 eventId = UUID.randomUUID().toString(),
                 runId = runId,
                 endpoint = "ocid-lookup",
                 manifestPath = "ocid-mapping/${outputPath.fileName}",
                 totalRecords = results.size,
-                totalFailed = failCount.get(),
+                totalFailed = failCount,
                 chunkCount = 1,
                 startedAt = start,
                 finishedAt = Instant.now(),
                 createdAt = Instant.now(),
             ))
             outputPath
+        }
+    }
+
+    /**
+     * Batch processing with coroutine-based parallelism and semaphore-gated concurrency.
+     * Replaces recursive CF chain + AtomicInteger with while loop + local accumulators.
+     */
+    private suspend fun processBatchSuspend(
+        rateLimiter: io.github.bucket4j.Bucket,
+        igns: List<String>,
+        results: MutableList<String>,
+    ): Pair<Int, Int> {
+        var processed = 0
+        var successCount = 0
+        var failCount = 0
+        var lastProgressLog = 0
+        val start = Instant.now()
+
+        while (processed < igns.size) {
+            val permits = SchedulerPhaseUtils.acquirePermitsSuspend(rateLimiter, batchSize, igns.size - processed)
+            if (permits == 0) continue // acquirePermitsSuspend already delays 100ms
+
+            val chunk = igns.subList(processed, processed + permits)
+            val batchResults = coroutineScope {
+                chunk.map { ign ->
+                    async {
+                        runCatching { fetchOcid(ign) }.getOrNull()
+                    }
+                }.awaitAll()
+            }
+
+            val batchSuccess = batchResults.filterNotNull()
+            results.addAll(batchSuccess)
+            successCount += batchSuccess.size
+            failCount += chunk.size - batchSuccess.size
+
+            processed += permits
+
+            val progress = successCount + failCount
+            if (progress - lastProgressLog >= 5000) {
+                lastProgressLog = progress
+                SchedulerPhaseUtils.logProgress("OCID lookup", progress, igns.size, successCount, failCount, start)
+            }
+        }
+        return successCount to failCount
+    }
+
+    /**
+     * Fetches OCID for a single IGN. Coroutine Semaphore gates concurrency with
+     * 10s timeout to prevent indefinite hang on semaphore acquisition.
+     * Replaces tryAcquireWithBackoff() + Thread.sleep with structured suspension.
+     */
+    private suspend fun fetchOcid(ign: String): String? {
+        return withTimeoutOrNull(10_000L) {
+            semaphore.withPermit {
+                val data = clientPort.fetch(
+                    ExternalApiProvider.NEXON,
+                    ExternalApiEndpoint.OCID_LOOKUP,
+                    ign,
+                ).await()
+                val ocid = objectMapper.readTree(data).get("ocid")?.asText()
+                if (ocid != null) {
+                    String(objectMapper.writeValueAsBytes(mapOf("userIgn" to ign, "ocid" to ocid)))
+                } else null
+            }
         }
     }
 
@@ -149,88 +212,5 @@ class OcidLookupPhase(
         val size = Files.size(outputPath)
         log.info("[Scheduler] wrote {} OCID mappings to {} ({} bytes)", results.size, outputPath, size)
         return outputPath
-    }
-
-    private fun processBatch(
-        workerExecutor: ExecutorService,
-        rateLimiter: io.github.bucket4j.Bucket,
-        igns: List<String>,
-        processed: Int,
-        successCount: AtomicInteger,
-        failCount: AtomicInteger,
-        lastProgressLog: AtomicInteger,
-        results: MutableList<String>,
-        start: Instant,
-    ): CompletableFuture<Void> {
-        if (processed >= igns.size) {
-            return CompletableFuture.completedFuture(null)
-        }
-
-        val permits = SchedulerPhaseUtils.acquirePermits(rateLimiter, batchSize, igns.size - processed)
-        if (permits == 0) {
-            return processBatch(workerExecutor, rateLimiter, igns, processed, successCount, failCount, lastProgressLog, results, start)
-        }
-
-        val chunk = igns.subList(processed, processed + permits)
-        val futures = chunk.map { ign ->
-            fetchAndCollectOcidAsync(ign, workerExecutor, successCount, failCount, results)
-        }
-
-        return CompletableFuture.allOf(*futures.toTypedArray()).thenCompose {
-            val progress = successCount.get() + failCount.get()
-            if (progress - lastProgressLog.get() >= 5000) {
-                lastProgressLog.set(progress)
-                SchedulerPhaseUtils.logProgress("OCID lookup", progress, igns.size, successCount.get(), failCount.get(), start)
-            }
-            processBatch(workerExecutor, rateLimiter, igns, processed + permits, successCount, failCount, lastProgressLog, results, start)
-        }
-    }
-
-    private fun fetchAndCollectOcidAsync(
-        ign: String,
-        workerExecutor: ExecutorService,
-        successCount: AtomicInteger,
-        failCount: AtomicInteger,
-        results: MutableList<String>,
-    ): CompletableFuture<Void> {
-        return tryAcquireWithBackoff(semaphore, workerExecutor)
-            .thenCompose { acquired ->
-                val fetchFuture: CompletableFuture<Void> = if (!acquired) {
-                    log.warn("[OCID] backpressure: semaphore exhausted, skipping ign={}", ign.take(3) + "***")
-                    failCount.incrementAndGet()
-                    CompletableFuture.completedFuture(null)
-                } else {
-                    clientPort.fetch(
-                        ExternalApiProvider.NEXON,
-                        ExternalApiEndpoint.OCID_LOOKUP,
-                        ign,
-                    )
-                        .thenAcceptAsync({ data ->
-                            val ocid = objectMapper.readTree(data).get("ocid")?.asText()
-                            if (ocid != null) {
-                                val json = String(objectMapper.writeValueAsBytes(mapOf("userIgn" to ign, "ocid" to ocid)))
-                                results.add(json)
-                                successCount.incrementAndGet()
-                            }
-                        }, workerExecutor)
-                        .handle { _, ex ->
-                            if (ex != null) failCount.incrementAndGet()
-                            null
-                        }
-                }
-                fetchFuture.whenComplete { _, _ -> if (acquired) semaphore.release() }
-            }
-    }
-
-    private fun tryAcquireWithBackoff(semaphore: Semaphore, executor: ExecutorService): CompletableFuture<Boolean> {
-        if (semaphore.tryAcquire()) return CompletableFuture.completedFuture(true)
-        return CompletableFuture.supplyAsync({
-            var retries = 0
-            while (!semaphore.tryAcquire()) {
-                if (retries++ >= 3) return@supplyAsync false
-                Thread.sleep(50L * retries)
-            }
-            true
-        }, executor)
     }
 }

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/RankingFetchPhase.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/RankingFetchPhase.kt
@@ -1,6 +1,10 @@
 package maple.externalapi.scheduler.phase
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.future.await
+import kotlinx.coroutines.future.future
 import maple.externalapi.domain.ExternalApiEndpoint
 import maple.externalapi.domain.ExternalApiProvider
 import maple.externalapi.domain.KeyType
@@ -23,7 +27,6 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutorService
-import java.util.concurrent.atomic.AtomicInteger
 
 @Component
 @ConditionalOnProperty(name = ["external-api.ranking.enabled"], havingValue = "true", matchIfMissing = false)
@@ -64,67 +67,68 @@ class RankingFetchPhase(
         )
 
         val rateLimiter = SchedulerPhaseUtils.newRateLimiter(permitsPerSecond)
-        val fetched = AtomicInteger(0)
-        val failed = AtomicInteger(0)
+        val start = Instant.now()
+        val dispatcher = workerExecutor.asCoroutineDispatcher()
 
         log.info("[RankingFetch] starting: runId={}, date={}, maxPages={}, permitsPerSecond={}", runId, date, maxPages, permitsPerSecond)
-        val start = Instant.now()
 
-        return processPages(workerExecutor, sink, rateLimiter, date, 1, fetched, failed)
-            .whenComplete { _, ex ->
+        return CoroutineScope(dispatcher).future {
+            try {
+                val (fetched, failed) = processPagesSuspend(sink, rateLimiter, date)
+                SchedulerPhaseUtils.logSummary("RankingFetch", fetched, fetched, fetched, failed, start)
+            } catch (ex: Throwable) {
+                log.error("[RankingFetch] failed: runId={}, error={}", runId, ex.message)
+                throw ex
+            } finally {
                 sink.close()
-                if (ex != null) {
-                    log.error("[RankingFetch] failed: runId={}, fetched={}, failed={}", runId, fetched.get(), failed.get(), ex)
-                } else {
-                    SchedulerPhaseUtils.logSummary("RankingFetch", fetched.get(), fetched.get(), fetched.get(), failed.get(), start)
-                }
             }
-            .thenApply { runDir }
+            runDir
+        }
     }
 
-    private fun processPages(
-        workerExecutor: ExecutorService,
+    /**
+     * Sequential page processing with suspend-based rate limiting.
+     * Replaces recursive CompletableFuture chain with while loop.
+     */
+    private suspend fun processPagesSuspend(
         sink: ChunkedSnapshotSink,
         rateLimiter: io.github.bucket4j.Bucket,
         date: String,
-        currentPage: Int,
-        fetched: AtomicInteger,
-        failed: AtomicInteger,
-    ): CompletableFuture<Void> {
-        if (currentPage > maxPages) {
-            return CompletableFuture.completedFuture(null)
-        }
+    ): Pair<Int, Int> {
+        var fetched = 0
+        var failed = 0
+        var currentPage = 1
 
-        SchedulerPhaseUtils.acquirePermits(rateLimiter, 1, 1)
+        while (currentPage <= maxPages) {
+            val permits = SchedulerPhaseUtils.acquirePermitsSuspend(rateLimiter, 1, 1)
+            if (permits == 0) continue // acquirePermitsSuspend already delays 100ms
 
-        val requestKey = "$date:$currentPage"
-        return clientPort.fetch(ExternalApiProvider.NEXON, ExternalApiEndpoint.RANKING_OVERALL, requestKey)
-            .thenAcceptAsync({ bodyBytes ->
+            val requestKey = "$date:$currentPage"
+            try {
+                val bodyBytes = clientPort.fetch(ExternalApiProvider.NEXON, ExternalApiEndpoint.RANKING_OVERALL, requestKey).await()
                 val count = submitRankingEntries(sink, bodyBytes, currentPage)
-                fetched.addAndGet(count)
+                fetched += count
                 metrics.recordRankingFetched(count)
-                if (fetched.get() % 10000 == 0) {
-                    log.info("[RankingFetch] progress: fetched={}, failed={}, page={}/{}", fetched.get(), failed.get(), currentPage, maxPages)
+                if (fetched % 10000 == 0) {
+                    log.info("[RankingFetch] progress: fetched={}, failed={}, page={}/{}", fetched, failed, currentPage, maxPages)
                 }
-            }, workerExecutor)
-            .handle { _, ex ->
-                if (ex != null) {
-                    failed.incrementAndGet()
-                    metrics.recordRankingFailed()
-                    val status = SchedulerPhaseUtils.extractHttpStatus(ex)
-                    sink.submit(SnapshotChunkRecord.Failure(
-                        key = requestKey,
-                        endpoint = "ranking-overall",
-                        keyType = KeyType.DATE_PAGE.name,
-                        httpStatus = status,
-                        fetchedAt = Instant.now(),
-                        errorMessage = ex.message ?: "unknown",
-                    ))
-                    log.warn("[RankingFetch] page failed: page={}, status={}, error={}", currentPage, status, ex.message)
-                }
-                null
+            } catch (ex: Throwable) {
+                failed++
+                metrics.recordRankingFailed()
+                val status = SchedulerPhaseUtils.extractHttpStatus(ex)
+                sink.submit(SnapshotChunkRecord.Failure(
+                    key = requestKey,
+                    endpoint = "ranking-overall",
+                    keyType = KeyType.DATE_PAGE.name,
+                    httpStatus = status,
+                    fetchedAt = Instant.now(),
+                    errorMessage = ex.message ?: "unknown",
+                ))
+                log.warn("[RankingFetch] page failed: page={}, status={}, error={}", currentPage, status, ex.message)
             }
-            .thenCompose { processPages(workerExecutor, sink, rateLimiter, date, currentPage + 1, fetched, failed) }
+            currentPage++
+        }
+        return fetched to failed
     }
 
     private fun submitRankingEntries(

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/SchedulerPhaseUtils.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/SchedulerPhaseUtils.kt
@@ -2,6 +2,7 @@ package maple.externalapi.scheduler.phase
 
 import io.github.bucket4j.Bandwidth
 import io.github.bucket4j.Bucket
+import kotlinx.coroutines.delay
 import org.slf4j.LoggerFactory
 import java.nio.file.Files
 import java.nio.file.Path
@@ -27,6 +28,19 @@ internal object SchedulerPhaseUtils {
         return rateLimiter.tryConsumeAsMuchAsPossible(maxBatch.toLong()).toInt().also {
             if (it == 0) Thread.sleep(Duration.ofMillis(100))
         }
+    }
+
+    /**
+     * Suspend-friendly rate limit permit acquisition.
+     * Replaces Thread.sleep(100) with coroutine delay(100) when no permits available.
+     */
+    suspend fun acquirePermitsSuspend(rateLimiter: Bucket, batchSize: Int, remaining: Int): Int {
+        val maxBatch = minOf(batchSize, remaining)
+        val consumed = rateLimiter.tryConsumeAsMuchAsPossible(maxBatch.toLong()).toInt()
+        if (consumed == 0) {
+            delay(100)
+        }
+        return consumed
     }
 
     fun newRunId(): String {

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/SchedulerPhaseUtils.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/SchedulerPhaseUtils.kt
@@ -23,13 +23,6 @@ internal object SchedulerPhaseUtils {
         )
         .build()
 
-    fun acquirePermits(rateLimiter: Bucket, batchSize: Int, remaining: Int): Int {
-        val maxBatch = minOf(batchSize, remaining)
-        return rateLimiter.tryConsumeAsMuchAsPossible(maxBatch.toLong()).toInt().also {
-            if (it == 0) Thread.sleep(Duration.ofMillis(100))
-        }
-    }
-
     /**
      * Suspend-friendly rate limit permit acquisition.
      * Replaces Thread.sleep(100) with coroutine delay(100) when no permits available.

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/SnapshotFetchPhase.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/SnapshotFetchPhase.kt
@@ -12,6 +12,16 @@ import maple.externalapi.snapshot.SnapshotChunkRecord
 import maple.externalapi.snapshot.SnapshotChunkingProperties
 import maple.externalapi.snapshot.event.SnapshotChunkEventPublisher
 import com.fasterxml.jackson.databind.ObjectMapper
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.future.await
+import kotlinx.coroutines.future.future
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+import kotlinx.coroutines.withTimeoutOrNull
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
@@ -22,8 +32,6 @@ import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutorService
-import java.util.concurrent.Semaphore
-import java.util.concurrent.atomic.AtomicInteger
 
 data class SnapshotFetchConfig(
     val endpoint: String,
@@ -60,7 +68,7 @@ class SnapshotFetchPhase(
     private val log = LoggerFactory.getLogger(SnapshotFetchPhase::class.java)
     private val semaphore = Semaphore(maxInFlight)
 
-    fun executeCharacterBasic(workerExecutor: ExecutorService, ocidCache: Map<String, String>): CompletableFuture<Void> =
+    fun executeCharacterBasic(workerExecutor: ExecutorService, ocidCache: Map<String, String>): CompletableFuture<Unit> =
         execute(
             workerExecutor,
             ocidCache.entries.toList(),
@@ -75,7 +83,7 @@ class SnapshotFetchPhase(
             ),
         )
 
-    fun executeItemEquipment(workerExecutor: ExecutorService, entries: List<Map.Entry<String, String>>): CompletableFuture<Void> =
+    fun executeItemEquipment(workerExecutor: ExecutorService, entries: List<Map.Entry<String, String>>): CompletableFuture<Unit> =
         execute(
             workerExecutor,
             entries,
@@ -93,18 +101,18 @@ class SnapshotFetchPhase(
         workerExecutor: ExecutorService,
         entries: List<Map.Entry<String, String>>,
         config: SnapshotFetchConfig,
-    ): CompletableFuture<Void> {
+    ): CompletableFuture<Unit> {
         if (config.skipIfExisting) {
             val existing = artifactStore.listStoredKeys(config.apiEndpoint)
             if (existing.isNotEmpty()) {
                 log.info("[Scheduler] {} already done ({} files), skipping", config.endpoint, existing.size)
-                return CompletableFuture.completedFuture(null)
+                return CompletableFuture.completedFuture(Unit)
             }
         }
 
         if (entries.isEmpty()) {
             log.warn("[Scheduler] OCID cache empty, skipping {}", config.endpoint)
-            return CompletableFuture.completedFuture(null)
+            return CompletableFuture.completedFuture(Unit)
         }
 
         val runId = SchedulerPhaseUtils.newRunId()
@@ -132,58 +140,55 @@ class SnapshotFetchPhase(
         )
 
         val start = Instant.now()
-        val successCount = AtomicInteger(0)
-        val failCount = AtomicInteger(0)
-        val lastProgressLog = AtomicInteger(0)
+        val dispatcher = workerExecutor.asCoroutineDispatcher()
 
-        return processBatch(
-            workerExecutor = workerExecutor,
-            rateLimiter = rateLimiter,
-            entries = entries,
-            processed = 0,
-            config = config,
-            sink = sink,
-            runId = runId,
-            successCount = successCount,
-            failCount = failCount,
-            lastProgressLog = lastProgressLog,
-            start = start,
-        ).whenComplete { _, _ ->
-            sink.close()
-            config.recordDuration(Duration.between(start, Instant.now()))
-            SchedulerPhaseUtils.logSummary(config.endpoint, entries.size, successCount.get(), successCount.get(), failCount.get(), start)
+        return CoroutineScope(dispatcher).future {
+            try {
+                val (successCount, failCount) = processBatchSuspend(rateLimiter, entries, config, sink, runId, start)
+                SchedulerPhaseUtils.logSummary(config.endpoint, entries.size, successCount, successCount, failCount, start)
+            } finally {
+                sink.close()
+                config.recordDuration(Duration.between(start, Instant.now()))
+            }
         }
     }
 
-    private fun processBatch(
-        workerExecutor: ExecutorService,
+    /**
+     * Batch processing with coroutine-based parallelism and semaphore-gated concurrency.
+     * Replaces recursive CF chain + AtomicInteger with while loop + local accumulators.
+     */
+    private suspend fun processBatchSuspend(
         rateLimiter: io.github.bucket4j.Bucket,
         entries: List<Map.Entry<String, String>>,
-        processed: Int,
         config: SnapshotFetchConfig,
         sink: ChunkedSnapshotSink,
         runId: String,
-        successCount: AtomicInteger,
-        failCount: AtomicInteger,
-        lastProgressLog: AtomicInteger,
         start: Instant,
-    ): CompletableFuture<Void> {
-        if (processed >= entries.size) {
-            return CompletableFuture.completedFuture(null)
-        }
+    ): Pair<Int, Int> {
+        var processed = 0
+        var successCount = 0
+        var failCount = 0
+        var lastProgressLog = 0
 
-        val permits = SchedulerPhaseUtils.acquirePermits(rateLimiter, batchSize, entries.size - processed)
-        if (permits == 0) {
-            return processBatch(workerExecutor, rateLimiter, entries, processed, config, sink, runId, successCount, failCount, lastProgressLog, start)
-        }
+        while (processed < entries.size) {
+            val permits = SchedulerPhaseUtils.acquirePermitsSuspend(rateLimiter, batchSize, entries.size - processed)
+            if (permits == 0) continue // acquirePermitsSuspend already delays 100ms
 
-        val chunk = entries.subList(processed, processed + permits)
-        val batchWaitStart = Instant.now()
-        val futures = chunk.map { (_, ocid) ->
-            fetchSingleAsync(ocid, config, sink, workerExecutor, successCount, failCount)
-        }
+            val chunk = entries.subList(processed, processed + permits)
+            val batchWaitStart = Instant.now()
 
-        return CompletableFuture.allOf(*futures.toTypedArray()).thenCompose {
+            val batchResults = coroutineScope {
+                chunk.map { (_, ocid) ->
+                    async {
+                        runCatching {
+                            fetchSingle(ocid, config, sink)
+                        }.onFailure { ex ->
+                            handleSnapshotFailure(ocid, config, sink, ex)
+                        }.getOrNull()
+                    }
+                }.awaitAll()
+            }
+
             val batchWaitDuration = Duration.between(batchWaitStart, Instant.now())
             fetchMetrics.recordBatchWait(config.endpoint, batchWaitDuration, chunk.size)
             if (batchWaitDuration.toMillis() >= 1_000) {
@@ -193,113 +198,82 @@ class SnapshotFetchPhase(
                     runId,
                     chunk.size,
                     batchWaitDuration.toMillis(),
-                    successCount.get(),
-                    failCount.get(),
+                    successCount,
+                    failCount,
                 )
             }
 
-            val progress = successCount.get() + failCount.get()
-            if (progress - lastProgressLog.get() >= 5000) {
-                lastProgressLog.set(progress)
-                SchedulerPhaseUtils.logProgress(config.endpoint, progress, entries.size, successCount.get(), failCount.get(), start)
+            val batchSuccess = batchResults.filterNotNull().size
+            successCount += batchSuccess
+            failCount += chunk.size - batchSuccess
+
+            processed += permits
+
+            val progress = successCount + failCount
+            if (progress - lastProgressLog >= 5000) {
+                lastProgressLog = progress
+                SchedulerPhaseUtils.logProgress(config.endpoint, progress, entries.size, successCount, failCount, start)
             }
-            processBatch(workerExecutor, rateLimiter, entries, processed + permits, config, sink, runId, successCount, failCount, lastProgressLog, start)
         }
+        return successCount to failCount
     }
 
-    private fun fetchSingleAsync(
+    /**
+     * Fetches a single OCID with semaphore-gated concurrency and 10s timeout.
+     * Returns true on success, null on failure (for runCatching).
+     */
+    private suspend fun fetchSingle(
         ocid: String,
         config: SnapshotFetchConfig,
         sink: ChunkedSnapshotSink,
-        workerExecutor: ExecutorService,
-        successCount: AtomicInteger,
-        failCount: AtomicInteger,
-    ): CompletableFuture<Void> {
-        return tryAcquireWithBackoff(semaphore, workerExecutor)
-            .thenCompose { acquired ->
-                val fetchFuture: CompletableFuture<Void> = if (!acquired) {
-                    log.warn("[{}] backpressure: semaphore exhausted, skipping ocid={}", config.endpoint, ocid.take(3) + "***")
-                    failCount.incrementAndGet()
-                    config.onFailed()
-                    CompletableFuture.completedFuture(null)
-                } else {
-                    val fetchStart = Instant.now()
-                    clientPort.fetch(
-                        ExternalApiProvider.NEXON,
-                        config.apiEndpoint,
+    ): Boolean {
+        return withTimeoutOrNull(10_000L) {
+            semaphore.withPermit {
+                val fetchStart = Instant.now()
+                val bodyBytes = clientPort.fetch(
+                    ExternalApiProvider.NEXON,
+                    config.apiEndpoint,
+                    ocid,
+                ).await()
+
+                val fetchDuration = Duration.between(fetchStart, Instant.now())
+                fetchMetrics.recordFetchJoin(config.endpoint, fetchDuration)
+
+                val queueDepthBeforeSubmit = sink.queueDepth()
+                val submitStart = Instant.now()
+                sink.submit(
+                    SnapshotChunkRecord.Success(
+                        key = ocid,
+                        endpoint = config.endpoint,
+                        keyType = "OCID",
+                        httpStatus = 200,
+                        fetchedAt = Instant.now(),
+                        bodyBytes = bodyBytes,
+                    ),
+                )
+                val submitDuration = Duration.between(submitStart, Instant.now())
+                fetchMetrics.recordSinkSubmit(config.endpoint, submitDuration, queueDepthBeforeSubmit)
+                if (fetchDuration.toMillis() >= 500 || submitDuration.toMillis() >= 100) {
+                    log.info(
+                        "[SnapshotFetchMetrics] fetch/sink: endpoint={}, ocid={}, responseBytes={}, fetchJoinMs={}, sinkSubmitMs={}, sinkQueueDepthBeforeSubmit={}",
+                        config.endpoint,
                         ocid,
+                        bodyBytes.size,
+                        fetchDuration.toMillis(),
+                        submitDuration.toMillis(),
+                        queueDepthBeforeSubmit,
                     )
-                        .thenAcceptAsync({ bodyBytes ->
-                            handleSnapshotSuccess(ocid, config, sink, successCount, fetchStart, bodyBytes)
-                        }, workerExecutor)
-                        .handle { _, ex ->
-                            if (ex != null) {
-                                handleSnapshotFailure(ocid, config, sink, failCount, ex)
-                            }
-                            null
-                        }
                 }
-                fetchFuture.whenComplete { _, _ -> if (acquired) semaphore.release() }
+                config.onFetched()
+                true
             }
-    }
-
-    private fun tryAcquireWithBackoff(semaphore: Semaphore, executor: ExecutorService): CompletableFuture<Boolean> {
-        if (semaphore.tryAcquire()) return CompletableFuture.completedFuture(true)
-        return CompletableFuture.supplyAsync({
-            var retries = 0
-            while (!semaphore.tryAcquire()) {
-                if (retries++ >= 3) return@supplyAsync false
-                Thread.sleep(50L * retries)
-            }
-            true
-        }, executor)
-    }
-
-    private fun handleSnapshotSuccess(
-        ocid: String,
-        config: SnapshotFetchConfig,
-        sink: ChunkedSnapshotSink,
-        successCount: AtomicInteger,
-        fetchStart: Instant,
-        bodyBytes: ByteArray,
-    ) {
-        val fetchDuration = Duration.between(fetchStart, Instant.now())
-        fetchMetrics.recordFetchJoin(config.endpoint, fetchDuration)
-
-        val queueDepthBeforeSubmit = sink.queueDepth()
-        val submitStart = Instant.now()
-        sink.submit(
-            SnapshotChunkRecord.Success(
-                key = ocid,
-                endpoint = config.endpoint,
-                keyType = "OCID",
-                httpStatus = 200,
-                fetchedAt = Instant.now(),
-                bodyBytes = bodyBytes,
-            ),
-        )
-        val submitDuration = Duration.between(submitStart, Instant.now())
-        fetchMetrics.recordSinkSubmit(config.endpoint, submitDuration, queueDepthBeforeSubmit)
-        if (fetchDuration.toMillis() >= 500 || submitDuration.toMillis() >= 100) {
-            log.info(
-                "[SnapshotFetchMetrics] fetch/sink: endpoint={}, ocid={}, responseBytes={}, fetchJoinMs={}, sinkSubmitMs={}, sinkQueueDepthBeforeSubmit={}",
-                config.endpoint,
-                ocid,
-                bodyBytes.size,
-                fetchDuration.toMillis(),
-                submitDuration.toMillis(),
-                queueDepthBeforeSubmit,
-            )
-        }
-        successCount.incrementAndGet()
-        config.onFetched()
+        } ?: false
     }
 
     private fun handleSnapshotFailure(
         ocid: String,
         config: SnapshotFetchConfig,
         sink: ChunkedSnapshotSink,
-        failCount: AtomicInteger,
         ex: Throwable,
     ) {
         val httpStatus = SchedulerPhaseUtils.extractHttpStatus(ex)
@@ -313,7 +287,6 @@ class SnapshotFetchPhase(
                 errorMessage = ex.message ?: "unknown",
             ),
         )
-        failCount.incrementAndGet()
         config.onFailed()
     }
 }

--- a/module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/SchedulerPhaseUtilsTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/SchedulerPhaseUtilsTest.kt
@@ -1,0 +1,32 @@
+package maple.externalapi.scheduler.phase
+
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class SchedulerPhaseUtilsTest {
+
+    @Test
+    fun `acquirePermitsSuspend returns permits when available`() = runTest {
+        val bucket = SchedulerPhaseUtils.newRateLimiter(10)
+        val permits = SchedulerPhaseUtils.acquirePermitsSuspend(bucket, 5, 10)
+        assertThat(permits).isEqualTo(5)
+    }
+
+    @Test
+    fun `acquirePermitsSuspend respects remaining limit`() = runTest {
+        val bucket = SchedulerPhaseUtils.newRateLimiter(100)
+        val permits = SchedulerPhaseUtils.acquirePermitsSuspend(bucket, 50, 10)
+        assertThat(permits).isEqualTo(10) // min(batchSize, remaining)
+    }
+
+    @Test
+    fun `acquirePermitsSuspend returns zero when bucket empty without blocking`() = runTest {
+        val bucket = SchedulerPhaseUtils.newRateLimiter(1)
+        // Consume the only permit
+        SchedulerPhaseUtils.acquirePermitsSuspend(bucket, 1, 1)
+        // Bucket is now empty — should return 0 after delay (not throw, not block thread)
+        val permits = SchedulerPhaseUtils.acquirePermitsSuspend(bucket, 1, 1)
+        assertThat(permits).isEqualTo(0)
+    }
+}


### PR DESCRIPTION
## Summary

3 Phase classes in `module-external-api` converted from recursive `CompletableFuture` chains to `suspend fun` + while loop.

## Changes

| Phase | Key Change |
|-------|-----------|
| **SchedulerPhaseUtils** | Added `acquirePermitsSuspend()` — `delay(100)` instead of `Thread.sleep(100)` |
| **RankingFetchPhase** | `processPages()` recursive CF → `processPagesSuspend()` while loop. `AtomicInteger` → local `var` |
| **OcidLookupPhase** | `processBatch()` recursive CF → `processBatchSuspend()` while loop. `java.util.concurrent.Semaphore` → coroutine `Semaphore.withPermit` + `withTimeoutOrNull(10s)`. `Collections.synchronizedList` → `ArrayList` |
| **SnapshotFetchPhase** | Same pattern. `fetchSingle()` with `Semaphore.withPermit` + `withTimeoutOrNull(10s)`. `onFailure { handleSnapshotFailure() }` for Failure record submission |

## Design Decisions (from grill-me review)

- **suspend fun** (not Flow) — batch processors, not streams
- **`CF.await()`** from kotlinx-coroutines-jdk8 — no port interface change
- **`CoroutineScope(dispatcher).future {}`** — CF return type preserved, `ExternalApiScheduler` unchanged
- **`withTimeoutOrNull(10s)`** on Semaphore — prevents indefinite hang
- **`acquirePermitsSuspend`** handles `delay(100)` — callers do NOT add extra delay
- **VT executor** wrapped as `CoroutineDispatcher` — lifecycle/shutdown preserved

## Test Results

All existing tests pass unchanged (execute() API contract preserved):
- `RankingFetchPhaseTest` — 3 tests PASSED
- `OcidLookupPhaseTest` — 2 tests PASSED  
- `SchedulerPhaseUtilsTest` — 3 tests PASSED (new)
- `UrgentCharacterRequestConsumerTest` — 2 tests PASSED

Closes #984

🤖 Generated with [Claude Code](https://claude.com/claude-code)