### PR TITLE
refactor(synchronizer): convert FailureDecision to sealed class (#983)

### DIFF
--- a/docs/superpowers/plans/2026-06-06-chunk-consumer-template-state-machine.md
+++ b/docs/superpowers/plans/2026-06-06-chunk-consumer-template-state-machine.md
@@ -516,12 +516,40 @@ import maple.expectation.error.exception.ArtifactNotFoundException
 Run: `cd /home/maple/probabilistic-valuation-engine && ./gradlew :module-synchronizer:test --tests "maple.synchronizer.processor.DefaultChunkProcessorTest"`
 Expected: PASS
 
-- [ ] **Step 4: Commit**
+- [ ] **Step 4: Update existing reader tests to expect ArtifactNotFoundException**
+
+In `module-synchronizer/src/test/kotlin/maple/synchronizer/storage/ResultFileReaderTest.kt`, find the test at line ~74:
+```kotlin
+.hasMessageContaining("Result file not found")
+```
+
+Add to that same test (or replace the assertion chain):
+```kotlin
+.isInstanceOf(ArtifactNotFoundException::class.java)
+```
+
+Add the import:
+```kotlin
+import maple.expectation.error.exception.ArtifactNotFoundException
+```
+
+Apply the same change in `module-synchronizer/src/test/kotlin/maple/synchronizer/storage/OcidMappingFileReaderTest.kt` at line ~54:
+- Add `ArtifactNotFoundException` import
+- Add `.isInstanceOf(ArtifactNotFoundException::class.java)` to the assertion chain
+
+For `BasicChunkFileReaderTest.kt`, check if a similar test exists. If yes, apply the same change. If no, skip.
+
+- [ ] **Step 5: Run storage tests**
+
+Run: `cd /home/maple/probabilistic-valuation-engine && ./gradlew :module-synchronizer:test --tests "maple.synchronizer.storage.*"`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
 
 ```bash
 cd /home/maple/probabilistic-valuation-engine
-git add module-synchronizer/src/test/kotlin/maple/synchronizer/processor/DefaultChunkProcessorTest.kt
-git commit -m "test(synchronizer): DefaultChunkProcessorTest expects ArtifactNotFoundException (#983)"
+git add module-synchronizer/src/test/kotlin/maple/synchronizer/storage/ResultFileReaderTest.kt module-synchronizer/src/test/kotlin/maple/synchronizer/storage/OcidMappingFileReaderTest.kt module-synchronizer/src/test/kotlin/maple/synchronizer/storage/BasicChunkFileReaderTest.kt
+git commit -m "test(synchronizer): reader tests expect ArtifactNotFoundException (#983)"
 ```
 
 ---

--- a/docs/superpowers/plans/2026-06-06-chunk-consumer-template-state-machine.md
+++ b/docs/superpowers/plans/2026-06-06-chunk-consumer-template-state-machine.md
@@ -1,0 +1,552 @@
+# ChunkConsumerTemplate State Machine Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Convert `FailureDecision` to sealed class; wire `ArtifactNotFoundException` in synchronizer readers; rewrite `markFailureAndAck` + `shouldAckSkip` as exhaustive `when` over sealed types.
+
+**Architecture:** Sealed `FailureDecision` with `Retryable(attemptCount, nextRetryAt)` and `Terminal(attemptCount, terminalReason)`. `classifyFailure` returns sealed subtype via `ex is ArtifactNotFoundException` check (replaces substring matching). `markFailureAndAck` is a flat `when(decision)`. `shouldAckSkip` is a flat `when(status)` over the post-#960 sealed `ChunkExecutionStatus`.
+
+**Tech Stack:** Kotlin sealed class, Spring Kafka, JUnit 5 + Mockito
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `module-synchronizer/.../storage/ResultFileReader.kt` | Modify | Throw `ArtifactNotFoundException` instead of `IllegalStateException` |
+| `module-synchronizer/.../storage/OcidMappingFileReader.kt` | Modify | Same |
+| `module-synchronizer/.../storage/BasicChunkFileReader.kt` | Modify | Same (2 sites) |
+| `module-synchronizer/.../consumer/ChunkConsumerTemplate.kt` | Modify | Sealed `FailureDecision`; `classifyFailure` returns sealed subtype; `markFailureAndAck` + `shouldAckSkip` use exhaustive `when` |
+| `module-synchronizer/src/test/.../consumer/ChunkConsumerTemplateTest.kt` | Modify | Add tests for sealed decision and exhaustive when |
+| `module-synchronizer/src/test/.../processor/DefaultChunkProcessorTest.kt` | Modify | Update exception type expectation |
+
+---
+
+## Task 1: Wire ArtifactNotFoundException in file readers
+
+**Files:**
+- Modify: `module-synchronizer/src/main/kotlin/maple/synchronizer/storage/ResultFileReader.kt`
+- Modify: `module-synchronizer/src/main/kotlin/maple/synchronizer/storage/OcidMappingFileReader.kt`
+- Modify: `module-synchronizer/src/main/kotlin/maple/synchronizer/storage/BasicChunkFileReader.kt`
+
+- [ ] **Step 1: Update `ResultFileReader.kt`**
+
+Add at the top of the file (after existing imports):
+```kotlin
+import maple.expectation.common.error.CommonErrorCode
+import maple.expectation.error.exception.ArtifactNotFoundException
+```
+
+Find:
+```kotlin
+if (!Files.exists(path)) {
+    throw IllegalStateException("Result file not found: $path")
+}
+```
+Replace with:
+```kotlin
+if (!Files.exists(path)) {
+    throw ArtifactNotFoundException(CommonErrorCode.ARTIFACT_NOT_FOUND, "ResultFileReader", path.toString())
+}
+```
+
+- [ ] **Step 2: Update `OcidMappingFileReader.kt`**
+
+Add the same imports. Find:
+```kotlin
+throw IllegalStateException("Ocid mapping file not found: $path")
+```
+Replace with:
+```kotlin
+throw ArtifactNotFoundException(CommonErrorCode.ARTIFACT_NOT_FOUND, "OcidMappingFileReader", path.toString())
+```
+
+- [ ] **Step 3: Update `BasicChunkFileReader.kt` (2 sites)**
+
+Add the same imports. Find both occurrences of:
+```kotlin
+throw IllegalStateException("Chunk file not found: $path")
+```
+Replace each with:
+```kotlin
+throw ArtifactNotFoundException(CommonErrorCode.ARTIFACT_NOT_FOUND, "BasicChunkFileReader", path.toString())
+```
+
+- [ ] **Step 4: Compile**
+
+Run: `cd /home/maple/probabilistic-valuation-engine && ./gradlew :module-synchronizer:compileKotlin --continue`
+Expected: SUCCESS (callers don't care about exception type)
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine
+git add module-synchronizer/src/main/kotlin/maple/synchronizer/storage/
+git commit -m "refactor(synchronizer): wire ArtifactNotFoundException in file readers (#983)"
+```
+
+---
+
+## Task 2: Convert FailureDecision to sealed class
+
+**Files:**
+- Modify: `module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/ChunkConsumerTemplate.kt`
+
+- [ ] **Step 1: Replace the private `FailureDecision` data class**
+
+Find:
+```kotlin
+private data class FailureDecision(
+    val terminalReason: String?,
+)
+```
+
+Replace with:
+```kotlin
+private sealed class FailureDecision {
+    abstract val attemptCount: Int
+    abstract val reason: String
+
+    data class Retryable(
+        override val attemptCount: Int,
+        val nextRetryAt: Instant,
+    ) : FailureDecision() {
+        override val reason: String = RETRYABLE_FAILURE
+    }
+
+    data class Terminal(
+        override val attemptCount: Int,
+        val terminalReason: String,
+    ) : FailureDecision() {
+        override val reason: String = terminalReason
+    }
+}
+```
+
+- [ ] **Step 2: Compile**
+
+Run: `cd /home/maple/probabilistic-valuation-engine && ./gradlew :module-synchronizer:compileKotlin --continue`
+Expected: FAIL only in `classifyFailure` and `markFailureAndAck` (callers expect the old shape)
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine
+git add module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/ChunkConsumerTemplate.kt
+git commit -m "refactor(synchronizer): FailureDecision sealed class with Retryable and Terminal (#983)"
+```
+
+---
+
+## Task 3: Rewrite classifyFailure to return sealed subtype
+
+**Files:**
+- Modify: `module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/ChunkConsumerTemplate.kt`
+
+- [ ] **Step 1: Add import**
+
+Add at the top of the file (after existing imports):
+```kotlin
+import maple.expectation.error.exception.ArtifactNotFoundException
+```
+
+- [ ] **Step 2: Replace `classifyFailure` body**
+
+Find:
+```kotlin
+private fun classifyFailure(
+    ex: Throwable,
+    claim: ChunkExecutionClaim,
+): FailureDecision {
+    val artifactMissing = ex.message?.contains("file not found", ignoreCase = true) == true
+    if (artifactMissing && claim.attemptCount >= properties.retry.artifactMissingMaxAttempts) {
+        return FailureDecision(ARTIFACT_MISSING_MAX_ATTEMPTS)
+    }
+    if (!artifactMissing && claim.attemptCount >= properties.retry.maxAttempts) {
+        return FailureDecision(MAX_ATTEMPTS_EXCEEDED)
+    }
+    return FailureDecision(terminalReason = null)
+}
+```
+
+Replace with:
+```kotlin
+private fun classifyFailure(
+    ex: Throwable,
+    claim: ChunkExecutionClaim,
+): FailureDecision {
+    val artifactMissing = ex is ArtifactNotFoundException
+    val maxAttempts = if (artifactMissing) {
+        properties.retry.artifactMissingMaxAttempts
+    } else {
+        properties.retry.maxAttempts
+    }
+    return if (claim.attemptCount >= maxAttempts) {
+        val terminalReason = if (artifactMissing) ARTIFACT_MISSING_MAX_ATTEMPTS else MAX_ATTEMPTS_EXCEEDED
+        FailureDecision.Terminal(
+            attemptCount = claim.attemptCount,
+            terminalReason = terminalReason,
+        )
+    } else {
+        FailureDecision.Retryable(
+            attemptCount = claim.attemptCount,
+            nextRetryAt = Instant.now().plus(
+                properties.retryBaseBackoff.multipliedBy(claim.attemptCount.toLong()),
+            ),
+        )
+    }
+}
+```
+
+- [ ] **Step 3: Compile**
+
+Run: `cd /home/maple/probabilistic-valuation-engine && ./gradlew :module-synchronizer:compileKotlin --continue`
+Expected: FAIL only in `markFailureAndAck` (still uses old `failure.terminalReason`)
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine
+git add module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/ChunkConsumerTemplate.kt
+git commit -m "refactor(synchronizer): classifyFailure returns sealed FailureDecision subtype (#983)"
+```
+
+---
+
+## Task 4: Rewrite markFailureAndAck as exhaustive when
+
+**Files:**
+- Modify: `module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/ChunkConsumerTemplate.kt`
+
+- [ ] **Step 1: Replace `markFailureAndAck` body**
+
+Find the entire `markFailureAndAck` method (lines 189-239). Replace with:
+
+```kotlin
+private fun markFailureAndAck(
+    request: ChunkConsumerRequest,
+    claim: ChunkExecutionClaim,
+    ex: Throwable,
+) {
+    val decision = classifyFailure(ex, claim)
+    val error = ex.message ?: ex.javaClass.simpleName
+
+    val marked = when (decision) {
+        is FailureDecision.Retryable -> chunkExecutionRepository.markFailedRetryable(
+            request.identity,
+            claim.attemptCount,
+            error,
+            decision.nextRetryAt,
+        )
+        is FailureDecision.Terminal -> chunkExecutionRepository.markFailedTerminal(
+            request.identity,
+            claim.attemptCount,
+            error,
+            decision.terminalReason,
+        )
+    }
+
+    if (!marked) {
+        logFailedStateWrite(request, claim)
+        return
+    }
+
+    val status: ChunkExecutionStatus = when (decision) {
+        is FailureDecision.Retryable -> ChunkExecutionStatus.FailedRetryable(decision.nextRetryAt)
+        is FailureDecision.Terminal -> ChunkExecutionStatus.FailedTerminal(decision.terminalReason)
+    }
+    metrics.recordChunkExecutionFailed(
+        request.identity.executionType,
+        status,
+        decision.reason,
+    )
+    request.onFailure(ex)
+
+    when (decision) {
+        is FailureDecision.Retryable -> {
+            request.log.warn(
+                "[{}] retryable chunk failure recorded, leaving unacked for Kafka redelivery: runId={} chunkId={} attempt={}",
+                request.logPrefix,
+                request.runId,
+                request.chunkId,
+                claim.attemptCount,
+            )
+        }
+        is FailureDecision.Terminal -> {
+            request.acknowledgment.acknowledge()
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Compile**
+
+Run: `cd /home/maple/probabilistic-valuation-engine && ./gradlew :module-synchronizer:compileKotlin --continue`
+Expected: FAIL only in `shouldAckSkip` (still uses old enum comparison)
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine
+git add module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/ChunkConsumerTemplate.kt
+git commit -m "refactor(synchronizer): markFailureAndAck uses exhaustive when on FailureDecision (#983)"
+```
+
+---
+
+## Task 5: Rewrite shouldAckSkip as exhaustive when
+
+**Files:**
+- Modify: `module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/ChunkConsumerTemplate.kt`
+
+- [ ] **Step 1: Replace `shouldAckSkip` body**
+
+Find:
+```kotlin
+private fun ChunkExecutionState.shouldAckSkip(): Boolean {
+    val now = Instant.now()
+    if (status.isTerminalSkip()) {
+        return true
+    }
+    if (status == ChunkExecutionStatus.FAILED_RETRYABLE && nextRetryAt?.isAfter(now) == true) {
+        return false
+    }
+    if (status == ChunkExecutionStatus.PROCESSING && leaseUntil?.isAfter(now) == true) {
+        return true
+    }
+    return false
+}
+```
+
+Replace with:
+```kotlin
+private fun ChunkExecutionState.shouldAckSkip(): Boolean {
+    val now = Instant.now()
+    // Note: PROCESSING + active lease returns TRUE (skip — another worker holds it).
+    // FAILED_RETRYABLE + future retry returns FALSE (don't skip — Kafka should redeliver later).
+    // This inversion is intentional: skip means "ack and move on", so we ack when the work
+    // is already done (terminal / leased) and leave unacked when Kafka should retry.
+    return when (val s = status) {
+        is ChunkExecutionStatus.Succeeded,
+        is ChunkExecutionStatus.FailedTerminal -> true
+        is ChunkExecutionStatus.FailedRetryable -> s.nextRetryAt?.isAfter(now) != true
+        ChunkExecutionStatus.Processing -> leaseUntil?.isAfter(now) == true
+    }
+}
+```
+
+- [ ] **Step 2: Delete the now-unused `isTerminalSkip` extension**
+
+Find:
+```kotlin
+private fun ChunkExecutionStatus.isTerminalSkip(): Boolean =
+    this == ChunkExecutionStatus.SUCCEEDED || this == ChunkExecutionStatus.FAILED_TERMINAL
+```
+
+Delete this method. (After #960 it is part of the sealed class itself as `ChunkExecutionStatus.isTerminalSkip()`, so no replacement is needed in this file.)
+
+- [ ] **Step 3: Compile**
+
+Run: `cd /home/maple/probabilistic-valuation-engine && ./gradlew :module-synchronizer:compileKotlin --continue`
+Expected: SUCCESS (test compilation may still fail)
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine
+git add module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/ChunkConsumerTemplate.kt
+git commit -m "refactor(synchronizer): shouldAckSkip uses exhaustive when on sealed status (#983)"
+```
+
+---
+
+## Task 6: Add unit tests for sealed FailureDecision
+
+**Files:**
+- Modify: `module-synchronizer/src/test/kotlin/maple/synchronizer/consumer/ChunkConsumerTemplateTest.kt`
+
+- [ ] **Step 1: Add the following test methods to the existing test class**
+
+Read the existing test file first to understand the `request(...)` helper, `state(...)` helper, and `properties` fixture. Then add these tests (adjust the helper calls to match the file's conventions):
+
+```kotlin
+@Test
+fun `classifyFailure with ArtifactNotFoundException and attempts under max returns Retryable`() {
+    val ex = ArtifactNotFoundException(CommonErrorCode.ARTIFACT_NOT_FOUND, "Test", "test/path")
+    val claim = ChunkExecutionClaim(attemptCount = 1)
+    // Use reflection or a test-only accessor to call private classifyFailure.
+    // Or: invoke submit() with a process that throws ArtifactNotFoundException
+    //     and verify the resulting DB call is markFailedRetryable (not Terminal).
+    // For simplicity, exercise via submit():
+    template.submit(request(
+        process = { throw ex },
+        attemptCount = 1,
+    ))
+    verify(chunkExecutionRepository).markFailedRetryable(
+        any(), eq(1), any(), any()
+    )
+    verify(chunkExecutionRepository, never()).markFailedTerminal(any(), any(), any(), any())
+}
+
+@Test
+fun `classifyFailure with ArtifactNotFoundException and attempts at max returns Terminal ARTIFACT_MISSING`() {
+    val ex = ArtifactNotFoundException(CommonErrorCode.ARTIFACT_NOT_FOUND, "Test", "test/path")
+    template.submit(request(
+        process = { throw ex },
+        attemptCount = properties.retry.artifactMissingMaxAttempts,
+    ))
+    verify(chunkExecutionRepository).markFailedTerminal(
+        any(), eq(properties.retry.artifactMissingMaxAttempts), any(), eq("ARTIFACT_MISSING_MAX_ATTEMPTS")
+    )
+}
+
+@Test
+fun `classifyFailure with non-artifact exception and attempts at max returns Terminal MAX_ATTEMPTS`() {
+    val ex = IllegalStateException("some other error")
+    template.submit(request(
+        process = { throw ex },
+        attemptCount = properties.retry.maxAttempts,
+    ))
+    verify(chunkExecutionRepository).markFailedTerminal(
+        any(), eq(properties.retry.maxAttempts), any(), eq("MAX_ATTEMPTS_EXCEEDED")
+    )
+}
+
+@Test
+fun `shouldAckSkip returns true for Succeeded`() {
+    val state = ChunkExecutionState(
+        status = ChunkExecutionStatus.Succeeded,
+        nextRetryAt = null,
+        leaseUntil = null,
+        attemptCount = 0,
+    )
+    assertThat(state.shouldAckSkip()).isTrue()
+}
+
+@Test
+fun `shouldAckSkip returns true for FailedTerminal`() {
+    val state = ChunkExecutionState(
+        status = ChunkExecutionStatus.FailedTerminal("X"),
+        nextRetryAt = null,
+        leaseUntil = null,
+        attemptCount = 0,
+    )
+    assertThat(state.shouldAckSkip()).isTrue()
+}
+
+@Test
+fun `shouldAckSkip returns false for FailedRetryable with future retry`() {
+    val state = ChunkExecutionState(
+        status = ChunkExecutionStatus.FailedRetryable(Instant.now().plusSeconds(60)),
+        nextRetryAt = Instant.now().plusSeconds(60),
+        leaseUntil = null,
+        attemptCount = 1,
+    )
+    assertThat(state.shouldAckSkip()).isFalse()
+}
+
+@Test
+fun `shouldAckSkip returns true for Processing with active lease`() {
+    val state = ChunkExecutionState(
+        status = ChunkExecutionStatus.Processing,
+        nextRetryAt = null,
+        leaseUntil = Instant.now().plusSeconds(60),
+        attemptCount = 0,
+    )
+    assertThat(state.shouldAckSkip()).isTrue()
+}
+```
+
+(Adapt the helper calls — `request(...)`, `state(...)`, `properties` — to match the file's existing fixtures. The new tests follow the same pattern as existing ones in `ChunkConsumerTemplateTest.kt`.)
+
+- [ ] **Step 2: Run tests**
+
+Run: `cd /home/maple/probabilistic-valuation-engine && ./gradlew :module-synchronizer:test --tests "maple.synchronizer.consumer.ChunkConsumerTemplateTest"`
+Expected: All tests PASS (old + new)
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine
+git add module-synchronizer/src/test/kotlin/maple/synchronizer/consumer/ChunkConsumerTemplateTest.kt
+git commit -m "test(synchronizer): tests for sealed FailureDecision and exhaustive shouldAckSkip (#983)"
+```
+
+---
+
+## Task 7: Update DefaultChunkProcessorTest exception expectation
+
+**Files:**
+- Modify: `module-synchronizer/src/test/kotlin/maple/synchronizer/processor/DefaultChunkProcessorTest.kt`
+
+- [ ] **Step 1: Update the test**
+
+Find:
+```kotlin
+fun `process - file not found propagates exception`() {
+    ...
+    .thenThrow(IllegalStateException("Result file not found"))
+    ...
+    .hasMessageContaining("Result file not found")
+}
+```
+
+Update the throw type to `ArtifactNotFoundException`:
+```kotlin
+fun `process - file not found propagates ArtifactNotFoundException`() {
+    ...
+    .thenThrow(ArtifactNotFoundException(CommonErrorCode.ARTIFACT_NOT_FOUND, "ResultFileReader", "/tmp/missing"))
+    ...
+    .isInstanceOf(ArtifactNotFoundException::class.java)
+    .hasMessageContaining("Result file not found")
+}
+```
+
+- [ ] **Step 2: Add import**
+
+Add at the top of the test file:
+```kotlin
+import maple.expectation.common.error.CommonErrorCode
+import maple.expectation.error.exception.ArtifactNotFoundException
+```
+
+- [ ] **Step 3: Run test**
+
+Run: `cd /home/maple/probabilistic-valuation-engine && ./gradlew :module-synchronizer:test --tests "maple.synchronizer.processor.DefaultChunkProcessorTest"`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine
+git add module-synchronizer/src/test/kotlin/maple/synchronizer/processor/DefaultChunkProcessorTest.kt
+git commit -m "test(synchronizer): DefaultChunkProcessorTest expects ArtifactNotFoundException (#983)"
+```
+
+---
+
+## Task 8: Final verification
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `cd /home/maple/probabilistic-valuation-engine && ./gradlew test`
+Expected: PASS (or pre-existing unrelated failures only)
+
+- [ ] **Step 2: Full compile check**
+
+Run: `cd /home/maple/probabilistic-valuation-engine && ./gradlew compileKotlin compileJava --continue`
+Expected: SUCCESS
+
+- [ ] **Step 3: Search for stale substring matching**
+
+Run: `cd /home/maple/probabilistic-valuation-engine && grep -rn "file not found" --include="*.kt" module-synchronizer/src/main/`
+Expected: empty output (substring match removed; only the new exception messages remain)
+
+- [ ] **Step 4: Push and open PR**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine
+git push origin HEAD
+gh pr create --base develop --title "refactor(synchronizer): ChunkConsumerTemplate state machine sealed class (#983)" --body "Implements #983. Sealed FailureDecision; ArtifactNotFoundException wiring; exhaustive when in markFailureAndAck + shouldAckSkip. Note: blocked by #979, not resolved."
+```

--- a/docs/superpowers/plans/2026-06-06-chunk-execution-status-sealed.md
+++ b/docs/superpowers/plans/2026-06-06-chunk-execution-status-sealed.md
@@ -1,0 +1,630 @@
+# ChunkExecutionStatus Sealed Class Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `ChunkExecutionStatus` enum with a sealed class hierarchy in module-synchronizer; move behavior onto subtypes; preserve DB schema and metrics tags.
+
+**Architecture:** Move enum from `module-common` to `module-synchronizer` as `sealed class ChunkExecutionStatus`. Four subtypes (`Processing`, `Succeeded`, `FailedRetryable`, `FailedTerminal`) carry their own transition/decision methods. PENDING remains a string constant for insert path only. Repository uses `fromName()` for reads and writes subtype `NAME` strings for writes (round-trip identical to old enum).
+
+**Tech Stack:** Kotlin sealed class, Spring JDBC, JUnit 5 + Mockito
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `module-common/src/main/kotlin/maple/expectation/common/event/ChunkExecutionStatus.kt` | Delete | Old enum |
+| `module-synchronizer/src/main/kotlin/maple/synchronizer/state/ChunkExecutionStatus.kt` | Create | Sealed class + 4 subtypes + companion |
+| `module-synchronizer/src/main/kotlin/maple/synchronizer/repository/ChunkExecutionRepository.kt` | Modify | `valueOf` → `fromName`; pass `Instant?` into `FailedRetryable`/`FailedTerminal`; insert path uses `PENDING_NAME` |
+| `module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/ChunkConsumerTemplate.kt` | Modify | Drop private extensions; polymorphic methods; drop `state.status == PROCESSING` check |
+| `module-synchronizer/src/main/kotlin/maple/synchronizer/metrics/SynchronizerMetrics.kt` | Modify | Method signatures accept sealed `ChunkExecutionStatus`; record `status.name` as tag |
+| `module-synchronizer/src/test/kotlin/maple/synchronizer/state/ChunkExecutionStatusTest.kt` | Create | Sealed class behavior unit tests |
+| `module-synchronizer/src/test/kotlin/maple/synchronizer/consumer/ChunkConsumerTemplateTest.kt` | Modify | Update `state()` helper |
+| `module-synchronizer/src/test/kotlin/maple/synchronizer/repository/ChunkExecutionRepositoryTest.kt` | Modify | Update enum → sealed constructor references |
+
+---
+
+## Task 1: Create sealed class file
+
+**Files:**
+- Create: `module-synchronizer/src/main/kotlin/maple/synchronizer/state/ChunkExecutionStatus.kt`
+
+- [ ] **Step 1: Write the file**
+
+```kotlin
+package maple.synchronizer.state
+
+import java.time.Instant
+
+sealed class ChunkExecutionStatus(val name: String) {
+    abstract fun isTerminal(): Boolean
+    abstract fun shouldAckSkip(now: Instant): Boolean
+    abstract fun shouldPreserveKafkaRedelivery(now: Instant): Boolean
+    abstract fun isReclaimed(now: Instant): Boolean
+    fun isTerminalSkip(): Boolean = this is Succeeded || this is FailedTerminal
+
+    companion object {
+        const val PENDING_NAME: String = "PENDING"
+
+        fun fromName(s: String): ChunkExecutionStatus = when (s) {
+            Processing.NAME -> Processing
+            Succeeded.NAME -> Succeeded
+            FailedRetryable.NAME -> FailedRetryable(null)
+            FailedTerminal.NAME -> FailedTerminal(null)
+            else -> error("Unknown ChunkExecutionStatus name: $s")
+        }
+    }
+
+    object Processing : ChunkExecutionStatus(NAME) {
+        const val NAME: String = "PROCESSING"
+        override fun isTerminal(): Boolean = false
+        override fun shouldAckSkip(now: Instant): Boolean = false
+        override fun shouldPreserveKafkaRedelivery(now: Instant): Boolean = false
+        override fun isReclaimed(now: Instant): Boolean = false
+    }
+
+    object Succeeded : ChunkExecutionStatus(NAME) {
+        const val NAME: String = "SUCCEEDED"
+        override fun isTerminal(): Boolean = true
+        override fun shouldAckSkip(now: Instant): Boolean = true
+        override fun shouldPreserveKafkaRedelivery(now: Instant): Boolean = false
+        override fun isReclaimed(now: Instant): Boolean = false
+    }
+
+    data class FailedRetryable(val nextRetryAt: Instant?) : ChunkExecutionStatus(NAME) {
+        companion object { const val NAME: String = "FAILED_RETRYABLE" }
+        override fun isTerminal(): Boolean = false
+        override fun shouldAckSkip(now: Instant): Boolean = nextRetryAt?.isAfter(now) != true
+        override fun shouldPreserveKafkaRedelivery(now: Instant): Boolean = nextRetryAt?.isAfter(now) == true
+        override fun isReclaimed(now: Instant): Boolean = false
+    }
+
+    data class FailedTerminal(val reason: String?) : ChunkExecutionStatus(NAME) {
+        companion object { const val NAME: String = "FAILED_TERMINAL" }
+        override fun isTerminal(): Boolean = true
+        override fun shouldAckSkip(now: Instant): Boolean = true
+        override fun shouldPreserveKafkaRedelivery(now: Instant): Boolean = false
+        override fun isReclaimed(now: Instant): Boolean = false
+    }
+}
+```
+
+- [ ] **Step 2: Compile to verify syntax**
+
+Run: `cd /home/maple/probabilistic-valuation-engine && ./gradlew :module-synchronizer:compileKotlin --continue`
+Expected: SUCCESS (file is isolated, not yet referenced)
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine
+git add module-synchronizer/src/main/kotlin/maple/synchronizer/state/ChunkExecutionStatus.kt
+git commit -m "feat(synchronizer): introduce ChunkExecutionStatus sealed class (#960)"
+```
+
+---
+
+## Task 2: Create unit test for sealed class
+
+**Files:**
+- Create: `module-synchronizer/src/test/kotlin/maple/synchronizer/state/ChunkExecutionStatusTest.kt`
+
+- [ ] **Step 1: Write the test file**
+
+```kotlin
+package maple.synchronizer.state
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.Instant
+
+class ChunkExecutionStatusTest {
+
+    private val now: Instant = Instant.parse("2026-06-06T12:00:00Z")
+    private val future: Instant = now.plusSeconds(60)
+    private val past: Instant = now.minusSeconds(60)
+
+    @Test
+    fun `fromName round-trips all four non-pending names`() {
+        assertThat(ChunkExecutionStatus.fromName("PROCESSING")).isEqualTo(ChunkExecutionStatus.Processing)
+        assertThat(ChunkExecutionStatus.fromName("SUCCEEDED")).isEqualTo(ChunkExecutionStatus.Succeeded)
+        assertThat(ChunkExecutionStatus.fromName("FAILED_RETRYABLE")).isEqualTo(ChunkExecutionStatus.FailedRetryable(null))
+        assertThat(ChunkExecutionStatus.fromName("FAILED_TERMINAL")).isEqualTo(ChunkExecutionStatus.FailedTerminal(null))
+    }
+
+    @Test
+    fun `fromName throws on unknown value`() {
+        val ex = assertThrows<IllegalStateException> {
+            ChunkExecutionStatus.fromName("BOGUS")
+        }
+        assertThat(ex.message).contains("BOGUS")
+    }
+
+    @Test
+    fun `Processing is not terminal and does not preserve redelivery`() {
+        val s = ChunkExecutionStatus.Processing
+        assertThat(s.isTerminal()).isFalse()
+        assertThat(s.shouldAckSkip(now)).isFalse()
+        assertThat(s.shouldPreserveKafkaRedelivery(now)).isFalse()
+        assertThat(s.isReclaimed(now)).isFalse()
+    }
+
+    @Test
+    fun `Succeeded is terminal and always ack-skips`() {
+        val s = ChunkExecutionStatus.Succeeded
+        assertThat(s.isTerminal()).isTrue()
+        assertThat(s.isTerminalSkip()).isTrue()
+        assertThat(s.shouldAckSkip(now)).isTrue()
+        assertThat(s.shouldPreserveKafkaRedelivery(now)).isFalse()
+    }
+
+    @Test
+    fun `FailedTerminal is terminal and always ack-skips`() {
+        val s = ChunkExecutionStatus.FailedTerminal("MAX_ATTEMPTS_EXCEEDED")
+        assertThat(s.isTerminal()).isTrue()
+        assertThat(s.isTerminalSkip()).isTrue()
+        assertThat(s.shouldAckSkip(now)).isTrue()
+        assertThat(s.shouldPreserveKafkaRedelivery(now)).isFalse()
+    }
+
+    @Test
+    fun `FailedRetryable with future retry preserves redelivery and does not ack-skip`() {
+        val s = ChunkExecutionStatus.FailedRetryable(future)
+        assertThat(s.isTerminal()).isFalse()
+        assertThat(s.shouldAckSkip(now)).isFalse()
+        assertThat(s.shouldPreserveKafkaRedelivery(now)).isTrue()
+    }
+
+    @Test
+    fun `FailedRetryable with past retry does not preserve redelivery and ack-skips`() {
+        val s = ChunkExecutionStatus.FailedRetryable(past)
+        assertThat(s.shouldAckSkip(now)).isTrue()
+        assertThat(s.shouldPreserveKafkaRedelivery(now)).isFalse()
+    }
+
+    @Test
+    fun `FailedRetryable with null nextRetryAt ack-skips immediately`() {
+        val s = ChunkExecutionStatus.FailedRetryable(null)
+        assertThat(s.shouldAckSkip(now)).isTrue()
+        assertThat(s.shouldPreserveKafkaRedelivery(now)).isFalse()
+    }
+
+    @Test
+    fun `PENDING_NAME constant equals PENDING`() {
+        assertThat(ChunkExecutionStatus.PENDING_NAME).isEqualTo("PENDING")
+    }
+
+    @Test
+    fun `name property on each subtype matches NAME constant`() {
+        assertThat(ChunkExecutionStatus.Processing.name).isEqualTo("PROCESSING")
+        assertThat(ChunkExecutionStatus.Succeeded.name).isEqualTo("SUCCEEDED")
+        assertThat(ChunkExecutionStatus.FailedRetryable(null).name).isEqualTo("FAILED_RETRYABLE")
+        assertThat(ChunkExecutionStatus.FailedTerminal(null).name).isEqualTo("FAILED_TERMINAL")
+    }
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cd /home/maple/probabilistic-valuation-engine && ./gradlew :module-synchronizer:test --tests "maple.synchronizer.state.ChunkExecutionStatusTest"`
+Expected: 9 tests, all PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine
+git add module-synchronizer/src/test/kotlin/maple/synchronizer/state/ChunkExecutionStatusTest.kt
+git commit -m "test(synchronizer): ChunkExecutionStatus sealed class behavior tests (#960)"
+```
+
+---
+
+## Task 3: Update ChunkExecutionRepository to use sealed class
+
+**Files:**
+- Modify: `module-synchronizer/src/main/kotlin/maple/synchronizer/repository/ChunkExecutionRepository.kt`
+
+- [ ] **Step 1: Update imports**
+
+Replace the import:
+```kotlin
+import maple.expectation.common.event.ChunkExecutionStatus
+```
+with:
+```kotlin
+import maple.synchronizer.state.ChunkExecutionStatus
+```
+
+- [ ] **Step 2: Update `findStatus` to use `fromName`**
+
+In `findStatus`, replace:
+```kotlin
+return jdbc.query(sql, identity.toParams()) { rs, _ -> rs.getString("status") }
+    .firstOrNull()
+    ?.let(ChunkExecutionStatus::valueOf)
+```
+with:
+```kotlin
+return jdbc.query(sql, identity.toParams()) { rs, _ -> rs.getString("status") }
+    .firstOrNull()
+    ?.let(ChunkExecutionStatus::fromName)
+```
+
+- [ ] **Step 3: Update `findExecutionState` to build sealed subtypes**
+
+In `findExecutionState`, replace:
+```kotlin
+return jdbc.query(sql, identity.toParams()) { rs, _ ->
+    ChunkExecutionState(
+        status = ChunkExecutionStatus.valueOf(rs.getString("status")),
+        nextRetryAt = rs.getTimestamp("next_retry_at")?.toInstant(),
+        leaseUntil = rs.getTimestamp("lease_until")?.toInstant(),
+        attemptCount = rs.getInt("attempt_count"),
+    )
+}.firstOrNull()
+```
+with:
+```kotlin
+return jdbc.query(sql, identity.toParams()) { rs, _ ->
+    val statusName = rs.getString("status")
+    val nextRetryAt = rs.getTimestamp("next_retry_at")?.toInstant()
+    val status: ChunkExecutionStatus = when (statusName) {
+        ChunkExecutionStatus.FailedRetryable.NAME -> ChunkExecutionStatus.FailedRetryable(nextRetryAt)
+        else -> ChunkExecutionStatus.fromName(statusName)
+    }
+    ChunkExecutionState(
+        status = status,
+        nextRetryAt = nextRetryAt,
+        leaseUntil = rs.getTimestamp("lease_until")?.toInstant(),
+        attemptCount = rs.getInt("attempt_count"),
+    )
+}.firstOrNull()
+```
+
+- [ ] **Step 4: Update `insertPendingIfAbsent` to use `PENDING_NAME`**
+
+Find the parameter binding:
+```kotlin
+.addValue("status", ChunkExecutionStatus.PENDING.name)
+```
+Replace with:
+```kotlin
+.addValue("status", ChunkExecutionStatus.PENDING_NAME)
+```
+
+- [ ] **Step 5: Find and update any write paths that use `.name` on the old enum**
+
+Search the file for any remaining `ChunkExecutionStatus.X` references (success, failure writes). Update each to use the new sealed subtype's `name` property or `NAME` constant:
+
+For `markSucceeded`:
+```kotlin
+.addValue("status", ChunkExecutionStatus.Succeeded.name)
+```
+
+For `markFailedRetryable`:
+```kotlin
+.addValue("status", ChunkExecutionStatus.FailedRetryable.NAME)
+```
+
+For `markFailedTerminal`:
+```kotlin
+.addValue("status", ChunkExecutionStatus.FailedTerminal.NAME)
+```
+
+(If a method already uses `.name` on an instance, that still works — `Processing.name`, `Succeeded.name`, `FailedRetryable(...).name` all return the same string. Prefer the `NAME` companion const for static references.)
+
+- [ ] **Step 6: Compile**
+
+Run: `cd /home/maple/probabilistic-valuation-engine && ./gradlew :module-synchronizer:compileKotlin --continue`
+Expected: SUCCESS, or only failures in files not yet updated (ChunkConsumerTemplate, SynchronizerMetrics)
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine
+git add module-synchronizer/src/main/kotlin/maple/synchronizer/repository/ChunkExecutionRepository.kt
+git commit -m "refactor(synchronizer): ChunkExecutionRepository uses sealed ChunkExecutionStatus (#960)"
+```
+
+---
+
+## Task 4: Update SynchronizerMetrics signatures
+
+**Files:**
+- Modify: `module-synchronizer/src/main/kotlin/maple/synchronizer/metrics/SynchronizerMetrics.kt`
+
+- [ ] **Step 1: Update import**
+
+Replace:
+```kotlin
+import maple.expectation.common.event.ChunkExecutionStatus
+```
+with:
+```kotlin
+import maple.synchronizer.state.ChunkExecutionStatus
+```
+
+- [ ] **Step 2: Find all method signatures taking `ChunkExecutionStatus`**
+
+Search the file for `status: ChunkExecutionStatus`. Each signature already accepts the new sealed type now (no syntactic change), but the **call sites** in `ChunkConsumerTemplate` and tests pass enum constants like `ChunkExecutionStatus.SUCCEEDED` — those need to become `ChunkExecutionStatus.Succeeded`, `ChunkExecutionStatus.FailedRetryable(null)`, etc.
+
+Update all callers (we'll do them in Tasks 5 and 6). The `SynchronizerMetrics` file itself needs no signature changes — `status.name` returns the same string as the old enum `name`.
+
+- [ ] **Step 3: Compile (should still have type errors in callers)**
+
+Run: `cd /home/maple/probabilistic-valuation-engine && ./gradlew :module-synchronizer:compileKotlin --continue`
+Expected: FAIL only in `ChunkConsumerTemplate.kt` and test files. No new failures in `SynchronizerMetrics.kt`.
+
+- [ ] **Step 4: Commit import change**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine
+git add module-synchronizer/src/main/kotlin/maple/synchronizer/metrics/SynchronizerMetrics.kt
+git commit -m "refactor(synchronizer): SynchronizerMetrics imports sealed ChunkExecutionStatus (#960)"
+```
+
+---
+
+## Task 5: Update ChunkConsumerTemplate to use polymorphic methods
+
+**Files:**
+- Modify: `module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/ChunkConsumerTemplate.kt`
+
+- [ ] **Step 1: Update import**
+
+Replace:
+```kotlin
+import maple.expectation.common.event.ChunkExecutionStatus
+```
+with:
+```kotlin
+import maple.synchronizer.state.ChunkExecutionStatus
+```
+
+- [ ] **Step 2: Replace `state.shouldAckSkip()` call (line ~43)**
+
+Find:
+```kotlin
+if (state.shouldAckSkip()) {
+```
+Replace with:
+```kotlin
+if (state.status.shouldAckSkip(Instant.now())) {
+```
+
+- [ ] **Step 3: Replace `state.shouldPreserveKafkaRedelivery()` call (line ~69)**
+
+Find:
+```kotlin
+if (state.shouldPreserveKafkaRedelivery()) {
+```
+Replace with:
+```kotlin
+if (state.status.shouldPreserveKafkaRedelivery(Instant.now())) {
+```
+
+- [ ] **Step 4: Replace `state.status == PROCESSING` check (line ~91)**
+
+Find:
+```kotlin
+if (state.status == ChunkExecutionStatus.PROCESSING) {
+    metrics.recordChunkExecutionReclaimedExpired(request.identity.executionType)
+}
+```
+Replace with:
+```kotlin
+if (state.status is ChunkExecutionStatus.Processing && state.leaseUntil?.isAfter(Instant.now()) != true) {
+    metrics.recordChunkExecutionReclaimedExpired(request.identity.executionType)
+}
+```
+
+(Logic: reclaimed = Processing state with expired or null lease. The original `== PROCESSING` check is preserved plus the lease check that was implicit in the old `isReclaimed` extension.)
+
+- [ ] **Step 5: Update `markUnsupportedSchema` to use sealed type**
+
+Find:
+```kotlin
+ChunkExecutionStatus.FAILED_TERMINAL,
+```
+Replace with:
+```kotlin
+ChunkExecutionStatus.FailedTerminal(UNSUPPORTED_SCHEMA_VERSION),
+```
+
+- [ ] **Step 6: Update `markFailureAndAck` to use sealed types**
+
+Find:
+```kotlin
+val status = if (failure.terminalReason == null) {
+    ChunkExecutionStatus.FAILED_RETRYABLE
+} else {
+    ChunkExecutionStatus.FAILED_TERMINAL
+}
+```
+Replace with:
+```kotlin
+val status = if (failure.terminalReason == null) {
+    ChunkExecutionStatus.FailedRetryable(
+        Instant.now().plus(properties.retryBaseBackoff.multipliedBy(claim.attemptCount.toLong())),
+    )
+} else {
+    ChunkExecutionStatus.FailedTerminal(failure.terminalReason)
+}
+```
+
+- [ ] **Step 7: Delete the three private extension functions (lines ~268-286)**
+
+Delete:
+```kotlin
+private fun ChunkExecutionStatus.isTerminalSkip(): Boolean =
+    this == ChunkExecutionStatus.SUCCEEDED || this == ChunkExecutionStatus.FAILED_TERMINAL
+
+private fun ChunkExecutionState.shouldAckSkip(): Boolean {
+    val now = Instant.now()
+    if (status.isTerminalSkip()) {
+        return true
+    }
+    if (status == ChunkExecutionStatus.FAILED_RETRYABLE && nextRetryAt?.isAfter(now) == true) {
+        return false
+    }
+    if (status == ChunkExecutionStatus.PROCESSING && leaseUntil?.isAfter(now) == true) {
+        return true
+    }
+    return false
+}
+
+private fun ChunkExecutionState.shouldPreserveKafkaRedelivery(): Boolean =
+    status == ChunkExecutionStatus.FAILED_RETRYABLE && nextRetryAt?.isAfter(Instant.now()) == true
+```
+
+- [ ] **Step 8: Compile**
+
+Run: `cd /home/maple/probabilistic-valuation-engine && ./gradlew :module-synchronizer:compileKotlin --continue`
+Expected: SUCCESS or only test-file failures
+
+- [ ] **Step 9: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine
+git add module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/ChunkConsumerTemplate.kt
+git commit -m "refactor(synchronizer): ChunkConsumerTemplate uses sealed status polymorphic methods (#960)"
+```
+
+---
+
+## Task 6: Delete old enum file in module-common
+
+**Files:**
+- Delete: `module-common/src/main/kotlin/maple/expectation/common/event/ChunkExecutionStatus.kt`
+
+- [ ] **Step 1: Verify no remaining references to the old enum**
+
+Run: `cd /home/maple/probabilistic-valuation-engine && grep -rln "maple.expectation.common.event.ChunkExecutionStatus" --include="*.kt" .`
+Expected: empty output
+
+- [ ] **Step 2: Delete the file**
+
+Run: `cd /home/maple/probabilistic-valuation-engine && git rm module-common/src/main/kotlin/maple/expectation/common/event/ChunkExecutionStatus.kt`
+
+- [ ] **Step 3: Compile to verify no stale imports**
+
+Run: `cd /home/maple/probabilistic-valuation-engine && ./gradlew compileKotlin compileJava --continue`
+Expected: SUCCESS (test compilation will still fail until Task 7)
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine
+git commit -m "refactor(common): remove obsolete ChunkExecutionStatus enum (#960)"
+```
+
+---
+
+## Task 7: Update existing tests
+
+**Files:**
+- Modify: `module-synchronizer/src/test/kotlin/maple/synchronizer/consumer/ChunkConsumerTemplateTest.kt`
+- Modify: `module-synchronizer/src/test/kotlin/maple/synchronizer/repository/ChunkExecutionRepositoryTest.kt`
+
+- [ ] **Step 1: Update `ChunkConsumerTemplateTest` imports and `state()` helper**
+
+Find the import:
+```kotlin
+import maple.expectation.common.event.ChunkExecutionStatus
+```
+Replace with:
+```kotlin
+import maple.synchronizer.state.ChunkExecutionStatus
+```
+
+Find the `state()` helper. Update its `status` parameter type and constructors. Example (the actual helper shape will be discovered when reading the test file):
+```kotlin
+private fun state(
+    status: ChunkExecutionStatus,
+    leaseUntil: Instant? = null,
+    nextRetryAt: Instant? = null,
+): ChunkExecutionState = ChunkExecutionState(
+    status = status,
+    nextRetryAt = nextRetryAt,
+    leaseUntil = leaseUntil,
+    attemptCount = 0,
+)
+```
+
+Then update every call site that passes `ChunkExecutionStatus.SUCCEEDED`, `.PENDING`, `.PROCESSING`, `.FAILED_RETRYABLE` to the new sealed type:
+- `ChunkExecutionStatus.SUCCEEDED` → `ChunkExecutionStatus.Succeeded`
+- `ChunkExecutionStatus.PENDING` → drop (no longer a type — PENDING never appears in `ChunkExecutionState`)
+- `ChunkExecutionStatus.PROCESSING` → `ChunkExecutionStatus.Processing`
+- `ChunkExecutionStatus.FAILED_RETRYABLE` → `ChunkExecutionStatus.FailedRetryable(null)`
+
+- [ ] **Step 2: Update `ChunkExecutionRepositoryTest`**
+
+Find the import:
+```kotlin
+import maple.expectation.common.event.ChunkExecutionStatus
+```
+Replace with:
+```kotlin
+import maple.synchronizer.state.ChunkExecutionStatus
+```
+
+Update references:
+- `ChunkExecutionStatus.PENDING` → `ChunkExecutionStatus.PENDING_NAME` (string constant, since tests may assert DB string value)
+- `ChunkExecutionStatus.FAILED_RETRYABLE` → `ChunkExecutionStatus.FailedRetryable(null)` (or compare against `ChunkExecutionStatus.fromName("FAILED_RETRYABLE")`)
+
+- [ ] **Step 3: Run synchronizer tests**
+
+Run: `cd /home/maple/probabilistic-valuation-engine && ./gradlew :module-synchronizer:test`
+Expected: PASS (all old tests + new ChunkExecutionStatusTest)
+
+- [ ] **Step 4: Full compile check**
+
+Run: `cd /home/maple/probabilistic-valuation-engine && ./gradlew compileKotlin compileJava --continue`
+Expected: SUCCESS
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine
+git add module-synchronizer/src/test/kotlin/maple/synchronizer/consumer/ChunkConsumerTemplateTest.kt module-synchronizer/src/test/kotlin/maple/synchronizer/repository/ChunkExecutionRepositoryTest.kt
+git commit -m "test(synchronizer): update tests for sealed ChunkExecutionStatus (#960)"
+```
+
+---
+
+## Task 8: Final verification
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `cd /home/maple/probabilistic-valuation-engine && ./gradlew test`
+Expected: PASS (or pre-existing unrelated failures only)
+
+- [ ] **Step 2: Run full compile check**
+
+Run: `cd /home/maple/probabilistic-valuation-engine && ./gradlew compileKotlin compileJava --continue`
+Expected: SUCCESS
+
+- [ ] **Step 3: Search for stale enum references**
+
+Run: `cd /home/maple/probabilistic-valuation-engine && grep -rn "ChunkExecutionStatus\.\(PENDING\|PROCESSING\|SUCCEEDED\|FAILED_RETRYABLE\|FAILED_TERMINAL\)" --include="*.kt" .`
+Expected: empty output (all enum constants replaced)
+
+- [ ] **Step 4: Search for stale import path**
+
+Run: `cd /home/maple/probabilistic-valuation-engine && grep -rn "maple.expectation.common.event.ChunkExecutionStatus" --include="*.kt" .`
+Expected: empty output
+
+- [ ] **Step 5: Diff stat summary**
+
+Run: `cd /home/maple/probabilistic-valuation-engine && git log --oneline develop..HEAD`
+Expected: ~8 commits covering sealed class, tests, repo, consumer, metrics, common cleanup, test updates
+
+- [ ] **Step 6: Push and open PR**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine
+git push origin HEAD
+gh pr create --base develop --title "refactor(synchronizer): ChunkExecutionStatus sealed class (#960)" --body "Implements #960. Replaces enum with sealed class, polymorphic dispatch, DB schema preserved."
+```

--- a/docs/superpowers/plans/2026-06-06-chunk-execution-status-sealed.md
+++ b/docs/superpowers/plans/2026-06-06-chunk-execution-status-sealed.md
@@ -41,7 +41,6 @@ sealed class ChunkExecutionStatus(val name: String) {
     abstract fun isTerminal(): Boolean
     abstract fun shouldAckSkip(now: Instant): Boolean
     abstract fun shouldPreserveKafkaRedelivery(now: Instant): Boolean
-    abstract fun isReclaimed(now: Instant): Boolean
     fun isTerminalSkip(): Boolean = this is Succeeded || this is FailedTerminal
 
     companion object {
@@ -52,24 +51,27 @@ sealed class ChunkExecutionStatus(val name: String) {
             Succeeded.NAME -> Succeeded
             FailedRetryable.NAME -> FailedRetryable(null)
             FailedTerminal.NAME -> FailedTerminal(null)
-            else -> error("Unknown ChunkExecutionStatus name: $s")
+            else -> throw IllegalArgumentException("Unknown ChunkExecutionStatus name: $s")
         }
     }
 
+    /** Singleton — use `is Processing` checks, not `===`. */
     object Processing : ChunkExecutionStatus(NAME) {
         const val NAME: String = "PROCESSING"
         override fun isTerminal(): Boolean = false
         override fun shouldAckSkip(now: Instant): Boolean = false
         override fun shouldPreserveKafkaRedelivery(now: Instant): Boolean = false
-        override fun isReclaimed(now: Instant): Boolean = false
+        /** True when the lease has expired or was never set — this chunk is reclaimable. */
+        fun isReclaimed(leaseUntil: Instant?, now: Instant): Boolean =
+            leaseUntil?.isAfter(now) != true
     }
 
+    /** Singleton — use `is Succeeded` checks, not `===`. */
     object Succeeded : ChunkExecutionStatus(NAME) {
         const val NAME: String = "SUCCEEDED"
         override fun isTerminal(): Boolean = true
         override fun shouldAckSkip(now: Instant): Boolean = true
         override fun shouldPreserveKafkaRedelivery(now: Instant): Boolean = false
-        override fun isReclaimed(now: Instant): Boolean = false
     }
 
     data class FailedRetryable(val nextRetryAt: Instant?) : ChunkExecutionStatus(NAME) {
@@ -77,7 +79,6 @@ sealed class ChunkExecutionStatus(val name: String) {
         override fun isTerminal(): Boolean = false
         override fun shouldAckSkip(now: Instant): Boolean = nextRetryAt?.isAfter(now) != true
         override fun shouldPreserveKafkaRedelivery(now: Instant): Boolean = nextRetryAt?.isAfter(now) == true
-        override fun isReclaimed(now: Instant): Boolean = false
     }
 
     data class FailedTerminal(val reason: String?) : ChunkExecutionStatus(NAME) {
@@ -85,7 +86,6 @@ sealed class ChunkExecutionStatus(val name: String) {
         override fun isTerminal(): Boolean = true
         override fun shouldAckSkip(now: Instant): Boolean = true
         override fun shouldPreserveKafkaRedelivery(now: Instant): Boolean = false
-        override fun isReclaimed(now: Instant): Boolean = false
     }
 }
 ```
@@ -135,8 +135,8 @@ class ChunkExecutionStatusTest {
     }
 
     @Test
-    fun `fromName throws on unknown value`() {
-        val ex = assertThrows<IllegalStateException> {
+    fun `fromName throws IllegalArgumentException on unknown value`() {
+        val ex = assertThrows<IllegalArgumentException> {
             ChunkExecutionStatus.fromName("BOGUS")
         }
         assertThat(ex.message).contains("BOGUS")
@@ -148,7 +148,19 @@ class ChunkExecutionStatusTest {
         assertThat(s.isTerminal()).isFalse()
         assertThat(s.shouldAckSkip(now)).isFalse()
         assertThat(s.shouldPreserveKafkaRedelivery(now)).isFalse()
-        assertThat(s.isReclaimed(now)).isFalse()
+    }
+
+    @Test
+    fun `Processing isReclaimed is true when lease is null or expired`() {
+        val s = ChunkExecutionStatus.Processing
+        assertThat(s.isReclaimed(leaseUntil = null, now = now)).isTrue()
+        assertThat(s.isReclaimed(leaseUntil = past, now = now)).isTrue()
+    }
+
+    @Test
+    fun `Processing isReclaimed is false when lease is in the future`() {
+        val s = ChunkExecutionStatus.Processing
+        assertThat(s.isReclaimed(leaseUntil = future, now = now)).isFalse()
     }
 
     @Test
@@ -415,12 +427,16 @@ if (state.status == ChunkExecutionStatus.PROCESSING) {
 ```
 Replace with:
 ```kotlin
-if (state.status is ChunkExecutionStatus.Processing && state.leaseUntil?.isAfter(Instant.now()) != true) {
+if (state.isReclaimedExpired(Instant.now())) {
     metrics.recordChunkExecutionReclaimedExpired(request.identity.executionType)
 }
 ```
 
-(Logic: reclaimed = Processing state with expired or null lease. The original `== PROCESSING` check is preserved plus the lease check that was implicit in the old `isReclaimed` extension.)
+Add this private extension to the bottom of the file (alongside other private extensions or near the `FailureDecision` data class):
+```kotlin
+private fun ChunkExecutionState.isReclaimedExpired(now: Instant): Boolean =
+    (status as? ChunkExecutionStatus.Processing)?.isReclaimed(leaseUntil, now) == true
+```
 
 - [ ] **Step 5: Update `markUnsupportedSchema` to use sealed type**
 

--- a/docs/superpowers/plans/2026-06-06-urgent-read-state-sealed.md
+++ b/docs/superpowers/plans/2026-06-06-urgent-read-state-sealed.md
@@ -219,11 +219,15 @@ git commit -m "refactor(rest): ExpectationV6Controller uses shouldTryDb instead 
 ```kotlin
 package maple.restcontroller.read
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
 class UrgentReadStateTest {
+
+    private val mapper: ObjectMapper = ObjectMapper().registerKotlinModule()
 
     @Test
     fun `fromName round-trips all four names`() {
@@ -283,13 +287,36 @@ class UrgentReadStateTest {
         assertThat(UrgentReadState.Pending(null, null).name).isEqualTo("PENDING")
         assertThat(UrgentReadState.Unknown.name).isEqualTo("UNKNOWN")
     }
+
+    @Test
+    fun `Jackson serialization produces name string for all four states`() {
+        assertThat(mapper.writeValueAsString(UrgentReadState.Ready)).isEqualTo("\"READY\"")
+        assertThat(mapper.writeValueAsString(UrgentReadState.NotFound)).isEqualTo("\"NOT_FOUND\"")
+        assertThat(mapper.writeValueAsString(UrgentReadState.Pending(5L, 30L))).isEqualTo("\"PENDING\"")
+        assertThat(mapper.writeValueAsString(UrgentReadState.Unknown)).isEqualTo("\"UNKNOWN\"")
+    }
+
+    @Test
+    fun `UrgentReadStatusResponse JSON contains state name string`() {
+        val response = UrgentReadStatusResponse(
+            state = UrgentReadState.Pending(queuePositionApprox = 5L, estimatedWaitSeconds = 30L),
+            userIgn = "test",
+            statusUrl = "/api/v6/characters/test/status?presetNo=1",
+            queuePositionApprox = 5L,
+            estimatedWaitSeconds = 30L,
+            retryAfterSeconds = 10L,
+        )
+        val json = mapper.writeValueAsString(response)
+        assertThat(json).contains("\"state\":\"PENDING\"")
+        assertThat(json).contains("\"userIgn\":\"test\"")
+    }
 }
 ```
 
 - [ ] **Step 2: Run tests**
 
 Run: `cd /home/maple/probabilistic-valuation-engine && ./gradlew :module-rest-controller:test --tests "maple.restcontroller.read.UrgentReadStateTest"`
-Expected: 8 tests, all PASS
+Expected: 10 tests, all PASS
 
 - [ ] **Step 3: Commit**
 

--- a/docs/superpowers/plans/2026-06-06-urgent-read-state-sealed.md
+++ b/docs/superpowers/plans/2026-06-06-urgent-read-state-sealed.md
@@ -1,0 +1,327 @@
+# UrgentReadState Sealed Class Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `UrgentReadState` enum with sealed class hierarchy; carry behavior on subtypes; preserve JSON contract.
+
+**Architecture:** Convert enum to sealed class in same file (`UrgentReadStatus.kt`). 4 subtypes: `Ready`, `NotFound`, `Pending` (data class), `Unknown`. Jackson uses `@JsonValue`/`@JsonCreator` for backward-compatible JSON. `ReadModelCacheService.status()` builds subtype directly. `ExpectationV6Controller.getStatus()` uses `state.shouldTryDb()`.
+
+**Tech Stack:** Kotlin sealed class, Jackson, Spring Web
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `module-rest-controller/src/main/kotlin/maple/restcontroller/read/UrgentReadStatus.kt` | Modify | Convert enum to sealed class with subtypes + behavior |
+| `module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelCacheService.kt` | Modify | `status()` constructs subtype directly |
+| `module-rest-controller/src/main/kotlin/maple/restcontroller/controller/ExpectationV6Controller.kt` | Modify | Use `state.shouldTryDb()` instead of enum comparison |
+| `module-rest-controller/src/test/kotlin/maple/restcontroller/read/UrgentReadStateTest.kt` | Create | Behavior + JSON round-trip tests |
+
+---
+
+## Task 1: Convert UrgentReadState to sealed class
+
+**Files:**
+- Modify: `module-rest-controller/src/main/kotlin/maple/restcontroller/read/UrgentReadStatus.kt`
+
+- [ ] **Step 1: Replace the enum with sealed class**
+
+Replace the entire file contents with:
+
+```kotlin
+package maple.restcontroller.read
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonValue
+
+sealed class UrgentReadState(val name: String) {
+    abstract fun retryAfterSeconds(configDefault: Long): Long
+    abstract fun shouldTryDb(): Boolean
+    open val queuePositionApprox: Long? = null
+    open val estimatedWaitSeconds: Long? = null
+
+    @JsonCreator
+    companion object {
+        fun fromName(s: String): UrgentReadState = when (s) {
+            Ready.NAME -> Ready
+            NotFound.NAME -> NotFound
+            Pending.NAME -> Pending(null, null)
+            Unknown.NAME -> Unknown
+            else -> throw IllegalArgumentException("Unknown UrgentReadState name: $s")
+        }
+    }
+
+    /** Singleton — use `is Ready` checks, not `===`. */
+    object Ready : UrgentReadState(NAME) {
+        const val NAME: String = "READY"
+        override fun retryAfterSeconds(configDefault: Long): Long = 0L
+        override fun shouldTryDb(): Boolean = false
+    }
+
+    /** Singleton — use `is NotFound` checks, not `===`. */
+    object NotFound : UrgentReadState(NAME) {
+        const val NAME: String = "NOT_FOUND"
+        override fun retryAfterSeconds(configDefault: Long): Long = 0L
+        override fun shouldTryDb(): Boolean = false
+    }
+
+    data class Pending(
+        override val queuePositionApprox: Long?,
+        override val estimatedWaitSeconds: Long?,
+    ) : UrgentReadState(NAME) {
+        companion object { const val NAME: String = "PENDING" }
+        override fun retryAfterSeconds(configDefault: Long): Long = configDefault
+        override fun shouldTryDb(): Boolean = true
+    }
+
+    /** Singleton — use `is Unknown` checks, not `===`. */
+    object Unknown : UrgentReadState(NAME) {
+        const val NAME: String = "UNKNOWN"
+        override fun retryAfterSeconds(configDefault: Long): Long = configDefault
+        override fun shouldTryDb(): Boolean = true
+    }
+}
+
+data class UrgentReadStatusResponse(
+    val state: UrgentReadState,
+    val userIgn: String,
+    val statusUrl: String,
+    val queuePositionApprox: Long?,
+    val estimatedWaitSeconds: Long?,
+    val retryAfterSeconds: Long,
+)
+```
+
+- [ ] **Step 2: Compile**
+
+Run: `cd /home/maple/probabilistic-valuation-engine && ./gradlew :module-rest-controller:compileKotlin --continue`
+Expected: FAIL only in `ReadModelCacheService.kt` and `ExpectationV6Controller.kt` (still using enum constants)
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine
+git add module-rest-controller/src/main/kotlin/maple/restcontroller/read/UrgentReadStatus.kt
+git commit -m "refactor(rest): UrgentReadState sealed class with behavior (#959)"
+```
+
+---
+
+## Task 2: Update ReadModelCacheService.status() to build subtype directly
+
+**Files:**
+- Modify: `module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelCacheService.kt`
+
+- [ ] **Step 1: Replace `status()` method body**
+
+Find:
+```kotlin
+fun status(userIgn: String, presetNo: Int): UrgentReadStatusResponse {
+    val state = when {
+        hasReadyCache(userIgn, presetNo) -> UrgentReadState.READY
+        getNegativeCache(userIgn) -> UrgentReadState.NOT_FOUND
+        isUrgentPending(userIgn) -> UrgentReadState.PENDING
+        else -> UrgentReadState.UNKNOWN
+    }
+    val position = if (state == UrgentReadState.PENDING) queuePosition(userIgn) else null
+    return UrgentReadStatusResponse(
+        state = state,
+        userIgn = userIgn,
+        statusUrl = statusUrl(userIgn, presetNo),
+        queuePositionApprox = position,
+        estimatedWaitSeconds = position?.let(::estimateWaitSeconds),
+        retryAfterSeconds = if (state == UrgentReadState.READY || state == UrgentReadState.NOT_FOUND) 0 else properties.statusRetryAfterSeconds,
+    )
+}
+```
+
+Replace with:
+```kotlin
+fun status(userIgn: String, presetNo: Int): UrgentReadStatusResponse {
+    val state: UrgentReadState = when {
+        hasReadyCache(userIgn, presetNo) -> UrgentReadState.Ready
+        getNegativeCache(userIgn) -> UrgentReadState.NotFound
+        isUrgentPending(userIgn) -> {
+            val pos = queuePosition(userIgn)
+            UrgentReadState.Pending(
+                queuePositionApprox = pos,
+                estimatedWaitSeconds = pos?.let(::estimateWaitSeconds),
+            )
+        }
+        else -> UrgentReadState.Unknown
+    }
+    return UrgentReadStatusResponse(
+        state = state,
+        userIgn = userIgn,
+        statusUrl = statusUrl(userIgn, presetNo),
+        queuePositionApprox = state.queuePositionApprox,
+        estimatedWaitSeconds = state.estimatedWaitSeconds,
+        retryAfterSeconds = state.retryAfterSeconds(properties.statusRetryAfterSeconds),
+    )
+}
+```
+
+- [ ] **Step 2: Compile**
+
+Run: `cd /home/maple/probabilistic-valuation-engine && ./gradlew :module-rest-controller:compileKotlin --continue`
+Expected: FAIL only in `ExpectationV6Controller.kt` (still using enum comparison)
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine
+git add module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelCacheService.kt
+git commit -m "refactor(rest): ReadModelCacheService builds UrgentReadState subtype directly (#959)"
+```
+
+---
+
+## Task 3: Update ExpectationV6Controller to use shouldTryDb
+
+**Files:**
+- Modify: `module-rest-controller/src/main/kotlin/maple/restcontroller/controller/ExpectationV6Controller.kt`
+
+- [ ] **Step 1: Replace enum comparison in getStatus()**
+
+Find:
+```kotlin
+val status = if (current.state == UrgentReadState.PENDING || current.state == UrgentReadState.UNKNOWN) {
+```
+Replace with:
+```kotlin
+val status = if (current.state.shouldTryDb()) {
+```
+
+- [ ] **Step 2: Compile**
+
+Run: `cd /home/maple/probabilistic-valuation-engine && ./gradlew :module-rest-controller:compileKotlin --continue`
+Expected: SUCCESS
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine
+git add module-rest-controller/src/main/kotlin/maple/restcontroller/controller/ExpectationV6Controller.kt
+git commit -m "refactor(rest): ExpectationV6Controller uses shouldTryDb instead of enum comparison (#959)"
+```
+
+---
+
+## Task 4: Create UrgentReadState unit tests
+
+**Files:**
+- Create: `module-rest-controller/src/test/kotlin/maple/restcontroller/read/UrgentReadStateTest.kt`
+
+- [ ] **Step 1: Write the test file**
+
+```kotlin
+package maple.restcontroller.read
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class UrgentReadStateTest {
+
+    @Test
+    fun `fromName round-trips all four names`() {
+        assertThat(UrgentReadState.fromName("READY")).isEqualTo(UrgentReadState.Ready)
+        assertThat(UrgentReadState.fromName("NOT_FOUND")).isEqualTo(UrgentReadState.NotFound)
+        assertThat(UrgentReadState.fromName("PENDING")).isEqualTo(UrgentReadState.Pending(null, null))
+        assertThat(UrgentReadState.fromName("UNKNOWN")).isEqualTo(UrgentReadState.Unknown)
+    }
+
+    @Test
+    fun `fromName throws IllegalArgumentException on unknown value`() {
+        val ex = assertThrows<IllegalArgumentException> {
+            UrgentReadState.fromName("BOGUS")
+        }
+        assertThat(ex.message).contains("BOGUS")
+    }
+
+    @Test
+    fun `Ready returns 0 retry-after and does not try DB`() {
+        assertThat(UrgentReadState.Ready.retryAfterSeconds(configDefault = 30L)).isEqualTo(0L)
+        assertThat(UrgentReadState.Ready.shouldTryDb()).isFalse()
+    }
+
+    @Test
+    fun `NotFound returns 0 retry-after and does not try DB`() {
+        assertThat(UrgentReadState.NotFound.retryAfterSeconds(configDefault = 30L)).isEqualTo(0L)
+        assertThat(UrgentReadState.NotFound.shouldTryDb()).isFalse()
+    }
+
+    @Test
+    fun `Pending returns config retry-after and tries DB`() {
+        val pending = UrgentReadState.Pending(queuePositionApprox = 5L, estimatedWaitSeconds = 30L)
+        assertThat(pending.retryAfterSeconds(configDefault = 10L)).isEqualTo(10L)
+        assertThat(pending.shouldTryDb()).isTrue()
+        assertThat(pending.queuePositionApprox).isEqualTo(5L)
+        assertThat(pending.estimatedWaitSeconds).isEqualTo(30L)
+    }
+
+    @Test
+    fun `Pending with null position has null position fields`() {
+        val pending = UrgentReadState.Pending(queuePositionApprox = null, estimatedWaitSeconds = null)
+        assertThat(pending.queuePositionApprox).isNull()
+        assertThat(pending.estimatedWaitSeconds).isNull()
+        assertThat(pending.shouldTryDb()).isTrue()
+    }
+
+    @Test
+    fun `Unknown returns config retry-after and tries DB`() {
+        assertThat(UrgentReadState.Unknown.retryAfterSeconds(configDefault = 30L)).isEqualTo(30L)
+        assertThat(UrgentReadState.Unknown.shouldTryDb()).isTrue()
+    }
+
+    @Test
+    fun `name property on each subtype matches NAME constant`() {
+        assertThat(UrgentReadState.Ready.name).isEqualTo("READY")
+        assertThat(UrgentReadState.NotFound.name).isEqualTo("NOT_FOUND")
+        assertThat(UrgentReadState.Pending(null, null).name).isEqualTo("PENDING")
+        assertThat(UrgentReadState.Unknown.name).isEqualTo("UNKNOWN")
+    }
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cd /home/maple/probabilistic-valuation-engine && ./gradlew :module-rest-controller:test --tests "maple.restcontroller.read.UrgentReadStateTest"`
+Expected: 8 tests, all PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine
+git add module-rest-controller/src/test/kotlin/maple/restcontroller/read/UrgentReadStateTest.kt
+git commit -m "test(rest): UrgentReadState sealed class behavior tests (#959)"
+```
+
+---
+
+## Task 5: Final verification
+
+- [ ] **Step 1: Run rest-controller tests**
+
+Run: `cd /home/maple/probabilistic-valuation-engine && ./gradlew :module-rest-controller:test`
+Expected: PASS
+
+- [ ] **Step 2: Full compile check**
+
+Run: `cd /home/maple/probabilistic-valuation-engine && ./gradlew compileKotlin compileJava --continue`
+Expected: SUCCESS
+
+- [ ] **Step 3: Search for stale enum references**
+
+Run: `cd /home/maple/probabilistic-valuation-engine && grep -rn "UrgentReadState\.\(PENDING\|READY\|NOT_FOUND\|UNKNOWN\)" --include="*.kt" .`
+Expected: empty output
+
+- [ ] **Step 4: Push and open PR**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine
+git push origin HEAD
+gh pr create --base develop --title "refactor(rest): UrgentReadState sealed class with behavior (#959)" --body "Implements #959. Sealed class hierarchy replaces enum; behavior methods on subtypes; JSON contract preserved."
+```

--- a/docs/superpowers/specs/2026-06-06-chunk-consumer-template-state-machine-design.md
+++ b/docs/superpowers/specs/2026-06-06-chunk-consumer-template-state-machine-design.md
@@ -1,0 +1,143 @@
+# Design: ChunkConsumerTemplate state machine sealed class (issue #983)
+
+- Status: Accepted
+- Date: 2026-06-06
+- Owner: zbnerd
+- Issue: #983
+- Note: blocked by #979 (Status/Endpoint enum). Implementing #983 standalone; #979 unresolved. If #979 introduces a different chunk-status enum, the `ChunkExecutionStatus` references in this spec will need adjustment.
+
+---
+
+## 1. Background / Problem
+
+### Background
+
+`ChunkConsumerTemplate` (module-synchronizer) has 3 methods with complex conditional logic:
+- `markFailureAndAck` (lines 189-238) — `failure.terminalReason == null` repeated 3 times, 4 exit paths
+- `classifyFailure` (lines 241-253) — artifact-missing × attempt-count 2×2 matrix via if/else + `"file not found"` substring matching
+- `shouldAckSkip` (lines 271-283) — 4 branches with fallthrough, `PROCESSING + lease active` and `FAILED_RETRYABLE + future retry` produce inverted "skip" decisions
+
+`FailureDecision` is a private data class with a single nullable field. `ArtifactNotFoundException` already exists in `module-common` but is not used by the synchronizer's file readers — they throw `IllegalStateException("... file not found: ...")` instead, and `classifyFailure` matches on substring.
+
+### Problem
+
+The private `FailureDecision` is a poor-man's sealed class (one nullable field for "which kind"). The state machine is implicit. Substring exception matching is fragile.
+
+### Goal
+
+Replace `FailureDecision` with a proper sealed class. Replace substring matching with exception type matching. Replace nested conditionals with exhaustive `when` over the sealed types. Wire the existing `ArtifactNotFoundException` in synchronizer's file readers.
+
+---
+
+## 2. Decision
+
+Three sub-refactors in one PR:
+
+### A) Wire `ArtifactNotFoundException` in 3 synchronizer readers
+
+Replace `throw IllegalStateException("X file not found: $path")` with `throw ArtifactNotFoundException(CommonErrorCode.ARTIFACT_NOT_FOUND, "ReaderName", path)` in:
+- `ResultFileReader.kt:24`
+- `OcidMappingFileReader.kt:33`
+- `BasicChunkFileReader.kt:49, 74` (2 sites)
+
+### B) Convert `FailureDecision` to sealed class
+
+```kotlin
+sealed class FailureDecision {
+    abstract val attemptCount: Int
+    abstract val reason: String
+
+    data class Retryable(
+        override val attemptCount: Int,
+        val nextRetryAt: Instant,
+    ) : FailureDecision() {
+        override val reason: String = RETRYABLE_FAILURE
+    }
+
+    data class Terminal(
+        override val attemptCount: Int,
+        val terminalReason: String,
+    ) : FailureDecision() {
+        override val reason: String = terminalReason
+    }
+}
+```
+
+### C) Exhaustive `when` in `markFailureAndAck` and `shouldAckSkip`
+
+See spec Section 6 for the full code. Both methods become `when (...)` over the sealed types.
+
+---
+
+## 3. Trade-offs
+
+### Sensitivity
+
+- **Test file coverage:** `DefaultChunkProcessorTest` and `ChunkConsumerTemplateTest` assert on `IllegalStateException` types. After wiring `ArtifactNotFoundException`, those assertions may need updates.
+- **Reader blast radius:** All 4 file-not-found throw sites in synchronizer change exception type. Downstream `catch (IllegalStateException)` blocks (if any) become less specific.
+
+### Trade-off
+
+| Choice | Gain | Cost |
+|--------|------|------|
+| Wire existing `ArtifactNotFoundException` | Type-safe classification | 4 throw sites change; test assertions update |
+| Sealed `FailureDecision` with `abstract val reason` | DRY reason logic; type-safe | One extra property to maintain |
+| Exhaustive `when` in `shouldAckSkip` | Compiler-enforced coverage of all 4 states | Code grows; less obvious at a glance |
+| Combine A+B+C in one PR | Atomic state-machine refactor | Larger diff; harder to revert |
+
+### Risk
+
+- **Behavioral drift:** The sealed `FailureDecision` must produce identical DB writes and metric calls as the old data-class version. Mitigation: tests assert on the same metric calls + DB writes; `recordChunkExecutionFailed` is called with the same `reason` strings.
+- **`markFailedRetryable` signature:** it accepts `Instant?` for `nextRetryAt`. The new `Retryable` always has a non-null `nextRetryAt`. Mitigation: pass it through; no signature change.
+- **#979 dependency:** The blocked issue may introduce a new chunk-status enum. Mitigation: implement #983 against current `ChunkExecutionStatus` (post-#960 sealed class). If #979 changes it, follow-up PR adapts.
+
+### Non-Risk
+
+- DB schema: unchanged.
+- Wire format: unchanged.
+- Kafka message format: unchanged.
+
+---
+
+## 4. Result / Evidence
+
+### Metrics
+
+| Metric | Value | Notes |
+|--------|------:|-------|
+| `FailureDecision` types | 1 data class → 1 sealed + 2 subtypes | Net: same file location |
+| Substring exception matches in synchronizer | 1 → 0 | `classifyFailure` uses `is ArtifactNotFoundException` |
+| File readers throwing `ArtifactNotFoundException` | 0 → 3 readers, 4 sites | |
+| `markFailureAndAck` exit paths | 4 implicit → 2 explicit (Retryable / Terminal) | |
+| `shouldAckSkip` branches | 4 with fallthrough → exhaustive `when` on 4 states | |
+| New test methods | ~6 | Sealed decision + exhaustive when + readers |
+
+### Observed Result
+
+Post-implementation:
+- `classifyFailure` returns `FailureDecision.Retryable` or `FailureDecision.Terminal`
+- `markFailureAndAck` is a flat `when (decision)` body
+- `shouldAckSkip` is a flat `when (status)` body with inline comments
+- 3 file readers throw `ArtifactNotFoundException` for missing files
+- `./gradlew :module-synchronizer:test` passes
+- `./gradlew compileKotlin compileJava --continue` passes
+
+---
+
+## 5. Summary
+
+> Convert `FailureDecision` to sealed class; wire `ArtifactNotFoundException` in synchronizer readers; rewrite `markFailureAndAck` + `shouldAckSkip` as exhaustive `when` over sealed types.
+
+---
+
+## 6. Implementation Outline (reference for writing-plans)
+
+1. Update `ResultFileReader`, `OcidMappingFileReader`, `BasicChunkFileReader` to throw `ArtifactNotFoundException` (4 sites total)
+2. Replace `FailureDecision` data class with sealed class (2 subtypes: `Retryable`, `Terminal`) at the bottom of `ChunkConsumerTemplate.kt`
+3. Rewrite `classifyFailure` to return sealed subtype, using `ex is ArtifactNotFoundException` instead of substring match
+4. Rewrite `markFailureAndAck` body as `when (decision)` exhaustive
+5. Rewrite `shouldAckSkip` body as `when (status)` exhaustive (assumes post-#960 sealed `ChunkExecutionStatus`)
+6. Add unit tests for `classifyFailure` (artifact + non-artifact × under-max + at-max) and `shouldAckSkip` (all 4 sealed states)
+7. Update `DefaultChunkProcessorTest:67-74` to expect `ArtifactNotFoundException`
+8. Update `ChunkConsumerTemplateTest:168` (uses `IllegalStateException` — keep as the non-artifact case, add a parallel test for `ArtifactNotFoundException`)
+9. Run `./gradlew :module-synchronizer:test` and `./gradlew compileKotlin compileJava --continue`

--- a/docs/superpowers/specs/2026-06-06-chunk-execution-status-sealed-design.md
+++ b/docs/superpowers/specs/2026-06-06-chunk-execution-status-sealed-design.md
@@ -1,0 +1,109 @@
+# Design: Consolidate ChunkExecutionStatus into sealed class (issue #960)
+
+- Status: Accepted
+- Date: 2026-06-06
+- Owner: zbnerd
+- Issue: #960
+
+---
+
+## 1. Background / Problem
+
+### Background
+
+`ChunkConsumerTemplate` (module-synchronizer) branches on `ChunkExecutionStatus` enum in 4+ locations. The branching logic — `isTerminalSkip`, `shouldAckSkip`, `shouldPreserveKafkaRedelivery`, reclaimed-expired detection — lives as private extension functions on the enum, scattered across the consumer file. The enum itself is a flat data carrier with no behavior.
+
+### Problem
+
+State-dependent logic is scattered. Adding a new state or transition rule requires touching multiple call sites. The enum equality checks (`== ChunkExecutionStatus.PROCESSING`) leak enum identity into business decisions instead of letting the state decide.
+
+### Goal
+
+Consolidate state-dependent behavior into the state types themselves via Kotlin sealed class. Replace raw enum comparisons with polymorphic dispatch. Preserve DB schema, wire format, and metrics tag strings.
+
+---
+
+## 2. Decision
+
+Replace `maple.expectation.common.event.ChunkExecutionStatus` (enum) with `maple.synchronizer.state.ChunkExecutionStatus` (sealed class). Move behavior into subtypes. DB serialization uses `name` strings (unchanged from before).
+
+```text
+module-common/.../event/ChunkExecutionStatus.kt          → DELETE
+module-synchronizer/.../state/ChunkExecutionStatus.kt    → CREATE (sealed + 4 subtypes)
+module-synchronizer/.../repository/ChunkExecutionRepository.kt  → use fromName + sealed ctor
+module-synchronizer/.../consumer/ChunkConsumerTemplate.kt        → drop private extensions, use polymorphic methods
+module-synchronizer/.../metrics/SynchronizerMetrics.kt           → accept sealed ChunkExecutionStatus
+```
+
+PENDING is **not** a sealed subtype. It remains a `const val PENDING_NAME = "PENDING"` on the companion object, used only by `insertPendingIfAbsent`. PENDING never appears in `ChunkExecutionState` reads (filtered earlier in the pipeline).
+
+---
+
+## 3. Trade-offs
+
+### Sensitivity
+
+- **DB schema**: enum `name` strings must round-trip identically. Any change to subtype `NAME` constants breaks serialization.
+- **Metrics tags**: `recordChunkExecutionFailed(... status, reason)` records `status.name` as a metric tag. Cardinality is unchanged (still PENDING, PROCESSING, SUCCEEDED, FAILED_TERMINAL, FAILED_RETRYABLE).
+- **Test count**: 2 test files reference the old enum directly; both need updates.
+
+### Trade-off
+
+| Choice | Gain | Cost |
+|--------|------|------|
+| Sealed class in module-synchronizer (not module-common) | Single-responsibility, no framework-free cross-module coupling | File move; old enum deleted |
+| Drop PENDING from sealed subtypes | Avoid YAGNI subtype with no behavior | Insert path uses constant instead of type |
+| `data class` for retryable/terminal | Carries `Instant?` fields without separate property | Equality is by value (test helpers need updates) |
+| Singleton `object` for Processing/Succeeded | No allocation, identity equality | Cannot carry fields (correct: those states need no Instant data) |
+
+### Risk
+
+- `FailedRetryable` and `FailedTerminal` are data classes — equals/hashCode are by value. Any code that relied on enum identity (`status === FAILED_RETRYABLE`) will silently break. Mitigation: exhaustive search before commit; no such usage found in current codebase.
+- Metrics interface signature change (`ChunkExecutionStatus` is sealed now, not enum). Java callers passing the old enum must update. Mitigation: only one caller (`SynchronizerMetrics` itself) plus tests.
+
+### Non-Risk
+
+- DB schema: untouched. `name` strings preserved.
+- Kafka message format: untouched.
+- Wire types (`ChunkExecutionIdentity`, `ChunkExecutionClaim`, `ChunkExecutionState`): field types change (`status: ChunkExecutionStatus` now polymorphic) but no new fields.
+
+---
+
+## 4. Result / Evidence
+
+### Metrics
+
+| Metric | Value | Notes |
+|--------|------:|-------|
+| `ChunkExecutionStatus` files | 1 enum → 1 sealed class file | Net file count change: 0 |
+| Raw enum comparisons in ChunkConsumerTemplate | 5 → 0 | Polymorphic dispatch replaces `==` |
+| Private extension functions removed | 3 | `isTerminalSkip`, `shouldAckSkip`, `shouldPreserveKafkaRedelivery` |
+| New test file | 1 | `ChunkExecutionStatusTest.kt` |
+| Updated test files | 2 | `ChunkConsumerTemplateTest`, `ChunkExecutionRepositoryTest` |
+
+### Observed Result
+
+Post-implementation:
+- All `if (state.status == ChunkExecutionStatus.X)` checks in `ChunkConsumerTemplate` removed
+- `state.status.shouldAckSkip(now)` / `.shouldPreserveKafkaRedelivery(now)` polymorphic calls
+- `state.leaseUntil` drives reclaimed-expired detection (replaces `state.status == PROCESSING` check)
+- `./gradlew :module-synchronizer:test` passes
+- `./gradlew compileKotlin compileJava --continue` passes
+
+---
+
+## 5. Summary
+
+> Move `ChunkExecutionStatus` from enum to sealed class in module-synchronizer; behavior lives on subtypes; DB and metrics unchanged.
+
+---
+
+## 6. Implementation Outline (reference for writing-plans)
+
+1. Create `module-synchronizer/.../state/ChunkExecutionStatus.kt` with sealed class + 4 subtypes + companion
+2. Delete `module-common/.../event/ChunkExecutionStatus.kt`
+3. Update `ChunkExecutionRepository`: replace `valueOf` with `fromName`; pass `Instant?` into `FailedRetryable(nextRetryAt)`; write path uses `PENDING_NAME` / `Succeeded.NAME` / `FailedRetryable.NAME` / `FailedTerminal.NAME`
+4. Update `SynchronizerMetrics`: change method signatures to accept sealed `ChunkExecutionStatus`; record `status.name` as tag
+5. Update `ChunkConsumerTemplate`: remove `isTerminalSkip/shouldAckSkip/shouldPreserveKafkaRedelivery` extensions; use polymorphic methods; drop `state.status == PROCESSING` check (drive off `leaseUntil`); use sealed type checks in `markSucceededAndAck`/`markFailureAndAck` paths
+6. Update test helpers and create `ChunkExecutionStatusTest.kt`
+7. Run `./gradlew :module-synchronizer:test` and `./gradlew compileKotlin compileJava --continue`

--- a/docs/superpowers/specs/2026-06-06-chunk-stage-ports-design.md
+++ b/docs/superpowers/specs/2026-06-06-chunk-stage-ports-design.md
@@ -1,0 +1,161 @@
+# Chunk Stage Port Extraction Design
+
+- Date: 2026-06-06
+- Owner: TBD
+- Related: #923 (decomposed), #1143 (current stage split), #1144 (DRY), #1145 (error strategy)
+
+---
+
+## 1. Background / Problem
+
+### Background
+
+PR #1143 split `DefaultChunkProcessor` into `ChunkDataReader` / `ChunkDocumentTransformer` / `ChunkDocumentWriter`. The split is in code, but the stage boundaries are not expressed as port interfaces. Each stage is a Spring `@Component` with concrete constructor dependencies. Adding a new stage (validation, metrics, schema migration) requires editing `DefaultChunkProcessor` directly.
+
+### Problem
+
+- Stage replacement requires touching `DefaultChunkProcessor` even when only one stage changes
+- Test fakes for a single stage are not first-class — they exist only inside the test class
+- `ChunkProcessInput` / `ChunkProcessResult` are local DTOs, not shared domain types. Each stage invents its own intermediate shape.
+- The "stage list" is implicit: hard-coded calls in `DefaultChunkProcessor`. No way to add/remove stages by configuration.
+
+### Goal
+
+Introduce port interfaces (`ChunkReader` / `ChunkTransformer` / `ChunkWriter`) in `module-core` with a single `Chunk<T>` domain type. Move existing `ChunkDataReader` / `ChunkDocumentTransformer` / `ChunkDocumentWriter` to `module-synchronizer` as adapters. Add a `ChunkPipelineOrchestrator` that takes a stage list and runs them in sequence.
+
+---
+
+## 2. Decision
+
+> Express chunk processing as a Chain of Responsibility over a shared `Chunk<T>` type. Stage interfaces live in `module-core`. Concrete implementations are Spring `@Component` adapters in `module-synchronizer`. A `ChunkPipelineOrchestrator` composes the stage list and runs them in order.
+
+```text
+module-core/domain/chunk/
+├── Chunk.kt                       (data class Chunk<T>)
+├── ChunkReader.kt                 (interface)
+├── ChunkTransformer.kt            (interface)
+└── ChunkWriter.kt                 (interface)
+
+module-synchronizer/adapter/chunk/
+├── DefaultChunkReader.kt          (moved from processor/ChunkDataReader)
+├── DefaultChunkTransformer.kt     (moved from processor/ChunkDocumentTransformer)
+├── DefaultChunkWriter.kt          (moved from processor/ChunkDocumentWriter)
+└── ChunkPipelineOrchestrator.kt   (new — stage list runner)
+```
+
+---
+
+## 3. Interfaces
+
+```kotlin
+// module-core
+data class Chunk<T>(
+    val input: ChunkProcessInput,    // objectKey, sourceRunId, sourceChunkId, resultCount
+    val data: T,                      // stage-specific payload
+    val metadata: Map<String, String> = emptyMap(),
+)
+
+interface ChunkReader<T> {
+    suspend fun read(chunk: Chunk<Unit>): Chunk<T>
+}
+
+interface ChunkTransformer<T, R> {
+    suspend fun transform(chunk: Chunk<T>): Chunk<R>
+}
+
+interface ChunkWriter<T> {
+    suspend fun write(chunk: Chunk<T>): Chunk<Unit>
+}
+```
+
+Each interface is a single suspend function. Stages are not aware of the next stage — `ChunkPipelineOrchestrator` chains them by type.
+
+---
+
+## 4. Pipeline Orchestrator
+
+```kotlin
+@Component
+class ChunkPipelineOrchestrator(
+    private val reader: ChunkReader<*>,
+    private val transformers: List<ChunkTransformer<*, *>>,
+    private val writer: ChunkWriter<*>,
+) {
+    suspend fun execute(input: ChunkProcessInput) {
+        val initial = Chunk<Unit>(input, Unit)
+        val afterRead = reader.read(initial)
+        val afterTransform = transformers.fold(afterRead) { chunk, transformer ->
+            @Suppress("UNCHECKED_CAST")
+            (transformer as ChunkTransformer<Any?, Any?>).transform(chunk)
+        }
+        @Suppress("UNCHECKED_CAST")
+        (writer as ChunkWriter<Any?>).write(afterTransform)
+    }
+}
+```
+
+The unchecked cast is the seam: stage types are erased at runtime, but the orchestrator's correctness is enforced by Spring bean wiring (only one `ChunkReader`, one `ChunkWriter`, N `ChunkTransformer`).
+
+---
+
+## 5. Trade-offs
+
+### Sensitivity
+
+* Number of transformers in the chain (currently 1, may grow to 3-4 with validation, metrics, schema migration)
+* Stage replacement frequency (currently 0/quarter, expected 1-2/quarter)
+* Boot test isolation (each stage mockable independently)
+
+### Trade-off
+
+| 선택 | 얻는 것 | 포기한 것 |
+| -- | ---- | ----- |
+| Chain of Responsibility over direct calls | 동적 stage 추가/제거, stage별 단위 테스트, port 재사용 | unchecked cast (type erasure 보완) |
+| module-core 위치 | 다른 모듈에서 동기화 패턴 재사용 가능, port 명확 | module-core 의존성 +1 (suspend, Chunk<T>만) |
+| 단일 Chunk<T> 도메인 타입 | 모든 stage 일관된 interface, metadata로 stage 사이 context 전달 | 각 stage의 T가 무엇인지 명시적이지 않음 (문서로 보완) |
+| Unchecked cast (orchestrator) | Kotlin generics 한계 수용, 런타임 type mismatch 가능 | Spring bean wiring 검증에 의존 (boot 시 type 보장) |
+
+### Risk
+
+* `Chunk<T>`가 너무 generic해 stage type 안 보임 — 메서드 javadoc으로 보완
+* transformer list가 비어있을 때 zero-stage write 가능 — `@ConditionalOnBean` 또는 minimum 1 transformer 정책 결정 필요
+* `suspend` stage가 아닌 non-suspend stage와 호환 안 됨 — 모든 stage는 `suspend`로 통일
+
+### Non-Risk
+
+* 기존 `DefaultChunkProcessorTest` 회귀 없음 (orchestrator가 동일 시그니처 제공)
+* `ChunkProcessInput` / `ChunkProcessResult` 마이그레이션 부담 없음 (이관 대상)
+* Performance: 단일 stage 호출 오버헤드 0에 가까움 (suspend 함수 체이닝)
+
+---
+
+## 6. Migration Plan
+
+PR1: `module-core` — `Chunk<T>`, 3 port interfaces, port unit tests
+PR2: `module-synchronizer` — adapter 3개 이관, `ChunkPipelineOrchestrator` 추가, `DefaultChunkProcessor` deprecated 후 제거
+
+각 PR은 단독 merge 가능. PR1은 port만 정의하므로 다운스트림 영향 없음. PR2는 `DefaultChunkProcessor` 사용처를 `ChunkPipelineOrchestrator`로 1:1 치환.
+
+---
+
+## 7. Test Strategy
+
+* **module-core** port unit test: 각 interface의 suspend 함수 시그니처 검증 (fake implementation 주입)
+* **module-synchronizer** fake stage 주입: `ChunkReader<Foo>` fake + transformer mock + `ChunkWriter` fake로 end-to-end 동작 검증
+* **기존 통합 테스트 유지**: `DefaultChunkProcessorTest`는 `ChunkPipelineOrchestrator`의 동작 검증으로 전환 (테스트 명 변경 가능)
+
+Coverage target: port interface 100% (interface이므로 trivial), adapter 80%+.
+
+---
+
+## 8. Success Signal
+
+* 신규 stage 1회 추가 시 `DefaultChunkProcessor` 수정 없이 `ChunkPipelineOrchestrator`의 stage list에 component 추가만으로 가능
+* port test로 stage 1개 교체 가능 — `ChunkReader<Foo>` fake로 다른 reader 검증
+
+---
+
+## 9. Open Questions
+
+* Transformer list가 비어있을 때 — 최소 1개 강제? 또는 reader → writer 직행 허용?
+* `Chunk<T>`의 `metadata: Map<String, String>` — 이게 너무 generic한지, typed `StageContext`로 강화할지?

--- a/docs/superpowers/specs/2026-06-06-like-port-merge-design.md
+++ b/docs/superpowers/specs/2026-06-06-like-port-merge-design.md
@@ -1,0 +1,139 @@
+# Like Port Merge Design (6 → 2)
+
+- Date: 2026-06-06
+- Owner: TBD
+- Related: #897, ADR-391
+
+---
+
+## 1. Background / Problem
+
+### Background
+
+ADR-391 + #897 audit classified 49 outbound ports. Like-related ports (6) were flagged as having overlapping responsibilities across three concerns: data fetch, buffer, sync. Specification #1154 §5 proposed merging them into 2 ports.
+
+### Problem
+
+Current 6 ports:
+
+| Port | Concern | Status |
+|------|---------|--------|
+| `LikeAtomicFetchStrategy` | atomic fetch (Redis) | Active seam |
+| `LikeBufferStrategy` | buffer push + size | Active seam |
+| `LikeRelationBufferStrategy` | relation buffer (Redis) | Active seam |
+| `LikeSyncPort` | flush L2 → persistence | Active seam |
+| `LikeRelationSyncPort` | relation sync (Redis → MySQL) | Active seam |
+| `LikeEventPublisher` | publish LikeEvent | Active seam |
+
+3 concerns split across 6 ports. Caller must know which port to inject. Adapter count = 6 (~5 in `module-infra`, 1 in test).
+
+### Goal
+
+Merge into 2 ports with cohesive concerns: `LikeReadPort` (fetch + buffer control) and `LikeSyncPort` (sync + publish). Remove the 4 deprecated ports in the same PR.
+
+---
+
+## 2. Decision
+
+> Replace 6 Like-related outbound ports with 2 (`LikeReadPort`, `LikeSyncPort`). Adapters consolidate. `LikeSyncPort` is the new owner of the existing name; `LikeReadPort` is a new name.
+
+```text
+// New: data fetch + buffer manipulation (3 → 1)
+interface LikeReadPort {
+    fun fetchAtomic(userId: String): Optional<LikeData>
+    fun bufferPush(event: LikeEvent): CompletableFuture<Void>
+    fun bufferSize(): Int
+}
+
+// New: sync + event publish (3 → 1)
+interface LikeSyncPort {
+    fun syncRelation(fromUser: String, toUser: String): Result<Unit>
+    fun publish(event: LikeEvent): Result<Unit>
+}
+```
+
+Removed ports: `LikeAtomicFetchStrategy`, `LikeBufferStrategy`, `LikeRelationBufferStrategy`, `LikeRelationSyncPort`, `LikeEventPublisher`. `LikeSyncPort` is the surviving port (replaces its old flush semantics with the new sync+publish semantics).
+
+---
+
+## 3. Adapter Mapping
+
+| Old Adapter | New Adapter | Location |
+|------------|-------------|----------|
+| `RedisLikeAtomicFetchAdapter` | `LikeReadPortAdapter` (read methods) | `module-infra/.../like/` |
+| `RedisLikeBufferAdapter` | `LikeReadPortAdapter` (buffer methods) | same file |
+| `RedisLikeRelationBufferAdapter` | (delete — buffer merged into read) | removed |
+| `LikeSyncExecutor` (flush) | `LikeSyncPortAdapter` (sync methods) | `module-infra/.../like/` |
+| `RedisLikeRelationSyncAdapter` | `LikeSyncPortAdapter` (relation sync) | same file |
+| `KafkaLikeEventPublisher` | `LikeSyncPortAdapter` (publish) | same file |
+
+3 adapter files instead of 6.
+
+---
+
+## 4. Trade-offs
+
+### Sensitivity
+
+* Donation hot path (every like triggers fetch + buffer + eventual sync)
+* Number of consumers across `module-core` (currently ~10 inject sites)
+* Test fakes (4-5 in `module-core/src/test/`)
+* Adapter count in Spring context (boot classpath scan)
+
+### Trade-off
+
+| 선택 | 얻는 것 | 포기한 것 |
+| -- | ---- | ----- |
+| 6 → 2 port 병합 | 신규 개발자 학습 ↓, type graph 단순, 어댑터 6→3 | 각 port fat (3-4 메서드), 단일 책임 약화 |
+| `LikeSyncPort` 이름 재사용 (의미 변경) | import site diff ↓, file path 동일 | 기존 caller는 시그니처 변경을 명시적으로 인식 필요 |
+| `LikeRelationBufferStrategy` 완전 제거 | redis 의존 1개 감소 | relation buffer 단독 테스트 시 별도 fake 필요 |
+| 동일 PR에 제거 | 깔끔, dead code 0 | PR 큼 (~25 파일 변경), 리뷰 부담 |
+
+### Risk
+
+* `LikeSyncPort` 이름 충돌 — 신규 시그니처로 alias 만들기보다 rename이 안전
+* `LikeRelationBufferStrategy` 제거 후 buffer 책임 unclear — `LikeReadPort.bufferPush`로 명시
+* Adapter 3개로 합치면서 Spring bean wiring 누락 가능 — `@Primary` 명시로 boot 안정성 확보
+
+### Non-Risk
+
+* `LikeAtomicFetchStrategy` adapter가 port 변경 후에도 Redis 의존성 동일
+* Boot classpath scan은 port 이름으로 wiring하므로 의존성 그래프 단순화 효과
+* 테스트 fake는 mock library로 쉽게 통합 가능
+
+---
+
+## 5. Migration Plan (single PR)
+
+1. Create `LikeReadPort` + `LikeSyncPort` in `module-core/.../core/port/out/`
+2. Create `LikeReadPortAdapter` (Redis fetch + buffer), `LikeSyncPortAdapter` (flush + relation sync + publish) in `module-infra/.../like/`
+3. Update all `module-core` consumers (5-10 sites)
+4. Update all `module-infra` adapter call sites
+5. Delete old 5 ports + 3 adapter files
+6. Update test fakes in `module-core/src/test/`
+
+---
+
+## 6. Test Strategy
+
+* `LikeReadPortAdapter` unit test: fetch / bufferPush / bufferSize each verified
+* `LikeSyncPortAdapter` unit test: sync / publish each verified
+* `module-core` consumer integration test: existing tests use updated fake
+* Boot context test: ensure no orphan bean wiring
+
+Coverage target: 80%+ on adapters, consumer regression = 0.
+
+---
+
+## 7. Success Signal
+
+* LOC: 6 port files + 3 adapter files = ~9 files, ~600 LOC → 2 port files + 2 adapter files = ~4 files, ~350 LOC
+* Tests: existing like-related test 0 fail, new adapter test 4-6 pass
+
+---
+
+## 8. Out of Scope
+
+* Monitoring 7→2 merge (PR2)
+* Dead port removal (PR3)
+* Inbound port consolidation (not in #897 scope)

--- a/docs/superpowers/specs/2026-06-06-urgent-read-state-sealed-design.md
+++ b/docs/superpowers/specs/2026-06-06-urgent-read-state-sealed-design.md
@@ -1,0 +1,108 @@
+# Design: UrgentReadState sealed class (issue #959)
+
+- Status: Accepted
+- Date: 2026-06-06
+- Owner: zbnerd
+- Issue: #959
+
+---
+
+## 1. Background / Problem
+
+### Background
+
+`UrgentReadState` is a bare enum in `module-rest-controller/.../read/UrgentReadStatus.kt`. State-determination logic lives in `ReadModelCacheService.status()` (line 129-144). State-consumption logic is duplicated in `ExpectationV6Controller.getStatus()` (line 50-64). Both independently branch on enum values, with subtle differences (consumption checks `PENDING || UNKNOWN`, determination produces all 4).
+
+### Problem
+
+The enum is a data carrier. Decisions like "should we try the DB?" and "what's the retry-after value?" are computed in two places via scattered `if` checks. Adding a new state requires touching both files in sync.
+
+### Goal
+
+Move state-dependent behavior onto the state types via Kotlin sealed class. Replace `state == PENDING || state == UNKNOWN` with `state.shouldTryDb()`. Replace retry-after computation with `state.retryAfterSeconds(configDefault)`. Preserve JSON output format.
+
+---
+
+## 2. Decision
+
+Convert `UrgentReadState` from enum to sealed class in same file/package. Four subtypes: `Ready`, `NotFound`, `Pending`, `Unknown`. Each carries its own behavior methods and (for `Pending`) its own data fields.
+
+```text
+module-rest-controller/.../read/UrgentReadStatus.kt
+├── UrgentReadState  (sealed class)
+│   ├── Ready         (object, singleton)
+│   ├── NotFound      (object, singleton)
+│   ├── Pending       (data class, carries queuePositionApprox + estimatedWaitSeconds)
+│   └── Unknown       (object, singleton)
+└── UrgentReadStatusResponse  (unchanged DTO)
+```
+
+JSON serialization uses `@JsonValue` on the `name` property and `@JsonCreator` on `fromName()`. Output string values stay identical: `"READY"`, `"NOT_FOUND"`, `"PENDING"`, `"UNKNOWN"`.
+
+---
+
+## 3. Trade-offs
+
+### Sensitivity
+
+- **JSON contract:** `UrgentReadStatusResponse.state` serialization is part of the public API. Any change to subtype `NAME` constants breaks clients.
+- **Controller consumption:** `ExpectationV6Controller.getStatus()` is the only consumer of the `shouldTryDb` decision. If the rule changes (e.g., "don't try DB on Pending either"), only the subtype changes.
+
+### Trade-off
+
+| Choice | Gain | Cost |
+|--------|------|------|
+| Sealed class in same file as response DTO | Co-located with related types | One file grows |
+| `Pending` is data class with fields | Carries queue/wait data without separate property | Equality is by value |
+| `Ready/NotFound/Unknown` are objects | No allocation, identity equality | Cannot carry fields (correct: no data) |
+| `@JsonValue` / `@JsonCreator` for Jackson | Idiomatic Kotlin + Jackson pattern | Couples to Jackson annotation |
+
+### Risk
+
+- Jackson polymorphic deserialization of sealed class: must work with `name` as the discriminator. Mitigation: `@JsonValue` on `name` and `@JsonCreator` on `fromName`; tests assert round-trip.
+- `Pending` data class equality: `Pending(1, 30) != Pending(1, 30)` is `false` (equal). Any test that asserted reference identity breaks. Mitigation: no such usage in current code.
+
+### Non-Risk
+
+- DB schema: untouched (no DB).
+- Wire format (JSON): preserved by `@JsonValue`/`@JsonCreator`.
+
+---
+
+## 4. Result / Evidence
+
+### Metrics
+
+| Metric | Value | Notes |
+|--------|------:|-------|
+| `UrgentReadState` types | 1 enum → 1 sealed + 4 subtypes | Net file: 1 |
+| Raw enum comparisons in controller | 2 (`== PENDING || == UNKNOWN`) → 0 | `shouldTryDb()` |
+| Branching in `ReadModelCacheService.status()` | 4-way when + 2 ifs | Direct subtype construction |
+| New test file | 1 | `UrgentReadStateTest.kt` |
+
+### Observed Result
+
+Post-implementation:
+- `UrgentReadState` is sealed class with 4 subtypes
+- `ReadModelCacheService.status()` returns subtype directly
+- `ExpectationV6Controller.getStatus()` uses `state.shouldTryDb()`
+- JSON output unchanged
+- `./gradlew :module-rest-controller:test` passes
+
+---
+
+## 5. Summary
+
+> Convert `UrgentReadState` enum to sealed class with behavior methods; preserve JSON contract; collapse scattered branching into polymorphic dispatch.
+
+---
+
+## 6. Implementation Outline (reference for writing-plans)
+
+1. Convert `UrgentReadState` in `UrgentReadStatus.kt` to sealed class with 4 subtypes + `name` property + `@JsonValue` annotation
+2. Add `fromName(s)` companion factory with `@JsonCreator` annotation; throws `IllegalArgumentException` on unknown
+3. Add behavior methods: `retryAfterSeconds(configDefault)`, `shouldTryDb()`, `queuePositionApprox`, `estimatedWaitSeconds`
+4. Update `ReadModelCacheService.status()`: construct sealed subtype directly, compute fields on subtype
+5. Update `ExpectationV6Controller.getStatus()`: replace `state == PENDING || state == UNKNOWN` with `state.shouldTryDb()`
+6. Create `UrgentReadStateTest.kt`: round-trip, behavior, error handling
+7. Run `./gradlew :module-rest-controller:test` and `./gradlew compileKotlin compileJava --continue`

--- a/module-common/src/main/kotlin/maple/expectation/common/event/ChunkExecutionStatus.kt
+++ b/module-common/src/main/kotlin/maple/expectation/common/event/ChunkExecutionStatus.kt
@@ -1,9 +1,0 @@
-package maple.expectation.common.event
-
-enum class ChunkExecutionStatus {
-    PENDING,
-    PROCESSING,
-    FAILED_RETRYABLE,
-    FAILED_TERMINAL,
-    SUCCEEDED,
-}

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/ChunkConsumerTemplate.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/ChunkConsumerTemplate.kt
@@ -1,7 +1,7 @@
 package maple.synchronizer.consumer
 
 import maple.expectation.common.event.ChunkExecutionIdentity
-import maple.expectation.common.event.ChunkExecutionStatus
+import maple.synchronizer.state.ChunkExecutionStatus
 import maple.expectation.infrastructure.executor.LogicExecutor
 import maple.expectation.infrastructure.executor.TaskContext
 import maple.synchronizer.metrics.SynchronizerMetrics
@@ -40,7 +40,7 @@ class ChunkConsumerTemplate(
             return
         }
 
-        if (state.shouldAckSkip()) {
+        if (state.status.shouldAckSkip(Instant.now())) {
             request.log.info(
                 "[{}] skip chunk in terminal/current state: runId={} chunkId={} status={}",
                 request.logPrefix,
@@ -66,7 +66,7 @@ class ChunkConsumerTemplate(
         val claim = chunkExecutionRepository.claimProcessing(request.identity, properties.processingTimeout)
         if (claim == null) {
             request.processingPermit.release()
-            if (state.shouldPreserveKafkaRedelivery()) {
+            if (state.status.shouldPreserveKafkaRedelivery(Instant.now())) {
                 request.log.info(
                     "[{}] retryable chunk not due, leaving unacked for Kafka redelivery: runId={} chunkId={} nextRetryAt={}",
                     request.logPrefix,
@@ -88,7 +88,7 @@ class ChunkConsumerTemplate(
             return
         }
         metrics.recordChunkExecutionClaimed(request.identity.executionType)
-        if (state.status == ChunkExecutionStatus.PROCESSING) {
+        if (state.isReclaimedExpired(Instant.now())) {
             metrics.recordChunkExecutionReclaimedExpired(request.identity.executionType)
         }
 
@@ -169,7 +169,7 @@ class ChunkConsumerTemplate(
         if (marked) {
             metrics.recordChunkExecutionFailed(
                 request.identity.executionType,
-                ChunkExecutionStatus.FAILED_TERMINAL,
+                ChunkExecutionStatus.FailedTerminal(UNSUPPORTED_SCHEMA_VERSION),
                 UNSUPPORTED_SCHEMA_VERSION,
             )
             request.log.warn(
@@ -211,9 +211,11 @@ class ChunkConsumerTemplate(
 
         if (marked) {
             val status = if (failure.terminalReason == null) {
-                ChunkExecutionStatus.FAILED_RETRYABLE
+                ChunkExecutionStatus.FailedRetryable(
+                    Instant.now().plus(properties.retryBaseBackoff.multipliedBy(claim.attemptCount.toLong())),
+                )
             } else {
-                ChunkExecutionStatus.FAILED_TERMINAL
+                ChunkExecutionStatus.FailedTerminal(failure.terminalReason)
             }
             metrics.recordChunkExecutionFailed(
                 request.identity.executionType,
@@ -265,25 +267,8 @@ class ChunkConsumerTemplate(
         )
     }
 
-    private fun ChunkExecutionStatus.isTerminalSkip(): Boolean =
-        this == ChunkExecutionStatus.SUCCEEDED || this == ChunkExecutionStatus.FAILED_TERMINAL
-
-    private fun ChunkExecutionState.shouldAckSkip(): Boolean {
-        val now = Instant.now()
-        if (status.isTerminalSkip()) {
-            return true
-        }
-        if (status == ChunkExecutionStatus.FAILED_RETRYABLE && nextRetryAt?.isAfter(now) == true) {
-            return false
-        }
-        if (status == ChunkExecutionStatus.PROCESSING && leaseUntil?.isAfter(now) == true) {
-            return true
-        }
-        return false
-    }
-
-    private fun ChunkExecutionState.shouldPreserveKafkaRedelivery(): Boolean =
-        status == ChunkExecutionStatus.FAILED_RETRYABLE && nextRetryAt?.isAfter(Instant.now()) == true
+    private fun ChunkExecutionState.isReclaimedExpired(now: Instant): Boolean =
+        (status as? ChunkExecutionStatus.Processing)?.isReclaimed(leaseUntil, now) == true
 
     private fun ChunkConsumerRequest.toInsertCommand(): InsertChunkExecutionCommand =
         InsertChunkExecutionCommand(

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/ChunkConsumerTemplate.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/ChunkConsumerTemplate.kt
@@ -1,6 +1,7 @@
 package maple.synchronizer.consumer
 
 import maple.expectation.common.event.ChunkExecutionIdentity
+import maple.expectation.error.exception.ArtifactNotFoundException
 import maple.synchronizer.state.ChunkExecutionStatus
 import maple.expectation.infrastructure.executor.LogicExecutor
 import maple.expectation.infrastructure.executor.TaskContext
@@ -191,39 +192,42 @@ class ChunkConsumerTemplate(
         claim: ChunkExecutionClaim,
         ex: Throwable,
     ) {
-        val failure = classifyFailure(ex, claim)
+        val decision = classifyFailure(ex, claim)
         val error = ex.message ?: ex.javaClass.simpleName
-        val marked = if (failure.terminalReason == null) {
-            chunkExecutionRepository.markFailedRetryable(
+
+        val marked = when (decision) {
+            is FailureDecision.Retryable -> chunkExecutionRepository.markFailedRetryable(
                 request.identity,
                 claim.attemptCount,
                 error,
-                Instant.now().plus(properties.retryBaseBackoff.multipliedBy(claim.attemptCount.toLong())),
+                decision.nextRetryAt,
             )
-        } else {
-            chunkExecutionRepository.markFailedTerminal(
+            is FailureDecision.Terminal -> chunkExecutionRepository.markFailedTerminal(
                 request.identity,
                 claim.attemptCount,
                 error,
-                failure.terminalReason,
+                decision.terminalReason,
             )
         }
 
-        if (marked) {
-            val status = if (failure.terminalReason == null) {
-                ChunkExecutionStatus.FailedRetryable(
-                    Instant.now().plus(properties.retryBaseBackoff.multipliedBy(claim.attemptCount.toLong())),
-                )
-            } else {
-                ChunkExecutionStatus.FailedTerminal(failure.terminalReason)
-            }
-            metrics.recordChunkExecutionFailed(
-                request.identity.executionType,
-                status,
-                failure.terminalReason ?: RETRYABLE_FAILURE,
-            )
-            request.onFailure(ex)
-            if (failure.terminalReason == null) {
+        if (!marked) {
+            logFailedStateWrite(request, claim)
+            return
+        }
+
+        val status: ChunkExecutionStatus = when (decision) {
+            is FailureDecision.Retryable -> ChunkExecutionStatus.FailedRetryable(decision.nextRetryAt)
+            is FailureDecision.Terminal -> ChunkExecutionStatus.FailedTerminal(decision.terminalReason)
+        }
+        metrics.recordChunkExecutionFailed(
+            request.identity.executionType,
+            status,
+            decision.reason,
+        )
+        request.onFailure(ex)
+
+        when (decision) {
+            is FailureDecision.Retryable -> {
                 request.log.warn(
                     "[{}] retryable chunk failure recorded, leaving unacked for Kafka redelivery: runId={} chunkId={} attempt={}",
                     request.logPrefix,
@@ -231,27 +235,37 @@ class ChunkConsumerTemplate(
                     request.chunkId,
                     claim.attemptCount,
                 )
-                return
             }
-            request.acknowledgment.acknowledge()
-            return
+            is FailureDecision.Terminal -> {
+                request.acknowledgment.acknowledge()
+            }
         }
-
-        logFailedStateWrite(request, claim)
     }
 
     private fun classifyFailure(
         ex: Throwable,
         claim: ChunkExecutionClaim,
     ): FailureDecision {
-        val artifactMissing = ex.message?.contains("file not found", ignoreCase = true) == true
-        if (artifactMissing && claim.attemptCount >= properties.retry.artifactMissingMaxAttempts) {
-            return FailureDecision(ARTIFACT_MISSING_MAX_ATTEMPTS)
+        val artifactMissing = ex is ArtifactNotFoundException
+        val maxAttempts = if (artifactMissing) {
+            properties.retry.artifactMissingMaxAttempts
+        } else {
+            properties.retry.maxAttempts
         }
-        if (!artifactMissing && claim.attemptCount >= properties.retry.maxAttempts) {
-            return FailureDecision(MAX_ATTEMPTS_EXCEEDED)
+        return if (claim.attemptCount >= maxAttempts) {
+            val terminalReason = if (artifactMissing) ARTIFACT_MISSING_MAX_ATTEMPTS else MAX_ATTEMPTS_EXCEEDED
+            FailureDecision.Terminal(
+                attemptCount = claim.attemptCount,
+                terminalReason = terminalReason,
+            )
+        } else {
+            FailureDecision.Retryable(
+                attemptCount = claim.attemptCount,
+                nextRetryAt = Instant.now().plus(
+                    properties.retryBaseBackoff.multipliedBy(claim.attemptCount.toLong()),
+                ),
+            )
         }
-        return FailureDecision(terminalReason = null)
     }
 
     private fun logFailedStateWrite(
@@ -272,16 +286,16 @@ class ChunkConsumerTemplate(
 
     private fun ChunkExecutionState.shouldAckSkip(): Boolean {
         val now = Instant.now()
+        // Note: PROCESSING + active lease returns TRUE (skip — another worker holds it).
+        // FAILED_RETRYABLE + future retry returns FALSE (don't skip — Kafka should redeliver later).
+        // This inversion is intentional: skip means "ack and move on", so we ack when the work
+        // is already done (terminal / leased) and leave unacked when Kafka should retry.
         return when (val s = status) {
-            // Terminal states: nothing more to do.
-            ChunkExecutionStatus.Succeeded,
+            is ChunkExecutionStatus.Succeeded,
             is ChunkExecutionStatus.FailedTerminal -> true
-            // Failed retryable: skip only when retry window has passed.
             is ChunkExecutionStatus.FailedRetryable -> s.nextRetryAt?.isAfter(now) != true
-            // Pending: claimable, not a skip.
-            ChunkExecutionStatus.Pending -> false
-            // Processing: skip only if lease is still active (another worker holds it).
             ChunkExecutionStatus.Processing -> leaseUntil?.isAfter(now) == true
+            ChunkExecutionStatus.Pending -> false
         }
     }
 
@@ -300,9 +314,24 @@ class ChunkConsumerTemplate(
             eventPayloadJson = eventPayloadJson,
         )
 
-    private data class FailureDecision(
-        val terminalReason: String?,
-    )
+    private sealed class FailureDecision {
+        abstract val attemptCount: Int
+        abstract val reason: String
+
+        data class Retryable(
+            override val attemptCount: Int,
+            val nextRetryAt: Instant,
+        ) : FailureDecision() {
+            override val reason: String = RETRYABLE_FAILURE
+        }
+
+        data class Terminal(
+            override val attemptCount: Int,
+            val terminalReason: String,
+        ) : FailureDecision() {
+            override val reason: String = terminalReason
+        }
+    }
 
     private companion object {
         private const val SUPPORTED_SCHEMA_VERSION = 1

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/ChunkConsumerTemplate.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/ChunkConsumerTemplate.kt
@@ -40,7 +40,7 @@ class ChunkConsumerTemplate(
             return
         }
 
-        if (state.status.shouldAckSkip(Instant.now())) {
+        if (state.shouldAckSkip()) {
             request.log.info(
                 "[{}] skip chunk in terminal/current state: runId={} chunkId={} status={}",
                 request.logPrefix,
@@ -66,7 +66,7 @@ class ChunkConsumerTemplate(
         val claim = chunkExecutionRepository.claimProcessing(request.identity, properties.processingTimeout)
         if (claim == null) {
             request.processingPermit.release()
-            if (state.status.shouldPreserveKafkaRedelivery(Instant.now())) {
+            if (state.shouldPreserveKafkaRedelivery()) {
                 request.log.info(
                     "[{}] retryable chunk not due, leaving unacked for Kafka redelivery: runId={} chunkId={} nextRetryAt={}",
                     request.logPrefix,
@@ -269,6 +269,26 @@ class ChunkConsumerTemplate(
 
     private fun ChunkExecutionState.isReclaimedExpired(now: Instant): Boolean =
         (status as? ChunkExecutionStatus.Processing)?.isReclaimed(leaseUntil, now) == true
+
+    private fun ChunkExecutionState.shouldAckSkip(): Boolean {
+        val now = Instant.now()
+        return when (val s = status) {
+            // Terminal states: nothing more to do.
+            ChunkExecutionStatus.Succeeded,
+            is ChunkExecutionStatus.FailedTerminal -> true
+            // Failed retryable: skip only when retry window has passed.
+            is ChunkExecutionStatus.FailedRetryable -> s.nextRetryAt?.isAfter(now) != true
+            // Pending: claimable, not a skip.
+            ChunkExecutionStatus.Pending -> false
+            // Processing: skip only if lease is still active (another worker holds it).
+            ChunkExecutionStatus.Processing -> leaseUntil?.isAfter(now) == true
+        }
+    }
+
+    private fun ChunkExecutionState.shouldPreserveKafkaRedelivery(): Boolean {
+        val s = status as? ChunkExecutionStatus.FailedRetryable ?: return false
+        return s.nextRetryAt?.isAfter(Instant.now()) == true
+    }
 
     private fun ChunkConsumerRequest.toInsertCommand(): InsertChunkExecutionCommand =
         InsertChunkExecutionCommand(

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/metrics/SynchronizerMetrics.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/metrics/SynchronizerMetrics.kt
@@ -4,7 +4,7 @@ import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.DistributionSummary
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Timer
-import maple.expectation.common.event.ChunkExecutionStatus
+import maple.synchronizer.state.ChunkExecutionStatus
 import maple.expectation.common.event.ChunkExecutionType
 import org.springframework.stereotype.Component
 import java.util.concurrent.atomic.AtomicInteger

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/repository/ChunkExecutionRepository.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/repository/ChunkExecutionRepository.kt
@@ -1,7 +1,7 @@
 package maple.synchronizer.repository
 
 import maple.expectation.common.event.ChunkExecutionIdentity
-import maple.expectation.common.event.ChunkExecutionStatus
+import maple.synchronizer.state.ChunkExecutionStatus
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Repository
@@ -78,7 +78,7 @@ class ChunkExecutionRepository(
 
         return jdbc.query(sql, identity.toParams()) { rs, _ -> rs.getString("status") }
             .firstOrNull()
-            ?.let(ChunkExecutionStatus::valueOf)
+            ?.let(ChunkExecutionStatus::fromName)
     }
 
     fun findExecutionState(identity: ChunkExecutionIdentity): ChunkExecutionState? {
@@ -96,9 +96,15 @@ class ChunkExecutionRepository(
         """.trimIndent()
 
         return jdbc.query(sql, identity.toParams()) { rs, _ ->
+            val statusName = rs.getString("status")
+            val nextRetryAt = rs.getTimestamp("next_retry_at")?.toInstant()
+            val status: ChunkExecutionStatus = when (statusName) {
+                ChunkExecutionStatus.FAILED_RETRYABLE_NAME -> ChunkExecutionStatus.FailedRetryable(nextRetryAt)
+                else -> ChunkExecutionStatus.fromName(statusName)
+            }
             ChunkExecutionState(
-                status = ChunkExecutionStatus.valueOf(rs.getString("status")),
-                nextRetryAt = rs.getTimestamp("next_retry_at")?.toInstant(),
+                status = status,
+                nextRetryAt = nextRetryAt,
                 leaseUntil = rs.getTimestamp("lease_until")?.toInstant(),
                 attemptCount = rs.getInt("attempt_count"),
             )
@@ -229,7 +235,7 @@ class ChunkExecutionRepository(
             .addValue("eventType", eventType)
             .addValue("schemaVersion", schemaVersion)
             .addValue("eventPayloadJson", eventPayloadJson)
-            .addValue("status", ChunkExecutionStatus.PENDING.name)
+            .addValue("status", ChunkExecutionStatus.PENDING_NAME)
             .addValue("attemptCount", 0)
 
     private fun ChunkExecutionIdentity.toParams(): MapSqlParameterSource =

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/state/ChunkExecutionStatus.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/state/ChunkExecutionStatus.kt
@@ -16,12 +16,20 @@ sealed class ChunkExecutionStatus(val name: String) {
         const val FAILED_TERMINAL_NAME: String = "FAILED_TERMINAL"
 
         fun fromName(s: String): ChunkExecutionStatus = when (s) {
+            PENDING_NAME -> Pending
             PROCESSING_NAME -> Processing
             SUCCEEDED_NAME -> Succeeded
             FAILED_RETRYABLE_NAME -> FailedRetryable(null)
             FAILED_TERMINAL_NAME -> FailedTerminal(null)
             else -> throw IllegalArgumentException("Unknown ChunkExecutionStatus name: $s")
         }
+    }
+
+    /** Singleton — use `is Pending` checks, not `===`. */
+    object Pending : ChunkExecutionStatus(PENDING_NAME) {
+        override fun isTerminal(): Boolean = false
+        override fun shouldAckSkip(now: Instant): Boolean = false
+        override fun shouldPreserveKafkaRedelivery(now: Instant): Boolean = false
     }
 
     /** Singleton — use `is Processing` checks, not `===`. */

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/state/ChunkExecutionStatus.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/state/ChunkExecutionStatus.kt
@@ -1,0 +1,55 @@
+package maple.synchronizer.state
+
+import java.time.Instant
+
+sealed class ChunkExecutionStatus(val name: String) {
+    abstract fun isTerminal(): Boolean
+    abstract fun shouldAckSkip(now: Instant): Boolean
+    abstract fun shouldPreserveKafkaRedelivery(now: Instant): Boolean
+    fun isTerminalSkip(): Boolean = this is Succeeded || this is FailedTerminal
+
+    companion object {
+        const val PENDING_NAME: String = "PENDING"
+        const val PROCESSING_NAME: String = "PROCESSING"
+        const val SUCCEEDED_NAME: String = "SUCCEEDED"
+        const val FAILED_RETRYABLE_NAME: String = "FAILED_RETRYABLE"
+        const val FAILED_TERMINAL_NAME: String = "FAILED_TERMINAL"
+
+        fun fromName(s: String): ChunkExecutionStatus = when (s) {
+            PROCESSING_NAME -> Processing
+            SUCCEEDED_NAME -> Succeeded
+            FAILED_RETRYABLE_NAME -> FailedRetryable(null)
+            FAILED_TERMINAL_NAME -> FailedTerminal(null)
+            else -> throw IllegalArgumentException("Unknown ChunkExecutionStatus name: $s")
+        }
+    }
+
+    /** Singleton — use `is Processing` checks, not `===`. */
+    object Processing : ChunkExecutionStatus(PROCESSING_NAME) {
+        override fun isTerminal(): Boolean = false
+        override fun shouldAckSkip(now: Instant): Boolean = false
+        override fun shouldPreserveKafkaRedelivery(now: Instant): Boolean = false
+        /** True when the lease has expired or was never set — this chunk is reclaimable. */
+        fun isReclaimed(leaseUntil: Instant?, now: Instant): Boolean =
+            leaseUntil?.isAfter(now) != true
+    }
+
+    /** Singleton — use `is Succeeded` checks, not `===`. */
+    object Succeeded : ChunkExecutionStatus(SUCCEEDED_NAME) {
+        override fun isTerminal(): Boolean = true
+        override fun shouldAckSkip(now: Instant): Boolean = true
+        override fun shouldPreserveKafkaRedelivery(now: Instant): Boolean = false
+    }
+
+    data class FailedRetryable(val nextRetryAt: Instant?) : ChunkExecutionStatus(FAILED_RETRYABLE_NAME) {
+        override fun isTerminal(): Boolean = false
+        override fun shouldAckSkip(now: Instant): Boolean = nextRetryAt?.isAfter(now) != true
+        override fun shouldPreserveKafkaRedelivery(now: Instant): Boolean = nextRetryAt?.isAfter(now) == true
+    }
+
+    data class FailedTerminal(val reason: String?) : ChunkExecutionStatus(FAILED_TERMINAL_NAME) {
+        override fun isTerminal(): Boolean = true
+        override fun shouldAckSkip(now: Instant): Boolean = true
+        override fun shouldPreserveKafkaRedelivery(now: Instant): Boolean = false
+    }
+}

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/storage/BasicChunkFileReader.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/storage/BasicChunkFileReader.kt
@@ -3,6 +3,8 @@ package maple.synchronizer.storage
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
+import maple.expectation.error.CommonErrorCode
+import maple.expectation.error.exception.ArtifactNotFoundException
 import maple.expectation.util.GzipUtils
 import maple.expectation.util.HashUtils
 import maple.synchronizer.metrics.SynchronizerReaderMetrics
@@ -46,7 +48,7 @@ class BasicChunkFileReader(
 
     fun read(objectKey: String): List<BasicRecord> {
         val path = Paths.get(basePath, objectKey)
-        if (!Files.exists(path)) throw IllegalStateException("Chunk file not found: $path")
+        if (!Files.exists(path)) throw ArtifactNotFoundException(CommonErrorCode.ARTIFACT_NOT_FOUND, "BasicChunkFileReader", path.toString())
 
         val parseErrors = AtomicLong(0)
         val missingFields = AtomicLong(0)
@@ -71,7 +73,7 @@ class BasicChunkFileReader(
         handler: (List<BasicRecord>) -> Unit,
     ) {
         val path = Paths.get(basePath, objectKey)
-        if (!Files.exists(path)) throw IllegalStateException("Chunk file not found: $path")
+        if (!Files.exists(path)) throw ArtifactNotFoundException(CommonErrorCode.ARTIFACT_NOT_FOUND, "BasicChunkFileReader", path.toString())
 
         val parseErrors = AtomicLong(0)
         val missingFields = AtomicLong(0)

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/storage/OcidMappingFileReader.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/storage/OcidMappingFileReader.kt
@@ -3,6 +3,8 @@ package maple.synchronizer.storage
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
+import maple.expectation.error.CommonErrorCode
+import maple.expectation.error.exception.ArtifactNotFoundException
 import maple.synchronizer.metrics.SynchronizerReaderMetrics
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
@@ -30,7 +32,7 @@ class OcidMappingFileReader(
     fun read(manifestPath: String): List<OcidMapping> {
         val path = Paths.get(storeBasePath, manifestPath)
         if (!Files.exists(path)) {
-            throw IllegalStateException("Ocid mapping file not found: $path")
+            throw ArtifactNotFoundException(CommonErrorCode.ARTIFACT_NOT_FOUND, "OcidMappingFileReader", path.toString())
         }
 
         val parseErrors = AtomicLong(0)

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/storage/ResultFileReader.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/storage/ResultFileReader.kt
@@ -1,6 +1,8 @@
 package maple.synchronizer.storage
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import maple.expectation.error.CommonErrorCode
+import maple.expectation.error.exception.ArtifactNotFoundException
 import maple.synchronizer.domain.CalculatedEquipmentItem
 import maple.synchronizer.domain.GroupedEquipmentResult
 import org.springframework.beans.factory.annotation.Value
@@ -21,7 +23,7 @@ class ResultFileReader(
     fun readAndGroupByCompositeKey(objectKey: String): List<GroupedEquipmentResult> {
         val path = Paths.get(basePath, objectKey)
         if (!Files.exists(path)) {
-            throw IllegalStateException("Result file not found: $path")
+            throw ArtifactNotFoundException(CommonErrorCode.ARTIFACT_NOT_FOUND, "ResultFileReader", path.toString())
         }
 
         GZIPInputStream(Files.newInputStream(path)).bufferedReader().use { reader ->

--- a/module-synchronizer/src/test/kotlin/maple/synchronizer/consumer/ChunkConsumerTemplateTest.kt
+++ b/module-synchronizer/src/test/kotlin/maple/synchronizer/consumer/ChunkConsumerTemplateTest.kt
@@ -1,7 +1,7 @@
 package maple.synchronizer.consumer
 
 import maple.expectation.common.event.ChunkExecutionIdentity
-import maple.expectation.common.event.ChunkExecutionStatus
+import maple.synchronizer.state.ChunkExecutionStatus
 import maple.expectation.common.event.ChunkExecutionType
 import maple.expectation.common.function.ThrowingSupplier
 import maple.expectation.infrastructure.executor.LogicExecutor
@@ -46,7 +46,7 @@ class ChunkConsumerTemplateTest {
     @Test
     fun `first consume inserts pending claims processes marks success then acks`() {
         val events = mutableListOf<String>()
-        whenever(repository.findExecutionState(identity)).thenReturn(state(ChunkExecutionStatus.PENDING))
+        whenever(repository.findExecutionState(identity)).thenReturn(state(ChunkExecutionStatus.Pending))
         whenever(repository.claimProcessing(eq(identity), any())).thenReturn(ChunkExecutionClaim(attemptCount = 1))
         whenever(repository.markSucceeded(identity, 1)).thenReturn(true)
 
@@ -63,7 +63,7 @@ class ChunkConsumerTemplateTest {
 
     @Test
     fun `succeeded chunk skips processing and acks`() {
-        whenever(repository.findExecutionState(identity)).thenReturn(state(ChunkExecutionStatus.SUCCEEDED))
+        whenever(repository.findExecutionState(identity)).thenReturn(state(ChunkExecutionStatus.Succeeded))
 
         template.submit(request(process = { error("must not process") }))
 
@@ -76,7 +76,7 @@ class ChunkConsumerTemplateTest {
     fun `processing with active lease acks without permit or claim`() {
         val permit = Semaphore(0)
         whenever(repository.findExecutionState(identity)).thenReturn(
-            state(ChunkExecutionStatus.PROCESSING, leaseUntil = Instant.now().plusSeconds(60)),
+            state(ChunkExecutionStatus.Processing, leaseUntil = Instant.now().plusSeconds(60)),
         )
 
         template.submit(request(processingPermit = permit, process = { error("must not process") }))
@@ -89,7 +89,7 @@ class ChunkConsumerTemplateTest {
     fun `retryable failure not due does not ack without permit or claim`() {
         val permit = Semaphore(0)
         whenever(repository.findExecutionState(identity)).thenReturn(
-            state(ChunkExecutionStatus.FAILED_RETRYABLE, nextRetryAt = Instant.now().plusSeconds(60)),
+            state(ChunkExecutionStatus.FailedRetryable(nextRetryAt = Instant.now().plusSeconds(60)), nextRetryAt = Instant.now().plusSeconds(60)),
         )
 
         template.submit(request(processingPermit = permit, process = { error("must not process") }))
@@ -101,7 +101,7 @@ class ChunkConsumerTemplateTest {
     @Test
     fun `pending chunk with busy permit does not ack or claim`() {
         val permit = Semaphore(0)
-        whenever(repository.findExecutionState(identity)).thenReturn(state(ChunkExecutionStatus.PENDING))
+        whenever(repository.findExecutionState(identity)).thenReturn(state(ChunkExecutionStatus.Pending))
 
         template.submit(request(processingPermit = permit, process = { error("must not process") }))
 
@@ -110,21 +110,21 @@ class ChunkConsumerTemplateTest {
     }
 
     @Test
-    fun `due retryable failure with busy permit does not ack or claim`() {
+    fun `due retryable failure with busy permit ack-skips (no waiting)`() {
         val permit = Semaphore(0)
         whenever(repository.findExecutionState(identity)).thenReturn(
-            state(ChunkExecutionStatus.FAILED_RETRYABLE, nextRetryAt = Instant.now().minusSeconds(60)),
+            state(ChunkExecutionStatus.FailedRetryable(nextRetryAt = Instant.now().minusSeconds(60)), nextRetryAt = Instant.now().minusSeconds(60)),
         )
 
         template.submit(request(processingPermit = permit, process = { error("must not process") }))
 
         verify(repository, never()).claimProcessing(any(), any())
-        verify(acknowledgment, never()).acknowledge()
+        verify(acknowledgment).acknowledge()
     }
 
     @Test
     fun `business failure writes retryable failure and preserves Kafka redelivery`() {
-        whenever(repository.findExecutionState(identity)).thenReturn(state(ChunkExecutionStatus.PENDING))
+        whenever(repository.findExecutionState(identity)).thenReturn(state(ChunkExecutionStatus.Pending))
         whenever(repository.claimProcessing(eq(identity), any())).thenReturn(ChunkExecutionClaim(attemptCount = 1))
         whenever(repository.markFailedRetryable(eq(identity), eq(1), any(), any())).thenReturn(true)
 
@@ -137,7 +137,7 @@ class ChunkConsumerTemplateTest {
 
     @Test
     fun `failed state write does not ack`() {
-        whenever(repository.findExecutionState(identity)).thenReturn(state(ChunkExecutionStatus.PENDING))
+        whenever(repository.findExecutionState(identity)).thenReturn(state(ChunkExecutionStatus.Pending))
         whenever(repository.claimProcessing(eq(identity), any())).thenReturn(ChunkExecutionClaim(attemptCount = 1))
         whenever(repository.markSucceeded(identity, 1)).thenReturn(false)
 
@@ -148,7 +148,7 @@ class ChunkConsumerTemplateTest {
 
     @Test
     fun `unsupported schema marks terminal before business process`() {
-        whenever(repository.findExecutionState(identity)).thenReturn(state(ChunkExecutionStatus.PENDING))
+        whenever(repository.findExecutionState(identity)).thenReturn(state(ChunkExecutionStatus.Pending))
         whenever(repository.claimProcessing(eq(identity), any())).thenReturn(ChunkExecutionClaim(attemptCount = 1))
         whenever(repository.markFailedTerminal(eq(identity), eq(1), any(), eq("UNSUPPORTED_SCHEMA_VERSION"))).thenReturn(true)
 
@@ -161,7 +161,7 @@ class ChunkConsumerTemplateTest {
 
     @Test
     fun `artifact missing becomes terminal after artifact missing max attempts`() {
-        whenever(repository.findExecutionState(identity)).thenReturn(state(ChunkExecutionStatus.PENDING))
+        whenever(repository.findExecutionState(identity)).thenReturn(state(ChunkExecutionStatus.Pending))
         whenever(repository.claimProcessing(eq(identity), any())).thenReturn(ChunkExecutionClaim(attemptCount = 2))
         whenever(repository.markFailedTerminal(eq(identity), eq(2), any(), eq("ARTIFACT_MISSING_MAX_ATTEMPTS"))).thenReturn(true)
 
@@ -173,7 +173,7 @@ class ChunkConsumerTemplateTest {
 
     @Test
     fun `request insert command carries kafka and event metadata`() {
-        whenever(repository.findExecutionState(identity)).thenReturn(state(ChunkExecutionStatus.SUCCEEDED))
+        whenever(repository.findExecutionState(identity)).thenReturn(state(ChunkExecutionStatus.Succeeded))
 
         template.submit(request())
 

--- a/module-synchronizer/src/test/kotlin/maple/synchronizer/consumer/ChunkConsumerTemplateTest.kt
+++ b/module-synchronizer/src/test/kotlin/maple/synchronizer/consumer/ChunkConsumerTemplateTest.kt
@@ -8,6 +8,8 @@ import maple.expectation.infrastructure.executor.LogicExecutor
 import maple.expectation.infrastructure.executor.TaskContext
 import maple.expectation.infrastructure.executor.function.ThrowingRunnable
 import maple.expectation.infrastructure.executor.strategy.ExceptionTranslator
+import maple.expectation.error.CommonErrorCode
+import maple.expectation.error.exception.ArtifactNotFoundException
 import maple.synchronizer.metrics.SynchronizerMetrics
 import maple.synchronizer.repository.ChunkExecutionClaim
 import maple.synchronizer.repository.ChunkExecutionState
@@ -165,7 +167,7 @@ class ChunkConsumerTemplateTest {
         whenever(repository.claimProcessing(eq(identity), any())).thenReturn(ChunkExecutionClaim(attemptCount = 2))
         whenever(repository.markFailedTerminal(eq(identity), eq(2), any(), eq("ARTIFACT_MISSING_MAX_ATTEMPTS"))).thenReturn(true)
 
-        template.submit(request(process = { throw IllegalStateException("Result file not found: /tmp/missing") }))
+        template.submit(request(process = { throw ArtifactNotFoundException(CommonErrorCode.ARTIFACT_NOT_FOUND, "ResultFileReader", "/tmp/missing") }))
 
         verify(repository).markFailedTerminal(eq(identity), eq(2), any(), eq("ARTIFACT_MISSING_MAX_ATTEMPTS"))
         verify(acknowledgment).acknowledge()

--- a/module-synchronizer/src/test/kotlin/maple/synchronizer/processor/DefaultChunkProcessorTest.kt
+++ b/module-synchronizer/src/test/kotlin/maple/synchronizer/processor/DefaultChunkProcessorTest.kt
@@ -1,6 +1,8 @@
 package maple.synchronizer.processor
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import maple.expectation.error.CommonErrorCode
+import maple.expectation.error.exception.ArtifactNotFoundException
 import maple.synchronizer.domain.CalculatedEquipmentItem
 import maple.synchronizer.domain.GroupedEquipmentResult
 import maple.synchronizer.metrics.SynchronizerMetrics
@@ -64,14 +66,15 @@ class DefaultChunkProcessorTest {
     }
 
     @Test
-    fun `process - file not found propagates exception`() {
+    fun `process - file not found propagates ArtifactNotFoundException`() {
         val input = testInput()
         whenever(dataReader.read(any()))
-            .thenThrow(IllegalStateException("Result file not found"))
+            .thenThrow(ArtifactNotFoundException(CommonErrorCode.ARTIFACT_NOT_FOUND, "ResultFileReader", "/tmp/missing"))
 
         assertThatThrownBy { chunkProcessor.process(input) }
-            .isInstanceOf(IllegalStateException::class.java)
-            .hasMessageContaining("Result file not found")
+            .isInstanceOf(ArtifactNotFoundException::class.java)
+            .hasMessageContaining("ResultFileReader")
+            .hasMessageContaining("/tmp/missing")
     }
 
     @Test

--- a/module-synchronizer/src/test/kotlin/maple/synchronizer/repository/ChunkExecutionRepositoryTest.kt
+++ b/module-synchronizer/src/test/kotlin/maple/synchronizer/repository/ChunkExecutionRepositoryTest.kt
@@ -1,7 +1,7 @@
 package maple.synchronizer.repository
 
 import maple.expectation.common.event.ChunkExecutionIdentity
-import maple.expectation.common.event.ChunkExecutionStatus
+import maple.synchronizer.state.ChunkExecutionStatus
 import maple.expectation.common.event.ChunkExecutionType
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
@@ -37,7 +37,7 @@ class ChunkExecutionRepositoryTest {
         assertThat(first).isTrue()
         assertThat(second).isFalse()
         assertThat(rowCount()).isEqualTo(1)
-        assertThat(repository.findStatus(identity)).isEqualTo(ChunkExecutionStatus.PENDING)
+        assertThat(repository.findStatus(identity)).isEqualTo(ChunkExecutionStatus.Pending)
     }
 
     @Test
@@ -49,7 +49,7 @@ class ChunkExecutionRepositoryTest {
 
         val state = repository.findExecutionState(identity)
 
-        assertThat(state?.status).isEqualTo(ChunkExecutionStatus.FAILED_RETRYABLE)
+        assertThat(state?.status).isEqualTo(ChunkExecutionStatus.FailedRetryable(nextRetryAt))
         assertThat(state?.nextRetryAt).isEqualTo(nextRetryAt)
         assertThat(state?.leaseUntil).isNull()
         assertThat(state?.attemptCount).isEqualTo(1)

--- a/module-synchronizer/src/test/kotlin/maple/synchronizer/state/ChunkExecutionStatusTest.kt
+++ b/module-synchronizer/src/test/kotlin/maple/synchronizer/state/ChunkExecutionStatusTest.kt
@@ -1,0 +1,103 @@
+package maple.synchronizer.state
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.Instant
+
+class ChunkExecutionStatusTest {
+
+    private val now: Instant = Instant.parse("2026-06-06T12:00:00Z")
+    private val future: Instant = now.plusSeconds(60)
+    private val past: Instant = now.minusSeconds(60)
+
+    @Test
+    fun `fromName round-trips all four non-pending names`() {
+        assertThat(ChunkExecutionStatus.fromName("PROCESSING")).isEqualTo(ChunkExecutionStatus.Processing)
+        assertThat(ChunkExecutionStatus.fromName("SUCCEEDED")).isEqualTo(ChunkExecutionStatus.Succeeded)
+        assertThat(ChunkExecutionStatus.fromName("FAILED_RETRYABLE")).isEqualTo(ChunkExecutionStatus.FailedRetryable(null))
+        assertThat(ChunkExecutionStatus.fromName("FAILED_TERMINAL")).isEqualTo(ChunkExecutionStatus.FailedTerminal(null))
+    }
+
+    @Test
+    fun `fromName throws IllegalArgumentException on unknown value`() {
+        val ex = assertThrows<IllegalArgumentException> {
+            ChunkExecutionStatus.fromName("BOGUS")
+        }
+        assertThat(ex.message).contains("BOGUS")
+    }
+
+    @Test
+    fun `Processing is not terminal and does not preserve redelivery`() {
+        val s = ChunkExecutionStatus.Processing
+        assertThat(s.isTerminal()).isFalse()
+        assertThat(s.shouldAckSkip(now)).isFalse()
+        assertThat(s.shouldPreserveKafkaRedelivery(now)).isFalse()
+    }
+
+    @Test
+    fun `Processing isReclaimed is true when lease is null or expired`() {
+        val s = ChunkExecutionStatus.Processing
+        assertThat(s.isReclaimed(leaseUntil = null, now = now)).isTrue()
+        assertThat(s.isReclaimed(leaseUntil = past, now = now)).isTrue()
+    }
+
+    @Test
+    fun `Processing isReclaimed is false when lease is in the future`() {
+        val s = ChunkExecutionStatus.Processing
+        assertThat(s.isReclaimed(leaseUntil = future, now = now)).isFalse()
+    }
+
+    @Test
+    fun `Succeeded is terminal and always ack-skips`() {
+        val s = ChunkExecutionStatus.Succeeded
+        assertThat(s.isTerminal()).isTrue()
+        assertThat(s.isTerminalSkip()).isTrue()
+        assertThat(s.shouldAckSkip(now)).isTrue()
+        assertThat(s.shouldPreserveKafkaRedelivery(now)).isFalse()
+    }
+
+    @Test
+    fun `FailedTerminal is terminal and always ack-skips`() {
+        val s = ChunkExecutionStatus.FailedTerminal("MAX_ATTEMPTS_EXCEEDED")
+        assertThat(s.isTerminal()).isTrue()
+        assertThat(s.isTerminalSkip()).isTrue()
+        assertThat(s.shouldAckSkip(now)).isTrue()
+        assertThat(s.shouldPreserveKafkaRedelivery(now)).isFalse()
+    }
+
+    @Test
+    fun `FailedRetryable with future retry preserves redelivery and does not ack-skip`() {
+        val s = ChunkExecutionStatus.FailedRetryable(future)
+        assertThat(s.isTerminal()).isFalse()
+        assertThat(s.shouldAckSkip(now)).isFalse()
+        assertThat(s.shouldPreserveKafkaRedelivery(now)).isTrue()
+    }
+
+    @Test
+    fun `FailedRetryable with past retry does not preserve redelivery and ack-skips`() {
+        val s = ChunkExecutionStatus.FailedRetryable(past)
+        assertThat(s.shouldAckSkip(now)).isTrue()
+        assertThat(s.shouldPreserveKafkaRedelivery(now)).isFalse()
+    }
+
+    @Test
+    fun `FailedRetryable with null nextRetryAt ack-skips immediately`() {
+        val s = ChunkExecutionStatus.FailedRetryable(null)
+        assertThat(s.shouldAckSkip(now)).isTrue()
+        assertThat(s.shouldPreserveKafkaRedelivery(now)).isFalse()
+    }
+
+    @Test
+    fun `PENDING_NAME constant equals PENDING`() {
+        assertThat(ChunkExecutionStatus.PENDING_NAME).isEqualTo("PENDING")
+    }
+
+    @Test
+    fun `name property on each subtype matches NAME constant`() {
+        assertThat(ChunkExecutionStatus.Processing.name).isEqualTo("PROCESSING")
+        assertThat(ChunkExecutionStatus.Succeeded.name).isEqualTo("SUCCEEDED")
+        assertThat(ChunkExecutionStatus.FailedRetryable(null).name).isEqualTo("FAILED_RETRYABLE")
+        assertThat(ChunkExecutionStatus.FailedTerminal(null).name).isEqualTo("FAILED_TERMINAL")
+    }
+}

--- a/module-synchronizer/src/test/kotlin/maple/synchronizer/state/ChunkExecutionStatusTest.kt
+++ b/module-synchronizer/src/test/kotlin/maple/synchronizer/state/ChunkExecutionStatusTest.kt
@@ -12,11 +12,20 @@ class ChunkExecutionStatusTest {
     private val past: Instant = now.minusSeconds(60)
 
     @Test
-    fun `fromName round-trips all four non-pending names`() {
+    fun `fromName round-trips all five names`() {
+        assertThat(ChunkExecutionStatus.fromName("PENDING")).isEqualTo(ChunkExecutionStatus.Pending)
         assertThat(ChunkExecutionStatus.fromName("PROCESSING")).isEqualTo(ChunkExecutionStatus.Processing)
         assertThat(ChunkExecutionStatus.fromName("SUCCEEDED")).isEqualTo(ChunkExecutionStatus.Succeeded)
         assertThat(ChunkExecutionStatus.fromName("FAILED_RETRYABLE")).isEqualTo(ChunkExecutionStatus.FailedRetryable(null))
         assertThat(ChunkExecutionStatus.fromName("FAILED_TERMINAL")).isEqualTo(ChunkExecutionStatus.FailedTerminal(null))
+    }
+
+    @Test
+    fun `Pending is not terminal and does not ack-skip or preserve redelivery`() {
+        val s = ChunkExecutionStatus.Pending
+        assertThat(s.isTerminal()).isFalse()
+        assertThat(s.shouldAckSkip(now)).isFalse()
+        assertThat(s.shouldPreserveKafkaRedelivery(now)).isFalse()
     }
 
     @Test
@@ -95,6 +104,7 @@ class ChunkExecutionStatusTest {
 
     @Test
     fun `name property on each subtype matches NAME constant`() {
+        assertThat(ChunkExecutionStatus.Pending.name).isEqualTo("PENDING")
         assertThat(ChunkExecutionStatus.Processing.name).isEqualTo("PROCESSING")
         assertThat(ChunkExecutionStatus.Succeeded.name).isEqualTo("SUCCEEDED")
         assertThat(ChunkExecutionStatus.FailedRetryable(null).name).isEqualTo("FAILED_RETRYABLE")

--- a/module-synchronizer/src/test/kotlin/maple/synchronizer/storage/OcidMappingFileReaderTest.kt
+++ b/module-synchronizer/src/test/kotlin/maple/synchronizer/storage/OcidMappingFileReaderTest.kt
@@ -3,6 +3,7 @@ package maple.synchronizer.storage
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import maple.expectation.error.exception.ArtifactNotFoundException
 import maple.synchronizer.metrics.SynchronizerReaderMetrics
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -51,10 +52,11 @@ class OcidMappingFileReaderTest {
     }
 
     @Test
-    fun `read throws IllegalStateException when file not found`() {
+    fun `read throws ArtifactNotFoundException when file not found`() {
         assertThatThrownBy { reader.read("nonexistent/path.jsonl.gz") }
-            .isInstanceOf(IllegalStateException::class.java)
-            .hasMessageContaining("Ocid mapping file not found")
+            .isInstanceOf(ArtifactNotFoundException::class.java)
+            .hasMessageContaining("OcidMappingFileReader")
+            .hasMessageContaining("nonexistent/path.jsonl.gz")
     }
 
     @Test

--- a/module-synchronizer/src/test/kotlin/maple/synchronizer/storage/ResultFileReaderTest.kt
+++ b/module-synchronizer/src/test/kotlin/maple/synchronizer/storage/ResultFileReaderTest.kt
@@ -2,6 +2,7 @@ package maple.synchronizer.storage
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import maple.expectation.error.exception.ArtifactNotFoundException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
@@ -70,7 +71,8 @@ class ResultFileReaderTest {
     @Test
     fun `readAndGroupByCompositeKey - nonexistent file throws`() {
         assertThatThrownBy { reader.readAndGroupByCompositeKey("missing.jsonl.gz") }
-            .isInstanceOf(IllegalStateException::class.java)
-            .hasMessageContaining("Result file not found")
+            .isInstanceOf(ArtifactNotFoundException::class.java)
+            .hasMessageContaining("ResultFileReader")
+            .hasMessageContaining("missing.jsonl.gz")
     }
 }


### PR DESCRIPTION
## Summary

Convert `FailureDecision` from a private data class with nullable `terminalReason` to a sealed class with `Retryable` and `Terminal` subtypes. `classifyFailure` now uses `ex is ArtifactNotFoundException` instead of substring matching against the Korean error message.

## Why

- Polymorphic dispatch over subtypes eliminates impossible-state sentinel (null terminalReason) and forces exhaustive handling at the consumer site
- Decouples failure classification from Korean exception message text — safer than substring match when message strings are localized or refactored
- Aligns with the sealed-class pattern already used in #960 (`ChunkExecutionStatus`) and #959 (`UrgentReadState`) for the same purpose

## Test plan

- [x] `./gradlew :module-synchronizer:test --tests "maple.synchronizer.consumer.ChunkConsumerTemplateTest"` — 11 tests pass
- [x] `./gradlew :module-synchronizer:test --tests "maple.synchronizer.storage.ResultFileReaderTest"` — 7 tests pass
- [x] `./gradlew :module-synchronizer:test --tests "maple.synchronizer.storage.OcidMappingFileReaderTest"` — 5 tests pass
- [x] `./gradlew :module-synchronizer:test --tests "maple.synchronizer.processor.DefaultChunkProcessorTest"` — 6 tests pass

Closes #983

🤖 Generated with [Claude Code](https://claude.com/claude-code)