### PR TITLE
docs(adr): ADR-722 package naming policy + ADR-050 post-EPIC-4 update

### DIFF
--- a/docs/01_ADR/ADR-050-module-infra-decomposition-roadmap.md
+++ b/docs/01_ADR/ADR-050-module-infra-decomposition-roadmap.md
@@ -212,3 +212,34 @@ core ← executor ← {pgmq, aop, security, monitoring, cache, persistence, exte
 2. `ExecutorPort` 정의 + `module-infra` adapter (port/interface 분리)
 3. 7개 후속 모듈별 별도 이슈 (각 PR 1-3건)
 4. `module-infra` 축소 트리거: fan-in 0 도달 시 facade 삭제
+
+---
+
+## Post-ADR Updates (2026-06-05)
+
+### 선행 작업 완료
+
+| 작업 | PR/이슈 | ADR-050 영향 |
+|------|---------|-------------|
+| ExecutorConfig → CoreExecutorConfig + InfraExecutorConfig 분리 | #1119 | `module-executor` 추출의 설정 분리 선제 완료 |
+| VT ExecutorManager inline → @Bean injection | #1120 | executor bean 관리 체계 정비 |
+| LogicExecutor/TaskContext core 승격 | #904 (closed — 위험 과대) | **선행 불필요로 판단** — #1119 분리로 충분 |
+| domain/v2 → infrastructure/persistence 이관 | #896 (#1148) | `module-persistence` 후보 파일 정리 완료 |
+| 동시성 어댑터 6종 도입 | #1157 | `module-aop` 후보에 concurrency 패키지 포함 |
+| 포트 인터페이스 기술명 제거 | #906 (#1146) | 모듈 분해 시 port 이름이 기술 중립적 |
+
+### 우선순위 재조정
+
+| 후보 | 기존 순위 | 변경 순위 | 이유 |
+|------|----------|----------|------|
+| `module-executor` | 1 | **2** | #1119 분리로 긴급도 하락. core 승격(#904) close |
+| `module-persistence` | 4 | **1** | #896 이관 완료, 파일 정리 상태 가장 좋음 |
+| `module-aop` (+concurrency) | 6 | **3** | #1157 어댑터 포함 필요 |
+| `module-cache` | 5 | **4** | 변동 없음 |
+
+### `module-executor` 추출 재평가
+
+#904(LogicExecutor core 승격) close로 인해 `module-executor` 독립 모듈 필요성 감소. 대신:
+- #1119 CoreExecutorConfig가 이미 `module-core` 인접 설정 담당
+- #1157 ConcurrencyConfiguration이 동시성 어댑터 wiring 담당
+- **권장**: `module-executor` 추출 보류, `module-persistence`를 1순위로 진행

--- a/docs/01_ADR/ADR-722_infrastructure-package-naming-policy.md
+++ b/docs/01_ADR/ADR-722_infrastructure-package-naming-policy.md
@@ -1,0 +1,94 @@
+# ADR-722: Infrastructure Package Naming — Legacy 누적 방지 정책
+
+- Status: Accepted
+- Date: 2026-06-05
+- Owner: arch
+- Related: #896, #1157
+
+---
+
+## 1. Background / Problem
+
+### Background
+
+ADR-050에서 `module-infra` 분해 로드맵 수립. #896에서 `domain/v2/` 7개 엔티티를 `infrastructure/persistence/entity/`로 이관 완료. #1157에서 `concurrency/` 패키지에 6개 어댑터 도입.
+
+### Problem
+
+- `domain/v2/` 같은 버전 접미사 패키지가 재발 가능 — `v3/`, `v4/` 등장 시 동일 이관 작업 반복
+- flat `entity/` 패키지에 모든 JPA 엔티티가 모이면 도메인 경계 불명확
+- 신규 인프라 코드가 패키지 컨벤션 없이 임의 위치에 생성됨
+
+### Goal
+
+`module-infra` 내 패키지 명명 규칙을 정의하여 레거시 누적을 구조적으로 방지.
+
+---
+
+## 2. Decision
+
+> `module-infra/infrastructure/` 하위 패키지는 **도메인 단위 + 기술 역할** 2-level 구조만 사용. 버전 접미사, flat 패키지, `domain/` 내 JPA 엔티티 금지.
+
+```text
+infrastructure/
+├── persistence/
+│   ├── entity/character/      (GameCharacterJpaEntity 등)
+│   ├── entity/equipment/      (CharacterEquipmentJpaEntity 등)
+│   ├── entity/calculation/    (CalculationJobJpaEntity 등)
+│   └── repository/            (JPA repository 인터페이스)
+├── concurrency/               (6 adapters from #1157)
+├── cache/                     (TieredCache, SingleFlight)
+├── config/                    (Spring @Configuration beans)
+└── ...                        (기타 도메인별 패키지)
+```
+
+---
+
+## 3. Trade-offs
+
+### Sensitivity
+
+* `module-infra` 내 패키지 수 (~30개)
+* 신규 개발자가 패키지를 찾는 속도
+* 마이그레이션 PR 크기 (기존 flat 패키지 → 도메인별 이동)
+
+### Trade-off
+
+| 선택 | 얻는 것 | 포기한 것 |
+| -- | ---- | ----- |
+| 도메인 단위 하위 패키지 | 관련 코드 응집, 변경 범위 국지화 | 패키지 depth +1 |
+| 버전 접미사 금지 | v2/v3 재발 방지 | 일시적 병행 기간 필요 (이관 PR) |
+| JPA 엔티티 `infrastructure/` 내 강제 | domain 패키지 순수성 유지 | infra 패키지 크기 증가 |
+
+### Risk
+
+* 기존 flat `entity/` 패키지에서 도메인별 이동 시 import 변경量大 — 점진적 이관 필요
+* `config/` 패키지는 104파일로 이미 과대 — ADR-050 분해 시 함께 분할 필요
+
+### Non-Risk
+
+* `module-core` 순수성 — 이 정책은 `module-infra` 내부만 해당
+* 빌드/런타임 영향 — 패키지 이동은 compile-only 변경
+
+---
+
+## 4. Result / Evidence
+
+### Metrics
+
+| Metric | Value | Notes |
+| ------ | ----: | ----- |
+| `domain/v2/` 잔여 파일 | 0 | #896 이관 완료 |
+| `infrastructure/persistence/entity/` 파일 | 7 | #896 결과 |
+| `concurrency/` 파일 | 10 | #1157 결과 |
+
+### Observed Result
+
+* #896 이관 후 `domain/` 패키지에 JPA 엔티티 0건
+* #1157 도입 후 `concurrency/` 패키지에 동시성 코드 집중
+
+---
+
+## 5. Summary
+
+> **`infrastructure/{domain}/{role}/` 구조만 허용, 버전 접미사·flat 패키지·domain 내 JPA 금지.**


### PR DESCRIPTION
## Summary
- **ADR-722**: `infrastructure/{domain}/{role}/` package naming policy. Bans version suffixes, flat entity packages, JPA in `domain/`.
- **ADR-050 update**: Reprioritize extraction order after #1119, #904 close, #896, #1157. `module-persistence` now 1st priority, `module-executor` deferred.

No code changes. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
