### PR TITLE
refactor(1077): split OcidMappingRepository into DB and Redis

### DIFF
--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/OcidLookupRunConsumer.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/OcidLookupRunConsumer.kt
@@ -2,6 +2,7 @@ package maple.synchronizer.consumer
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import maple.expectation.common.event.SnapshotRunCompletedEvent
+import maple.synchronizer.redis.OcidMappingRedisWriter
 import maple.synchronizer.repository.OcidMappingRepository
 import maple.synchronizer.storage.OcidMappingFileReader
 import org.apache.kafka.clients.consumer.ConsumerRecord
@@ -18,6 +19,7 @@ import org.springframework.stereotype.Component
 class OcidLookupRunConsumer(
     private val fileReader: OcidMappingFileReader,
     private val repository: OcidMappingRepository,
+    private val ocidMappingRedisWriter: OcidMappingRedisWriter,
     private val objectMapper: ObjectMapper,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
@@ -49,7 +51,7 @@ class OcidLookupRunConsumer(
 
         repository.batchUpsert(mappings)
         runCatching {
-            repository.writeOcidToRedis(mappings)
+            ocidMappingRedisWriter.writeOcidToRedis(mappings)
         }.onFailure { ex ->
             log.error(
                 "[OcidConsumer] Redis write failed after DB upsert: runId={} mappings={} - {}. Redis may be stale until next run.",

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/redis/OcidMappingRedisWriter.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/redis/OcidMappingRedisWriter.kt
@@ -1,0 +1,38 @@
+package maple.synchronizer.redis
+
+import maple.synchronizer.storage.OcidMapping
+import org.slf4j.LoggerFactory
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Component
+
+@Component
+class OcidMappingRedisWriter(
+    private val redisTemplate: StringRedisTemplate,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    companion object {
+        private const val REDIS_KEY = "ocid:mapping"
+    }
+
+    fun writeOcidToRedis(mappings: List<OcidMapping>) {
+        if (mappings.isEmpty()) {
+            redisTemplate.delete(REDIS_KEY)
+            log.info("[OcidMapping] Redis cleared: empty mappings")
+            return
+        }
+        val tempKey = "$REDIS_KEY:tmp:${System.nanoTime()}"
+        redisTemplate.executePipelined { connection ->
+            for (mapping in mappings) {
+                connection.hashCommands().hSet(
+                    tempKey.toByteArray(),
+                    mapping.userIgn.toByteArray(),
+                    mapping.ocid.toByteArray(),
+                )
+            }
+            null
+        }
+        redisTemplate.rename(tempKey, REDIS_KEY)
+        log.info("[OcidMapping] Redis written atomically via RENAME: {} mappings to {}", mappings.size, REDIS_KEY)
+    }
+}

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/repository/OcidMappingRepository.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/repository/OcidMappingRepository.kt
@@ -4,7 +4,6 @@ import maple.synchronizer.storage.OcidMapping
 import org.postgresql.copy.CopyManager
 import org.postgresql.core.BaseConnection
 import org.slf4j.LoggerFactory
-import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.jdbc.core.ConnectionCallback
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Repository
@@ -13,13 +12,8 @@ import java.sql.Connection
 @Repository
 class OcidMappingRepository(
     private val jdbc: NamedParameterJdbcTemplate,
-    private val redisTemplate: StringRedisTemplate,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
-
-    companion object {
-        private const val REDIS_KEY = "ocid:mapping"
-    }
 
     fun batchUpsert(mappings: List<OcidMapping>) {
         val affected: Int = jdbc.jdbcTemplate.execute(
@@ -65,26 +59,5 @@ class OcidMappingRepository(
         ) ?: 0
 
         log.info("[OcidMapping] DB upserted via COPY→merge: {} mappings, {} affected", mappings.size, affected)
-    }
-
-    fun writeOcidToRedis(mappings: List<OcidMapping>) {
-        if (mappings.isEmpty()) {
-            redisTemplate.delete(REDIS_KEY)
-            log.info("[OcidMapping] Redis cleared: empty mappings")
-            return
-        }
-        val tempKey = "$REDIS_KEY:tmp:${System.nanoTime()}"
-        redisTemplate.executePipelined { connection ->
-            for (mapping in mappings) {
-                connection.hashCommands().hSet(
-                    tempKey.toByteArray(),
-                    mapping.userIgn.toByteArray(),
-                    mapping.ocid.toByteArray(),
-                )
-            }
-            null
-        }
-        redisTemplate.rename(tempKey, REDIS_KEY)
-        log.info("[OcidMapping] Redis written atomically via RENAME: {} mappings to {}", mappings.size, REDIS_KEY)
     }
 }


### PR DESCRIPTION
## Summary
- Split `OcidMappingRepository` (DB-only) and new `OcidMappingRedisWriter` (Redis-only).
- `OcidLookupRunConsumer` injects both; `BasicSnapshotChunkConsumer` unchanged.
- Zero behavioral change.

## Files
- New: `module-synchronizer/.../redis/OcidMappingRedisWriter.kt`
- Modified: `OcidMappingRepository.kt` (slimmed), `OcidLookupRunConsumer.kt` (new injection)

## Verification
- [x] `./gradlew :module-synchronizer:compileKotlin compileJava --continue` passes
- [x] `./gradlew :module-synchronizer:test` passes
- [x] `ChunkConsumerMappingTest` unchanged and passing
- [x] Spec compliance review: PASS
- [x] Code quality review: APPROVE (1 pre-existing MEDIUM, out of scope)

Closes #1077