### PR TITLE
refactor(933): decompose synchronizer repository SQL methods

### DIFF
--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/repository/CharacterBasicRepository.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/repository/CharacterBasicRepository.kt
@@ -12,6 +12,31 @@ class CharacterBasicRepository(
 ) {
     companion object {
         private const val SUB_BATCH_SIZE = 100
+        private const val DELETE_STALE_SQL =
+            "DELETE FROM character_basic_read_model WHERE ocid = ANY(:ocids) AND NOT (user_ign = ANY(:userIgns))"
+        private val UPSERT_SQL = """
+            INSERT INTO character_basic_read_model (
+                user_ign, ocid, world_name, character_class, character_level,
+                guild_name, basic_data, document_hash, source_run_id, source_chunk_id, updated_at
+            )
+            SELECT
+                unnest(:userIgns), unnest(:ocids), unnest(:worldNames),
+                unnest(:characterClasses), unnest(:characterLevels),
+                unnest(:guildNames), unnest(:basicData), unnest(:documentHashes),
+                :runId, :chunkId, now()
+            ON CONFLICT (user_ign) DO UPDATE SET
+                ocid = excluded.ocid,
+                world_name = excluded.world_name,
+                character_class = excluded.character_class,
+                character_level = excluded.character_level,
+                guild_name = excluded.guild_name,
+                basic_data = excluded.basic_data,
+                document_hash = excluded.document_hash,
+                source_run_id = excluded.source_run_id,
+                source_chunk_id = excluded.source_chunk_id,
+                updated_at = now()
+            WHERE character_basic_read_model.document_hash IS DISTINCT FROM excluded.document_hash
+        """.trimIndent()
     }
 
     fun bulkUpsert(runId: String, chunkId: String, records: List<BasicRecord>) {
@@ -35,47 +60,26 @@ class CharacterBasicRepository(
         val userIgns = batch.map { it.userIgn }.toTypedArray()
 
         jdbc.update(
-            "DELETE FROM character_basic_read_model WHERE ocid = ANY(:ocids) AND NOT (user_ign = ANY(:userIgns))",
+            DELETE_STALE_SQL,
             MapSqlParameterSource()
                 .addValue("ocids", ocids)
                 .addValue("userIgns", userIgns),
         )
 
-        val sql = """
-            INSERT INTO character_basic_read_model (
-                user_ign, ocid, world_name, character_class, character_level,
-                guild_name, basic_data, document_hash, source_run_id, source_chunk_id, updated_at
-            )
-            SELECT
-                unnest(:userIgns), unnest(:ocids), unnest(:worldNames),
-                unnest(:characterClasses), unnest(:characterLevels),
-                unnest(:guildNames), unnest(:basicData), unnest(:documentHashes),
-                :runId, :chunkId, now()
-            ON CONFLICT (user_ign) DO UPDATE SET
-                ocid = excluded.ocid,
-                world_name = excluded.world_name,
-                character_class = excluded.character_class,
-                character_level = excluded.character_level,
-                guild_name = excluded.guild_name,
-                basic_data = excluded.basic_data,
-                document_hash = excluded.document_hash,
-                source_run_id = excluded.source_run_id,
-                source_chunk_id = excluded.source_chunk_id,
-                updated_at = now()
-            WHERE character_basic_read_model.document_hash IS DISTINCT FROM excluded.document_hash
-        """.trimIndent()
+        return jdbc.update(UPSERT_SQL, buildUpsertParams(runId, chunkId, batch))
+    }
 
-        return jdbc.update(sql, MapSqlParameterSource()
+    private fun buildUpsertParams(runId: String, chunkId: String, batch: List<BasicRecord>): MapSqlParameterSource {
+        return MapSqlParameterSource()
             .addValue("runId", runId)
             .addValue("chunkId", chunkId)
-            .addValue("userIgns", userIgns)
-            .addValue("ocids", ocids)
+            .addValue("userIgns", batch.map { it.userIgn }.toTypedArray())
+            .addValue("ocids", batch.map { it.ocid }.toTypedArray())
             .addValue("worldNames", batch.map { it.worldName }.toTypedArray())
             .addValue("characterClasses", batch.map { it.characterClass }.toTypedArray())
             .addValue("characterLevels", batch.map { it.characterLevel }.toTypedArray())
             .addValue("guildNames", batch.map { it.guildName }.toTypedArray())
             .addValue("basicData", batch.map { it.compressedBody }.toTypedArray())
             .addValue("documentHashes", batch.map { it.bodyHash }.toTypedArray())
-        )
     }
 }

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/repository/EquipmentReadModelRepository.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/repository/EquipmentReadModelRepository.kt
@@ -15,30 +15,7 @@ class EquipmentReadModelRepository(
 
     companion object {
         private const val SUB_BATCH_SIZE = 100
-    }
-
-    fun bulkUpsert(runId: String, chunkId: String, documents: List<PreppedDocument>) {
-        val compSizes = documents.map { it.compressed.size }
-
-        log.info("[Synchronizer] upsert start: docs={} batches={} batchSize={} " +
-            "compressedBytes avg={} max={} total={} : runId={} chunkId={}",
-            documents.size, documents.chunked(SUB_BATCH_SIZE).size, SUB_BATCH_SIZE,
-            compSizes.average().toInt(), compSizes.max(), compSizes.sum(),
-            runId, chunkId)
-
-        batchExecutor.execute(
-            label = "Synchronizer",
-            itemLabel = "docs",
-            runId = runId,
-            chunkId = chunkId,
-            items = documents,
-            batchSize = SUB_BATCH_SIZE,
-            upsertBatch = { batch -> upsertBatch(runId, chunkId, batch) },
-        )
-    }
-
-    private fun upsertBatch(runId: String, chunkId: String, batch: List<PreppedDocument>): Int {
-        val sql = """
+        private val UPSERT_SQL = """
             INSERT INTO character_equipment_read_model (
                 read_key, ocid, preset_no, user_ign, document, document_hash,
                 total_cost, equipment_count, calculated_at,
@@ -62,8 +39,34 @@ class EquipmentReadModelRepository(
             WHERE character_equipment_read_model.document_hash IS DISTINCT FROM excluded.document_hash
                OR character_equipment_read_model.user_ign IS DISTINCT FROM excluded.user_ign
         """.trimIndent()
+    }
 
-        return jdbc.update(sql, MapSqlParameterSource()
+    fun bulkUpsert(runId: String, chunkId: String, documents: List<PreppedDocument>) {
+        val compSizes = documents.map { it.compressed.size }
+
+        log.info("[Synchronizer] upsert start: docs={} batches={} batchSize={} " +
+            "compressedBytes avg={} max={} total={} : runId={} chunkId={}",
+            documents.size, documents.chunked(SUB_BATCH_SIZE).size, SUB_BATCH_SIZE,
+            compSizes.average().toInt(), compSizes.max(), compSizes.sum(),
+            runId, chunkId)
+
+        batchExecutor.execute(
+            label = "Synchronizer",
+            itemLabel = "docs",
+            runId = runId,
+            chunkId = chunkId,
+            items = documents,
+            batchSize = SUB_BATCH_SIZE,
+            upsertBatch = { batch -> upsertBatch(runId, chunkId, batch) },
+        )
+    }
+
+    private fun upsertBatch(runId: String, chunkId: String, batch: List<PreppedDocument>): Int {
+        return jdbc.update(UPSERT_SQL, buildUpsertParams(runId, chunkId, batch))
+    }
+
+    private fun buildUpsertParams(runId: String, chunkId: String, batch: List<PreppedDocument>): MapSqlParameterSource {
+        return MapSqlParameterSource()
             .addValue("runId", runId)
             .addValue("chunkId", chunkId)
             .addValue("readKeys", batch.map { it.readKey }.toTypedArray())
@@ -75,6 +78,5 @@ class EquipmentReadModelRepository(
             .addValue("totalCosts", batch.map { it.totalCost }.toTypedArray())
             .addValue("equipmentCounts", batch.map { it.equipmentCount }.toTypedArray())
             .addValue("calculatedAts", batch.map { it.calculatedAt }.toTypedArray())
-        )
     }
 }

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/repository/OcidMappingRepository.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/repository/OcidMappingRepository.kt
@@ -15,40 +15,35 @@ class OcidMappingRepository(
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
+    companion object {
+        private const val DROP_TMP_SQL = "DROP TABLE IF EXISTS tmp_ocid_mapping"
+        private const val CREATE_TMP_SQL = "CREATE TEMP TABLE tmp_ocid_mapping (user_ign text NOT NULL, ocid text NOT NULL) ON COMMIT DROP"
+        private val DELETE_CONFLICT_SQL = """
+            DELETE FROM game_character
+            WHERE EXISTS (
+                SELECT 1 FROM tmp_ocid_mapping t
+                WHERE t.ocid = game_character.ocid AND t.user_ign != game_character.user_ign
+            )
+        """.trimIndent()
+        private val MERGE_SQL = """
+            INSERT INTO game_character (user_ign, ocid, updated_at)
+            SELECT user_ign, ocid, now()
+            FROM tmp_ocid_mapping
+            ON CONFLICT (user_ign) DO UPDATE SET
+                ocid = EXCLUDED.ocid,
+                updated_at = now()
+            WHERE game_character.ocid IS DISTINCT FROM EXCLUDED.ocid
+        """.trimIndent()
+    }
+
     fun batchUpsert(mappings: List<OcidMapping>) {
         val affected: Int = jdbc.jdbcTemplate.execute(
             ConnectionCallback { con: Connection ->
                 con.autoCommit = false
-
                 runCatching {
-                    con.createStatement().use { stmt ->
-                        stmt.execute("DROP TABLE IF EXISTS tmp_ocid_mapping")
-                        stmt.execute("CREATE TEMP TABLE tmp_ocid_mapping (user_ign text NOT NULL, ocid text NOT NULL) ON COMMIT DROP")
-                    }
-
-                    val copyManager = CopyManager(con.unwrap(BaseConnection::class.java))
-                    val data = mappings.joinToString("\n") { "${it.userIgn}\t${it.ocid}" }
-                    copyManager.copyIn("COPY tmp_ocid_mapping (user_ign, ocid) FROM STDIN", data.reader())
-
-                    val rows = con.createStatement().use { stmt ->
-                        stmt.executeUpdate("""
-                            DELETE FROM game_character
-                            WHERE EXISTS (
-                                SELECT 1 FROM tmp_ocid_mapping t
-                                WHERE t.ocid = game_character.ocid AND t.user_ign != game_character.user_ign
-                            )
-                        """.trimIndent())
-                        stmt.executeUpdate("""
-                            INSERT INTO game_character (user_ign, ocid, updated_at)
-                            SELECT user_ign, ocid, now()
-                            FROM tmp_ocid_mapping
-                            ON CONFLICT (user_ign) DO UPDATE SET
-                                ocid = EXCLUDED.ocid,
-                                updated_at = now()
-                            WHERE game_character.ocid IS DISTINCT FROM EXCLUDED.ocid
-                        """.trimIndent())
-                    }
-
+                    createTempTable(con)
+                    copyToTemp(con, mappings)
+                    val rows = mergeFromTemp(con)
                     con.commit()
                     rows
                 }.getOrElse { ex ->
@@ -59,5 +54,25 @@ class OcidMappingRepository(
         ) ?: 0
 
         log.info("[OcidMapping] DB upserted via COPY→merge: {} mappings, {} affected", mappings.size, affected)
+    }
+
+    private fun createTempTable(con: Connection) {
+        con.createStatement().use { stmt ->
+            stmt.execute(DROP_TMP_SQL)
+            stmt.execute(CREATE_TMP_SQL)
+        }
+    }
+
+    private fun copyToTemp(con: Connection, mappings: List<OcidMapping>) {
+        val copyManager = CopyManager(con.unwrap(BaseConnection::class.java))
+        val data = mappings.joinToString("\n") { "${it.userIgn}\t${it.ocid}" }
+        copyManager.copyIn("COPY tmp_ocid_mapping (user_ign, ocid) FROM STDIN", data.reader())
+    }
+
+    private fun mergeFromTemp(con: Connection): Int {
+        return con.createStatement().use { stmt ->
+            stmt.executeUpdate(DELETE_CONFLICT_SQL)
+            stmt.executeUpdate(MERGE_SQL)
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Extract SQL strings to companion constants in 3 repositories.
- Extract parameter binding to `buildUpsertParams()` helpers (CharacterBasic, Equipment).
- Extract temp table lifecycle to private helpers with explicit `Connection` params (OcidMapping).
- Use `private val` + `.trimIndent()` for multi-line SQL (no leading whitespace).
- All batch methods now ≤30 lines. Zero behavioral change.

## Files
- Modified: `CharacterBasicRepository.kt`, `EquipmentReadModelRepository.kt`, `OcidMappingRepository.kt`

## Verification
- [x] `./gradlew :module-synchronizer:compileKotlin compileJava --continue` passes
- [x] `./gradlew :module-synchronizer:test` passes
- [x] Spec compliance review: PASS
- [x] Code quality review: APPROVED (MEDIUM trimIndent fix applied)

Closes #933