### PR TITLE
refactor(952): unify missing-file error strategy in BasicChunkFileReader

### DIFF
--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/storage/BasicChunkFileReader.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/storage/BasicChunkFileReader.kt
@@ -46,7 +46,7 @@ class BasicChunkFileReader(
 
     fun read(objectKey: String): List<BasicRecord> {
         val path = Paths.get(basePath, objectKey)
-        require(Files.exists(path)) { "Chunk file not found: $path" }
+        if (!Files.exists(path)) throw IllegalStateException("Chunk file not found: $path")
 
         val parseErrors = AtomicLong(0)
         val missingFields = AtomicLong(0)
@@ -71,7 +71,7 @@ class BasicChunkFileReader(
         handler: (List<BasicRecord>) -> Unit,
     ) {
         val path = Paths.get(basePath, objectKey)
-        require(Files.exists(path)) { "Chunk file not found: $path" }
+        if (!Files.exists(path)) throw IllegalStateException("Chunk file not found: $path")
 
         val parseErrors = AtomicLong(0)
         val missingFields = AtomicLong(0)


### PR DESCRIPTION
## Summary
Unify missing-file error handling in `BasicChunkFileReader` — changed `require()` (→ `IllegalArgumentException`) to explicit `if (!Files.exists) throw IllegalStateException`, matching `ResultFileReader` and `OcidMappingFileReader`.

This ensures `ChunkConsumerTemplate.classifyFailure()` correctly catches "file not found" messages from all 3 readers.

## Skipped (per design discussion)
- GzipJsonlReader extraction — low value, 3-4 lines of boilerplate shared, domain logic differs
- unnestUpsert generic — `JdbcChunkedBatchExecutor` already exists, remaining boilerplate is repo-specific
- endpoint-filter function — 3-line inline check already clear, function adds indirection for minimal benefit

## Verification
- [x] `./gradlew :module-synchronizer:compileKotlin compileJava --continue` passes
- [x] `./gradlew :module-synchronizer:test` passes

Closes #952