### PR TITLE
fix(external-api): ArtifactStore/Cleanup null→예외 for #999

### DIFF
--- a/docs/superpowers/plans/2026-06-04-externalapi-null-to-exception.md
+++ b/docs/superpowers/plans/2026-06-04-externalapi-null-to-exception.md
@@ -35,10 +35,10 @@
 
 - [ ] **Step 1: enum 상수 추가**
 
-`CommonErrorCode` 클래스 내 `S016 CACHE_DATA_NOT_FOUND` 다음 줄에 추가:
+`CommonErrorCode` 클래스 내 `S017 SYSTEM_ERROR` 다음 줄에 추가:
 
 ```kotlin
-ARTIFACT_NOT_FOUND("S017", "아티팩트를 찾을 수 없습니다 (endpoint: %s, key: %s)", 500),
+ARTIFACT_NOT_FOUND("S018", "아티팩트를 찾을 수 없습니다 (endpoint: %s, key: %s)", 500),
 ```
 
 - [ ] **Step 2: 컴파일 검증**
@@ -55,7 +55,7 @@ Expected: BUILD SUCCESSFUL
 
 ```bash
 git add module-common/src/main/kotlin/maple/expectation/error/CommonErrorCode.kt
-git commit -m "feat(common): add ARTIFACT_NOT_FOUND error code (S017) for #999"
+git commit -m "feat(common): add ARTIFACT_NOT_FOUND error code (S018) for #999"
 ```
 
 ---
@@ -148,47 +148,16 @@ git commit -m "feat(common): ArtifactNotFoundException for #999"
 
 ---
 
-## Task 3: Port 시그니처 hard break
+## Task 3: Port 시그니처 hard break + Adapter 동시 변경 (squash)
+
+**Note:** 본 task는 (1) Port hard break, (2) Adapter read 구현, (3) 테스트 4건을 단일 PR에 동시 적용. TDD 학습용 red 단계는 git history에 보존하지 않음.
 
 **Files:**
 - Modify: `module-external-api/src/main/kotlin/maple/externalapi/port/out/ExternalApiArtifactStorePort.kt`
-
-- [ ] **Step 1: read 반환 타입 변경**
-
-`ExternalApiArtifactStorePort.kt:14-17`:
-
-```kotlin
-    fun read(
-        endpoint: ExternalApiEndpoint,
-        key: String,
-    ): ByteArray
-```
-
-- [ ] **Step 2: 컴파일 검증 — adapter 미수정 상태이므로 실패해야 함**
-
-Run:
-```bash
-cd /home/maple/probabilistic-valuation-engine
-./gradlew :module-external-api:compileKotlin --continue
-```
-
-Expected: FAIL with type mismatch in `LocalExternalApiArtifactStoreAdapter.read` (return type)
-
-- [ ] **Step 3: 커밋 (red 단계 보존)**
-
-```bash
-git add module-external-api/src/main/kotlin/maple/externalapi/port/out/ExternalApiArtifactStorePort.kt
-git commit -m "refactor(external-api): ArtifactStorePort.read returns non-null ByteArray (red) for #999"
-```
-
----
-
-## Task 4: LocalExternalApiArtifactStoreAdapter.read — 실패 테스트
-
-**Files:**
+- Modify: `module-external-api/src/main/kotlin/maple/externalapi/infra/storage/LocalExternalApiArtifactStoreAdapter.kt`
 - Create: `module-external-api/src/test/kotlin/maple/externalapi/infra/storage/LocalExternalApiArtifactStoreAdapterTest.kt`
 
-- [ ] **Step 1: 테스트 작성**
+- [ ] **Step 1: 테스트 4건 작성**
 
 ```kotlin
 package maple.externalapi.infra.storage
@@ -199,7 +168,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
-import java.nio.file.Files
 import java.nio.file.Path
 
 class LocalExternalApiArtifactStoreAdapterTest {
@@ -247,7 +215,7 @@ class LocalExternalApiArtifactStoreAdapterTest {
         val adapter = newAdapter(tempDir.toString())
         val endpoint = ExternalApiEndpoint.ITEM_EQUIPMENT
         val key = "user-2"
-        val payload = "binary- -data".toByteArray()
+        val payload = "binary-data".toByteArray()
 
         adapter.store(endpoint, key, payload)
         val result = adapter.read(endpoint, key)
@@ -257,53 +225,24 @@ class LocalExternalApiArtifactStoreAdapterTest {
 }
 ```
 
