### PR TITLE
fix(1138): add debug logging for empty userIgn exclusions in OcidUserIgnResolver

### DIFF
--- a/docs/superpowers/plans/2026-06-04-1138-ocid-user-ign-resolver-logging.md
+++ b/docs/superpowers/plans/2026-06-04-1138-ocid-user-ign-resolver-logging.md
@@ -1,0 +1,116 @@
+# OcidUserIgnResolver Logging Implementation Plan (Issue #1138)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add aggregate debug log to `OcidUserIgnResolver.resolve()` showing count + sample of OCIDs excluded due to empty `user_ign`.
+
+**Architecture:** Replace the existing single-line `log.debug` with a branching log: if exclusions exist, log with sample; else log the existing happy-path message. No behavior change, no signature change, no new tests.
+
+**Tech Stack:** Kotlin, SLF4J (existing — no new deps).
+
+**Spec:** `docs/superpowers/specs/2026-06-04-1138-ocid-user-ign-resolver-logging-design.md`
+
+---
+
+## File Structure
+
+**Modify:**
+- `module-synchronizer/src/main/kotlin/maple/synchronizer/resolver/OcidUserIgnResolver.kt` — `resolve()` only (lines 14-30)
+
+**No new files.** No test changes (logging-only, behavior unchanged per spec).
+
+---
+
+## Task 1: Add exclusion logging to OcidUserIgnResolver.resolve()
+
+**Files:**
+- Modify: `module-synchronizer/src/main/kotlin/maple/synchronizer/resolver/OcidUserIgnResolver.kt:14-30`
+
+- [ ] **Step 1: Replace `resolve()` body**
+
+Replace the entire `resolve()` function body (lines 14-30 in current file) with:
+
+```kotlin
+    fun resolve(ocids: Set<String>): Map<String, String> {
+        if (ocids.isEmpty()) return emptyMap()
+
+        val sql = """
+            SELECT ocid, user_ign FROM character_basic_read_model WHERE ocid IN (:ocids)
+        """.trimIndent()
+
+        val params = MapSqlParameterSource("ocids", ocids.toList())
+
+        val rows = jdbc.queryForList(sql, params)
+        val mapping = rows.associate { row ->
+            row["ocid"].toString() to (row["user_ign"]?.toString() ?: "")
+        }
+        val excluded = mapping.filterValues { it.isEmpty() }
+        val result = mapping.filterValues { it.isNotEmpty() }
+        if (excluded.isNotEmpty()) {
+            log.debug("Resolved {} of {} ocids; excluded {} with empty user_ign (sample: {})",
+                result.size, ocids.size, excluded.size, excluded.keys.take(5))
+        } else {
+            log.debug("Resolved {} of {} ocids to userIgn", result.size, ocids.size)
+        }
+        return result
+    }
+```
+
+Key points:
+- `rows` is now a local val (was inlined into `jdbc.queryForList(...).associate { ... }`).
+- `mapping.filterValues { it.isEmpty() }` produces the excluded map.
+- `result = mapping.filterValues { it.isNotEmpty() }` is the previously-returned map.
+- `excluded.keys.take(5)` bounds log payload.
+- `log` is class-level (line 12) — no new field.
+
+- [ ] **Step 2: Verify compile**
+
+Run:
+```bash
+./gradlew :module-synchronizer:compileKotlin --continue
+```
+
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 3: Run synchronizer tests**
+
+Run:
+```bash
+./gradlew :module-synchronizer:test
+```
+
+Expected: `BUILD SUCCESSFUL`. Existing tests pass (no behavior change — only logging path added).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add module-synchronizer/src/main/kotlin/maple/synchronizer/resolver/OcidUserIgnResolver.kt
+git commit -m "fix(1138): add debug logging for empty userIgn exclusions in OcidUserIgnResolver"
+```
+
+---
+
+## Task 2: Final diff check
+
+- [ ] **Step 1: Verify diff size**
+
+Run:
+```bash
+git diff HEAD~1 -- module-synchronizer/src/main/kotlin/maple/synchronizer/resolver/OcidUserIgnResolver.kt
+```
+
+Expected: ~8 lines added, ~2 lines removed, no formatting churn.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- ✓ Aggregate log with sample — Task 1
+- ✓ No behavior change — preserved `filterValues { it.isNotEmpty() }` on `result`
+- ✓ Compile + test verification — Task 1 step 2-3
+- ✓ No new tests — explicitly skipped per spec
+
+**Placeholder scan:** none.
+
+**Type consistency:** `Map<String, String>` types preserved, `excluded` is `Map<String, String>`, `excluded.keys` is `Set<String>`, `take(5)` returns `List<String>` — log accepts.

--- a/docs/superpowers/specs/2026-06-04-1138-ocid-user-ign-resolver-logging-design.md
+++ b/docs/superpowers/specs/2026-06-04-1138-ocid-user-ign-resolver-logging-design.md
@@ -1,0 +1,94 @@
+# Spec: OcidUserIgnResolver Empty-UserIgn Logging (Issue #1138)
+
+- Status: Approved
+- Date: 2026-06-04
+- Issue: #1138 (originally part of #1096)
+- Owner: zbnerd
+
+## Background
+
+`OcidUserIgnResolver.resolve()` filters out OCIDs whose `user_ign` is null/empty without any log or metric. Operators have no way to detect when the synchronizer write model is missing data.
+
+## Decision
+
+Add aggregate debug log to `resolve()` showing exclusion count + sample of excluded OCIDs.
+
+## Scope
+
+**Modify:** `module-synchronizer/src/main/kotlin/maple/synchronizer/resolver/OcidUserIgnResolver.kt:14-30`
+
+```kotlin
+fun resolve(ocids: Set<String>): Map<String, String> {
+    if (ocids.isEmpty()) return emptyMap()
+
+    val sql = """
+        SELECT ocid, user_ign FROM character_basic_read_model WHERE ocid IN (:ocids)
+    """.trimIndent()
+
+    val params = MapSqlParameterSource("ocids", ocids.toList())
+
+    val rows = jdbc.queryForList(sql, params)
+    val mapping = rows.associate { row ->
+        row["ocid"].toString() to (row["user_ign"]?.toString() ?: "")
+    }
+    val excluded = mapping.filterValues { it.isEmpty() }
+    val result = mapping.filterValues { it.isNotEmpty() }
+    if (excluded.isNotEmpty()) {
+        log.debug("Resolved {} of {} ocids; excluded {} with empty user_ign (sample: {})",
+            result.size, ocids.size, excluded.size, excluded.keys.take(5))
+    } else {
+        log.debug("Resolved {} of {} ocids to userIgn", result.size, ocids.size)
+    }
+    return result
+}
+```
+
+Key points:
+- `mapping.filterValues { it.isEmpty() }` runs first to keep excluded count available.
+- `excluded.keys.take(5)` bounds payload.
+- Original happy-path log retained as `else` branch.
+
+## Out of Scope
+
+- Counter/metric (issue requests log only).
+- Behavior change (filter still applied).
+- New tests (log-only, behavior unchanged).
+
+## Trade-offs
+
+### Sensitivity
+
+- Log volume: 1 line per call regardless of excluded count. Bounded.
+- Sample size (5): chosen as low-cardinality; no PII risk because OCID is an internal ID, not IGN.
+
+### Trade-off
+
+| Choice | Gain | Cost |
+| --- | --- | --- |
+| aggregate log w/ sample | bounded volume, actionable | tiny 2-pass overhead on small map |
+| per-IGN log | full audit | log spam when many exclusions |
+| metric + log | aggregate visibility + time series | new infra |
+
+→ Chose aggregate (issue request).
+
+### Risk
+
+- `excluded.keys` ordering: `LinkedHashMap` preserves insertion order from `associate { }`. Stable, no concern.
+- `take(5)` allocates a new list — fine for small sizes.
+
+### Non-Risk
+
+- No SQL change.
+- No new dependency.
+- No API surface change.
+
+## Result / Evidence
+
+Will be measured by:
+- `./gradlew compileKotlin compileJava --continue` exits 0
+- `./gradlew :module-synchronizer:test` passes
+- Diff <10 lines
+
+## Summary
+
+> Add aggregate debug log to `OcidUserIgnResolver.resolve()` showing count + sample of OCIDs excluded for empty user_ign; no behavior change.

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/resolver/OcidUserIgnResolver.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/resolver/OcidUserIgnResolver.kt
@@ -20,12 +20,18 @@ class OcidUserIgnResolver(
 
         val params = MapSqlParameterSource("ocids", ocids.toList())
 
-        val mapping = jdbc.queryForList(sql, params)
-            .associate { row ->
-                row["ocid"].toString() to (row["user_ign"]?.toString() ?: "")
-            }
-            .filterValues { it.isNotEmpty() }
-        log.debug("Resolved {} of {} ocids to userIgn", mapping.size, ocids.size)
-        return mapping
+        val rows = jdbc.queryForList(sql, params)
+        val mapping = rows.associate { row ->
+            row["ocid"].toString() to (row["user_ign"]?.toString() ?: "")
+        }
+        val excluded = mapping.filterValues { it.isEmpty() }
+        val result = mapping.filterValues { it.isNotEmpty() }
+        if (excluded.isNotEmpty()) {
+            log.debug("Resolved {} of {} ocids; excluded {} with empty user_ign (sample: {})",
+                result.size, ocids.size, excluded.size, excluded.keys.take(5))
+        } else {
+            log.debug("Resolved {} of {} ocids to userIgn", result.size, ocids.size)
+        }
+        return result
     }
 }


### PR DESCRIPTION
## Summary
- Add aggregate debug log to OcidUserIgnResolver.resolve() showing count + sample of OCIDs excluded for empty user_ign
- No behavior change; no API surface change; no new tests

## Test plan
- [x] ./gradlew :module-synchronizer:compileKotlin --continue → BUILD SUCCESSFUL
- [x] ./gradlew :module-synchronizer:test → BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)