### PR TITLE
refactor(923): decompose DefaultChunkProcessor into read/transform/write stages

### DIFF
--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/processor/ChunkDataReader.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/processor/ChunkDataReader.kt
@@ -1,0 +1,32 @@
+package maple.synchronizer.processor
+
+import io.micrometer.core.instrument.Timer
+import maple.synchronizer.domain.GroupedEquipmentResult
+import maple.synchronizer.metrics.SynchronizerMetrics
+import maple.synchronizer.resolver.OcidUserIgnResolver
+import maple.synchronizer.storage.ResultFileReader
+import org.springframework.stereotype.Component
+
+@Component
+class ChunkDataReader(
+    private val resultFileReader: ResultFileReader,
+    private val ocidUserIgnResolver: OcidUserIgnResolver,
+    private val metrics: SynchronizerMetrics,
+) {
+
+    fun read(objectKey: String): List<GroupedEquipmentResult> {
+        val grouped = timed(metrics.fileReadTimer()) {
+            resultFileReader.readAndGroupByCompositeKey(objectKey)
+        }
+
+        val ocids = grouped.map { it.ocid }.toSet()
+        val ocidToUserIgn = ocidUserIgnResolver.resolve(ocids)
+
+        return grouped.map { it.copy(userIgn = ocidToUserIgn[it.ocid]) }
+    }
+
+    private inline fun <T> timed(timer: Timer, block: () -> T): T {
+        val sample = Timer.start()
+        return block().also { sample.stop(timer) }
+    }
+}

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/processor/ChunkDocumentTransformer.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/processor/ChunkDocumentTransformer.kt
@@ -1,0 +1,48 @@
+package maple.synchronizer.processor
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.micrometer.core.instrument.Timer
+import maple.synchronizer.builder.EquipmentDocumentBuilder
+import maple.synchronizer.domain.GroupedEquipmentResult
+import maple.synchronizer.metrics.SynchronizerMetrics
+import maple.synchronizer.preparer.EquipmentDocumentPreparer
+import maple.synchronizer.preparer.PreppedDocument
+import org.springframework.stereotype.Component
+
+data class TransformResult(
+    val documentCount: Int,
+    val itemCount: Long,
+    val prepped: List<PreppedDocument>,
+)
+
+@Component
+class ChunkDocumentTransformer(
+    objectMapper: ObjectMapper,
+    private val metrics: SynchronizerMetrics,
+) {
+
+    private val documentBuilder = EquipmentDocumentBuilder()
+    private val preparer = EquipmentDocumentPreparer(objectMapper)
+
+    fun transform(runId: String, chunkId: String, grouped: List<GroupedEquipmentResult>): TransformResult {
+        val documents = timed(metrics.documentBuildTimer()) {
+            grouped.map { g ->
+                documentBuilder.build(runId, chunkId, g)
+            }
+        }
+
+        val itemCount = grouped.sumOf { it.items.size.toLong() }
+        val prepped = preparer.prepare(documents)
+
+        return TransformResult(
+            documentCount = documents.size,
+            itemCount = itemCount,
+            prepped = prepped,
+        )
+    }
+
+    private inline fun <T> timed(timer: Timer, block: () -> T): T {
+        val sample = Timer.start()
+        return block().also { sample.stop(timer) }
+    }
+}

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/processor/ChunkDocumentWriter.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/processor/ChunkDocumentWriter.kt
@@ -1,0 +1,22 @@
+package maple.synchronizer.processor
+
+import maple.synchronizer.metrics.SynchronizerMetrics
+import maple.synchronizer.preparer.PreppedDocument
+import maple.synchronizer.ranking.EquipmentRankingRedisWriter
+import maple.synchronizer.repository.EquipmentReadModelRepository
+import org.springframework.stereotype.Component
+
+@Component
+class ChunkDocumentWriter(
+    private val readModelRepository: EquipmentReadModelRepository,
+    private val rankingWriter: EquipmentRankingRedisWriter,
+    private val metrics: SynchronizerMetrics,
+) {
+
+    fun write(runId: String, chunkId: String, prepped: List<PreppedDocument>) {
+        metrics.mainUpsertTimer().record(Runnable {
+            readModelRepository.bulkUpsert(runId, chunkId, prepped)
+        })
+        rankingWriter.update(prepped)
+    }
+}

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/processor/DefaultChunkProcessor.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/processor/DefaultChunkProcessor.kt
@@ -1,71 +1,37 @@
 package maple.synchronizer.processor
 
