### PR TITLE
feat(core): add Chunk stage port interfaces (PR1)

### DIFF
--- a/module-core/build.gradle
+++ b/module-core/build.gradle
@@ -17,11 +17,15 @@ dependencies {
 	implementation(libs.jackson.annotations)
 	implementation(libs.jackson.databind)
 
+	// Coroutines (suspend in port interfaces)
+	implementation(libs.kotlinx.coroutines.core)
+
 	// Testing
 	testImplementation(libs.junit.jupiter)
 	testImplementation(libs.jqwik)
 	testImplementation(libs.assertj.core)
 	testImplementation(libs.jackson.module.kotlin)
+	testImplementation(libs.kotlinx.coroutines.test)
 }
 
 test {

--- a/module-core/src/main/kotlin/maple/core/domain/chunk/Chunk.kt
+++ b/module-core/src/main/kotlin/maple/core/domain/chunk/Chunk.kt
@@ -1,0 +1,7 @@
+package maple.core.domain.chunk
+
+data class Chunk<T>(
+    val input: ChunkProcessInput,
+    val data: T,
+    val metadata: Map<String, String> = emptyMap(),
+)

--- a/module-core/src/main/kotlin/maple/core/domain/chunk/ChunkProcessInput.kt
+++ b/module-core/src/main/kotlin/maple/core/domain/chunk/ChunkProcessInput.kt
@@ -1,0 +1,8 @@
+package maple.core.domain.chunk
+
+data class ChunkProcessInput(
+    val objectKey: String,
+    val sourceRunId: String,
+    val sourceChunkId: String,
+    val resultCount: Int,
+)

--- a/module-core/src/main/kotlin/maple/core/domain/chunk/ChunkReader.kt
+++ b/module-core/src/main/kotlin/maple/core/domain/chunk/ChunkReader.kt
@@ -1,0 +1,5 @@
+package maple.core.domain.chunk
+
+interface ChunkReader<T> {
+    suspend fun read(chunk: Chunk<Unit>): Chunk<T>
+}

--- a/module-core/src/main/kotlin/maple/core/domain/chunk/ChunkTransformer.kt
+++ b/module-core/src/main/kotlin/maple/core/domain/chunk/ChunkTransformer.kt
@@ -1,0 +1,5 @@
+package maple.core.domain.chunk
+
+interface ChunkTransformer<T, R> {
+    suspend fun transform(chunk: Chunk<T>): Chunk<R>
+}

--- a/module-core/src/main/kotlin/maple/core/domain/chunk/ChunkWriter.kt
+++ b/module-core/src/main/kotlin/maple/core/domain/chunk/ChunkWriter.kt
@@ -1,0 +1,5 @@
+package maple.core.domain.chunk
+
+interface ChunkWriter<T> {
+    suspend fun write(chunk: Chunk<T>): Chunk<Unit>
+}

--- a/module-core/src/test/kotlin/maple/core/domain/chunk/ChunkReaderTest.kt
+++ b/module-core/src/test/kotlin/maple/core/domain/chunk/ChunkReaderTest.kt
@@ -1,0 +1,20 @@
+package maple.core.domain.chunk
+
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+
+class ChunkReaderTest {
+    @Test
+    fun `read returns chunk with payload`() = runTest {
+        val reader = object : ChunkReader<String> {
+            override suspend fun read(chunk: Chunk<Unit>): Chunk<String> =
+                Chunk(chunk.input, "loaded", chunk.metadata)
+        }
+        val input = ChunkProcessInput("k", "r", "c", 0)
+        val initial = Chunk<Unit>(input, Unit)
+        val result = reader.read(initial)
+        assertEquals("loaded", result.data)
+        assertEquals(input, result.input)
+    }
+}

--- a/module-core/src/test/kotlin/maple/core/domain/chunk/ChunkTest.kt
+++ b/module-core/src/test/kotlin/maple/core/domain/chunk/ChunkTest.kt
@@ -1,0 +1,27 @@
+package maple.core.domain.chunk
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+
+class ChunkTest {
+    @Test
+    fun `holds input data and metadata`() {
+        val input = ChunkProcessInput(
+            objectKey = "key1",
+            sourceRunId = "run1",
+            sourceChunkId = "chunk1",
+            resultCount = 42,
+        )
+        val chunk = Chunk(input = input, data = "payload", metadata = mapOf("trace" to "abc"))
+        assertEquals(input, chunk.input)
+        assertEquals("payload", chunk.data)
+        assertEquals("abc", chunk.metadata["trace"])
+    }
+
+    @Test
+    fun `metadata defaults to empty`() {
+        val input = ChunkProcessInput("k", "r", "c", 0)
+        val chunk = Chunk(input, Unit)
+        assertEquals(emptyMap<String, String>(), chunk.metadata)
+    }
+}

--- a/module-core/src/test/kotlin/maple/core/domain/chunk/ChunkTransformerTest.kt
+++ b/module-core/src/test/kotlin/maple/core/domain/chunk/ChunkTransformerTest.kt
@@ -1,0 +1,33 @@
+package maple.core.domain.chunk
+
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+
+class ChunkTransformerTest {
+    @Test
+    fun `transform maps data and propagates input`() = runTest {
+        val transformer = object : ChunkTransformer<String, Int> {
+            override suspend fun transform(chunk: Chunk<String>): Chunk<Int> =
+                Chunk(chunk.input, chunk.data.length, chunk.metadata)
+        }
+        val input = ChunkProcessInput("k", "r", "c", 0)
+        val chunk = Chunk(input, "hello")
+        val result = transformer.transform(chunk)
+        assertEquals(5, result.data)
+        assertEquals(input, result.input)
+    }
+
+    @Test
+    fun `transform passes metadata through`() = runTest {
+        val transformer = object : ChunkTransformer<String, String> {
+            override suspend fun transform(chunk: Chunk<String>): Chunk<String> =
+                Chunk(chunk.input, chunk.data.uppercase(), chunk.metadata)
+        }
+        val input = ChunkProcessInput("k", "r", "c", 0)
+        val chunk = Chunk(input, "abc", metadata = mapOf("step" to "1"))
+        val result = transformer.transform(chunk)
+        assertEquals("ABC", result.data)
+        assertEquals("1", result.metadata["step"])
+    }
+}

--- a/module-core/src/test/kotlin/maple/core/domain/chunk/ChunkWriterTest.kt
+++ b/module-core/src/test/kotlin/maple/core/domain/chunk/ChunkWriterTest.kt
@@ -1,0 +1,24 @@
+package maple.core.domain.chunk
+
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import java.util.concurrent.atomic.AtomicReference
+
+class ChunkWriterTest {
+    @Test
+    fun `write receives chunk and returns terminal chunk`() = runTest {
+        val captured = AtomicReference<Chunk<String>?>()
+        val writer = object : ChunkWriter<String> {
+            override suspend fun write(chunk: Chunk<String>): Chunk<Unit> {
+                captured.set(chunk)
+                return Chunk(chunk.input, Unit, chunk.metadata)
+            }
+        }
+        val input = ChunkProcessInput("k", "r", "c", 0)
+        val chunk = Chunk(input, "payload")
+        val result = writer.write(chunk)
+        assertEquals("payload", captured.get()?.data)
+        assertEquals(Unit, result.data)
+    }
+}

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/KafkaResultChunkConsumer.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/KafkaResultChunkConsumer.kt
@@ -9,7 +9,7 @@ import maple.expectation.infrastructure.executor.TaskContext
 import maple.synchronizer.event.KafkaChunkConsumedEventPublisher
 import maple.synchronizer.metrics.SynchronizerChunkMetricsListener
 import maple.synchronizer.metrics.SynchronizerMetrics
-import maple.synchronizer.processor.ChunkProcessInput
+import maple.core.domain.chunk.ChunkProcessInput
 import maple.synchronizer.processor.ChunkProcessor
 import org.slf4j.LoggerFactory
 import org.springframework.kafka.annotation.KafkaListener

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/processor/ChunkProcessInput.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/processor/ChunkProcessInput.kt
@@ -1,8 +1,0 @@
-package maple.synchronizer.processor
-
-data class ChunkProcessInput(
-    val objectKey: String,
-    val sourceRunId: String,
-    val sourceChunkId: String,
-    val resultCount: Int,
-)

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/processor/ChunkProcessor.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/processor/ChunkProcessor.kt
@@ -1,5 +1,7 @@
 package maple.synchronizer.processor
 
+import maple.core.domain.chunk.ChunkProcessInput
+
 interface ChunkProcessor {
     fun process(input: ChunkProcessInput): ChunkProcessResult
 }

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/processor/DefaultChunkProcessor.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/processor/DefaultChunkProcessor.kt
@@ -1,5 +1,6 @@
 package maple.synchronizer.processor
 
+import maple.core.domain.chunk.ChunkProcessInput
 import maple.synchronizer.metrics.SynchronizerMetrics
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component

--- a/module-synchronizer/src/test/kotlin/maple/synchronizer/processor/DefaultChunkProcessorTest.kt
+++ b/module-synchronizer/src/test/kotlin/maple/synchronizer/processor/DefaultChunkProcessorTest.kt
@@ -1,6 +1,7 @@
 package maple.synchronizer.processor
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import maple.core.domain.chunk.ChunkProcessInput
 import maple.synchronizer.domain.CalculatedEquipmentItem
 import maple.synchronizer.domain.GroupedEquipmentResult
 import maple.synchronizer.metrics.SynchronizerMetrics


### PR DESCRIPTION
## Summary
Introduces `module-core/domain/chunk/`:
- `Chunk<T>` data class with `input` + `data` + `metadata`
- `ChunkProcessInput` (moved from module-synchronizer)
- `ChunkReader<T>`, `ChunkTransformer<T, R>`, `ChunkWriter<T>` port interfaces (single suspend function each)
- 6 unit tests

`module-synchronizer` imports updated to use `maple.core.domain.chunk.ChunkProcessInput`.

## Spec
`docs/superpowers/specs/2026-06-06-chunk-stage-ports-design.md`

## Plan
`docs/superpowers/plans/2026-06-06-chunk-stage-ports-pr1.md`

## Test
6 port unit tests pass. Full repo compile + module-synchronizer test pass.

## Commits (5)
```
526c7703c feat(core): add Chunk<T> domain type and ChunkProcessInput
4b5f3d7d4 feat(core): add ChunkReader port interface
a62ed0d7e feat(core): add ChunkTransformer port interface
e3450ca8f feat(core): add ChunkWriter port interface
c29746091 build(sync): depend on module-core Chunk types + update import paths
```

## Next
PR2 will move `module-synchronizer` `ChunkDataReader`/`ChunkDocumentTransformer`/`ChunkDocumentWriter` to adapters implementing these ports, and add `ChunkPipelineOrchestrator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
