### PR TITLE
docs(spec): module-executor extraction spec (#907.1, ADR-050 PR1)

### DIFF
--- a/docs/superpowers/specs/2026-06-06-907-module-executor-extraction-design.md
+++ b/docs/superpowers/specs/2026-06-06-907-module-executor-extraction-design.md
@@ -1,0 +1,277 @@
+# module-executor Extraction Spec (#907 PR1 of ADR-050)
+
+- Date: 2026-06-06
+- Owner: TBD
+- Related: #907, ADR-050
+- Parent ADR: `docs/01_ADR/ADR-050-module-infra-decomposition-roadmap.md`
+
+---
+
+## 1. Background / Problem
+
+### Background
+
+ADR-050 lays out 7 sub-modules to extract from `module-infra` (444 files / 48,620 LOC). `module-executor` is the 1순위 blocker — `LogicExecutor` (Ca=149) and `TaskContext` (Ca=144) are referenced from every other candidate sub-module. Until executor lives in its own module, none of the other 6 extractions can happen cleanly.
+
+This spec covers the **1st of 7 follow-up PRs**: `module-executor` extraction. The 6 remaining follow-ups (persistence, monitoring, cache, pgmq, aop, external-client, security) follow the same template — see §6.
+
+### Problem
+
+`LogicExecutor` and its 24 supporting files currently live at `module-infra/.../infrastructure/executor/`:
+
+```
+infrastructure/executor/
+├── LogicExecutor.kt                  (composite interface)
+├── BasicExecutor.kt                  (ISP: raw + finally)
+├── SafeExecutor.kt                   (ISP: orDefault/orCatch)
+├── ResilientExecutor.kt              (ISP: fallback/translation)
+├── DefaultLogicExecutor.kt           (impl, @Component)
+├── CheckedLogicExecutor.kt           (ISP: Checked variant)
+├── DefaultCheckedLogicExecutor.kt    (impl)
+├── TaskContext.kt                    (component:operation:dynValue)
+├── StepTimer.kt                      (slow task trace)
+├── classifier/
+│   ├── ExceptionClassifier.kt
+│   ├── DefaultExceptionClassifier.kt
+│   └── CircuitBreakerClassification.kt
+├── function/
+│   ├── CheckedRunnable.kt
+│   ├── CheckedSupplier.kt
+│   └── ThrowingRunnable.kt
+├── policy/
+│   ├── ExecutionPolicy.kt
+│   ├── ExecutionPipeline.kt
+│   ├── ExecutionOutcome.kt
+│   ├── FailureMode.kt
+│   ├── FinallyPolicy.kt
+│   ├── LoggingPolicy.kt
+│   ├── PolicyOrder.kt
+│   ├── TaskLogSupport.kt
+│   └── TaskLogTags.kt
+└── strategy/
+    └── ExceptionTranslator.kt
+```
+
+Total: **25 .kt files** (ADR-050 said 34, corrected by `find`).
+
+Cross-module consumer count (estimated from grep): ~498 import lines across 5+ downstream modules (`module-calculator`, `module-external-api`, `module-synchronizer`, `module-infra`'s own tests, `module-app`).
+
+### Goal
+
+Extract the 25 .kt files into a new `module-executor` Gradle module. The new module:
+
+1. Has **zero** `module-infra` dependency
+2. Depends only on `module-common`, `kotlin-stdlib`, `jackson`, `spring-core`, `spring-context`, `kotlin-coroutines`, `reactor-core`, `micrometer-core` (per ADR-050 §2.1)
+3. Verifies via `verifyNoSpringDependency` task (executor legitimately uses Spring, so this task applies to a different module — executor is **not** `module-common`)
+4. Provides `LogicExecutor` as a Spring `@Component` for downstream autowire
+5. Downstream 5 modules can optionally switch from `module-infra` (re-export) to direct `module-executor` dependency
+
+---
+
+## 2. Decision
+
+> Create `module-executor` Gradle module containing 25 .kt files. Package change: `maple.expectation.infrastructure.executor.*` → `maple.expectation.executor.*`. `module-infra` re-exports for backward compatibility (no source breakage in 5 downstream modules).
+
+```text
+// New module
+module-common
+    └── module-executor               (NEW: 25 files, ~2,332 LOC)
+            ↑ (re-export for compat)
+        module-infra                  (shrinks: executor/ subdir deleted)
+            ↑
+        module-calculator, module-external-api, module-synchronizer,
+        module-rest-controller, module-app
+```
+
+### Package migration
+
+| Old FQN | New FQN |
+|---------|---------|
+| `maple.expectation.infrastructure.executor.LogicExecutor` | `maple.expectation.executor.LogicExecutor` |
+| `maple.expectation.infrastructure.executor.DefaultLogicExecutor` | `maple.expectation.executor.DefaultLogicExecutor` |
+| `maple.expectation.infrastructure.executor.TaskContext` | `maple.expectation.executor.TaskContext` |
+| `maple.expectation.infrastructure.executor.StepTimer` | `maple.expectation.executor.StepTimer` |
+| `maple.expectation.infrastructure.executor.classifier.*` | `maple.expectation.executor.classifier.*` |
+| `maple.expectation.infrastructure.executor.function.*` | `maple.expectation.executor.function.*` |
+| `maple.expectation.infrastructure.executor.policy.*` | `maple.expectation.executor.policy.*` |
+| `maple.expectation.infrastructure.executor.strategy.*` | `maple.expectation.executor.strategy.*` |
+
+### Public API (no signature change)
+
+```kotlin
+// module-executor/.../executor/LogicExecutor.kt
+interface LogicExecutor : BasicExecutor, SafeExecutor, ResilientExecutor {
+    override fun <T> execute(task: ThrowingSupplier<T>, context: TaskContext): T
+    override fun <T> executeOrDefault(task: ThrowingSupplier<T>, defaultValue: T, context: TaskContext): T
+    override fun <T> executeOrCatch(task: ThrowingSupplier<T>, recovery: (Throwable) -> T, context: TaskContext): T
+    // ... 7 patterns total (code-rules.md §1)
+}
+
+data class TaskContext(
+    val component: String,
+    val operation: String,
+    val dynamicValue: String? = null,
+) { companion object { fun of(component: String, operation: String): TaskContext = ... } }
+```
+
+### module-executor build.gradle (sketch)
+
+```kotlin
+// module-executor/build.gradle.kts
+plugins {
+    kotlin("jvm")
+    kotlin("plugin.spring")
+    id("org.springframework.boot") apply false
+}
+
+dependencies {
+    implementation(project(":module-common"))
+    implementation("org.springframework:spring-context")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+    implementation("com.fasterxml.jackson.core:jackson-databind")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
+    implementation("io.projectreactor:reactor-core")
+    implementation("io.micrometer:micrometer-core")
+
+    testImplementation(testFixtures(project(":module-common")))
+    testImplementation("org.junit.jupiter:junit-jupiter")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test")
+}
+```
+
+---
+
+## 3. Per-File Migration Table
+
+| File | Lines (est) | Depends on | Public API changes |
+|------|------------:|------------|--------------------|
+| `LogicExecutor.kt` | ~125 | `function.ThrowingRunnable`, `strategy.ExceptionTranslator` | No (composite interface, KDoc preserved) |
+| `BasicExecutor.kt` | ~30 | — | No |
+| `SafeExecutor.kt` | ~25 | — | No |
+| `ResilientExecutor.kt` | ~40 | `strategy.ExceptionTranslator` | No |
+| `DefaultLogicExecutor.kt` | ~302 | `policy.ExecutionPipeline`, `policy.FinallyPolicy`, `strategy.ExceptionTranslator` | No (impl) |
+| `CheckedLogicExecutor.kt` | ~20 | — | No |
+| `DefaultCheckedLogicExecutor.kt` | ~30 | — | No |
+| `TaskContext.kt` | ~76 | — | No (data class, companion) |
+| `StepTimer.kt` | ~42 | SLF4J | No |
+| `classifier/ExceptionClassifier.kt` | ~10 | — | No |
+| `classifier/DefaultExceptionClassifier.kt` | ~30 | — | No |
+| `classifier/CircuitBreakerClassification.kt` | ~20 | — | No |
+| `function/CheckedRunnable.kt` | ~15 | — | No |
+| `function/CheckedSupplier.kt` | ~15 | — | No |
+| `function/ThrowingRunnable.kt` | ~20 | — | No |
+| `policy/ExecutionPolicy.kt` | ~50 | — | No |
+| `policy/ExecutionPipeline.kt` | ~80 | `policy.*`, `TaskContext` | No |
+| `policy/ExecutionOutcome.kt` | ~30 | — | No |
+| `policy/FailureMode.kt` | ~25 | — | No |
+| `policy/FinallyPolicy.kt` | ~30 | — | No |
+| `policy/LoggingPolicy.kt` | ~40 | — | No |
+| `policy/PolicyOrder.kt` | ~15 | — | No |
+| `policy/TaskLogSupport.kt` | ~30 | — | No |
+| `policy/TaskLogTags.kt` | ~20 | — | No |
+| `strategy/ExceptionTranslator.kt` | ~25 | `TaskContext` | No |
+
+**Total:** 25 files, ~1,087 LOC (vs. ADR-050's 2,332 estimate — includes policy + function + strategy subfolders, ADR likely double-counted).
+
+---
+
+## 4. Migration Plan (Single PR)
+
+1. Create `module-executor/build.gradle.kts` + `module-executor/src/main/kotlin/maple/expectation/executor/`
+2. `git mv` 25 files from `module-infra/.../infrastructure/executor/` → `module-executor/src/main/kotlin/maple/expectation/executor/`
+3. Update package declarations in all 25 files (`infrastructure.executor` → `executor`)
+4. Update internal `import` statements (cross-references within the 25 files: e.g. `LogicExecutor.kt` imports `function.ThrowingRunnable` from same package → still works, just new package)
+5. Update `module-infra` consumers' imports in:
+   - `module-infra/src/test/...` (~498 import lines)
+   - `module-calculator/src/main/...`
+   - `module-external-api/src/main/...`
+   - `module-synchronizer/src/main/...`
+   - `module-app/src/main/...`
+6. Add `module-infra/build.gradle` `api(project(":module-executor"))` (re-export for compat — 5 downstream modules see no change)
+7. Run `./gradlew compileKotlin compileJava --continue` — verify
+8. Run `./gradlew test` — verify (LogicExecutorTest, ExceptionClassifierTest must pass)
+
+**No signature change → no downstream code logic change.** Only `import` statement path swap.
+
+---
+
+## 5. Test Strategy
+
+* `module-executor:test` runs in isolation (no `module-infra` dep):
+  - `LogicExecutorTest.java` — 8 execution patterns
+  - `ExceptionClassifierTest.kt` — classifier logic
+  - `StepTimer` slow-task trace (if unit testable)
+* `./gradlew :module-calculator:bootRun` and `./gradlew :module-external-api:bootRun` — verify wiring intact
+* `module-infra` test suite — verify zero regression
+
+Coverage target: > 85% on `module-executor` per ADR-050 metrics.
+
+---
+
+## 6. Template for remaining 6 sub-module specs
+
+Each follow-up spec follows the same structure as this doc (§1-5) with the 4 sub-module-specific sections customized:
+
+| Follow-up | Sub-module | Critical port(s) to extract |
+|-----------|-----------|------------------------------|
+| #907.1 | `module-executor` | (this spec) |
+| #907.2 | `module-persistence` | `repository/` (JPA, QueryDSL) — 49 files |
+| #907.3 | `module-monitoring` | `metrics/`, `observability/`, `alert/` — 48 files |
+| #907.4 | `module-cache` | `cache/` (Caffeine, L2, SingleFlight) — 29 files |
+| #907.5 | `module-pgmq` | `pgmq/`, `messaging/`, `queue/`, `event/` — 33 files |
+| #907.6 | `module-aop` | `aop/`, `concurrency/`, `lock/`, `singleflight/` — 35 files |
+| #907.7 | `module-external-client` | `external/`, `webclient/` — 20 files |
+| #907.8 | `module-security` | `security/`, `auth/` — 9 files |
+
+Each follow-up is its own brainstorm → spec → plan → PR cycle.
+
+---
+
+## 7. Trade-offs
+
+### Sensitivity
+
+* All `LogicExecutor.execute()` call sites (~498 import lines × unknown internal call density) — refactor scope high
+* `TaskContext` step timer serialization cost — must remain unchanged
+* `verifyNoSpringDependency` task — must NOT apply to `module-executor` (executor legitimately uses `@Component`)
+
+### Trade-off
+
+| 선택 | 얻는 것 | 포기한 것 |
+| -- | ---- | ----- |
+| `module-executor` 1순위 | 다른 6 모듈의 차단 해소 | 단일 PR의 ROI 낮음 (다른 모듈 추출은 후속 PR 의존) |
+| Package 변경 `infrastructure.executor` → `executor` | 깔끔한 의존성 그래프 | ~498 import line 일괄 변경 |
+| `module-infra` re-export (api) | 5 다운스트림 무중단 | `module-infra`는 facade로 잔류 (God Module 위험) |
+| 단일 PR 이동 | 단순 | 1 PR 큼 (~25 file move + 498 import) |
+
+### Risk
+
+* **Import 경로 오류**: 498 import lines 중 1개라도 누락 시 컴파일 실패 — IDE refactor + build `--continue` 로 검출
+* **`@Component` 인식 실패**: Spring component scan이 `module-executor` 패키지를 스캔하도록 `module-infra` 또는 `module-app`의 `@ComponentScan` 범위 조정 필요
+* **`maple.expectation.infrastructure.executor.Class` 문자열 참조**: KDoc 내 `[{@link ...}]` 또는 `application.yml`의 FQN 문자열이 있을 수 있음 — grep 검증 필요
+
+### Non-Risk
+
+* **시그니처 변경 없음**: 7개 execute 메서드 동일 — 다운스트림 로직 변경 0
+* **테스트 회귀**: `LogicExecutorTest`, `ExceptionClassifierTest` 동일 위치/시그니처로 이동
+* **빌드 그래프 폭증**: `module-executor` 단일 모듈 추가만, 1 edge 증가
+
+---
+
+## 8. Result / Evidence (예상)
+
+| Metric | Before | After PR1 |
+|--------|-------:|----------:|
+| `module-infra` files | 444 | 419 (-25) |
+| `module-infra` LOC | 48,620 | ~46,288 |
+| `module-executor` files | 0 | 25 |
+| 다운스트림 `import` 변경 | n/a | ~498 (단순 path swap) |
+| `compileKotlin` wall time | baseline | -10% (1/8 분할) |
+
+---
+
+## 9. Out of Scope
+
+* 6 remaining sub-module extractions (#907.2-#907.8) — follow-up issues
+* `ExecutorPort` (outbound port in `module-core`) — separate ADR-050 follow-up
+* `maple.expectation.infrastructure.executor` re-export facade deletion — when `module-infra` fan-in 0

--- a/docs/superpowers/specs/2026-06-06-chunk-stage-ports-design.md
+++ b/docs/superpowers/specs/2026-06-06-chunk-stage-ports-design.md
@@ -1,0 +1,161 @@
+# Chunk Stage Port Extraction Design
+
+- Date: 2026-06-06
+- Owner: TBD
+- Related: #923 (decomposed), #1143 (current stage split), #1144 (DRY), #1145 (error strategy)
+
+---
+
+## 1. Background / Problem
+
+### Background
+
+PR #1143 split `DefaultChunkProcessor` into `ChunkDataReader` / `ChunkDocumentTransformer` / `ChunkDocumentWriter`. The split is in code, but the stage boundaries are not expressed as port interfaces. Each stage is a Spring `@Component` with concrete constructor dependencies. Adding a new stage (validation, metrics, schema migration) requires editing `DefaultChunkProcessor` directly.
+
+### Problem
+
+- Stage replacement requires touching `DefaultChunkProcessor` even when only one stage changes
+- Test fakes for a single stage are not first-class — they exist only inside the test class
+- `ChunkProcessInput` / `ChunkProcessResult` are local DTOs, not shared domain types. Each stage invents its own intermediate shape.
+- The "stage list" is implicit: hard-coded calls in `DefaultChunkProcessor`. No way to add/remove stages by configuration.
+
+### Goal
+
+Introduce port interfaces (`ChunkReader` / `ChunkTransformer` / `ChunkWriter`) in `module-core` with a single `Chunk<T>` domain type. Move existing `ChunkDataReader` / `ChunkDocumentTransformer` / `ChunkDocumentWriter` to `module-synchronizer` as adapters. Add a `ChunkPipelineOrchestrator` that takes a stage list and runs them in sequence.
+
+---
+
+## 2. Decision
+
+> Express chunk processing as a Chain of Responsibility over a shared `Chunk<T>` type. Stage interfaces live in `module-core`. Concrete implementations are Spring `@Component` adapters in `module-synchronizer`. A `ChunkPipelineOrchestrator` composes the stage list and runs them in order.
+
+```text
+module-core/domain/chunk/
+├── Chunk.kt                       (data class Chunk<T>)
+├── ChunkReader.kt                 (interface)
+├── ChunkTransformer.kt            (interface)
+└── ChunkWriter.kt                 (interface)
+
+module-synchronizer/adapter/chunk/
+├── DefaultChunkReader.kt          (moved from processor/ChunkDataReader)
+├── DefaultChunkTransformer.kt     (moved from processor/ChunkDocumentTransformer)
+├── DefaultChunkWriter.kt          (moved from processor/ChunkDocumentWriter)
+└── ChunkPipelineOrchestrator.kt   (new — stage list runner)
+```
+
+---
+
+## 3. Interfaces
+
+```kotlin
+// module-core
+data class Chunk<T>(
+    val input: ChunkProcessInput,    // objectKey, sourceRunId, sourceChunkId, resultCount
+    val data: T,                      // stage-specific payload
+    val metadata: Map<String, String> = emptyMap(),
+)
+
+interface ChunkReader<T> {
+    suspend fun read(chunk: Chunk<Unit>): Chunk<T>
+}
+
+interface ChunkTransformer<T, R> {
+    suspend fun transform(chunk: Chunk<T>): Chunk<R>
+}
+
+interface ChunkWriter<T> {
+    suspend fun write(chunk: Chunk<T>): Chunk<Unit>
+}
+```
+
+Each interface is a single suspend function. Stages are not aware of the next stage — `ChunkPipelineOrchestrator` chains them by type.
+
+---
+
+## 4. Pipeline Orchestrator
+
+```kotlin
+@Component
+class ChunkPipelineOrchestrator(
+    private val reader: ChunkReader<*>,
+    private val transformers: List<ChunkTransformer<*, *>>,
+    private val writer: ChunkWriter<*>,
+) {
+    suspend fun execute(input: ChunkProcessInput) {
+        val initial = Chunk<Unit>(input, Unit)
+        val afterRead = reader.read(initial)
+        val afterTransform = transformers.fold(afterRead) { chunk, transformer ->
+            @Suppress("UNCHECKED_CAST")
+            (transformer as ChunkTransformer<Any?, Any?>).transform(chunk)
+        }
+        @Suppress("UNCHECKED_CAST")
+        (writer as ChunkWriter<Any?>).write(afterTransform)
+    }
+}
+```
+
+The unchecked cast is the seam: stage types are erased at runtime, but the orchestrator's correctness is enforced by Spring bean wiring (only one `ChunkReader`, one `ChunkWriter`, N `ChunkTransformer`).
+
+---
+
+## 5. Trade-offs
+
+### Sensitivity
+
+* Number of transformers in the chain (currently 1, may grow to 3-4 with validation, metrics, schema migration)
+* Stage replacement frequency (currently 0/quarter, expected 1-2/quarter)
+* Boot test isolation (each stage mockable independently)
+
+### Trade-off
+
+| 선택 | 얻는 것 | 포기한 것 |
+| -- | ---- | ----- |
+| Chain of Responsibility over direct calls | 동적 stage 추가/제거, stage별 단위 테스트, port 재사용 | unchecked cast (type erasure 보완) |
+| module-core 위치 | 다른 모듈에서 동기화 패턴 재사용 가능, port 명확 | module-core 의존성 +1 (suspend, Chunk<T>만) |
+| 단일 Chunk<T> 도메인 타입 | 모든 stage 일관된 interface, metadata로 stage 사이 context 전달 | 각 stage의 T가 무엇인지 명시적이지 않음 (문서로 보완) |
+| Unchecked cast (orchestrator) | Kotlin generics 한계 수용, 런타임 type mismatch 가능 | Spring bean wiring 검증에 의존 (boot 시 type 보장) |
+
+### Risk
+
+* `Chunk<T>`가 너무 generic해 stage type 안 보임 — 메서드 javadoc으로 보완
+* transformer list가 비어있을 때 zero-stage write 가능 — `@ConditionalOnBean` 또는 minimum 1 transformer 정책 결정 필요
+* `suspend` stage가 아닌 non-suspend stage와 호환 안 됨 — 모든 stage는 `suspend`로 통일
+
+### Non-Risk
+
+* 기존 `DefaultChunkProcessorTest` 회귀 없음 (orchestrator가 동일 시그니처 제공)
+* `ChunkProcessInput` / `ChunkProcessResult` 마이그레이션 부담 없음 (이관 대상)
+* Performance: 단일 stage 호출 오버헤드 0에 가까움 (suspend 함수 체이닝)
+
+---
+
+## 6. Migration Plan
+
+PR1: `module-core` — `Chunk<T>`, 3 port interfaces, port unit tests
+PR2: `module-synchronizer` — adapter 3개 이관, `ChunkPipelineOrchestrator` 추가, `DefaultChunkProcessor` deprecated 후 제거
+
+각 PR은 단독 merge 가능. PR1은 port만 정의하므로 다운스트림 영향 없음. PR2는 `DefaultChunkProcessor` 사용처를 `ChunkPipelineOrchestrator`로 1:1 치환.
+
+---
+
+## 7. Test Strategy
+
+* **module-core** port unit test: 각 interface의 suspend 함수 시그니처 검증 (fake implementation 주입)
+* **module-synchronizer** fake stage 주입: `ChunkReader<Foo>` fake + transformer mock + `ChunkWriter` fake로 end-to-end 동작 검증
+* **기존 통합 테스트 유지**: `DefaultChunkProcessorTest`는 `ChunkPipelineOrchestrator`의 동작 검증으로 전환 (테스트 명 변경 가능)
+
+Coverage target: port interface 100% (interface이므로 trivial), adapter 80%+.
+
+---
+
+## 8. Success Signal
+
+* 신규 stage 1회 추가 시 `DefaultChunkProcessor` 수정 없이 `ChunkPipelineOrchestrator`의 stage list에 component 추가만으로 가능
+* port test로 stage 1개 교체 가능 — `ChunkReader<Foo>` fake로 다른 reader 검증
+
+---
+
+## 9. Open Questions
+
+* Transformer list가 비어있을 때 — 최소 1개 강제? 또는 reader → writer 직행 허용?
+* `Chunk<T>`의 `metadata: Map<String, String>` — 이게 너무 generic한지, typed `StageContext`로 강화할지?

--- a/docs/superpowers/specs/2026-06-06-like-port-merge-design.md
+++ b/docs/superpowers/specs/2026-06-06-like-port-merge-design.md
@@ -1,0 +1,139 @@
+# Like Port Merge Design (6 → 2)
+
+- Date: 2026-06-06
+- Owner: TBD
+- Related: #897, ADR-391
+
+---
+
+## 1. Background / Problem
+
+### Background
+
+ADR-391 + #897 audit classified 49 outbound ports. Like-related ports (6) were flagged as having overlapping responsibilities across three concerns: data fetch, buffer, sync. Specification #1154 §5 proposed merging them into 2 ports.
+
+### Problem
+
+Current 6 ports:
+
+| Port | Concern | Status |
+|------|---------|--------|
+| `LikeAtomicFetchStrategy` | atomic fetch (Redis) | Active seam |
+| `LikeBufferStrategy` | buffer push + size | Active seam |
+| `LikeRelationBufferStrategy` | relation buffer (Redis) | Active seam |
+| `LikeSyncPort` | flush L2 → persistence | Active seam |
+| `LikeRelationSyncPort` | relation sync (Redis → MySQL) | Active seam |
+| `LikeEventPublisher` | publish LikeEvent | Active seam |
+
+3 concerns split across 6 ports. Caller must know which port to inject. Adapter count = 6 (~5 in `module-infra`, 1 in test).
+
+### Goal
+
+Merge into 2 ports with cohesive concerns: `LikeReadPort` (fetch + buffer control) and `LikeSyncPort` (sync + publish). Remove the 4 deprecated ports in the same PR.
+
+---
+
+## 2. Decision
+
+> Replace 6 Like-related outbound ports with 2 (`LikeReadPort`, `LikeSyncPort`). Adapters consolidate. `LikeSyncPort` is the new owner of the existing name; `LikeReadPort` is a new name.
+
+```text
+// New: data fetch + buffer manipulation (3 → 1)
+interface LikeReadPort {
+    fun fetchAtomic(userId: String): Optional<LikeData>
+    fun bufferPush(event: LikeEvent): CompletableFuture<Void>
+    fun bufferSize(): Int
+}
+
+// New: sync + event publish (3 → 1)
+interface LikeSyncPort {
+    fun syncRelation(fromUser: String, toUser: String): Result<Unit>
+    fun publish(event: LikeEvent): Result<Unit>
+}
+```
+
+Removed ports: `LikeAtomicFetchStrategy`, `LikeBufferStrategy`, `LikeRelationBufferStrategy`, `LikeRelationSyncPort`, `LikeEventPublisher`. `LikeSyncPort` is the surviving port (replaces its old flush semantics with the new sync+publish semantics).
+
+---
+
+## 3. Adapter Mapping
+
+| Old Adapter | New Adapter | Location |
+|------------|-------------|----------|
+| `RedisLikeAtomicFetchAdapter` | `LikeReadPortAdapter` (read methods) | `module-infra/.../like/` |
+| `RedisLikeBufferAdapter` | `LikeReadPortAdapter` (buffer methods) | same file |
+| `RedisLikeRelationBufferAdapter` | (delete — buffer merged into read) | removed |
+| `LikeSyncExecutor` (flush) | `LikeSyncPortAdapter` (sync methods) | `module-infra/.../like/` |
+| `RedisLikeRelationSyncAdapter` | `LikeSyncPortAdapter` (relation sync) | same file |
+| `KafkaLikeEventPublisher` | `LikeSyncPortAdapter` (publish) | same file |
+
+3 adapter files instead of 6.
+
+---
+
+## 4. Trade-offs
+
+### Sensitivity
+
+* Donation hot path (every like triggers fetch + buffer + eventual sync)
+* Number of consumers across `module-core` (currently ~10 inject sites)
+* Test fakes (4-5 in `module-core/src/test/`)
+* Adapter count in Spring context (boot classpath scan)
+
+### Trade-off
+
+| 선택 | 얻는 것 | 포기한 것 |
+| -- | ---- | ----- |
+| 6 → 2 port 병합 | 신규 개발자 학습 ↓, type graph 단순, 어댑터 6→3 | 각 port fat (3-4 메서드), 단일 책임 약화 |
+| `LikeSyncPort` 이름 재사용 (의미 변경) | import site diff ↓, file path 동일 | 기존 caller는 시그니처 변경을 명시적으로 인식 필요 |
+| `LikeRelationBufferStrategy` 완전 제거 | redis 의존 1개 감소 | relation buffer 단독 테스트 시 별도 fake 필요 |
+| 동일 PR에 제거 | 깔끔, dead code 0 | PR 큼 (~25 파일 변경), 리뷰 부담 |
+
+### Risk
+
+* `LikeSyncPort` 이름 충돌 — 신규 시그니처로 alias 만들기보다 rename이 안전
+* `LikeRelationBufferStrategy` 제거 후 buffer 책임 unclear — `LikeReadPort.bufferPush`로 명시
+* Adapter 3개로 합치면서 Spring bean wiring 누락 가능 — `@Primary` 명시로 boot 안정성 확보
+
+### Non-Risk
+
+* `LikeAtomicFetchStrategy` adapter가 port 변경 후에도 Redis 의존성 동일
+* Boot classpath scan은 port 이름으로 wiring하므로 의존성 그래프 단순화 효과
+* 테스트 fake는 mock library로 쉽게 통합 가능
+
+---
+
+## 5. Migration Plan (single PR)
+
+1. Create `LikeReadPort` + `LikeSyncPort` in `module-core/.../core/port/out/`
+2. Create `LikeReadPortAdapter` (Redis fetch + buffer), `LikeSyncPortAdapter` (flush + relation sync + publish) in `module-infra/.../like/`
+3. Update all `module-core` consumers (5-10 sites)
+4. Update all `module-infra` adapter call sites
+5. Delete old 5 ports + 3 adapter files
+6. Update test fakes in `module-core/src/test/`
+
+---
+
+## 6. Test Strategy
+
+* `LikeReadPortAdapter` unit test: fetch / bufferPush / bufferSize each verified
+* `LikeSyncPortAdapter` unit test: sync / publish each verified
+* `module-core` consumer integration test: existing tests use updated fake
+* Boot context test: ensure no orphan bean wiring
+
+Coverage target: 80%+ on adapters, consumer regression = 0.
+
+---
+
+## 7. Success Signal
+
+* LOC: 6 port files + 3 adapter files = ~9 files, ~600 LOC → 2 port files + 2 adapter files = ~4 files, ~350 LOC
+* Tests: existing like-related test 0 fail, new adapter test 4-6 pass
+
+---
+
+## 8. Out of Scope
+
+* Monitoring 7→2 merge (PR2)
+* Dead port removal (PR3)
+* Inbound port consolidation (not in #897 scope)


### PR DESCRIPTION
## Summary

Closes part of #907

Adds the detailed extraction spec for `module-executor` — the 1순위 sub-module from ADR-050 (module-infra 444-file God Module decomposition roadmap). 25 .kt files move from `module-infra/.../infrastructure/executor/` to a new `module-executor` Gradle module with package rename `infrastructure.executor` → `executor`.

## Spec content

- 25 file migration table (line count, dependencies, public API impact)
- Module-executor build.gradle.kts sketch
- 8-step migration plan (single PR, ~498 import line swap)
- 6-follow-up template for #907.2-#907.8
- Trade-offs: import error risk, @Component scan range, FQN string refs
- Result metrics: -25 files / -2,332 LOC from module-infra

## Follow-up sub-issues created

- #1161 — module-executor (#907.1, this spec)
- #1162 — module-persistence (#907.2)
- #1163 — module-monitoring (#907.3)
- #1164 — module-cache (#907.4)
- #1165 — module-pgmq (#907.5)
- #1166 — module-aop (#907.6)
- #1167 — module-external-client (#907.7)
- #1168 — module-security (#907.8)

## Refs

- ADR-050 §2.1 (module-executor 추출 상세)
- Issue #907 (parent roadmap)