-import io.micrometer.core.instrument.Timer
-import maple.synchronizer.builder.EquipmentDocumentBuilder
 import maple.synchronizer.metrics.SynchronizerMetrics
-import maple.synchronizer.preparer.EquipmentDocumentPreparer
-import maple.synchronizer.ranking.EquipmentRankingRedisWriter
-import maple.synchronizer.repository.EquipmentReadModelRepository
-import maple.synchronizer.resolver.OcidUserIgnResolver
-import maple.synchronizer.storage.ResultFileReader
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 
 @Component
 class DefaultChunkProcessor(
-    private val resultFileReader: ResultFileReader,
-    private val readModelRepository: EquipmentReadModelRepository,
-    private val ocidUserIgnResolver: OcidUserIgnResolver,
+    private val dataReader: ChunkDataReader,
+    private val transformer: ChunkDocumentTransformer,
+    private val writer: ChunkDocumentWriter,
     private val metrics: SynchronizerMetrics,
-    private val rankingWriter: EquipmentRankingRedisWriter,
-    objectMapper: com.fasterxml.jackson.databind.ObjectMapper,
 ) : ChunkProcessor {
-
-    private val documentBuilder = EquipmentDocumentBuilder()
-    private val preparer = EquipmentDocumentPreparer(objectMapper)
 
     private val log = LoggerFactory.getLogger(DefaultChunkProcessor::class.java)
 
     override fun process(input: ChunkProcessInput): ChunkProcessResult {
-        val grouped = timed(metrics.fileReadTimer()) {
-            resultFileReader.readAndGroupByCompositeKey(input.objectKey)
-        }
+        val grouped = dataReader.read(input.objectKey)
 
-        val ocids = grouped.map { it.ocid }.toSet()
-        val ocidToUserIgn = ocidUserIgnResolver.resolve(ocids)
+        val transformResult = transformer.transform(input.sourceRunId, input.sourceChunkId, grouped)
 
-        val documents = timed(metrics.documentBuildTimer()) {
-            grouped.map { g ->
-                val withUserIgn = g.copy(userIgn = ocidToUserIgn[g.ocid])
-                documentBuilder.build(input.sourceRunId, input.sourceChunkId, withUserIgn)
-            }
-        }
+        log.info("[Synchronizer] grouped {} results into {} documents", input.resultCount, transformResult.documentCount)
 
-        val itemsCount = grouped.sumOf { it.items.size.toLong() }
+        metrics.incrementDocuments(transformResult.documentCount)
+        metrics.incrementItems(transformResult.itemCount)
+        metrics.recordChunkSize(transformResult.documentCount, transformResult.itemCount)
+        transformResult.prepped.forEach { metrics.recordDocumentEquipment(it.equipmentCount) }
 
-        log.info("[Synchronizer] grouped {} results into {} documents", input.resultCount, documents.size)
-
-        metrics.incrementDocuments(documents.size)
-        metrics.incrementItems(itemsCount)
-        metrics.recordChunkSize(documents.size, itemsCount)
-        documents.forEach { metrics.recordDocumentEquipment(it.summary.equipmentCount) }
-
-        val prepped = preparer.prepare(documents)
-
-        metrics.mainUpsertTimer().record(Runnable {
-            readModelRepository.bulkUpsert(input.sourceRunId, input.sourceChunkId, prepped)
-        })
-        rankingWriter.update(prepped)
+        writer.write(input.sourceRunId, input.sourceChunkId, transformResult.prepped)
 
         return ChunkProcessResult(
-            documentCount = documents.size,
-            itemCount = itemsCount,
+            documentCount = transformResult.documentCount,
+            itemCount = transformResult.itemCount,
             jsonRowCount = input.resultCount.toLong(),
         )
-    }
-
-    private inline fun <T> timed(timer: Timer, block: () -> T): T {
-        val sample = Timer.start()
-        return block().also { sample.stop(timer) }
     }
 }

