### PR TITLE
fix(1106,1107): DB access pattern fixes — N+1, LIMIT, chunking, batch INSERT

### DIFF
--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/jpa/GameCharacterJpaRepositoryCustomImpl.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/jpa/GameCharacterJpaRepositoryCustomImpl.kt
@@ -23,6 +23,7 @@ open class GameCharacterJpaRepositoryCustomImpl(
                 GameCharacterJpaEntity::class.java,
             )
             .setParameter("threshold", threshold)
+            .setMaxResults(100)
             .resultList
     }
 }

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/repository/ExpectationBatchRepository.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/persistence/repository/ExpectationBatchRepository.kt
@@ -35,6 +35,7 @@ class ExpectationBatchRepository(
 ) {
     companion object {
         private val log = LoggerFactory.getLogger(ExpectationBatchRepository::class.java)
+        private const val BATCH_SIZE = 100
 
         /**
          * PostgreSQL upsert query with ON CONFLICT ... DO UPDATE SET.
@@ -104,17 +105,18 @@ class ExpectationBatchRepository(
 
         val startTime = System.currentTimeMillis()
 
-        // Convert tasks to batch arguments
-        val batchArgs: List<Array<Any?>> = tasks.map { toBatchArgs(it) }
-
-        // Execute batch update
-        val results = jdbcTemplate.batchUpdate(UPSERT_SQL, batchArgs)
+        val results = tasks.chunked(BATCH_SIZE).flatMap { chunk ->
+            val batchArgs = chunk.map { toBatchArgs(it) }
+            jdbcTemplate.batchUpdate(UPSERT_SQL, batchArgs).toList()
+        }.toIntArray()
 
         val duration = System.currentTimeMillis() - startTime
 
         log.info(
-            "[ExpectationBatchRepo] Batch upsert completed: {} records in {}ms ({} records/sec)",
+            "[ExpectationBatchRepo] Batch upsert completed: {} records in {} chunks of {} in {}ms ({} records/sec)",
             tasks.size,
+            tasks.chunked(BATCH_SIZE).size,
+            BATCH_SIZE,
             duration,
             if (duration > 0) tasks.size * 1000L / duration else 0,
         )

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/DlqReplayWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/pgmq/DlqReplayWorker.kt
@@ -107,19 +107,12 @@ class DlqReplayWorker(
 
         if (untracked.isEmpty()) return
 
-        for (msgId in untracked) {
-            insertTracking(queueName, msgId)
-        }
+        jdbcTemplate.batchUpdate(
+            "INSERT INTO dlq_replay_meta (queue_name, message_id, replay_count, first_failed_at) VALUES (?, ?, 0, NOW()) ON CONFLICT DO NOTHING",
+            untracked.map { arrayOf<Any>(queueName, it) },
+        )
 
         log.info("[DlqReplayWorker] Discovered {} new DLQ messages in {}", untracked.size, queueName)
-    }
-
-    private fun insertTracking(queueName: String, messageId: Long) {
-        jdbcTemplate.update(
-            "INSERT INTO dlq_replay_meta (queue_name, message_id, replay_count, first_failed_at) VALUES (?, ?, 0, NOW()) ON CONFLICT DO NOTHING",
-            queueName,
-            messageId,
-        )
     }
 
     /**

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/AbstractExpectationCalcWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/AbstractExpectationCalcWorker.kt
@@ -3,6 +3,7 @@ package maple.expectation.infrastructure.worker
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.micrometer.core.instrument.MeterRegistry
 import maple.expectation.core.port.inbound.BatchComputeBuffer
+import maple.expectation.core.port.inbound.CharacterViewProjectionCommand
 import maple.expectation.core.port.inbound.CharacterViewQueryPort
 import maple.expectation.core.port.inbound.ExpectationV4Port
 import maple.expectation.core.port.out.CharacterOcidPort
@@ -161,9 +162,9 @@ abstract class AbstractExpectationCalcWorker(
         // 3. Bulk upsert — 3 queries total (SELECT + batch UPDATE/INSERT)
         batchRepo.bulkUpsert(parsed)
 
-        // 4. Sync read model for query-server
-        parsed.forEach { view ->
-            viewQueryPort.upsertFromCalculation(
+        // 4. Sync read model for query-server — batch upsert (was N+1)
+        val commands = parsed.map { view ->
+            CharacterViewProjectionCommand(
                 userIgn = view.userIgn,
                 messageId = view.messageId,
                 characterOcid = view.characterOcid,
@@ -175,6 +176,7 @@ abstract class AbstractExpectationCalcWorker(
                 presetsJson = view.presetsJson,
             )
         }
+        viewQueryPort.batchUpsertFromCalculations(commands)
     }
 
     private fun batchL2CachePut(results: List<CalculationResult>) {


### PR DESCRIPTION
## Summary
- **#1106:** Replace N+1 `forEach` in `AbstractExpectationCalcWorker` with existing `batchUpsertFromCalculations()` method.
- **#1107-1:** Add `LIMIT 100` to `findActiveCharacters()` JPA query (both callers already limit to 100).
- **#1107-2:** Add `chunked(100)` to `ExpectationBatchRepository.doBatchUpsert()` (matches `EquipmentExpectationSummaryBatchRepository.DEFAULT_BATCH_SIZE`).
- **#1107-3:** Replace `DlqReplayWorker` loop INSERT with `jdbcTemplate.batchUpdate()`.

## Skipped (per spec)
- `GameCharacterRepositoryImpl.findAll()` — no callers in prod
- `CharacterOcidAdapter.loadAllOcidsFromDb()` — intentional startup cache warmup

## Files
- Modified: `AbstractExpectationCalcWorker.kt`, `GameCharacterJpaRepositoryCustomImpl.kt`, `ExpectationBatchRepository.kt`, `DlqReplayWorker.kt`

## Verification
- [x] `./gradlew :module-infra:compileKotlin compileJava --continue` passes
- [x] `./gradlew :module-infra:test` passes
- [x] Spec compliance review passed
- [x] Code quality review passed

Closes #1106
Closes #1107