### PR TITLE
fix(external-api): log warn for null ocid in OcidLookupPhase (issue 1018)

### DIFF
--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/OcidLookupPhase.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/OcidLookupPhase.kt
@@ -16,6 +16,7 @@ import maple.externalapi.domain.ExternalApiProvider
 import maple.externalapi.port.out.ExternalApiClientPort
 import maple.externalapi.snapshot.event.SnapshotChunkEventPublisher
 import maple.expectation.common.event.SnapshotRunCompletedEvent
+import maple.expectation.util.StringMaskingUtils.maskIgn
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
@@ -157,7 +158,10 @@ class OcidLookupPhase(
                 val ocid = objectMapper.readTree(data).get("ocid")?.asText()
                 if (ocid != null) {
                     String(objectMapper.writeValueAsBytes(mapOf("userIgn" to ign, "ocid" to ocid)))
-                } else null
+                } else {
+                    log.warn("[OCID] null ocid for ign={}", maskIgn(ign))
+                    null
+                }
             }
         }
     }

--- a/module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/OcidLookupPhaseTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/OcidLookupPhaseTest.kt
@@ -96,10 +96,9 @@ class OcidLookupPhaseTest {
             clientPort.fetch(ExternalApiProvider.NEXON, ExternalApiEndpoint.OCID_LOOKUP, "PlayerNullOcid"),
         ).thenReturn(CompletableFuture.completedFuture("""{"character_name":"x"}""".toByteArray()))
 
-        val outputPath = phase.execute(executor, runDir).get()
+        val outputPath = requireNotNull(phase.execute(executor, runDir).get()) { "execute returned null path" }
 
-        assertThat(outputPath).isNotNull
-        assertThat(Files.exists(outputPath!!)).isTrue
+        assertThat(Files.exists(outputPath)).isTrue
 
         val lines = GZIPInputStream(BufferedInputStream(Files.newInputStream(outputPath)))
             .bufferedReader()

--- a/module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/OcidLookupPhaseTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/OcidLookupPhaseTest.kt
@@ -3,16 +3,23 @@ package maple.externalapi.scheduler.phase
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import maple.externalapi.domain.ExternalApiEndpoint
+import maple.externalapi.domain.ExternalApiProvider
 import maple.externalapi.port.out.ExternalApiClientPort
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.io.BufferedInputStream
 import java.io.BufferedOutputStream
 import java.io.FileOutputStream
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.concurrent.CompletableFuture
+import java.util.zip.GZIPInputStream
 import java.util.zip.GZIPOutputStream
 
 class OcidLookupPhaseTest {
@@ -21,13 +28,16 @@ class OcidLookupPhaseTest {
     lateinit var tempDir: Path
 
     private lateinit var objectMapper: ObjectMapper
+    private lateinit var clientPort: ExternalApiClientPort
     private lateinit var phase: OcidLookupPhase
+    private lateinit var executor: java.util.concurrent.ExecutorService
 
     @BeforeEach
     fun setUp() {
         objectMapper = ObjectMapper().registerKotlinModule().registerModule(JavaTimeModule())
+        clientPort = mock()
         phase = OcidLookupPhase(
-            clientPort = mock(),
+            clientPort = clientPort,
             objectMapper = objectMapper,
             ocidLookupPermitsPerSecond = 400,
             batchSize = 1000,
@@ -35,6 +45,12 @@ class OcidLookupPhaseTest {
             eventPublisher = maple.externalapi.snapshot.event.NoOpSnapshotChunkEventPublisher(),
             maxInFlight = 100,
         )
+        executor = java.util.concurrent.Executors.newVirtualThreadPerTaskExecutor()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        executor.close()
     }
 
     private fun writeGzipJsonl(chunkFilePath: Path, keys: List<String>) {
@@ -65,5 +81,31 @@ class OcidLookupPhaseTest {
         val names = phase.readCharacterNamesFromChunks(runDir)
 
         assertThat(names).isEmpty()
+    }
+
+    @Test
+    fun `execute writes only valid ocids when one Nexon response lacks ocid field`() {
+        val runDir = tempDir.resolve("runs").resolve("20260604-140000-001")
+        val chunksDir = runDir.resolve("ranking-overall").resolve("chunks")
+        writeGzipJsonl(chunksDir.resolve("part-000001.jsonl.gz"), listOf("PlayerValid", "PlayerNullOcid"))
+
+        whenever(
+            clientPort.fetch(ExternalApiProvider.NEXON, ExternalApiEndpoint.OCID_LOOKUP, "PlayerValid"),
+        ).thenReturn(CompletableFuture.completedFuture("""{"ocid":"abc123"}""".toByteArray()))
+        whenever(
+            clientPort.fetch(ExternalApiProvider.NEXON, ExternalApiEndpoint.OCID_LOOKUP, "PlayerNullOcid"),
+        ).thenReturn(CompletableFuture.completedFuture("""{"character_name":"x"}""".toByteArray()))
+
+        val outputPath = phase.execute(executor, runDir).get()
+
+        assertThat(outputPath).isNotNull
+        assertThat(Files.exists(outputPath!!)).isTrue
+
+        val lines = GZIPInputStream(BufferedInputStream(Files.newInputStream(outputPath)))
+            .bufferedReader()
+            .readLines()
+            .filter { it.isNotBlank() }
+        assertThat(lines).hasSize(1)
+        assertThat(lines[0]).contains("\"ocid\":\"abc123\"").contains("\"userIgn\":\"PlayerValid\"")
     }
 }


### PR DESCRIPTION
## Summary
- Add `log.warn("[OCID] null ocid for ign={}", maskIgn(ign))` to `OcidLookupPhase.fetchOcid()` else-branch
- Surface Nexon responses that lack `ocid` field so operators can identify affected IGNs
- Add end-to-end test verifying null-ocid responses are excluded from mapping file
- Count semantics (`successCount + failCount == totalCount`) were already correct via `processBatchSuspend` null-return handling

## Test plan
- [x] `./gradlew :module-external-api:compileKotlin :module-external-api:compileJava --continue` passes
- [x] `./gradlew :module-external-api:test` passes (25/25)
- [x] New test: `execute writes only valid ocids when one Nexon response lacks ocid field` — PASS
- [x] IGN masked in log line per `.claude/rules/code-style.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)