--- a/module-synchronizer/src/test/kotlin/maple/synchronizer/processor/DefaultChunkProcessorTest.kt
+++ b/module-synchronizer/src/test/kotlin/maple/synchronizer/processor/DefaultChunkProcessorTest.kt
@@ -6,16 +6,13 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import maple.synchronizer.domain.CalculatedEquipmentItem
 import maple.synchronizer.domain.GroupedEquipmentResult
 import maple.synchronizer.metrics.SynchronizerMetrics
-import maple.synchronizer.preparer.EquipmentDocumentPreparer
-import maple.synchronizer.ranking.EquipmentRankingRedisWriter
-import maple.synchronizer.repository.EquipmentReadModelRepository
-import maple.synchronizer.resolver.OcidUserIgnResolver
-import maple.synchronizer.storage.ResultFileReader
+import maple.synchronizer.preparer.PreppedDocument
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -24,34 +21,27 @@ import java.math.BigDecimal
 
 class DefaultChunkProcessorTest {
 
-    private val resultFileReader: ResultFileReader = mock()
-    private val readModelRepository: EquipmentReadModelRepository = mock()
-    private val ocidUserIgnResolver: OcidUserIgnResolver = mock()
-    private val rankingWriter: EquipmentRankingRedisWriter = mock()
+    private val dataReader: ChunkDataReader = mock()
+    private val transformer: ChunkDocumentTransformer = mock()
+    private val writer: ChunkDocumentWriter = mock()
     private val metrics = SynchronizerMetrics(SimpleMeterRegistry())
-    private val objectMapper = ObjectMapper().registerModule(JavaTimeModule())
 
     private lateinit var chunkProcessor: DefaultChunkProcessor
 
     @BeforeEach
     fun setUp() {
-        chunkProcessor = DefaultChunkProcessor(
-            resultFileReader,
-            readModelRepository,
-            ocidUserIgnResolver,
-            metrics,
-            rankingWriter,
-            objectMapper,
-        )
-        whenever(ocidUserIgnResolver.resolve(any())).thenReturn(emptyMap())
+        chunkProcessor = DefaultChunkProcessor(dataReader, transformer, writer, metrics)
     }
 
     @Test
     fun `process - happy path returns result with correct counts`() {
         val input = testInput()
         val grouped = listOf(GroupedEquipmentResult(readKey = "oc1:1", ocid = "oc1", presetNo = 1, items = listOf(testItem())))
+        val prepped = listOf<PreppedDocument>(mock())
+        val transformResult = TransformResult(documentCount = 1, itemCount = 1, prepped = prepped)
 
-        whenever(resultFileReader.readAndGroupByCompositeKey(any())).thenReturn(grouped)
+        whenever(dataReader.read(any())).thenReturn(grouped)
+        whenever(transformer.transform(any(), any(), any())).thenReturn(transformResult)
 
         val result = chunkProcessor.process(input)
 
@@ -61,22 +51,24 @@ class DefaultChunkProcessorTest {
     }
 
     @Test
-    fun `process - calls preparer then repository bulkUpsert`() {
+    fun `process - calls writer with prepped documents`() {
         val input = testInput()
         val grouped = listOf(GroupedEquipmentResult(readKey = "oc1:1", ocid = "oc1", presetNo = 1, items = listOf(testItem())))
+        val prepped = listOf<PreppedDocument>(mock())
+        val transformResult = TransformResult(documentCount = 1, itemCount = 1, prepped = prepped)
 
-        whenever(resultFileReader.readAndGroupByCompositeKey(any())).thenReturn(grouped)
+        whenever(dataReader.read(any())).thenReturn(grouped)
+        whenever(transformer.transform(any(), any(), any())).thenReturn(transformResult)
 
         chunkProcessor.process(input)
 
-        verify(readModelRepository).bulkUpsert(eq(input.sourceRunId), eq(input.sourceChunkId), any())
-        verify(rankingWriter).update(any())
+        verify(writer).write(eq(input.sourceRunId), eq(input.sourceChunkId), eq(prepped))
     }
 
     @Test
     fun `process - file not found propagates exception`() {
         val input = testInput()
-        whenever(resultFileReader.readAndGroupByCompositeKey(any()))
+        whenever(dataReader.read(any()))
             .thenThrow(IllegalStateException("Result file not found"))
 
         assertThatThrownBy { chunkProcessor.process(input) }
@@ -88,10 +80,13 @@ class DefaultChunkProcessorTest {
     fun `process - upsert failure propagates exception`() {
         val input = testInput()
         val grouped = listOf(GroupedEquipmentResult(readKey = "oc1:1", ocid = "oc1", presetNo = 1, items = listOf(testItem())))
+        val prepped = listOf<PreppedDocument>(mock())
+        val transformResult = TransformResult(documentCount = 1, itemCount = 1, prepped = prepped)
 
-        whenever(resultFileReader.readAndGroupByCompositeKey(any())).thenReturn(grouped)
-        whenever(readModelRepository.bulkUpsert(any(), any(), any()))
-            .thenThrow(RuntimeException("DB connection failed"))
+        whenever(dataReader.read(any())).thenReturn(grouped)
+        whenever(transformer.transform(any(), any(), any())).thenReturn(transformResult)
+        doThrow(RuntimeException("DB connection failed"))
+            .whenever(writer).write(any(), any(), any())
 
         assertThatThrownBy { chunkProcessor.process(input) }
             .isInstanceOf(RuntimeException::class.java)
@@ -105,8 +100,11 @@ class DefaultChunkProcessorTest {
             GroupedEquipmentResult(readKey = "oc1:1", ocid = "oc1", presetNo = 1, items = listOf(testItem(ocid = "oc1"))),
             GroupedEquipmentResult(readKey = "oc2:1", ocid = "oc2", presetNo = 1, items = listOf(testItem(ocid = "oc2"), testItem(ocid = "oc2"))),
         )
+        val prepped = listOf<PreppedDocument>(mock(), mock())
+        val transformResult = TransformResult(documentCount = 2, itemCount = 3, prepped = prepped)
 
-        whenever(resultFileReader.readAndGroupByCompositeKey(any())).thenReturn(grouped)
+        whenever(dataReader.read(any())).thenReturn(grouped)
+        whenever(transformer.transform(any(), any(), any())).thenReturn(transformResult)
 
         val result = chunkProcessor.process(input)
 

--- a/module-synchronizer/src/test/kotlin/maple/synchronizer/processor/DefaultChunkProcessorTest.kt
+++ b/module-synchronizer/src/test/kotlin/maple/synchronizer/processor/DefaultChunkProcessorTest.kt
@@ -1,7 +1,5 @@
 package maple.synchronizer.processor
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import maple.synchronizer.domain.CalculatedEquipmentItem
 import maple.synchronizer.domain.GroupedEquipmentResult


### PR DESCRIPTION
## Summary
Decompose `DefaultChunkProcessor.process()` into 3 `@Component` stages:
- **ChunkDataReader** — file read + OCID resolution
- **ChunkDocumentTransformer** — document build + prepare (includes `TransformResult` data class)
- **ChunkDocumentWriter** — DB bulk upsert + Redis ranking update

`DefaultChunkProcessor` becomes a thin orchestrator: `read() → transform() → write()` with metrics at stage boundaries.

## Files
- Created: `ChunkDataReader.kt`, `ChunkDocumentTransformer.kt`, `ChunkDocumentWriter.kt`
- Modified: `DefaultChunkProcessor.kt` (37-line process → 3 stage calls), `DefaultChunkProcessorTest.kt` (stage-based mocks)

## Verification
- [x] `./gradlew :module-synchronizer:compileKotlin compileJava --continue` passes
- [x] `./gradlew :module-synchronizer:test` passes
- [x] Spec compliance review passed
- [x] Code quality review passed

Closes #923