### PR TITLE
refactor: #1071 dead dependencies + #1086 RuleBasedAnalyzer extraction

### DIFF
--- a/docs/superpowers/plans/2026-06-06-1071-remove-dead-dependencies.md
+++ b/docs/superpowers/plans/2026-06-06-1071-remove-dead-dependencies.md
@@ -1,0 +1,194 @@
+# #1071 — Remove Dead Dependencies Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Remove 5 injected constructor fields that are never read by any method in their containing class. Pure mechanical refactor — no behavior change.
+
+**Architecture:** Each task is a single-file edit. Remove the field, remove its constructor parameter, update any `@Autowired` / Spring injection if the field is the only consumer of a bean (likely not — these are dead fields, so the bean has other consumers). One commit per file.
+
+**Tech Stack:** Kotlin, Spring Boot, Gradle multi-module.
+
+---
+
+## File Structure
+
+| File | Change |
+|---|---|
+| `module-infra/.../worker/AbstractExpectationCalcWorker.kt` | Drop `characterOcidPort` + `computeBuffer` fields |
+| `module-calculator/.../processor/CalculationCache.kt` | Drop `log` field |
+| `module-infra/.../ai/AiSreService.kt` | Drop `aiEnabled` field (unblocks #1086) |
+| `module-rest-controller/.../auth/JwtAuthInterceptor.kt` | Drop `objectMapper` field |
+| `module-rest-controller/.../metrics/V6ReadMetrics.kt` | Convert `requestBuffer` + `inflightRegistry` to constructor-local vals (no field) |
+
+---
+
+## Task 1: `AbstractExpectationCalcWorker` — drop 2 dead fields
+
+**Files:**
+- Modify: `module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/AbstractExpectationCalcWorker.kt`
+
+- [ ] **Step 1: Find the file and read**
+
+```bash
+find /home/maple/probabilistic-valuation-engine/.worktrees/refactor-batch-2/module-infra/src -name "AbstractExpectationCalcWorker.kt"
+```
+
+Verify the file lists `characterOcidPort` and `computeBuffer` as constructor params and that no method body references either. (If any method does reference them, skip the removal — issue premise is wrong.)
+
+- [ ] **Step 2: Remove from constructor**
+
+Delete the two constructor parameters and their `private val` declarations. Update the bean wiring if needed:
+```bash
+cd /home/maple/probabilistic-valuation-engine/.worktrees/refactor-batch-2
+./gradlew :module-infra:compileKotlin --console=plain
+```
+
+If compile fails, find the bean factory method that constructs this class and remove the corresponding args.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/AbstractExpectationCalcWorker.kt
+git commit -m "refactor(infra): drop dead characterOcidPort + computeBuffer from AbstractExpectationCalcWorker (#1071)"
+```
+
+---
+
+## Task 2: `CalculationCache` — drop dead `log` field
+
+**Files:**
+- Modify: `module-calculator/src/main/kotlin/maple/calculator/processor/CalculationCache.kt`
+
+- [ ] **Step 1: Read and verify**
+
+```bash
+grep -n "log" /home/maple/probabilistic-valuation-engine/.worktrees/refactor-batch-2/module-calculator/src/main/kotlin/maple/calculator/processor/CalculationCache.kt
+```
+
+Confirm `log` is declared as `private val log: ...` (likely in companion object or class) but never used in any method body. Remove the field and the `LoggerFactory.getLogger(...)` call.
+
+- [ ] **Step 2: Compile + commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine/.worktrees/refactor-batch-2
+./gradlew :module-calculator:compileKotlin --console=plain
+git add module-calculator/src/main/kotlin/maple/calculator/processor/CalculationCache.kt
+git commit -m "refactor(calculator): drop dead log field from CalculationCache (#1071)"
+```
+
+---
+
+## Task 3: `AiSreService` — drop dead `aiEnabled` field (unblocks #1086)
+
+**Files:**
+- Modify: `module-infra/src/main/kotlin/maple/expectation/infrastructure/ai/AiSreService.kt`
+
+- [ ] **Step 1: Read and verify**
+
+```bash
+find /home/maple/probabilistic-valuation-engine/.worktrees/refactor-batch-2/module-infra/src -name "AiSreService.kt"
+grep -n "aiEnabled" <path>
+```
+
+Confirm `aiEnabled` is declared and never referenced in any method body. Remove the field + constructor param. **If a `@ConditionalOnProperty(name = ["ai.enabled"])` annotation is on the class itself, do NOT remove that — it gates the bean.** The `aiEnabled` field is an in-class copy, which is the dead dependency.
+
+- [ ] **Step 2: Compile + commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine/.worktrees/refactor-batch-2
+./gradlew :module-infra:compileKotlin --console=plain
+git add module-infra/src/main/kotlin/maple/expectation/infrastructure/ai/AiSreService.kt
+git commit -m "refactor(infra): drop dead aiEnabled field from AiSreService (#1071)"
+```
+
+---
+
+## Task 4: `JwtAuthInterceptor` — drop dead `objectMapper` field
+
+**Files:**
+- Modify: `module-rest-controller/src/main/kotlin/maple/restcontroller/auth/JwtAuthInterceptor.kt`
+
+- [ ] **Step 1: Read and verify**
+
+```bash
+grep -n "objectMapper" /home/maple/probabilistic-valuation-engine/.worktrees/refactor-batch-2/module-rest-controller/src/main/kotlin/maple/restcontroller/auth/JwtAuthInterceptor.kt
+```
+
+If `objectMapper` is in the constructor and no method body uses it, remove the param + the import. **NOTE:** this is the same file we just touched for #1093 (BEARER_PREFIX const, BEARER_PREFIX_LENGTH). The fix is purely additive (removing one more field) — no conflict.
+
+- [ ] **Step 2: Compile + commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine/.worktrees/refactor-batch-2
+./gradlew :module-rest-controller:compileKotlin --console=plain
+git add module-rest-controller/src/main/kotlin/maple/restcontroller/auth/JwtAuthInterceptor.kt
+git commit -m "refactor(rest-controller): drop dead objectMapper field from JwtAuthInterceptor (#1071)"
+```
+
+---
+
+## Task 5: `V6ReadMetrics` — convert 2 fields to constructor-local
+
+**Files:**
+- Modify: `module-rest-controller/src/main/kotlin/maple/restcontroller/metrics/V6ReadMetrics.kt`
+
+- [ ] **Step 1: Read and verify**
+
+```bash
+find /home/maple/probabilistic-valuation-engine/.worktrees/refactor-batch-2/module-rest-controller/src -name "V6ReadMetrics.kt"
+```
+
+If `requestBuffer` and `inflightRegistry` are stored as `private val` fields but only used in the `init` block for gauge registration (no method reads them), convert them to constructor parameters (no `val/var`):
+
+```kotlin
+class V6ReadMetrics(
+    registry: MeterRegistry,
+    requestBuffer: RequestBuffer,
+    inflightRegistry: InflightRequestRegistry,
+) {
+    init {
+        Gauge.builder("v6.read.requestBuffer.size") { requestBuffer.size() }.register(registry)
+        Gauge.builder("v6.read.inflight.size") { inflightRegistry.size() }.register(registry)
+    }
+    // ... other methods that may still use registry
+}
+```
+
+The fields become constructor-local — visible to `init` and the lambda captures, not stored as properties.
+
+- [ ] **Step 2: Compile + commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine/.worktrees/refactor-batch-2
+./gradlew :module-rest-controller:compileKotlin --console=plain
+git add module-rest-controller/src/main/kotlin/maple/restcontroller/metrics/V6ReadMetrics.kt
+git commit -m "refactor(rest-controller): V6ReadMetrics requestBuffer/inflightRegistry as init-only params (#1071)"
+```
+
+---
+
+## Task 6: Final verification
+
+- [ ] **Step 1: Full compile + test**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine/.worktrees/refactor-batch-2
+./gradlew compileKotlin compileJava --continue
+./gradlew :module-infra:test :module-calculator:test :module-rest-controller:test --console=plain
+```
+
+Expected: all pass.
+
+- [ ] **Step 2: Comment on + close #1071**
+
+```bash
+gh issue close 1071 --comment "Closed by refactor commit. Dead dependencies removed from 5 classes across module-infra, module-calculator, module-rest-controller. No behavior change. Unblocks #1086."
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** All 5 classes from issue body covered by Tasks 1-5. Build/test sweep in Task 6.
+- **Placeholder scan:** No TBD/TODO. "If a method does reference it, skip" is conditional guidance, not a placeholder.
+- **Type consistency:** Constructor params removed/converted match what the spec requires.

--- a/docs/superpowers/plans/2026-06-06-1086-rule-based-analyzer.md
+++ b/docs/superpowers/plans/2026-06-06-1086-rule-based-analyzer.md
@@ -1,0 +1,184 @@
+# #1086 — RuleBasedAnalyzer Extraction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Extract 4 pure rule-based analysis methods from `AiSreService` (module-infra) into a standalone `RuleBasedAnalyzer` class. `AiSreService` keeps only LLM orchestration. No behavior change.
+
+**Architecture:** Stateless `object` (Kotlin) or `@Component` (Spring) — the 4 methods have zero field dependencies, so a `private const val`-style stateless singleton is the cleanest shape. Pick the shape that matches the surrounding `module-infra` convention (check sibling utility classes).
+
+**Tech Stack:** Kotlin, Spring Boot, Gradle multi-module.
+
+---
+
+## File Structure
+
+| File | Change |
+|---|---|
+| `module-infra/src/main/kotlin/maple/expectation/infrastructure/ai/RuleBasedAnalyzer.kt` | NEW — 4 methods + return-type DTOs |
+| `module-infra/src/main/kotlin/maple/expectation/infrastructure/ai/AiSreService.kt` | MODIFIED — `fallbackAnalysis` delegates; class shrinks |
+
+---
+
+## Task 1: Verify issue preconditions
+
+- [ ] **Step 1: Confirm #1071 is closed on develop**
+
+```bash
+gh issue view 1071 --json state -q '.state'
+```
+
+Expected: `CLOSED`. If still OPEN, stop and run the #1071 plan first.
+
+- [ ] **Step 2: Read `AiSreService` to find the 4 methods + their return types + their callers**
+
+```bash
+find /home/maple/probabilistic-valuation-engine/.worktrees/refactor-batch-2/module-infra/src -name "AiSreService.kt"
+```
+
+Identify:
+- `analyzeByKeyword(input: <type>): <return>`
+- `determineSeverity(input: <type>): <return>`
+- `inferAffectedComponents(input: <type>): <return>`
+- `suggestActions(input: <type>): <return>`
+
+The `fallbackAnalysis` method likely calls all 4. Confirm: each method is `private` in `AiSreService` and takes only primitives/strings from its parameter list (no `this.x` access).
+
+---
+
+## Task 2: Create `RuleBasedAnalyzer`
+
+**Files:**
+- Create: `module-infra/src/main/kotlin/maple/expectation/infrastructure/ai/RuleBasedAnalyzer.kt`
+
+- [ ] **Step 1: Create the class**
+
+Use the same package as `AiSreService`. The 4 methods move verbatim — copy the body of each from `AiSreService`, change visibility from `private` to (depending on surrounding convention) `internal` or `public`. Adjust the qualifier:
+- If the methods are simple keyword/severity helpers → `object RuleBasedAnalyzer` (Kotlin singleton, no Spring)
+- If Spring DI is preferred → `@Component class RuleBasedAnalyzer` with a no-arg constructor
+
+```kotlin
+package maple.expectation.infrastructure.ai
+
+/**
+ * Stateless rule-based SRE analyzer. The 4 helpers here are pure functions —
+ * no field dependencies, no Spring beans — so they live in a singleton object.
+ *
+ * Separated from [AiSreService] which owns the LLM-based path. The LLM path
+ * delegates here when the model is unavailable or returns low confidence.
+ */
+internal object RuleBasedAnalyzer {
+    fun analyzeByKeyword(input: /* match original signature */): /* match */ = /* body */
+    fun determineSeverity(input: /* match */): /* match */ = /* body */
+    fun inferAffectedComponents(input: /* match */): /* match */ = /* body */
+    fun suggestActions(input: /* match */): /* match */ = /* body */
+}
+```
+
+Replace `/* match */` placeholders with the actual types and bodies from the original `AiSreService` methods.
+
+- [ ] **Step 2: Compile**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine/.worktrees/refactor-batch-2
+./gradlew :module-infra:compileKotlin --console=plain
+```
+
+Expected: success (object defined but unused — that's fine for this step).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add module-infra/src/main/kotlin/maple/expectation/infrastructure/ai/RuleBasedAnalyzer.kt
+git commit -m "refactor(infra): add RuleBasedAnalyzer with 4 rule-based helpers (#1086)"
+```
+
+---
+
+## Task 3: Refactor `AiSreService` to delegate
+
+**Files:**
+- Modify: `module-infra/src/main/kotlin/maple/expectation/infrastructure/ai/AiSreService.kt`
+
+- [ ] **Step 1: Remove the 4 private methods from `AiSreService`**
+
+Delete the bodies of `analyzeByKeyword`, `determineSeverity`, `inferAffectedComponents`, `suggestActions`. The class now references them via `RuleBasedAnalyzer.<method>(...)`.
+
+- [ ] **Step 2: Update `fallbackAnalysis` to call the new singleton**
+
+In the `fallbackAnalysis` method body, replace:
+```kotlin
+val keywords = analyzeByKeyword(input)
+val severity = determineSeverity(input)
+val components = inferAffectedComponents(input)
+val actions = suggestActions(input)
+```
+
+with:
+```kotlin
+val keywords = RuleBasedAnalyzer.analyzeByKeyword(input)
+val severity = RuleBasedAnalyzer.determineSeverity(input)
+val components = RuleBasedAnalyzer.inferAffectedComponents(input)
+val actions = RuleBasedAnalyzer.suggestActions(input)
+```
+
+(Or import statically if the project uses that style.)
+
+- [ ] **Step 3: Compile + test**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine/.worktrees/refactor-batch-2
+./gradlew :module-infra:compileKotlin --console=plain
+./gradlew :module-infra:test --console=plain
+```
+
+Expected: all pass (no behavior change).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add module-infra/src/main/kotlin/maple/expectation/infrastructure/ai/AiSreService.kt
+git commit -m "refactor(infra): AiSreService.fallbackAnalysis delegates to RuleBasedAnalyzer (#1086)"
+```
+
+---
+
+## Task 4: Final verification
+
+- [ ] **Step 1: AiSreService line count drops significantly**
+
+```bash
+wc -l module-infra/src/main/kotlin/maple/expectation/infrastructure/ai/AiSreService.kt
+```
+
+Expected: ~150-200 lines (down from 288).
+
+- [ ] **Step 2: RuleBasedAnalyzer exists and is the only place these methods are defined**
+
+```bash
+grep -rn "fun analyzeByKeyword\|fun determineSeverity\|fun inferAffectedComponents\|fun suggestActions" module-infra/src/main
+```
+
+Expected: only matches in `RuleBasedAnalyzer.kt`.
+
+- [ ] **Step 3: Full module test sweep**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine/.worktrees/refactor-batch-2
+./gradlew :module-infra:test --console=plain
+```
+
+Expected: all pass.
+
+- [ ] **Step 4: Comment on + close #1086**
+
+```bash
+gh issue close 1086 --comment "Closed by extraction. RuleBasedAnalyzer owns the 4 pure rule-based helpers; AiSreService keeps only LLM orchestration. No behavior change."
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** New class with 4 methods ✅. AiSreService delegates ✅. Line-count drop implicit but not enforced. No-behavior-change ✅.
+- **Placeholder scan:** `/* match */` placeholders are intentional — implementer must fill from source. Acceptable per plan rules.
+- **Type consistency:** All signatures must match originals verbatim.

--- a/module-calculator/src/main/kotlin/maple/calculator/processor/CalculationCache.kt
+++ b/module-calculator/src/main/kotlin/maple/calculator/processor/CalculationCache.kt
@@ -4,7 +4,6 @@ import com.github.benmanes.caffeine.cache.Cache
 import com.github.benmanes.caffeine.cache.Caffeine
 import maple.expectation.application.service.calculator.v4.EquipmentExpectationCalculatorFactory
 import maple.expectation.core.dto.v4.EquipmentCalculationInput
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 
 /** Caffeine max size — 100k entries × ~256 B/entry ≈ 25 MB heap. Sized to keep 5 min of calc hot-set in memory. */
@@ -14,8 +13,6 @@ private const val CACHE_MAX_SIZE: Long = 100_000L
 class CalculationCache(
     private val factory: EquipmentExpectationCalculatorFactory,
 ) {
-    private val log = LoggerFactory.getLogger(CalculationCache::class.java)
-
     data class CacheKey(
         val itemName: String,
         val itemPart: String,

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/monitoring/ai/AiSreService.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/monitoring/ai/AiSreService.kt
@@ -12,7 +12,6 @@ import maple.expectation.infrastructure.monitoring.copilot.model.IncidentContext
 import maple.expectation.infrastructure.monitoring.security.PiiMaskingFilter
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Service
 
@@ -26,7 +25,6 @@ class AiSreService(
     @Qualifier("aiTaskExecutor") private val aiTaskExecutor: Executor,
     private val promptBuilder: AiPromptBuilder,
     private val responseParser: AiResponseParser,
-    @Value("\${ai.sre.enabled:false}") private val aiEnabled: Boolean,
 ) {
     companion object {
         private val log = LoggerFactory.getLogger(AiSreService::class.java)

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/monitoring/ai/AiSreService.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/monitoring/ai/AiSreService.kt
@@ -66,60 +66,19 @@ class AiSreService(
         val errorType = exception.javaClass.simpleName
         val message = exception.message ?: "Unknown error"
 
-        val rootCause = analyzeByKeyword(errorType, message)
-        val severity = determineSeverity(errorType, message)
+        val rootCause = RuleBasedAnalyzer.analyzeByKeyword(errorType, message)
+        val severity = RuleBasedAnalyzer.determineSeverity(errorType, message)
 
         return Optional.of(
             AiAnalysisResult.builder()
                 .rootCause(rootCause)
                 .severity(severity)
-                .affectedComponents(inferAffectedComponents(errorType))
-                .actionItems(suggestActions(errorType))
+                .affectedComponents(RuleBasedAnalyzer.inferAffectedComponents(errorType))
+                .actionItems(RuleBasedAnalyzer.suggestActions(errorType))
                 .analysisSource("RULE_BASED")
                 .disclaimer("규칙 기반 분석 결과입니다. 수동 검증을 권장합니다.")
                 .build(),
         )
-    }
-
-    private fun analyzeByKeyword(errorType: String, message: String): String {
-        val combined = ("$errorType $message").lowercase()
-
-        return when {
-            combined.contains("timeout") || combined.contains("timed out") -> "타임아웃 발생 - 외부 서비스 응답 지연 또는 네트워크 문제"
-            combined.contains("connection") && combined.contains("refused") -> "연결 거부 - 대상 서비스 다운 또는 방화벽 차단"
-            combined.contains("circuit") && combined.contains("open") -> "서킷브레이커 오픈 - 연속 장애로 보호 모드 진입"
-            combined.contains("redis") || combined.contains("redisson") -> "Redis 관련 오류 - 캐시/락 서비스 문제"
-            combined.contains("hikari") || combined.contains("connection pool") -> "DB 커넥션 풀 문제 - 커넥션 부족 또는 누수 의심"
-            combined.contains("outofmemory") || combined.contains("heap") -> "메모리 부족 - JVM 힙 메모리 소진"
-            combined.contains("thread") && combined.contains("exhaust") -> "스레드 풀 고갈 - 동시 요청 초과"
-            else -> "원인 분석 필요 - 수동 점검 권장"
-        }
-    }
-
-    private fun determineSeverity(errorType: String, message: String): String {
-        val combined = ("$errorType $message").lowercase()
-
-        return when {
-            combined.contains("outofmemory") || combined.contains("critical") -> "CRITICAL"
-            combined.contains("circuit") || combined.contains("pool exhausted") -> "HIGH"
-            combined.contains("timeout") || combined.contains("connection") -> "MEDIUM"
-            else -> "LOW"
-        }
-    }
-
-    private fun inferAffectedComponents(errorType: String): String = when {
-        errorType.contains("Redis") -> "Redis, TieredCache, LockStrategy"
-        errorType.contains("Hikari") || errorType.contains("DataSource") -> "MySQL, Repository Layer"
-        errorType.contains("Nexon") || errorType.contains("External") -> "NexonApiClient, ExternalService"
-        errorType.contains("CircuitBreaker") -> "Resilience4j, Service Layer"
-        else -> "Unknown"
-    }
-
-    private fun suggestActions(errorType: String): String = when {
-        errorType.contains("Timeout") -> "1. 대상 서비스 상태 확인\n2. 네트워크 지연 점검\n3. 타임아웃 값 검토"
-        errorType.contains("Connection") -> "1. 연결 대상 서비스 확인\n2. 방화벽/보안그룹 점검\n3. DNS 확인"
-        errorType.contains("Circuit") -> "1. 서킷브레이커 상태 확인\n2. 장애 원인 파악\n3. 수동 리셋 고려"
-        else -> "1. 로그 상세 확인\n2. 메트릭 모니터링\n3. 개발팀 에스컬레이션"
     }
 
     private fun getTopStackTrace(exception: Throwable, count: Int): String {

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/monitoring/ai/RuleBasedAnalyzer.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/monitoring/ai/RuleBasedAnalyzer.kt
@@ -1,0 +1,51 @@
+package maple.expectation.infrastructure.monitoring.ai
+
+/**
+ * Stateless rule-based SRE analyzer. The 4 helpers here are pure functions —
+ * no field dependencies, no Spring beans — so they live in a singleton object.
+ *
+ * Separated from [AiSreService] which owns the LLM-based path. The LLM path
+ * delegates here when the model is unavailable or returns low confidence.
+ */
+internal object RuleBasedAnalyzer {
+    fun analyzeByKeyword(errorType: String, message: String): String {
+        val combined = ("$errorType $message").lowercase()
+
+        return when {
+            combined.contains("timeout") || combined.contains("timed out") -> "타임아웃 발생 - 외부 서비스 응답 지연 또는 네트워크 문제"
+            combined.contains("connection") && combined.contains("refused") -> "연결 거부 - 대상 서비스 다운 또는 방화벽 차단"
+            combined.contains("circuit") && combined.contains("open") -> "서킷브레이커 오픈 - 연속 장애로 보호 모드 진입"
+            combined.contains("redis") || combined.contains("redisson") -> "Redis 관련 오류 - 캐시/락 서비스 문제"
+            combined.contains("hikari") || combined.contains("connection pool") -> "DB 커넥션 풀 문제 - 커넥션 부족 또는 누수 의심"
+            combined.contains("outofmemory") || combined.contains("heap") -> "메모리 부족 - JVM 힙 메모리 소진"
+            combined.contains("thread") && combined.contains("exhaust") -> "스레드 풀 고갈 - 동시 요청 초과"
+            else -> "원인 분석 필요 - 수동 점검 권장"
+        }
+    }
+
+    fun determineSeverity(errorType: String, message: String): String {
+        val combined = ("$errorType $message").lowercase()
+
+        return when {
+            combined.contains("outofmemory") || combined.contains("critical") -> "CRITICAL"
+            combined.contains("circuit") || combined.contains("pool exhausted") -> "HIGH"
+            combined.contains("timeout") || combined.contains("connection") -> "MEDIUM"
+            else -> "LOW"
+        }
+    }
+
+    fun inferAffectedComponents(errorType: String): String = when {
+        errorType.contains("Redis") -> "Redis, TieredCache, LockStrategy"
+        errorType.contains("Hikari") || errorType.contains("DataSource") -> "MySQL, Repository Layer"
+        errorType.contains("Nexon") || errorType.contains("External") -> "NexonApiClient, ExternalService"
+        errorType.contains("CircuitBreaker") -> "Resilience4j, Service Layer"
+        else -> "Unknown"
+    }
+
+    fun suggestActions(errorType: String): String = when {
+        errorType.contains("Timeout") -> "1. 대상 서비스 상태 확인\n2. 네트워크 지연 점검\n3. 타임아웃 값 검토"
+        errorType.contains("Connection") -> "1. 연결 대상 서비스 확인\n2. 방화벽/보안그룹 점검\n3. DNS 확인"
+        errorType.contains("Circuit") -> "1. 서킷브레이커 상태 확인\n2. 장애 원인 파악\n3. 수동 리셋 고려"
+        else -> "1. 로그 상세 확인\n2. 메트릭 모니터링\n3. 개발팀 에스컬레이션"
+    }
+}

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/AbstractExpectationCalcWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/AbstractExpectationCalcWorker.kt
@@ -2,11 +2,9 @@ package maple.expectation.infrastructure.worker
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.micrometer.core.instrument.MeterRegistry
-import maple.expectation.core.port.inbound.BatchComputeBuffer
 import maple.expectation.core.port.inbound.CharacterViewProjectionCommand
 import maple.expectation.core.port.inbound.CharacterViewQueryPort
 import maple.expectation.core.port.inbound.ExpectationV4Port
-import maple.expectation.core.port.out.CharacterOcidPort
 import maple.expectation.core.port.out.GameCharacterPort
 import maple.expectation.infrastructure.cache.tiered.L2CacheStrategy
 import maple.expectation.infrastructure.config.CacheProperties
@@ -34,7 +32,6 @@ abstract class AbstractExpectationCalcWorker(
     queueMetrics: WorkerQueueMetrics,
     lifecycleWrapper: ScheduledTaskLifecycleWrapper,
     private val expectationPort: ExpectationV4Port,
-    private val characterOcidPort: CharacterOcidPort,
     // Two-phase batch processing dependencies
     private val gameCharacterPort: GameCharacterPort,
     private val l2CacheStrategy: L2CacheStrategy,
@@ -43,7 +40,6 @@ abstract class AbstractExpectationCalcWorker(
     private val viewQueryPort: CharacterViewQueryPort,
     private val batchRepo: CharacterViewBatchRepository,
     private val objectMapper: ObjectMapper,
-    private val computeBuffer: BatchComputeBuffer,
     private val jobService: CalculationJobService,
 ) : PgmqWorker<ExpectationCalcMessage>(pgmqClient, executor, config, meterRegistry, queueMetrics, lifecycleWrapper) {
 

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/ExpectationCalcLowWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/ExpectationCalcLowWorker.kt
@@ -2,10 +2,8 @@ package maple.expectation.infrastructure.worker
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.micrometer.core.instrument.MeterRegistry
-import maple.expectation.core.port.inbound.BatchComputeBuffer
 import maple.expectation.core.port.inbound.CharacterViewQueryPort
 import maple.expectation.core.port.inbound.ExpectationV4Port
-import maple.expectation.core.port.out.CharacterOcidPort
 import maple.expectation.core.port.out.GameCharacterPort
 import maple.expectation.infrastructure.cache.tiered.L2CacheStrategy
 import maple.expectation.infrastructure.config.CacheProperties
@@ -32,7 +30,6 @@ class ExpectationCalcLowWorker(
     queueMetrics: WorkerQueueMetrics,
     lifecycleWrapper: ScheduledTaskLifecycleWrapper,
     expectationPort: ExpectationV4Port,
-    characterOcidPort: CharacterOcidPort,
     gameCharacterPort: GameCharacterPort,
     l2CacheStrategy: L2CacheStrategy,
     cacheProperties: CacheProperties,
@@ -40,7 +37,6 @@ class ExpectationCalcLowWorker(
     viewQueryPort: CharacterViewQueryPort,
     batchRepo: CharacterViewBatchRepository,
     objectMapper: ObjectMapper,
-    computeBuffer: BatchComputeBuffer,
     jobService: CalculationJobService,
 ) : AbstractExpectationCalcWorker(
     pgmqClient,
@@ -50,7 +46,6 @@ class ExpectationCalcLowWorker(
     queueMetrics,
     lifecycleWrapper,
     expectationPort,
-    characterOcidPort,
     gameCharacterPort,
     l2CacheStrategy,
     cacheProperties,
@@ -58,7 +53,6 @@ class ExpectationCalcLowWorker(
     viewQueryPort,
     batchRepo,
     objectMapper,
-    computeBuffer,
     jobService,
 ) {
 

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/ExpectationCalcWorker.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/worker/ExpectationCalcWorker.kt
@@ -2,10 +2,8 @@ package maple.expectation.infrastructure.worker
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.micrometer.core.instrument.MeterRegistry
-import maple.expectation.core.port.inbound.BatchComputeBuffer
 import maple.expectation.core.port.inbound.CharacterViewQueryPort
 import maple.expectation.core.port.inbound.ExpectationV4Port
-import maple.expectation.core.port.out.CharacterOcidPort
 import maple.expectation.core.port.out.GameCharacterPort
 import maple.expectation.infrastructure.cache.tiered.L2CacheStrategy
 import maple.expectation.infrastructure.config.CacheProperties
@@ -32,7 +30,6 @@ class ExpectationCalcWorker(
     queueMetrics: WorkerQueueMetrics,
     lifecycleWrapper: ScheduledTaskLifecycleWrapper,
     expectationPort: ExpectationV4Port,
-    characterOcidPort: CharacterOcidPort,
     gameCharacterPort: GameCharacterPort,
     l2CacheStrategy: L2CacheStrategy,
     cacheProperties: CacheProperties,
@@ -40,7 +37,6 @@ class ExpectationCalcWorker(
     viewQueryPort: CharacterViewQueryPort,
     batchRepo: CharacterViewBatchRepository,
     objectMapper: ObjectMapper,
-    computeBuffer: BatchComputeBuffer,
     jobService: CalculationJobService,
 ) : AbstractExpectationCalcWorker(
     pgmqClient,
@@ -50,7 +46,6 @@ class ExpectationCalcWorker(
     queueMetrics,
     lifecycleWrapper,
     expectationPort,
-    characterOcidPort,
     gameCharacterPort,
     l2CacheStrategy,
     cacheProperties,
@@ -58,7 +53,6 @@ class ExpectationCalcWorker(
     viewQueryPort,
     batchRepo,
     objectMapper,
-    computeBuffer,
     jobService,
 ) {
 

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/auth/JwtAuthInterceptor.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/auth/JwtAuthInterceptor.kt
@@ -1,6 +1,5 @@
 package maple.restcontroller.auth
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import maple.expectation.core.auth.JwtParserPort
@@ -16,7 +15,6 @@ import org.springframework.web.servlet.HandlerInterceptor
 class JwtAuthInterceptor(
     private val jwtParserPort: JwtParserPort,
     private val characterOcidPort: CharacterOcidPort,
-    private val objectMapper: ObjectMapper,
 ) : HandlerInterceptor {
 
     companion object {


### PR DESCRIPTION
Resolves two ready-for-agent refactors in module-infra (and small touches in module-calculator / module-rest-controller).

## #1071 — Remove dead dependencies across 4 modules
- `AbstractExpectationCalcWorker` (module-infra): drop unused `characterOcidPort` + `computeBuffer` fields
- `CalculationCache` (module-calculator): drop unused `log` field
- `AiSreService` (module-infra): drop unused `aiEnabled` field (kept class-level `@ConditionalOnProperty` gating intact)
- `JwtAuthInterceptor` (module-rest-controller): drop unused `objectMapper` field
- `V6ReadMetrics` (module-rest-controller): already in target state (constructor params not stored as fields) — no-op

Net diff: 6 files, −23 / +0 lines.

## #1086 — Extract RuleBasedAnalyzer from AiSreService
- New `RuleBasedAnalyzer` (stateless `internal object`) with the 4 pure rule-based helpers: `analyzeByKeyword`, `determineSeverity`, `inferAffectedComponents`, `suggestActions`
- `AiSreService.fallbackAnalysis` delegates; class shrinks 287 → 245 lines
- Convention: matches sibling stateless singletons in module-infra (`WorkerMdcKeys`, `QueueNames`, etc.)

## Verification
- `./gradlew :module-infra:test :module-calculator:test :module-rest-controller:test` → BUILD SUCCESSFUL
- Module-isolated compile after each edit — no bean-wiring breakage
- No behavior change in either refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)