### PR TITLE
refactor(synchronizer): convert FailureDecision to sealed class (#983)

### DIFF
--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/ChunkConsumerTemplate.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/consumer/ChunkConsumerTemplate.kt
@@ -1,6 +1,7 @@
 package maple.synchronizer.consumer
 
 import maple.expectation.common.event.ChunkExecutionIdentity
+import maple.expectation.error.exception.ArtifactNotFoundException
 import maple.synchronizer.state.ChunkExecutionStatus
 import maple.expectation.infrastructure.executor.LogicExecutor
 import maple.expectation.infrastructure.executor.TaskContext
@@ -191,39 +192,42 @@ class ChunkConsumerTemplate(
         claim: ChunkExecutionClaim,
         ex: Throwable,
     ) {
-        val failure = classifyFailure(ex, claim)
+        val decision = classifyFailure(ex, claim)
         val error = ex.message ?: ex.javaClass.simpleName
-        val marked = if (failure.terminalReason == null) {
-            chunkExecutionRepository.markFailedRetryable(
+
+        val marked = when (decision) {
+            is FailureDecision.Retryable -> chunkExecutionRepository.markFailedRetryable(
                 request.identity,
                 claim.attemptCount,
                 error,
-                Instant.now().plus(properties.retryBaseBackoff.multipliedBy(claim.attemptCount.toLong())),
+                decision.nextRetryAt,
             )
-        } else {
-            chunkExecutionRepository.markFailedTerminal(
+            is FailureDecision.Terminal -> chunkExecutionRepository.markFailedTerminal(
                 request.identity,
                 claim.attemptCount,
                 error,
-                failure.terminalReason,
+                decision.terminalReason,
             )
         }
 
-        if (marked) {
-            val status = if (failure.terminalReason == null) {
-                ChunkExecutionStatus.FailedRetryable(
-                    Instant.now().plus(properties.retryBaseBackoff.multipliedBy(claim.attemptCount.toLong())),
-                )
-            } else {
-                ChunkExecutionStatus.FailedTerminal(failure.terminalReason)
-            }
-            metrics.recordChunkExecutionFailed(
-                request.identity.executionType,
-                status,
-                failure.terminalReason ?: RETRYABLE_FAILURE,
-            )
-            request.onFailure(ex)
-            if (failure.terminalReason == null) {
+        if (!marked) {
+            logFailedStateWrite(request, claim)
+            return
+        }
+
+        val status: ChunkExecutionStatus = when (decision) {
+            is FailureDecision.Retryable -> ChunkExecutionStatus.FailedRetryable(decision.nextRetryAt)
+            is FailureDecision.Terminal -> ChunkExecutionStatus.FailedTerminal(decision.terminalReason)
+        }
+        metrics.recordChunkExecutionFailed(
+            request.identity.executionType,
+            status,
+            decision.reason,
+        )
+        request.onFailure(ex)
+
+        when (decision) {
+            is FailureDecision.Retryable -> {
                 request.log.warn(
                     "[{}] retryable chunk failure recorded, leaving unacked for Kafka redelivery: runId={} chunkId={} attempt={}",
                     request.logPrefix,
@@ -231,27 +235,37 @@ class ChunkConsumerTemplate(
                     request.chunkId,
                     claim.attemptCount,
                 )
-                return
             }
-            request.acknowledgment.acknowledge()
-            return
+            is FailureDecision.Terminal -> {
+                request.acknowledgment.acknowledge()
+            }
         }
-
-        logFailedStateWrite(request, claim)
     }
 
     private fun classifyFailure(
         ex: Throwable,
         claim: ChunkExecutionClaim,
     ): FailureDecision {
-        val artifactMissing = ex.message?.contains("file not found", ignoreCase = true) == true
-        if (artifactMissing && claim.attemptCount >= properties.retry.artifactMissingMaxAttempts) {
-            return FailureDecision(ARTIFACT_MISSING_MAX_ATTEMPTS)
+        val artifactMissing = ex is ArtifactNotFoundException
+        val maxAttempts = if (artifactMissing) {
+            properties.retry.artifactMissingMaxAttempts
+        } else {
+            properties.retry.maxAttempts
         }
-        if (!artifactMissing && claim.attemptCount >= properties.retry.maxAttempts) {
-            return FailureDecision(MAX_ATTEMPTS_EXCEEDED)
+        return if (claim.attemptCount >= maxAttempts) {
+            val terminalReason = if (artifactMissing) ARTIFACT_MISSING_MAX_ATTEMPTS else MAX_ATTEMPTS_EXCEEDED
+            FailureDecision.Terminal(
+                attemptCount = claim.attemptCount,
+                terminalReason = terminalReason,
+            )
+        } else {
+            FailureDecision.Retryable(
+                attemptCount = claim.attemptCount,
+                nextRetryAt = Instant.now().plus(
+                    properties.retryBaseBackoff.multipliedBy(claim.attemptCount.toLong()),
+                ),
+            )
         }
-        return FailureDecision(terminalReason = null)
     }
 
     private fun logFailedStateWrite(
@@ -272,16 +286,16 @@ class ChunkConsumerTemplate(
 
     private fun ChunkExecutionState.shouldAckSkip(): Boolean {
         val now = Instant.now()
+        // Note: PROCESSING + active lease returns TRUE (skip — another worker holds it).
+        // FAILED_RETRYABLE + future retry returns FALSE (don't skip — Kafka should redeliver later).
+        // This inversion is intentional: skip means "ack and move on", so we ack when the work
+        // is already done (terminal / leased) and leave unacked when Kafka should retry.
         return when (val s = status) {
-            // Terminal states: nothing more to do.
-            ChunkExecutionStatus.Succeeded,
+            is ChunkExecutionStatus.Succeeded,
             is ChunkExecutionStatus.FailedTerminal -> true
-            // Failed retryable: skip only when retry window has passed.
             is ChunkExecutionStatus.FailedRetryable -> s.nextRetryAt?.isAfter(now) != true
-            // Pending: claimable, not a skip.
-            ChunkExecutionStatus.Pending -> false
-            // Processing: skip only if lease is still active (another worker holds it).
             ChunkExecutionStatus.Processing -> leaseUntil?.isAfter(now) == true
+            ChunkExecutionStatus.Pending -> false
         }
     }
 
@@ -300,9 +314,24 @@ class ChunkConsumerTemplate(
             eventPayloadJson = eventPayloadJson,
         )
 
-    private data class FailureDecision(
-        val terminalReason: String?,
-    )
+    private sealed class FailureDecision {
+        abstract val attemptCount: Int
+        abstract val reason: String
+
+        data class Retryable(
+            override val attemptCount: Int,
+            val nextRetryAt: Instant,
+        ) : FailureDecision() {
+            override val reason: String = RETRYABLE_FAILURE
+        }
+
+        data class Terminal(
+            override val attemptCount: Int,
+            val terminalReason: String,
+        ) : FailureDecision() {
+            override val reason: String = terminalReason
+        }
+    }
 
     private companion object {
         private const val SUPPORTED_SCHEMA_VERSION = 1

--- a/module-synchronizer/src/test/kotlin/maple/synchronizer/consumer/ChunkConsumerTemplateTest.kt
+++ b/module-synchronizer/src/test/kotlin/maple/synchronizer/consumer/ChunkConsumerTemplateTest.kt
@@ -8,6 +8,8 @@ import maple.expectation.infrastructure.executor.LogicExecutor
 import maple.expectation.infrastructure.executor.TaskContext
 import maple.expectation.infrastructure.executor.function.ThrowingRunnable
 import maple.expectation.infrastructure.executor.strategy.ExceptionTranslator
+import maple.expectation.error.CommonErrorCode
+import maple.expectation.error.exception.ArtifactNotFoundException
 import maple.synchronizer.metrics.SynchronizerMetrics
 import maple.synchronizer.repository.ChunkExecutionClaim
 import maple.synchronizer.repository.ChunkExecutionState
@@ -165,7 +167,7 @@ class ChunkConsumerTemplateTest {
         whenever(repository.claimProcessing(eq(identity), any())).thenReturn(ChunkExecutionClaim(attemptCount = 2))
         whenever(repository.markFailedTerminal(eq(identity), eq(2), any(), eq("ARTIFACT_MISSING_MAX_ATTEMPTS"))).thenReturn(true)
 
-        template.submit(request(process = { throw IllegalStateException("Result file not found: /tmp/missing") }))
+        template.submit(request(process = { throw ArtifactNotFoundException(CommonErrorCode.ARTIFACT_NOT_FOUND, "ResultFileReader", "/tmp/missing") }))
 
         verify(repository).markFailedTerminal(eq(identity), eq(2), any(), eq("ARTIFACT_MISSING_MAX_ATTEMPTS"))
         verify(acknowledgment).acknowledge()

--- a/module-synchronizer/src/test/kotlin/maple/synchronizer/processor/DefaultChunkProcessorTest.kt
+++ b/module-synchronizer/src/test/kotlin/maple/synchronizer/processor/DefaultChunkProcessorTest.kt
@@ -1,7 +1,8 @@
 package maple.synchronizer.processor
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
-import maple.core.domain.chunk.ChunkProcessInput
+import maple.expectation.error.CommonErrorCode
+import maple.expectation.error.exception.ArtifactNotFoundException
 import maple.synchronizer.domain.CalculatedEquipmentItem
 import maple.synchronizer.domain.GroupedEquipmentResult
 import maple.synchronizer.metrics.SynchronizerMetrics
@@ -65,14 +66,15 @@ class DefaultChunkProcessorTest {
     }
 
     @Test
-    fun `process - file not found propagates exception`() {
+    fun `process - file not found propagates ArtifactNotFoundException`() {
         val input = testInput()
         whenever(dataReader.read(any()))
-            .thenThrow(IllegalStateException("Result file not found"))
+            .thenThrow(ArtifactNotFoundException(CommonErrorCode.ARTIFACT_NOT_FOUND, "ResultFileReader", "/tmp/missing"))
 
         assertThatThrownBy { chunkProcessor.process(input) }
-            .isInstanceOf(IllegalStateException::class.java)
-            .hasMessageContaining("Result file not found")
+            .isInstanceOf(ArtifactNotFoundException::class.java)
+            .hasMessageContaining("ResultFileReader")
+            .hasMessageContaining("/tmp/missing")
     }
 
     @Test

--- a/module-synchronizer/src/test/kotlin/maple/synchronizer/storage/OcidMappingFileReaderTest.kt
+++ b/module-synchronizer/src/test/kotlin/maple/synchronizer/storage/OcidMappingFileReaderTest.kt
@@ -3,6 +3,7 @@ package maple.synchronizer.storage
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import maple.expectation.error.exception.ArtifactNotFoundException
 import maple.synchronizer.metrics.SynchronizerReaderMetrics
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -51,10 +52,11 @@ class OcidMappingFileReaderTest {
     }
 
     @Test
-    fun `read throws IllegalStateException when file not found`() {
+    fun `read throws ArtifactNotFoundException when file not found`() {
         assertThatThrownBy { reader.read("nonexistent/path.jsonl.gz") }
-            .isInstanceOf(IllegalStateException::class.java)
-            .hasMessageContaining("Ocid mapping file not found")
+            .isInstanceOf(ArtifactNotFoundException::class.java)
+            .hasMessageContaining("OcidMappingFileReader")
+            .hasMessageContaining("nonexistent/path.jsonl.gz")
     }
 
     @Test

--- a/module-synchronizer/src/test/kotlin/maple/synchronizer/storage/ResultFileReaderTest.kt
+++ b/module-synchronizer/src/test/kotlin/maple/synchronizer/storage/ResultFileReaderTest.kt
@@ -2,6 +2,7 @@ package maple.synchronizer.storage
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import maple.expectation.error.exception.ArtifactNotFoundException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
@@ -70,7 +71,8 @@ class ResultFileReaderTest {
     @Test
     fun `readAndGroupByCompositeKey - nonexistent file throws`() {
         assertThatThrownBy { reader.readAndGroupByCompositeKey("missing.jsonl.gz") }
-            .isInstanceOf(IllegalStateException::class.java)
-            .hasMessageContaining("Result file not found")
+            .isInstanceOf(ArtifactNotFoundException::class.java)
+            .hasMessageContaining("ResultFileReader")
+            .hasMessageContaining("missing.jsonl.gz")
     }
 }


### PR DESCRIPTION
## Summary

Convert `FailureDecision` from a private data class with nullable `terminalReason` to a sealed class with `Retryable` and `Terminal` subtypes. `classifyFailure` now uses `ex is ArtifactNotFoundException` instead of substring matching against the Korean error message.

## Why

- Polymorphic dispatch over subtypes eliminates impossible-state sentinel (null terminalReason) and forces exhaustive handling at the consumer site
- Decouples failure classification from Korean exception message text — safer than substring match when message strings are localized or refactored
- Aligns with the sealed-class pattern already used in #960 (`ChunkExecutionStatus`) and #959 (`UrgentReadState`)

## Test plan

- [x] `./gradlew :module-synchronizer:test --tests "*ChunkConsumerTemplateTest"` — 11 tests pass
- [x] `./gradlew :module-synchronizer:test --tests "*ResultFileReaderTest"` — 7 tests pass
- [x] `./gradlew :module-synchronizer:test --tests "*OcidMappingFileReaderTest"` — 5 tests pass
- [x] `./gradlew :module-synchronizer:test --tests "*DefaultChunkProcessorTest"` — 6 tests pass

Closes #983