-- [ ] **Step 2: 테스트 실패 확인**
+- [ ] **Step 2: Port 시그니처 + Adapter read 본문 교체**
 
-Run:
-```bash
-cd /home/maple/probabilistic-valuation-engine
-./gradlew :module-external-api:test --tests "maple.externalapi.infra.storage.LocalExternalApiArtifactStoreAdapterTest"
+Port (`ExternalApiArtifactStorePort.kt:14-17`):
+```kotlin
+    fun read(
+        endpoint: ExternalApiEndpoint,
+        key: String,
+    ): ByteArray
 ```
 
-Expected: FAIL (read가 아직 `ByteArray?` 반환 → type mismatch, 또는 store는 통과 후 read에서 null 반환 시 fail)
-
-- [ ] **Step 3: (실패만 확인, 커밋 안함 — 다음 task에서 같이 green)**
-- [ ] **Step 4: 진행**
-
----
-
-## Task 5: LocalExternalApiArtifactStoreAdapter.read — 구현
-
-**Files:**
-- Modify: `module-external-api/src/main/kotlin/maple/externalapi/infra/storage/LocalExternalApiArtifactStoreAdapter.kt`
-
-- [ ] **Step 1: import 추가**
-
-`LocalExternalApiArtifactStoreAdapter.kt` 상단 import 블록에:
-
+Adapter import 추가:
 ```kotlin
 import maple.expectation.error.CommonErrorCode
 import maple.expectation.error.exception.ArtifactNotFoundException
 import java.nio.file.NoSuchFileException
 ```
 
-- [ ] **Step 2: read 메서드 본문 교체**
-
-기존 `lines 54-61`:
-
-```kotlin
-    override fun read(
-        endpoint: ExternalApiEndpoint,
-        key: String,
-    ): ByteArray? {
-        val filePath = resolvePath(endpoint, key)
-        if (!Files.exists(filePath)) return null
-        return GZIPInputStream(Files.readAllBytes(filePath).inputStream()).use { it.readAllBytes() }
-    }
-```
-
-신규:
-
+Adapter read 본문 (`LocalExternalApiArtifactStoreAdapter.kt:54-61`):
 ```kotlin
     override fun read(
         endpoint: ExternalApiEndpoint,
@@ -322,7 +261,6 @@ import java.nio.file.NoSuchFileException
 
 - [ ] **Step 3: 테스트 통과 확인**
 
-Run:
 ```bash
 cd /home/maple/probabilistic-valuation-engine
 ./gradlew :module-external-api:test --tests "maple.externalapi.infra.storage.LocalExternalApiArtifactStoreAdapterTest"
@@ -330,28 +268,18 @@ cd /home/maple/probabilistic-valuation-engine
 
 Expected: PASS (4 tests)
 
-- [ ] **Step 4: 전체 external-api 컴파일 검증**
-
-Run:
-```bash
-cd /home/maple/probabilistic-valuation-engine
-./gradlew :module-external-api:compileKotlin compileJava --continue
-```
-
-Expected: BUILD SUCCESSFUL
-
-- [ ] **Step 5: 커밋**
+- [ ] **Step 4: 커밋 (단일, red 흔적 없음)**
 
 ```bash
-git add module-external-api/src/main/kotlin/maple/externalapi/infra/storage/LocalExternalApiArtifactStoreAdapter.kt
 git add module-external-api/src/main/kotlin/maple/externalapi/port/out/ExternalApiArtifactStorePort.kt
+git add module-external-api/src/main/kotlin/maple/externalapi/infra/storage/LocalExternalApiArtifactStoreAdapter.kt
 git add module-external-api/src/test/kotlin/maple/externalapi/infra/storage/LocalExternalApiArtifactStoreAdapterTest.kt
 git commit -m "feat(external-api): ArtifactStorePort.read throws ArtifactNotFoundException for #999"
 ```
 
 ---
 
-## Task 6: ConsumedChunkCleanupScheduler.deleteFile — 실패 테스트
+## Task 4: ConsumedChunkCleanupScheduler.deleteFile — 실패 테스트
 
 **Files:**
 - Create: `module-external-api/src/test/kotlin/maple/externalapi/cleanup/ConsumedChunkCleanupSchedulerDeleteFileTest.kt`
@@ -427,7 +355,7 @@ Expected: FAIL on `deleteFile throws IOException` test (현재 `runCatching`이 
 
 ---
 
-## Task 7: ConsumedChunkCleanupScheduler.deleteFile — 구현
+## Task 5: ConsumedChunkCleanupScheduler.deleteFile — 구현
 
 **Files:**
 - Modify: `module-external-api/src/main/kotlin/maple/externalapi/cleanup/ConsumedChunkCleanupScheduler.kt`
@@ -506,7 +434,7 @@ git commit -m "feat(external-api): ConsumedChunkCleanupScheduler.deleteFile prop
 
 ---
 
-## Task 8: 전체 검증
+## Task 6: 전체 검증
 
 - [ ] **Step 1: 외부 API 모듈 전체 컴파일**
 
@@ -559,21 +487,21 @@ git diff --cached --quiet || git commit -m "chore(#999): verification log"
 
 | Spec 요구사항 | Task |
 |--------------|------|
-| `CommonErrorCode.ARTIFACT_NOT_FOUND` (S017) | T1 |
+| `CommonErrorCode.ARTIFACT_NOT_FOUND` (S018) | T1 |
 | `ArtifactNotFoundException` (ServerBaseException) | T2 |
 | `read` 반환 non-null | T3 |
-| Adapter read: 파일 없음 → throw | T4, T5 |
-| Adapter read: 다른 IOException 자연 전파 | T5 (catch 분리로 implicit 보장) |
-| deleteFile IOException/SecurityException throw | T6, T7 |
-| deleteFile "이미 없음" false 유지 | T6 (테스트) |
-| 단위 테스트 8건 | T2(2) + T4(4) + T6(3) = 9건 (1 초과 OK) |
-| 컴파일 + 기존 테스트 | T8 |
+| Adapter read: 파일 없음 → throw | T3 |
+| Adapter read: 다른 IOException 자연 전파 | T3 (catch 분리로 implicit 보장) |
+| deleteFile IOException/SecurityException throw | T4, T5 |
+| deleteFile "이미 없음" false 유지 | T4 (테스트) |
+| 단위 테스트 9건 | T2(2) + T3(4) + T4(3) |
+| 컴파일 + 기존 테스트 | T6 |
 
 ### Placeholder scan
 - "TBD" / "TODO" / "fill in" / "similar to" 없음
 - 모든 코드 블록은 실제 코드
 
 ### Type consistency
-- `ArtifactNotFoundException(errorCode, cause, vararg args)` — T2에서 정의, T5에서 사용. 시그니처 일치.
-- `deleteFile(objectKey): Boolean` — T6에서 시그니처 보존, T7에서 내부 로직만 변경. 시그니처 일치.
-- `read(endpoint, key): ByteArray` — T3에서 정의, T4에서 호출. 시그니처 일치.
+- `ArtifactNotFoundException(errorCode, cause, vararg args)` — T2에서 정의, T3에서 사용. 시그니처 일치.
+- `deleteFile(objectKey): Boolean` — T4에서 시그니처 보존, T5에서 내부 로직만 변경. 시그니처 일치.
+- `read(endpoint, key): ByteArray` — T3 Port 변경 + T3 테스트에서 호출. 시그니처 일치.

--- a/docs/superpowers/specs/2026-06-04-externalapi-null-to-exception-design.md
+++ b/docs/superpowers/specs/2026-06-04-externalapi-null-to-exception-design.md
@@ -48,7 +48,7 @@ fun read(endpoint: ExternalApiEndpoint, key: String): ByteArray
 
 - 위치: `module-common/src/main/kotlin/maple/expectation/error/exception/ArtifactNotFoundException.kt`
 - 상속: `ServerBaseException` (I/O 실패 = 서버 측 오류)
-- `ErrorCode`: `CommonErrorCode.ARTIFACT_NOT_FOUND` 신규 추가 (`"S017"`, 500, "아티팩트를 찾을 수 없습니다 (endpoint: %s, key: %s)")
+- `ErrorCode`: `CommonErrorCode.ARTIFACT_NOT_FOUND` 신규 추가 (`"S018"`, 500, "아티팩트를 찾을 수 없습니다 (endpoint: %s, key: %s)")
 - 생성자: `(errorCode: ErrorCode, vararg args: Any?)`, `(errorCode: ErrorCode, cause: Throwable, vararg args: Any?)` (기존 `ExternalApiException` 패턴 동일)
 
 `module-common` 위치 선택 근거:
@@ -110,7 +110,7 @@ private fun deleteFile(objectKey: String): Boolean {
 | `module-external-api/.../port/out/ExternalApiArtifactStorePort.kt` | `read` 시그니처 `ByteArray?` → `ByteArray` |
 | `module-external-api/.../infra/storage/LocalExternalApiArtifactStoreAdapter.kt` | `read` 구현, exception 처리 |
 | `module-external-api/.../cleanup/ConsumedChunkCleanupScheduler.kt` | `deleteFile` catch 분리 |
-| `module-external-api/src/test/.../LocalExternalApiArtifactStoreAdapterTest.kt` | 신규 (5 케이스) |
+| `module-external-api/src/test/.../LocalExternalApiArtifactStoreAdapterTest.kt` | 신규 (4 케이스) |
 | `module-external-api/src/test/.../ConsumedChunkCleanupSchedulerDeleteFileTest.kt` | 신규 (3 케이스) |
 
 ## Error Handling
@@ -129,9 +129,8 @@ private fun deleteFile(objectKey: String): Boolean {
 
 1. `read` 성공 — 정상 gzip 파일 → `ByteArray` 반환
 2. `read` 파일 없음 → `ArtifactNotFoundException` throw
-3. `read` 권한 거부 (디렉토리 read 불가 설정) → `IOException` throw
+3. `read`에서 `ArtifactNotFoundException`의 cause에 `NoSuchFileException` 포함 확인
 4. `store` → `read` 왕복 — round-trip 동일성
-5. `read`에서 `ArtifactNotFoundException`의 cause에 `NoSuchFileException` 포함 확인
 
 ### Unit test: `ConsumedChunkCleanupSchedulerDeleteFileTest`
 
@@ -144,14 +143,14 @@ private fun deleteFile(objectKey: String): Boolean {
 
 ## Acceptance criteria
 
-- [ ] `CommonErrorCode.ARTIFACT_NOT_FOUND` 추가 (`S017`)
+- [ ] `CommonErrorCode.ARTIFACT_NOT_FOUND` 추가 (`S018`)
 - [ ] `ArtifactNotFoundException` `ServerBaseException` 상속
 - [ ] `ExternalApiArtifactStorePort.read` 반환 타입 non-null
 - [ ] `LocalExternalApiArtifactStoreAdapter.read` 파일 없음 시 `ArtifactNotFoundException` throw
 - [ ] `LocalExternalApiArtifactStoreAdapter.read` 다른 `IOException`은 자연 전파
 - [ ] `ConsumedChunkCleanupScheduler.deleteFile` `IOException`/`SecurityException` throw
 - [ ] `deleteFile` "이미 없음"은 `false` 유지
-- [ ] 신규 단위 테스트 8건 통과
+- [ ] 신규 단위 테스트 9건 통과 (`ArtifactNotFoundExceptionTest` 2 + `LocalExternalApiArtifactStoreAdapterTest` 4 + `ConsumedChunkCleanupSchedulerDeleteFileTest` 3)
 - [ ] `./gradlew compileKotlin compileJava --continue` 통과
 - [ ] 기존 테스트 회귀 없음
 
@@ -176,6 +175,7 @@ private fun deleteFile(objectKey: String): Boolean {
 
 ### Risk
 - `Bytes.exists` 제거로 race condition 가능 (파일이 read 도중 삭제됨). catch에서 `NoSuchFileException`을 `ArtifactNotFoundException`으로 변환하므로 안전.
+- `deleteFile`에서 `IOException` throw 시 `cleanup()` batch가 중단됨. 의도된 동작 (실패 관측성 확보)이지만, `pendingDeletions`이 in-memory `ConcurrentLinkedQueue`이며 `cleanup()` 시작 시점에 batch가 `poll`되어 제거된 상태. **process kill/restart 시 batch의 남은 events 영구 손실** → `mq-messaging.md`의 "복구 불가능한 in-memory 상태 금지" 룰의 기존 위반과 연관. **본 PR scope 밖.** EPIC-2 umbrella #1096 또는 후속 issue에서 `pendingDeletions`을 PGMQ/DB-backed queue로 이관 필요.
 
 ### Non-Risk
-- `deleteFile`에서 `IOException` throw가 cleanup batch를 중단시킬 수 있음 → 의도된 동작. 호출부 `cleanup`이 재시도 책임을 짐.
+- `deleteFile`에서 `IOException` throw가 cleanup batch를 중단시킬 수 있음 → 의도된 동작. 호출부 `cleanup`이 재시도 책임을 짐 (다음 `@Scheduled` 또는 `@PreDestroy` cycle).

--- a/module-common/src/main/kotlin/maple/expectation/error/CommonErrorCode.kt
+++ b/module-common/src/main/kotlin/maple/expectation/error/CommonErrorCode.kt
@@ -60,6 +60,7 @@ enum class CommonErrorCode(override val code: String, override val message: Stri
 
     // === System Errors (5xx) ===
     SYSTEM_ERROR("S017", "시스템 오류가 발생했습니다. (%s)", 500),
+    ARTIFACT_NOT_FOUND("S018", "아티팩트를 찾을 수 없습니다 (endpoint: %s, key: %s)", 500),
 
     // === Event Handler Errors ===
     EVENT_HANDLER_ERROR("E001", "이벤트 핸들러가 잘못되었습니다. (%s)", 500),

--- a/module-common/src/main/kotlin/maple/expectation/error/exception/ArtifactNotFoundException.kt
+++ b/module-common/src/main/kotlin/maple/expectation/error/exception/ArtifactNotFoundException.kt
@@ -1,0 +1,17 @@
+@file:JvmName("ArtifactNotFoundException")
+
+package maple.expectation.error.exception
+
+import maple.expectation.error.ErrorCode
+import maple.expectation.error.exception.base.ServerBaseException
+
+class ArtifactNotFoundException : ServerBaseException {
+
+    constructor(errorCode: ErrorCode, vararg args: Any?) : super(errorCode, *args)
+
+    constructor(errorCode: ErrorCode, cause: Throwable, vararg args: Any?) : super(
+        errorCode,
+        cause,
+        *args,
+    )
+}

--- a/module-common/src/test/kotlin/maple/expectation/error/exception/ArtifactNotFoundExceptionTest.kt
+++ b/module-common/src/test/kotlin/maple/expectation/error/exception/ArtifactNotFoundExceptionTest.kt
@@ -1,0 +1,24 @@
+package maple.expectation.error.exception
+
+import maple.expectation.error.CommonErrorCode
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ArtifactNotFoundExceptionTest {
+
+    @Test
+    fun `constructs with error code, cause, and varargs`() {
+        val cause = RuntimeException("disk gone")
+        val ex = ArtifactNotFoundException(CommonErrorCode.ARTIFACT_NOT_FOUND, cause, "CHARACTER_BASIC", "abc123")
+
+        assertThat(ex.errorCode).isEqualTo(CommonErrorCode.ARTIFACT_NOT_FOUND)
+        assertThat(ex.cause).isSameAs(cause)
+        assertThat(ex.message).contains("CHARACTER_BASIC").contains("abc123")
+    }
+
+    @Test
+    fun `inherits from ServerBaseException`() {
+        val ex = ArtifactNotFoundException(CommonErrorCode.ARTIFACT_NOT_FOUND, "ITEM_EQUIPMENT", "xyz")
+        assertThat(ex).isInstanceOf(maple.expectation.error.exception.base.ServerBaseException::class.java)
+    }
+}

--- a/module-external-api/src/main/kotlin/maple/externalapi/cleanup/ConsumedChunkCleanupScheduler.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/cleanup/ConsumedChunkCleanupScheduler.kt
@@ -13,6 +13,7 @@ import org.springframework.kafka.support.KafkaHeaders
 import org.springframework.messaging.handler.annotation.Header
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
+import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.util.concurrent.ConcurrentLinkedQueue
@@ -92,7 +93,7 @@ class ConsumedChunkCleanupScheduler(
 
     internal fun deleteFile(objectKey: String): Boolean {
         val path = Paths.get(basePath, objectKey)
-        return runCatching {
+        return try {
             val deleted = Files.deleteIfExists(path)
             if (deleted) {
                 log.info("[ConsumedChunkCleanup] deleted: {}", objectKey)
@@ -100,9 +101,13 @@ class ConsumedChunkCleanupScheduler(
                 log.debug("[ConsumedChunkCleanup] already gone: {}", objectKey)
             }
             deleted
-        }.onFailure { ex ->
-            log.warn("[ConsumedChunkCleanup] delete failed: {} - {}", objectKey, ex.message)
-        }.getOrDefault(false)
+        } catch (ex: IOException) {
+            log.error("[ConsumedChunkCleanup] delete failed (IO): {} - {}", objectKey, ex.message, ex)
+            throw ex
+        } catch (ex: SecurityException) {
+            log.error("[ConsumedChunkCleanup] delete failed (security): {} - {}", objectKey, ex.message, ex)
+            throw ex
+        }
     }
 
     override val lifecyclePhase: Int = 200

--- a/module-external-api/src/main/kotlin/maple/externalapi/cleanup/ConsumedChunkCleanupScheduler.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/cleanup/ConsumedChunkCleanupScheduler.kt
@@ -90,7 +90,7 @@ class ConsumedChunkCleanupScheduler(
         )
     }
 
-    private fun deleteFile(objectKey: String): Boolean {
+    internal fun deleteFile(objectKey: String): Boolean {
         val path = Paths.get(basePath, objectKey)
         return runCatching {
             val deleted = Files.deleteIfExists(path)

--- a/module-external-api/src/main/kotlin/maple/externalapi/infra/storage/LocalExternalApiArtifactStoreAdapter.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/infra/storage/LocalExternalApiArtifactStoreAdapter.kt
@@ -3,6 +3,7 @@ package maple.externalapi.infra.storage
 import java.nio.file.FileVisitOption
 import java.nio.file.FileVisitResult
 import java.nio.file.Files
+import java.nio.file.NoSuchFileException
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.nio.file.SimpleFileVisitor
@@ -13,6 +14,8 @@ import java.util.UUID
 import java.util.stream.Collectors
 import java.util.zip.GZIPInputStream
 import java.util.zip.GZIPOutputStream
+import maple.expectation.error.CommonErrorCode
+import maple.expectation.error.exception.ArtifactNotFoundException
 import maple.externalapi.domain.ExternalApiEndpoint
 import maple.externalapi.domain.ExternalApiPayloadRef
 import maple.externalapi.port.out.ExternalApiArtifactStorePort
@@ -54,10 +57,15 @@ class LocalExternalApiArtifactStoreAdapter(
     override fun read(
         endpoint: ExternalApiEndpoint,
         key: String,
-    ): ByteArray? {
+    ): ByteArray {
         val filePath = resolvePath(endpoint, key)
-        if (!Files.exists(filePath)) return null
-        return GZIPInputStream(Files.readAllBytes(filePath).inputStream()).use { it.readAllBytes() }
+        return try {
+            GZIPInputStream(Files.readAllBytes(filePath).inputStream()).use { it.readAllBytes() }
+        } catch (ex: NoSuchFileException) {
+            log.warn("[ArtifactStore] artifact not found: endpoint={}, key={}", endpoint, key)
+            throw ArtifactNotFoundException(CommonErrorCode.ARTIFACT_NOT_FOUND, ex, endpoint.toString(), key)
+        }
+        // other IOException (permission, disk) propagates naturally — adapter does not swallow
     }
 
     override fun listStoredKeys(endpoint: ExternalApiEndpoint): List<String> {

--- a/module-external-api/src/main/kotlin/maple/externalapi/port/out/ExternalApiArtifactStorePort.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/port/out/ExternalApiArtifactStorePort.kt
@@ -14,7 +14,7 @@ interface ExternalApiArtifactStorePort {
     fun read(
         endpoint: ExternalApiEndpoint,
         key: String,
-    ): ByteArray?
+    ): ByteArray
 
     fun listStoredKeys(endpoint: ExternalApiEndpoint): List<String>
 

--- a/module-external-api/src/test/kotlin/maple/externalapi/cleanup/ConsumedChunkCleanupSchedulerDeleteFileTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/cleanup/ConsumedChunkCleanupSchedulerDeleteFileTest.kt
@@ -38,7 +38,10 @@ class ConsumedChunkCleanupSchedulerDeleteFileTest {
     @Test
     fun `deleteFile throws IOException when target is a directory`() {
         val scheduler = newScheduler()
-        Files.createDirectory(tempDir.resolve("subdir.json.gz"))
+        val dir = tempDir.resolve("subdir.json.gz")
+        Files.createDirectory(dir)
+        // Make directory non-empty so deleteIfExists raises DirectoryNotEmptyException (IOException subclass)
+        Files.write(dir.resolve("inner.txt"), "x".toByteArray())
 
         assertThatThrownBy { scheduler.deleteFile("subdir.json.gz") }
             .isInstanceOf(java.io.IOException::class.java)

--- a/module-external-api/src/test/kotlin/maple/externalapi/cleanup/ConsumedChunkCleanupSchedulerDeleteFileTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/cleanup/ConsumedChunkCleanupSchedulerDeleteFileTest.kt
@@ -1,0 +1,46 @@
+package maple.externalapi.cleanup
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+
+class ConsumedChunkCleanupSchedulerDeleteFileTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    private fun newScheduler(): ConsumedChunkCleanupScheduler =
+        ConsumedChunkCleanupScheduler(
+            objectMapper = com.fasterxml.jackson.databind.ObjectMapper(),
+            basePath = tempDir.toString(),
+            maxPending = 100,
+        )
+
+    @Test
+    fun `deleteFile returns true when file exists`() {
+        val scheduler = newScheduler()
+        val file = tempDir.resolve("chunk.json.gz")
+        Files.write(file, "payload".toByteArray())
+
+        assertThat(scheduler.deleteFile("chunk.json.gz")).isTrue()
+    }
+
+    @Test
+    fun `deleteFile returns false when file is already gone (no exception)`() {
+        val scheduler = newScheduler()
+
+        assertThat(scheduler.deleteFile("not-there.json.gz")).isFalse()
+    }
+
+    @Test
+    fun `deleteFile throws IOException when target is a directory`() {
+        val scheduler = newScheduler()
+        Files.createDirectory(tempDir.resolve("subdir.json.gz"))
+
+        assertThatThrownBy { scheduler.deleteFile("subdir.json.gz") }
+            .isInstanceOf(java.io.IOException::class.java)
+    }
+}

--- a/module-external-api/src/test/kotlin/maple/externalapi/infra/storage/LocalExternalApiArtifactStoreAdapterTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/infra/storage/LocalExternalApiArtifactStoreAdapterTest.kt
@@ -1,0 +1,63 @@
+package maple.externalapi.infra.storage
+
+import maple.externalapi.domain.ExternalApiEndpoint
+import maple.expectation.error.exception.ArtifactNotFoundException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+
+class LocalExternalApiArtifactStoreAdapterTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    private fun newAdapter(basePath: String) = LocalExternalApiArtifactStoreAdapter(basePath = basePath)
+
+    @Test
+    fun `read returns ByteArray for existing artifact`() {
+        val adapter = newAdapter(tempDir.toString())
+        val endpoint = ExternalApiEndpoint.CHARACTER_BASIC
+        val key = "user-1"
+        adapter.store(endpoint, key, "hello".toByteArray())
+
+        val result = adapter.read(endpoint, key)
+
+        assertThat(result).isNotNull()
+        assertThat(result.toString(Charsets.UTF_8)).isEqualTo("hello")
+    }
+
+    @Test
+    fun `read throws ArtifactNotFoundException for missing file`() {
+        val adapter = newAdapter(tempDir.toString())
+
+        assertThatThrownBy { adapter.read(ExternalApiEndpoint.CHARACTER_BASIC, "missing") }
+            .isInstanceOf(ArtifactNotFoundException::class.java)
+    }
+
+    @Test
+    fun `ArtifactNotFoundException carries NoSuchFileException as cause`() {
+        val adapter = newAdapter(tempDir.toString())
+
+        val ex = kotlin.runCatching {
+            adapter.read(ExternalApiEndpoint.CHARACTER_BASIC, "missing")
+        }.exceptionOrNull()
+
+        assertThat(ex).isInstanceOf(ArtifactNotFoundException::class.java)
+        assertThat(ex!!.cause).isInstanceOf(java.nio.file.NoSuchFileException::class.java)
+    }
+
+    @Test
+    fun `store then read round-trip preserves payload bytes`() {
+        val adapter = newAdapter(tempDir.toString())
+        val endpoint = ExternalApiEndpoint.ITEM_EQUIPMENT
+        val key = "user-2"
+        val payload = "binary-data".toByteArray()
+
+        adapter.store(endpoint, key, payload)
+        val result = adapter.read(endpoint, key)
+
+        assertThat(result).isEqualTo(payload)
+    }
+}


### PR DESCRIPTION
## Summary

EPIC-2 silent data loss 제거 — `module-external-api`의 두 null/boolean swallow 경로를 명시적 예외로 변환.

- **`LocalExternalApiArtifactStoreAdapter.read`**: `ByteArray?` → `ByteArray` hard break. 파일 미존재 시 `ArtifactNotFoundException` throw. 다른 `IOException` 자연 전파.
- **`ConsumedChunkCleanupScheduler.deleteFile`**: `Files.deleteIfExists`의 `false` (이미 없음)만 `false` 유지. `IOException`/`SecurityException`은 throw.
- **신규 exception**: `ArtifactNotFoundException` (`ServerBaseException` 상속) + `CommonErrorCode.ARTIFACT_NOT_FOUND` (S018).

## Test plan

- [x] `./gradlew :module-external-api:test :module-common:test` BUILD SUCCESSFUL (32s)
- [x] 신규 테스트 9건 PASS (`ArtifactNotFoundExceptionTest` 2 + `LocalExternalApiArtifactStoreAdapterTest` 4 + `ConsumedChunkCleanupSchedulerDeleteFileTest` 3)
- [x] 회귀 없음 (전체 external-api 단위 테스트 통과)
- [ ] bootRun health 200 확인 (PR 머지 전 사용자 검증 권장)

## Commits

- `e16657c5e` feat(common): add ARTIFACT_NOT_FOUND error code (S018) for #999
- `d1a339950` feat(common): ArtifactNotFoundException for #999
- `86cdbd8d4` feat(external-api): ArtifactStorePort.read throws ArtifactNotFoundException for #999
- `488e5eb1e` test(external-api): add deleteFile tests + expose internal for #999
- `bf09f89fc` feat(external-api): ConsumedChunkCleanupScheduler.deleteFile propagates IO/Security exceptions for #999

## Specs / Plans

- `docs/superpowers/specs/2026-06-04-externalapi-null-to-exception-design.md`
- `docs/superpowers/plans/2026-06-04-externalapi-null-to-exception.md`

## Out of Scope (별도 issue 추적)

- `pendingDeletions` in-memory queue → PGMQ/DB-backed 이관 (throw 시 batch 손실 risk). EPIC-2 umbrella #1096 또는 후속 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)