### PR TITLE
refactor(synchronizer): split SynchronizerMetrics into meter registry + recording (#1066)

### DIFF
--- a/docs/superpowers/plans/2026-06-06-1066-synchronizer-metrics-split.md
+++ b/docs/superpowers/plans/2026-06-06-1066-synchronizer-metrics-split.md
@@ -4,7 +4,7 @@
 
 **Goal:** Split `SynchronizerMetrics` into a `SynchronizerMeterRegistry` (meter creation) and a refactored `SynchronizerMetrics` (recording methods only). Consumers and public API unchanged.
 
-**Architecture:** New `@Component` class `SynchronizerMeterRegistry` holds `MeterRegistry` and owns 19 meter declarations + 4 factory methods. `SynchronizerMetrics` is refactored to hold `SynchronizerMeterRegistry` and delegates every recording method. No consumer-side changes.
+**Architecture:** New `@Component` class `SynchronizerMeterRegistry` holds `MeterRegistry` and owns 19 meter declarations + 4 factory methods, all exposed as `public val` properties. `SynchronizerMetrics` is refactored to hold `SynchronizerMeterRegistry` and delegates every recording method. No consumer-side changes.
 
 **Tech Stack:** Kotlin, Spring `@Component`, Micrometer `MeterRegistry` (Counter, Timer, DistributionSummary, Gauge), `java.util.concurrent.atomic.AtomicInteger`.
 
@@ -14,7 +14,7 @@
 
 | File | Action | Responsibility |
 |------|--------|----------------|
-| `module-synchronizer/src/main/kotlin/maple/synchronizer/metrics/SynchronizerMeterRegistry.kt` | Create | Owns all meter creation, 1-time init. Exposes meters via getters. |
+| `module-synchronizer/src/main/kotlin/maple/synchronizer/metrics/SynchronizerMeterRegistry.kt` | Create | Owns all meter creation, 1-time init. Exposes meters as `public val`. |
 | `module-synchronizer/src/main/kotlin/maple/synchronizer/metrics/SynchronizerMetrics.kt` | Modify | Refactored: holds `SynchronizerMeterRegistry`, recording methods only. Public API unchanged. |
 | `module-synchronizer/src/test/kotlin/maple/synchronizer/processor/DefaultChunkProcessorTest.kt` | Modify | Update line 27 constructor call to wrap `SimpleMeterRegistry` in `SynchronizerMeterRegistry`. |
 
@@ -27,7 +27,7 @@ All consumer files (`ChunkConsumerTemplate.kt`, `ChunkDataReader.kt`, `ChunkDocu
 **Files:**
 - Create: `module-synchronizer/src/main/kotlin/maple/synchronizer/metrics/SynchronizerMeterRegistry.kt`
 
-- [ ] **Step 1: Create the new file with all 19 meter declarations + 4 factory methods**
+- [ ] **Step 1: Create the new file**
 
 Path: `module-synchronizer/src/main/kotlin/maple/synchronizer/metrics/SynchronizerMeterRegistry.kt`
 
@@ -44,104 +44,78 @@ import org.springframework.stereotype.Component
 import java.util.concurrent.atomic.AtomicInteger
 
 @Component
-class SynchronizerMeterRegistry(private val registry: MeterRegistry) {
+class SynchronizerMeterRegistry(registry: MeterRegistry) {
 
     // Chunk counters
-    private val chunksReceived = registry.counter("synchronizer_chunks_received_total")
-    private val chunksProcessing = AtomicInteger(0)
-    private val chunksProcessed = registry.counter("synchronizer_chunks_processed_total")
-    private val chunksFailed = registry.counter("synchronizer_chunks_failed_total")
+    val chunksReceived = registry.counter("synchronizer_chunks_received_total")
+    val chunksProcessing = AtomicInteger(0)
+    val chunksProcessed = registry.counter("synchronizer_chunks_processed_total")
+    val chunksFailed = registry.counter("synchronizer_chunks_failed_total")
 
     init {
         registry.gauge("synchronizer_chunks_processing", chunksProcessing)
     }
 
     // Document / item counters
-    private val documentsProcessed = registry.counter("synchronizer_documents_processed_total")
-    private val itemsProcessed = registry.counter("synchronizer_items_processed_total")
+    val documentsProcessed = registry.counter("synchronizer_documents_processed_total")
+    val itemsProcessed = registry.counter("synchronizer_items_processed_total")
 
     // Timers — 각 단계별 latency
-    private val chunkTimer = Timer.builder("synchronizer_chunk_duration_seconds")
+    val chunkTimer = Timer.builder("synchronizer_chunk_duration_seconds")
         .description("Total time to process a single chunk end-to-end")
         .publishPercentileHistogram()
         .register(registry)
 
-    private val fileReadTimer = Timer.builder("synchronizer_file_read_duration_seconds")
+    val fileReadTimer = Timer.builder("synchronizer_file_read_duration_seconds")
         .description("Time to read and decompress gzip JSONL file")
         .publishPercentileHistogram()
         .register(registry)
 
-    private val documentBuildTimer = Timer.builder("synchronizer_document_build_duration_seconds")
+    val documentBuildTimer = Timer.builder("synchronizer_document_build_duration_seconds")
         .description("Time to build read model documents from grouped results")
         .publishPercentileHistogram()
         .register(registry)
 
-    private val mainUpsertTimer = Timer.builder("synchronizer_main_upsert_duration_seconds")
+    val mainUpsertTimer = Timer.builder("synchronizer_main_upsert_duration_seconds")
         .description("Time to bulk upsert documents into main read model table")
         .publishPercentileHistogram()
         .register(registry)
 
     // Distribution summaries — chunk 크기/분포
-    private val chunkDocumentsSummary = DistributionSummary.builder("synchronizer_chunk_documents")
+    val chunkDocumentsSummary = DistributionSummary.builder("synchronizer_chunk_documents")
         .description("Number of documents per chunk")
         .register(registry)
 
-    private val chunkItemsSummary = DistributionSummary.builder("synchronizer_chunk_items")
+    val chunkItemsSummary = DistributionSummary.builder("synchronizer_chunk_items")
         .description("Number of items per chunk")
         .register(registry)
 
-    private val chunkBytesSummary = DistributionSummary.builder("synchronizer_chunk_bytes")
+    val chunkBytesSummary = DistributionSummary.builder("synchronizer_chunk_bytes")
         .description("Compressed document bytes per chunk")
         .register(registry)
 
-    private val documentEquipmentSummary = DistributionSummary.builder("synchronizer_document_equipment_count")
+    val documentEquipmentSummary = DistributionSummary.builder("synchronizer_document_equipment_count")
         .description("Equipment count per document")
         .register(registry)
 
     // Volume metrics — pre-upsert data volume
-    private val preUpsertCompressedBytesTotal = registry.counter("synchronizer_pre_upsert_compressed_bytes_total")
-    private val preUpsertUncompressedBytesTotal = registry.counter("synchronizer_pre_upsert_uncompressed_bytes_total")
-    private val preUpsertJsonRowsTotal = registry.counter("synchronizer_pre_upsert_json_rows_total")
+    val preUpsertCompressedBytesTotal = registry.counter("synchronizer_pre_upsert_compressed_bytes_total")
+    val preUpsertUncompressedBytesTotal = registry.counter("synchronizer_pre_upsert_uncompressed_bytes_total")
+    val preUpsertJsonRowsTotal = registry.counter("synchronizer_pre_upsert_json_rows_total")
 
-    private val preUpsertCompressedSummary = DistributionSummary.builder("synchronizer_pre_upsert_compressed_bytes")
+    val preUpsertCompressedSummary = DistributionSummary.builder("synchronizer_pre_upsert_compressed_bytes")
         .description("Compressed artifact bytes per chunk before DB upsert")
         .register(registry)
 
-    private val preUpsertUncompressedSummary = DistributionSummary.builder("synchronizer_pre_upsert_uncompressed_bytes")
+    val preUpsertUncompressedSummary = DistributionSummary.builder("synchronizer_pre_upsert_uncompressed_bytes")
         .description("Uncompressed artifact bytes per chunk before DB upsert")
         .register(registry)
 
-    private val preUpsertCompressionRatio = DistributionSummary.builder("synchronizer_pre_upsert_compression_ratio")
+    val preUpsertCompressionRatio = DistributionSummary.builder("synchronizer_pre_upsert_compression_ratio")
         .description("Compression ratio (uncompressed/compressed) per chunk before DB upsert")
         .register(registry)
 
-    // Counter getters
-    fun chunksReceived(): Counter = chunksReceived
-    fun chunksProcessing(): AtomicInteger = chunksProcessing
-    fun chunksProcessed(): Counter = chunksProcessed
-    fun chunksFailed(): Counter = chunksFailed
-    fun documentsProcessed(): Counter = documentsProcessed
-    fun itemsProcessed(): Counter = itemsProcessed
-    fun preUpsertCompressedBytesTotal(): Counter = preUpsertCompressedBytesTotal
-    fun preUpsertUncompressedBytesTotal(): Counter = preUpsertUncompressedBytesTotal
-    fun preUpsertJsonRowsTotal(): Counter = preUpsertJsonRowsTotal
-
-    // Timer getters
-    fun chunkTimer(): Timer = chunkTimer
-    fun fileReadTimer(): Timer = fileReadTimer
-    fun documentBuildTimer(): Timer = documentBuildTimer
-    fun mainUpsertTimer(): Timer = mainUpsertTimer
-
-    // DistributionSummary getters
-    fun chunkDocumentsSummary(): DistributionSummary = chunkDocumentsSummary
-    fun chunkItemsSummary(): DistributionSummary = chunkItemsSummary
-    fun chunkBytesSummary(): DistributionSummary = chunkBytesSummary
-    fun documentEquipmentSummary(): DistributionSummary = documentEquipmentSummary
-    fun preUpsertCompressedSummary(): DistributionSummary = preUpsertCompressedSummary
-    fun preUpsertUncompressedSummary(): DistributionSummary = preUpsertUncompressedSummary
-    fun preUpsertCompressionRatio(): DistributionSummary = preUpsertCompressionRatio
-
-    // Status transition counter
+    // Status / execution factory methods — these create per-tag meters on demand
     fun statusCounter(status: String): Counter =
         registry.counter("synchronizer_chunk_status_transition_total", "status", status)
 
@@ -177,7 +151,7 @@ class SynchronizerMeterRegistry(private val registry: MeterRegistry) {
 }
 ```
 
-Note: getter names mirror the private property names for the 1:1 meters (e.g. `chunksReceived()` returns `chunksReceived`). This is the only deliberate shadow — Kotlin allows it because one is a property and the other a function.
+Note: meters are exposed as `public val` properties (Kotlin-idiomatic). `SynchronizerMetrics` accesses them as `meterRegistry.chunksReceived.increment()`. The 4 factory methods remain functions because they take parameters and create per-tag meters on demand.
 
 - [ ] **Step 2: Compile to verify the new file builds**
 
@@ -209,8 +183,6 @@ Path: `module-synchronizer/src/main/kotlin/maple/synchronizer/metrics/Synchroniz
 ```kotlin
 package maple.synchronizer.metrics
 
-import io.micrometer.core.instrument.Counter
-import io.micrometer.core.instrument.DistributionSummary
 import io.micrometer.core.instrument.Timer
 import maple.synchronizer.state.ChunkExecutionStatus
 import maple.expectation.common.event.ChunkExecutionType
@@ -219,11 +191,11 @@ import org.springframework.stereotype.Component
 @Component
 class SynchronizerMetrics(private val meterRegistry: SynchronizerMeterRegistry) {
 
-    fun incrementReceived() = meterRegistry.chunksReceived().increment()
-    fun incrementProcessing() = meterRegistry.chunksProcessing().incrementAndGet()
-    fun decrementProcessing() = meterRegistry.chunksProcessing().decrementAndGet()
-    fun incrementProcessed() = meterRegistry.chunksProcessed().increment()
-    fun incrementFailed() = meterRegistry.chunksFailed().increment()
+    fun incrementReceived() = meterRegistry.chunksReceived.increment()
+    fun incrementProcessing() = meterRegistry.chunksProcessing.incrementAndGet()
+    fun decrementProcessing() = meterRegistry.chunksProcessing.decrementAndGet()
+    fun incrementProcessed() = meterRegistry.chunksProcessed.increment()
+    fun incrementFailed() = meterRegistry.chunksFailed.increment()
 
     fun recordChunkExecutionInserted(executionType: ChunkExecutionType) =
         meterRegistry.chunkExecutionCounter("chunk_execution_inserted_total", executionType).increment()
@@ -246,59 +218,59 @@ class SynchronizerMetrics(private val meterRegistry: SynchronizerMeterRegistry) 
     fun recordChunkExecutionReclaimedExpired(executionType: ChunkExecutionType) =
         meterRegistry.chunkExecutionCounter("chunk_execution_reclaimed_expired_total", executionType).increment()
 
-    fun incrementDocuments(count: Int) = meterRegistry.documentsProcessed().increment(count.toDouble())
-    fun incrementItems(count: Long) = meterRegistry.itemsProcessed().increment(count.toDouble())
+    fun incrementDocuments(count: Int) = meterRegistry.documentsProcessed.increment(count.toDouble())
+    fun incrementItems(count: Long) = meterRegistry.itemsProcessed.increment(count.toDouble())
 
     fun recordStatusTransition(status: String) = meterRegistry.statusCounter(status).increment()
 
     fun recordChunkSize(documents: Int, items: Long) {
-        meterRegistry.chunkDocumentsSummary().record(documents.toDouble())
-        meterRegistry.chunkItemsSummary().record(items.toDouble())
+        meterRegistry.chunkDocumentsSummary.record(documents.toDouble())
+        meterRegistry.chunkItemsSummary.record(items.toDouble())
     }
 
     fun recordChunkBytes(bytes: Long) {
-        meterRegistry.chunkBytesSummary().record(bytes.toDouble())
+        meterRegistry.chunkBytesSummary.record(bytes.toDouble())
     }
 
-    fun recordDocumentEquipment(count: Int) = meterRegistry.documentEquipmentSummary().record(count.toDouble())
+    fun recordDocumentEquipment(count: Int) = meterRegistry.documentEquipmentSummary.record(count.toDouble())
 
     fun recordPreUpsertVolume(compressedBytes: Long, uncompressedBytes: Long, jsonRows: Long) {
-        meterRegistry.preUpsertCompressedBytesTotal().increment(compressedBytes.toDouble())
-        meterRegistry.preUpsertUncompressedBytesTotal().increment(uncompressedBytes.toDouble())
-        meterRegistry.preUpsertJsonRowsTotal().increment(jsonRows.toDouble())
-        meterRegistry.preUpsertCompressedSummary().record(compressedBytes.toDouble())
-        meterRegistry.preUpsertUncompressedSummary().record(uncompressedBytes.toDouble())
+        meterRegistry.preUpsertCompressedBytesTotal.increment(compressedBytes.toDouble())
+        meterRegistry.preUpsertUncompressedBytesTotal.increment(uncompressedBytes.toDouble())
+        meterRegistry.preUpsertJsonRowsTotal.increment(jsonRows.toDouble())
+        meterRegistry.preUpsertCompressedSummary.record(compressedBytes.toDouble())
+        meterRegistry.preUpsertUncompressedSummary.record(uncompressedBytes.toDouble())
         if (compressedBytes > 0) {
-            meterRegistry.preUpsertCompressionRatio().record(uncompressedBytes.toDouble() / compressedBytes.toDouble())
+            meterRegistry.preUpsertCompressionRatio.record(uncompressedBytes.toDouble() / compressedBytes.toDouble())
         }
     }
 
-    fun chunkTimer(): Timer = meterRegistry.chunkTimer()
-    fun fileReadTimer(): Timer = meterRegistry.fileReadTimer()
-    fun documentBuildTimer(): Timer = meterRegistry.documentBuildTimer()
-    fun mainUpsertTimer(): Timer = meterRegistry.mainUpsertTimer()
+    fun chunkTimer(): Timer = meterRegistry.chunkTimer
+    fun fileReadTimer(): Timer = meterRegistry.fileReadTimer
+    fun documentBuildTimer(): Timer = meterRegistry.documentBuildTimer
+    fun mainUpsertTimer(): Timer = meterRegistry.mainUpsertTimer
 }
 ```
 
-Note: `Counter` and `DistributionSummary` imports remain because the **method signatures** of `recordChunkExecutionInserted` etc. resolve through the registry's factory methods which return `Counter`. Actually the return type is inferred — they can be dropped. Check after compile.
+Note: public API preserved byte-for-byte. The 4 `fun xxxTimer(): Timer` methods are kept (consumers like `SynchronizerChunkMetricsListener` call `metrics.chunkTimer()`). `Counter` and `DistributionSummary` imports dropped — only `Timer` is referenced explicitly in return types.
 
-- [ ] **Step 2: Compile to verify the refactor builds**
+- [ ] **Step 2: Compile the synchronizer module**
 
 Run:
 ```bash
 ./gradlew :module-synchronizer:compileKotlin --continue
 ```
 
-Expected: BUILD SUCCESSFUL. If `Counter`/`DistributionSummary` imports are flagged as unused, remove them and re-run.
+Expected: BUILD SUCCESSFUL.
 
-- [ ] **Step 3: Verify consumer sites still compile (the public API is byte-for-byte identical, so this should pass with no other changes)**
+- [ ] **Step 3: Full compile check across all modules**
 
 Run:
 ```bash
 ./gradlew compileKotlin compileJava --continue
 ```
 
-Expected: BUILD SUCCESSFUL across all modules.
+Expected: BUILD SUCCESSFUL. (No consumer diff — public API identical.)
 
 - [ ] **Step 4: Commit**
 
@@ -316,7 +288,7 @@ git commit -m "refactor(synchronizer): delegate SynchronizerMetrics recording to
 
 - [ ] **Step 1: Locate the constructor call at line 27**
 
-The current line is:
+Current line:
 ```kotlin
 private val metrics = SynchronizerMetrics(SimpleMeterRegistry())
 ```
@@ -327,9 +299,17 @@ private val metrics = SynchronizerMetrics(SimpleMeterRegistry())
 private val metrics = SynchronizerMetrics(SynchronizerMeterRegistry(SimpleMeterRegistry()))
 ```
 
-Verify the file imports `SynchronizerMeterRegistry` from `maple.synchronizer.metrics` — if not, add the import. (Test files in this module typically import with `import maple.synchronizer.metrics.SynchronizerMetrics` already; add `import maple.synchronizer.metrics.SynchronizerMeterRegistry` next to it.)
+- [ ] **Step 3: Verify the import for `SynchronizerMeterRegistry` is present**
 
-- [ ] **Step 3: Run the test file to verify the change**
+Open the file imports section. The file already imports `maple.synchronizer.metrics.SynchronizerMetrics`. Add adjacent:
+
+```kotlin
+import maple.synchronizer.metrics.SynchronizerMeterRegistry
+```
+
+If the import is already present (from wildcard or previous), no change needed.
+
+- [ ] **Step 4: Run the test file to verify the change**
 
 Run:
 ```bash
@@ -338,7 +318,7 @@ Run:
 
 Expected: BUILD SUCCESSFUL, tests pass.
 
-- [ ] **Step 4: Commit**
+- [ ] **Step 5: Commit**
 
 ```bash
 git add module-synchronizer/src/test/kotlin/maple/synchronizer/processor/DefaultChunkProcessorTest.kt
@@ -367,7 +347,7 @@ Run:
 ./gradlew compileKotlin compileJava --continue
 ```
 
-Expected: BUILD SUCCESSFUL. No errors emitted. (Per workflow-rules §11, only failures should appear; absence of error output = success.)
+Expected: BUILD SUCCESSFUL. (Per workflow-rules §11, only failures should appear; absence of error output = success.)
 
 ---
 
@@ -382,16 +362,16 @@ set -a && source .env && set +a
 ./gradlew :module-synchronizer:bootRun
 ```
 
-Run in background: `run_in_background: true`. Wait for `Started SynchronizerApplication` log line.
+Run with `run_in_background: true`. Wait for `Started SynchronizerApplication` log line (or equivalent startup success marker).
 
 - [ ] **Step 2: Verify the meter registry bean is registered**
 
-Hit Prometheus endpoint:
+Hit Prometheus endpoint (synchronizer is on port 8083):
 ```bash
-curl -s http://localhost:8083/actuator/prometheus | grep -E "^synchronizer_(chunks_received|chunks_processed|documents_processed)" | head -5
+curl -s http://localhost:8083/actuator/prometheus | grep -E "^synchronizer_(chunks_received|chunks_processed|documents_processed)_total" | head -5
 ```
 
-Expected: lines like `synchronizer_chunks_received_total{application="synchronizer"} 0.0` etc. (gauge is registered but not yet incremented). No `ERROR` in logs.
+Expected: lines like `synchronizer_chunks_received_total{application="synchronizer"} 0.0` etc. The gauge `synchronizer_chunks_processing` should also be present. No `ERROR` in logs.
 
 - [ ] **Step 3: Stop the server**
 
@@ -418,7 +398,9 @@ gh pr create \
   --base develop \
   --head refactor/issue-1066-sync-metrics-split \
   --title "refactor(synchronizer): split SynchronizerMetrics into meter registry + recording (#1066)" \
-  --body "Decomposes SynchronizerMetrics (176 lines) into SynchronizerMeterRegistry (meter creation, 80 lines) and SynchronizerMetrics (recording only, 90 lines). Public API of SynchronizerMetrics is unchanged — no consumer diff. New metrics now touch one class only.
+  --body "Decomposes SynchronizerMetrics (176 lines) into SynchronizerMeterRegistry (meter creation) and SynchronizerMetrics (recording only). Public API of SynchronizerMetrics is unchanged — no consumer diff. New metrics now touch one class only.
+
+Closes #1066
 
 Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 ```
@@ -429,7 +411,7 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 
 **1. Spec coverage:**
 - SynchronizerMeterRegistry separated → Task 1 ✓
-- SynchronizerMetrics recording only → Task 2 ✓
+- SynchronizerMetrics recording only → Task 2 (no `MeterRegistry` import, no meter declarations) ✓
 - Public API byte-for-byte identical → Task 2 explicitly preserves all 24 public methods ✓
 - New metric = 1 file change → enforced by file structure (registration in registry only) ✓
 - :module-synchronizer:test passes → Task 4 ✓
@@ -438,4 +420,4 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 
 **2. Placeholder scan:** No TBD/TODO. No "implement later". All code blocks are complete.
 
-**3. Type consistency:** `chunkTimer()` getter exists in `SynchronizerMeterRegistry` (Task 1) and is referenced in `SynchronizerMetrics.chunkTimer()` (Task 2) — names match. All factory method names (`statusCounter`, `chunkExecutionCounter`, `chunkExecutionSkippedCounter`, `chunkExecutionFailedCounter`) preserved exactly. `AtomicInteger` access via `incrementAndGet`/`decrementAndGet` preserved.
+**3. Type consistency:** `chunkTimer` property in `SynchronizerMeterRegistry` (Task 1) is referenced via `meterRegistry.chunkTimer` in `SynchronizerMetrics.chunkTimer()` (Task 2) — names match. All factory method names (`statusCounter`, `chunkExecutionCounter`, `chunkExecutionSkippedCounter`, `chunkExecutionFailedCounter`) preserved exactly. `AtomicInteger` access via `incrementAndGet`/`decrementAndGet` preserved.

--- a/docs/superpowers/plans/2026-06-06-1066-synchronizer-metrics-split.md
+++ b/docs/superpowers/plans/2026-06-06-1066-synchronizer-metrics-split.md
@@ -1,0 +1,441 @@
+# SynchronizerMetrics Split Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Split `SynchronizerMetrics` into a `SynchronizerMeterRegistry` (meter creation) and a refactored `SynchronizerMetrics` (recording methods only). Consumers and public API unchanged.
+
+**Architecture:** New `@Component` class `SynchronizerMeterRegistry` holds `MeterRegistry` and owns 19 meter declarations + 4 factory methods. `SynchronizerMetrics` is refactored to hold `SynchronizerMeterRegistry` and delegates every recording method. No consumer-side changes.
+
+**Tech Stack:** Kotlin, Spring `@Component`, Micrometer `MeterRegistry` (Counter, Timer, DistributionSummary, Gauge), `java.util.concurrent.atomic.AtomicInteger`.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `module-synchronizer/src/main/kotlin/maple/synchronizer/metrics/SynchronizerMeterRegistry.kt` | Create | Owns all meter creation, 1-time init. Exposes meters via getters. |
+| `module-synchronizer/src/main/kotlin/maple/synchronizer/metrics/SynchronizerMetrics.kt` | Modify | Refactored: holds `SynchronizerMeterRegistry`, recording methods only. Public API unchanged. |
+| `module-synchronizer/src/test/kotlin/maple/synchronizer/processor/DefaultChunkProcessorTest.kt` | Modify | Update line 27 constructor call to wrap `SimpleMeterRegistry` in `SynchronizerMeterRegistry`. |
+
+All consumer files (`ChunkConsumerTemplate.kt`, `ChunkDataReader.kt`, `ChunkDocumentWriter.kt`, `DefaultChunkProcessor.kt`, `ChunkDocumentTransformer.kt`, `SynchronizerChunkMetricsListener.kt`) are **untouched** — public API of `SynchronizerMetrics` is byte-for-byte identical.
+
+---
+
+## Task 1: Create SynchronizerMeterRegistry
+
+**Files:**
+- Create: `module-synchronizer/src/main/kotlin/maple/synchronizer/metrics/SynchronizerMeterRegistry.kt`
+
+- [ ] **Step 1: Create the new file with all 19 meter declarations + 4 factory methods**
+
+Path: `module-synchronizer/src/main/kotlin/maple/synchronizer/metrics/SynchronizerMeterRegistry.kt`
+
+```kotlin
+package maple.synchronizer.metrics
+
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.DistributionSummary
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Timer
+import maple.synchronizer.state.ChunkExecutionStatus
+import maple.expectation.common.event.ChunkExecutionType
+import org.springframework.stereotype.Component
+import java.util.concurrent.atomic.AtomicInteger
+
+@Component
+class SynchronizerMeterRegistry(private val registry: MeterRegistry) {
+
+    // Chunk counters
+    private val chunksReceived = registry.counter("synchronizer_chunks_received_total")
+    private val chunksProcessing = AtomicInteger(0)
+    private val chunksProcessed = registry.counter("synchronizer_chunks_processed_total")
+    private val chunksFailed = registry.counter("synchronizer_chunks_failed_total")
+
+    init {
+        registry.gauge("synchronizer_chunks_processing", chunksProcessing)
+    }
+
+    // Document / item counters
+    private val documentsProcessed = registry.counter("synchronizer_documents_processed_total")
+    private val itemsProcessed = registry.counter("synchronizer_items_processed_total")
+
+    // Timers — 각 단계별 latency
+    private val chunkTimer = Timer.builder("synchronizer_chunk_duration_seconds")
+        .description("Total time to process a single chunk end-to-end")
+        .publishPercentileHistogram()
+        .register(registry)
+
+    private val fileReadTimer = Timer.builder("synchronizer_file_read_duration_seconds")
+        .description("Time to read and decompress gzip JSONL file")
+        .publishPercentileHistogram()
+        .register(registry)
+
+    private val documentBuildTimer = Timer.builder("synchronizer_document_build_duration_seconds")
+        .description("Time to build read model documents from grouped results")
+        .publishPercentileHistogram()
+        .register(registry)
+
+    private val mainUpsertTimer = Timer.builder("synchronizer_main_upsert_duration_seconds")
+        .description("Time to bulk upsert documents into main read model table")
+        .publishPercentileHistogram()
+        .register(registry)
+
+    // Distribution summaries — chunk 크기/분포
+    private val chunkDocumentsSummary = DistributionSummary.builder("synchronizer_chunk_documents")
+        .description("Number of documents per chunk")
+        .register(registry)
+
+    private val chunkItemsSummary = DistributionSummary.builder("synchronizer_chunk_items")
+        .description("Number of items per chunk")
+        .register(registry)
+
+    private val chunkBytesSummary = DistributionSummary.builder("synchronizer_chunk_bytes")
+        .description("Compressed document bytes per chunk")
+        .register(registry)
+
+    private val documentEquipmentSummary = DistributionSummary.builder("synchronizer_document_equipment_count")
+        .description("Equipment count per document")
+        .register(registry)
+
+    // Volume metrics — pre-upsert data volume
+    private val preUpsertCompressedBytesTotal = registry.counter("synchronizer_pre_upsert_compressed_bytes_total")
+    private val preUpsertUncompressedBytesTotal = registry.counter("synchronizer_pre_upsert_uncompressed_bytes_total")
+    private val preUpsertJsonRowsTotal = registry.counter("synchronizer_pre_upsert_json_rows_total")
+
+    private val preUpsertCompressedSummary = DistributionSummary.builder("synchronizer_pre_upsert_compressed_bytes")
+        .description("Compressed artifact bytes per chunk before DB upsert")
+        .register(registry)
+
+    private val preUpsertUncompressedSummary = DistributionSummary.builder("synchronizer_pre_upsert_uncompressed_bytes")
+        .description("Uncompressed artifact bytes per chunk before DB upsert")
+        .register(registry)
+
+    private val preUpsertCompressionRatio = DistributionSummary.builder("synchronizer_pre_upsert_compression_ratio")
+        .description("Compression ratio (uncompressed/compressed) per chunk before DB upsert")
+        .register(registry)
+
+    // Counter getters
+    fun chunksReceived(): Counter = chunksReceived
+    fun chunksProcessing(): AtomicInteger = chunksProcessing
+    fun chunksProcessed(): Counter = chunksProcessed
+    fun chunksFailed(): Counter = chunksFailed
+    fun documentsProcessed(): Counter = documentsProcessed
+    fun itemsProcessed(): Counter = itemsProcessed
+    fun preUpsertCompressedBytesTotal(): Counter = preUpsertCompressedBytesTotal
+    fun preUpsertUncompressedBytesTotal(): Counter = preUpsertUncompressedBytesTotal
+    fun preUpsertJsonRowsTotal(): Counter = preUpsertJsonRowsTotal
+
+    // Timer getters
+    fun chunkTimer(): Timer = chunkTimer
+    fun fileReadTimer(): Timer = fileReadTimer
+    fun documentBuildTimer(): Timer = documentBuildTimer
+    fun mainUpsertTimer(): Timer = mainUpsertTimer
+
+    // DistributionSummary getters
+    fun chunkDocumentsSummary(): DistributionSummary = chunkDocumentsSummary
+    fun chunkItemsSummary(): DistributionSummary = chunkItemsSummary
+    fun chunkBytesSummary(): DistributionSummary = chunkBytesSummary
+    fun documentEquipmentSummary(): DistributionSummary = documentEquipmentSummary
+    fun preUpsertCompressedSummary(): DistributionSummary = preUpsertCompressedSummary
+    fun preUpsertUncompressedSummary(): DistributionSummary = preUpsertUncompressedSummary
+    fun preUpsertCompressionRatio(): DistributionSummary = preUpsertCompressionRatio
+
+    // Status transition counter
+    fun statusCounter(status: String): Counter =
+        registry.counter("synchronizer_chunk_status_transition_total", "status", status)
+
+    fun chunkExecutionCounter(name: String, executionType: ChunkExecutionType): Counter =
+        registry.counter(name, "execution_type", executionType.name)
+
+    fun chunkExecutionSkippedCounter(
+        executionType: ChunkExecutionType,
+        status: ChunkExecutionStatus,
+    ): Counter =
+        registry.counter(
+            "chunk_execution_skipped_total",
+            "execution_type",
+            executionType.name,
+            "status",
+            status.name,
+        )
+
+    fun chunkExecutionFailedCounter(
+        executionType: ChunkExecutionType,
+        status: ChunkExecutionStatus,
+        reason: String,
+    ): Counter =
+        registry.counter(
+            "chunk_execution_failed_total",
+            "execution_type",
+            executionType.name,
+            "status",
+            status.name,
+            "reason",
+            reason,
+        )
+}
+```
+
+Note: getter names mirror the private property names for the 1:1 meters (e.g. `chunksReceived()` returns `chunksReceived`). This is the only deliberate shadow — Kotlin allows it because one is a property and the other a function.
+
+- [ ] **Step 2: Compile to verify the new file builds**
+
+Run:
+```bash
+./gradlew :module-synchronizer:compileKotlin --continue
+```
+
+Expected: BUILD SUCCESSFUL. (Other modules may fail; use `--continue` to keep going.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add module-synchronizer/src/main/kotlin/maple/synchronizer/metrics/SynchronizerMeterRegistry.kt
+git commit -m "refactor(synchronizer): add SynchronizerMeterRegistry for meter creation"
+```
+
+---
+
+## Task 2: Refactor SynchronizerMetrics
+
+**Files:**
+- Modify: `module-synchronizer/src/main/kotlin/maple/synchronizer/metrics/SynchronizerMetrics.kt`
+
+- [ ] **Step 1: Replace the entire file**
+
+Path: `module-synchronizer/src/main/kotlin/maple/synchronizer/metrics/SynchronizerMetrics.kt`
+
+```kotlin
+package maple.synchronizer.metrics
+
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.DistributionSummary
+import io.micrometer.core.instrument.Timer
+import maple.synchronizer.state.ChunkExecutionStatus
+import maple.expectation.common.event.ChunkExecutionType
+import org.springframework.stereotype.Component
+
+@Component
+class SynchronizerMetrics(private val meterRegistry: SynchronizerMeterRegistry) {
+
+    fun incrementReceived() = meterRegistry.chunksReceived().increment()
+    fun incrementProcessing() = meterRegistry.chunksProcessing().incrementAndGet()
+    fun decrementProcessing() = meterRegistry.chunksProcessing().decrementAndGet()
+    fun incrementProcessed() = meterRegistry.chunksProcessed().increment()
+    fun incrementFailed() = meterRegistry.chunksFailed().increment()
+
+    fun recordChunkExecutionInserted(executionType: ChunkExecutionType) =
+        meterRegistry.chunkExecutionCounter("chunk_execution_inserted_total", executionType).increment()
+
+    fun recordChunkExecutionClaimed(executionType: ChunkExecutionType) =
+        meterRegistry.chunkExecutionCounter("chunk_execution_claimed_total", executionType).increment()
+
+    fun recordChunkExecutionSkipped(executionType: ChunkExecutionType, status: ChunkExecutionStatus) =
+        meterRegistry.chunkExecutionSkippedCounter(executionType, status).increment()
+
+    fun recordChunkExecutionSucceeded(executionType: ChunkExecutionType) =
+        meterRegistry.chunkExecutionCounter("chunk_execution_succeeded_total", executionType).increment()
+
+    fun recordChunkExecutionFailed(
+        executionType: ChunkExecutionType,
+        status: ChunkExecutionStatus,
+        reason: String,
+    ) = meterRegistry.chunkExecutionFailedCounter(executionType, status, reason).increment()
+
+    fun recordChunkExecutionReclaimedExpired(executionType: ChunkExecutionType) =
+        meterRegistry.chunkExecutionCounter("chunk_execution_reclaimed_expired_total", executionType).increment()
+
+    fun incrementDocuments(count: Int) = meterRegistry.documentsProcessed().increment(count.toDouble())
+    fun incrementItems(count: Long) = meterRegistry.itemsProcessed().increment(count.toDouble())
+
+    fun recordStatusTransition(status: String) = meterRegistry.statusCounter(status).increment()
+
+    fun recordChunkSize(documents: Int, items: Long) {
+        meterRegistry.chunkDocumentsSummary().record(documents.toDouble())
+        meterRegistry.chunkItemsSummary().record(items.toDouble())
+    }
+
+    fun recordChunkBytes(bytes: Long) {
+        meterRegistry.chunkBytesSummary().record(bytes.toDouble())
+    }
+
+    fun recordDocumentEquipment(count: Int) = meterRegistry.documentEquipmentSummary().record(count.toDouble())
+
+    fun recordPreUpsertVolume(compressedBytes: Long, uncompressedBytes: Long, jsonRows: Long) {
+        meterRegistry.preUpsertCompressedBytesTotal().increment(compressedBytes.toDouble())
+        meterRegistry.preUpsertUncompressedBytesTotal().increment(uncompressedBytes.toDouble())
+        meterRegistry.preUpsertJsonRowsTotal().increment(jsonRows.toDouble())
+        meterRegistry.preUpsertCompressedSummary().record(compressedBytes.toDouble())
+        meterRegistry.preUpsertUncompressedSummary().record(uncompressedBytes.toDouble())
+        if (compressedBytes > 0) {
+            meterRegistry.preUpsertCompressionRatio().record(uncompressedBytes.toDouble() / compressedBytes.toDouble())
+        }
+    }
+
+    fun chunkTimer(): Timer = meterRegistry.chunkTimer()
+    fun fileReadTimer(): Timer = meterRegistry.fileReadTimer()
+    fun documentBuildTimer(): Timer = meterRegistry.documentBuildTimer()
+    fun mainUpsertTimer(): Timer = meterRegistry.mainUpsertTimer()
+}
+```
+
+Note: `Counter` and `DistributionSummary` imports remain because the **method signatures** of `recordChunkExecutionInserted` etc. resolve through the registry's factory methods which return `Counter`. Actually the return type is inferred — they can be dropped. Check after compile.
+
+- [ ] **Step 2: Compile to verify the refactor builds**
+
+Run:
+```bash
+./gradlew :module-synchronizer:compileKotlin --continue
+```
+
+Expected: BUILD SUCCESSFUL. If `Counter`/`DistributionSummary` imports are flagged as unused, remove them and re-run.
+
+- [ ] **Step 3: Verify consumer sites still compile (the public API is byte-for-byte identical, so this should pass with no other changes)**
+
+Run:
+```bash
+./gradlew compileKotlin compileJava --continue
+```
+
+Expected: BUILD SUCCESSFUL across all modules.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add module-synchronizer/src/main/kotlin/maple/synchronizer/metrics/SynchronizerMetrics.kt
+git commit -m "refactor(synchronizer): delegate SynchronizerMetrics recording to meter registry"
+```
+
+---
+
+## Task 3: Update DefaultChunkProcessorTest constructor
+
+**Files:**
+- Modify: `module-synchronizer/src/test/kotlin/maple/synchronizer/processor/DefaultChunkProcessorTest.kt:27`
+
+- [ ] **Step 1: Locate the constructor call at line 27**
+
+The current line is:
+```kotlin
+private val metrics = SynchronizerMetrics(SimpleMeterRegistry())
+```
+
+- [ ] **Step 2: Replace with the new constructor that wraps the registry**
+
+```kotlin
+private val metrics = SynchronizerMetrics(SynchronizerMeterRegistry(SimpleMeterRegistry()))
+```
+
+Verify the file imports `SynchronizerMeterRegistry` from `maple.synchronizer.metrics` — if not, add the import. (Test files in this module typically import with `import maple.synchronizer.metrics.SynchronizerMetrics` already; add `import maple.synchronizer.metrics.SynchronizerMeterRegistry` next to it.)
+
+- [ ] **Step 3: Run the test file to verify the change**
+
+Run:
+```bash
+./gradlew :module-synchronizer:test --tests "maple.synchronizer.processor.DefaultChunkProcessorTest"
+```
+
+Expected: BUILD SUCCESSFUL, tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add module-synchronizer/src/test/kotlin/maple/synchronizer/processor/DefaultChunkProcessorTest.kt
+git commit -m "test(synchronizer): update DefaultChunkProcessorTest for split constructor"
+```
+
+---
+
+## Task 4: Run full module-synchronizer test suite
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the synchronizer module tests**
+
+Run:
+```bash
+./gradlew :module-synchronizer:test
+```
+
+Expected: BUILD SUCCESSFUL. All tests pass.
+
+- [ ] **Step 2: Run full compile check across all modules**
+
+Run:
+```bash
+./gradlew compileKotlin compileJava --continue
+```
+
+Expected: BUILD SUCCESSFUL. No errors emitted. (Per workflow-rules §11, only failures should appear; absence of error output = success.)
+
+---
+
+## Task 5: BootRun smoke check
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Start the synchronizer module**
+
+```bash
+set -a && source .env && set +a
+./gradlew :module-synchronizer:bootRun
+```
+
+Run in background: `run_in_background: true`. Wait for `Started SynchronizerApplication` log line.
+
+- [ ] **Step 2: Verify the meter registry bean is registered**
+
+Hit Prometheus endpoint:
+```bash
+curl -s http://localhost:8083/actuator/prometheus | grep -E "^synchronizer_(chunks_received|chunks_processed|documents_processed)" | head -5
+```
+
+Expected: lines like `synchronizer_chunks_received_total{application="synchronizer"} 0.0` etc. (gauge is registered but not yet incremented). No `ERROR` in logs.
+
+- [ ] **Step 3: Stop the server**
+
+```bash
+pkill -f 'gradlew :module-synchronizer:bootRun' || pkill -f 'SynchronizerApplication'
+```
+
+---
+
+## Task 6: Open PR to develop
+
+**Files:** none
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin refactor/issue-1066-sync-metrics-split
+```
+
+- [ ] **Step 2: Open PR via gh**
+
+```bash
+gh pr create \
+  --base develop \
+  --head refactor/issue-1066-sync-metrics-split \
+  --title "refactor(synchronizer): split SynchronizerMetrics into meter registry + recording (#1066)" \
+  --body "Decomposes SynchronizerMetrics (176 lines) into SynchronizerMeterRegistry (meter creation, 80 lines) and SynchronizerMetrics (recording only, 90 lines). Public API of SynchronizerMetrics is unchanged — no consumer diff. New metrics now touch one class only.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- SynchronizerMeterRegistry separated → Task 1 ✓
+- SynchronizerMetrics recording only → Task 2 ✓
+- Public API byte-for-byte identical → Task 2 explicitly preserves all 24 public methods ✓
+- New metric = 1 file change → enforced by file structure (registration in registry only) ✓
+- :module-synchronizer:test passes → Task 4 ✓
+- compileKotlin compileJava passes → Task 4 ✓
+- bootRun smoke check → Task 5 ✓
+
+**2. Placeholder scan:** No TBD/TODO. No "implement later". All code blocks are complete.
+
+**3. Type consistency:** `chunkTimer()` getter exists in `SynchronizerMeterRegistry` (Task 1) and is referenced in `SynchronizerMetrics.chunkTimer()` (Task 2) — names match. All factory method names (`statusCounter`, `chunkExecutionCounter`, `chunkExecutionSkippedCounter`, `chunkExecutionFailedCounter`) preserved exactly. `AtomicInteger` access via `incrementAndGet`/`decrementAndGet` preserved.

--- a/docs/superpowers/specs/2026-06-06-1066-synchronizer-metrics-split-design.md
+++ b/docs/superpowers/specs/2026-06-06-1066-synchronizer-metrics-split-design.md
@@ -1,0 +1,180 @@
+# SynchronizerMetrics Decomposition Design
+
+- Date: 2026-06-06
+- Issue: #1066
+- Branch: `refactor/issue-1066-sync-metrics-split`
+- Owner: TBD
+
+---
+
+## 1. Background / Problem
+
+### Background
+
+`module-synchronizer/.../metrics/SynchronizerMetrics.kt` is 176 lines and bundles two unrelated concerns:
+
+1. **Meter registration** (~67 lines) — 19 counter/timer/summary/gauge declarations in property initialisers plus a `init {}` block for the gauge
+2. **Recording methods** (~90 lines) — public API invoked from consumers (ChunkConsumerTemplate, ChunkDataReader, ChunkDocumentWriter, DefaultChunkProcessor, ChunkDocumentTransformer, SynchronizerChunkMetricsListener)
+
+Adding a new metric currently requires editing the same class as the recording logic, which is the wrong locality: the registration is structural (one-time at startup) and the recording is behavioural (called from business code paths).
+
+### Problem
+
+- Registration boilerplate and recording logic are co-mingled in a single file
+- A new metric touches the file that records values — separation of concerns is missing
+- Tests construct `SynchronizerMetrics(SimpleMeterRegistry())` to get a single metric, paying for 19 meter inits
+
+### Goal
+
+Separate meter registration from recording so that:
+
+1. Adding a new metric requires editing **one** class (`SynchronizerMeterRegistry`)
+2. Recording logic is the only thing in `SynchronizerMetrics`
+3. Consumers are unaffected (public API of `SynchronizerMetrics` unchanged)
+
+---
+
+## 2. Decision
+
+> Split `SynchronizerMetrics` into two `@Component` classes: `SynchronizerMeterRegistry` (meter creation, 1-time init) and `SynchronizerMetrics` (recording methods only, holding a reference to the registry).
+
+```text
+module-synchronizer/src/main/kotlin/maple/synchronizer/metrics/
+├── SynchronizerMeterRegistry.kt   (NEW — 80 lines)
+├── SynchronizerMetrics.kt          (refactored — 90 lines, no MeterRegistry)
+└── SynchronizerChunkMetricsListener.kt   (unchanged)
+```
+
+---
+
+## 3. Component Contracts
+
+### 3.1 `SynchronizerMeterRegistry` (new)
+
+```kotlin
+@Component
+class SynchronizerMeterRegistry(private val registry: MeterRegistry) {
+    // Counter getters
+    fun chunksReceived(): Counter
+    fun chunksProcessed(): Counter
+    fun chunksFailed(): Counter
+    fun documentsProcessed(): Counter
+    fun itemsProcessed(): Counter
+    fun preUpsertCompressedBytesTotal(): Counter
+    fun preUpsertUncompressedBytesTotal(): Counter
+    fun preUpsertJsonRowsTotal(): Counter
+
+    // Gauge source
+    fun chunksProcessing(): AtomicInteger   // gauge bound in init
+
+    // Timer getters
+    fun chunkTimer(): Timer
+    fun fileReadTimer(): Timer
+    fun documentBuildTimer(): Timer
+    fun mainUpsertTimer(): Timer
+
+    // DistributionSummary getters
+    fun chunkDocumentsSummary(): DistributionSummary
+    fun chunkItemsSummary(): DistributionSummary
+    fun chunkBytesSummary(): DistributionSummary
+    fun documentEquipmentSummary(): DistributionSummary
+    fun preUpsertCompressedSummary(): DistributionSummary
+    fun preUpsertUncompressedSummary(): DistributionSummary
+    fun preUpsertCompressionRatio(): DistributionSummary
+
+    // Status / execution factory methods (preserved verbatim)
+    fun statusCounter(status: String): Counter
+    fun chunkExecutionCounter(name: String, executionType: ChunkExecutionType): Counter
+    fun chunkExecutionSkippedCounter(executionType: ChunkExecutionType, status: ChunkExecutionStatus): Counter
+    fun chunkExecutionFailedCounter(
+        executionType: ChunkExecutionType,
+        status: ChunkExecutionStatus,
+        reason: String,
+    ): Counter
+}
+```
+
+All meters created in property initialisers / `init {}` block, identical to the current `SynchronizerMetrics` constructor. No recording logic.
+
+### 3.2 `SynchronizerMetrics` (refactored)
+
+```kotlin
+@Component
+class SynchronizerMetrics(private val meterRegistry: SynchronizerMeterRegistry) {
+    fun incrementReceived() = meterRegistry.chunksReceived().increment()
+    fun incrementProcessing() = meterRegistry.chunksProcessing().incrementAndGet()
+    fun decrementProcessing() = meterRegistry.chunksProcessing().decrementAndGet()
+    // ... all public methods preserved, body delegates to meterRegistry
+    fun chunkTimer(): Timer = meterRegistry.chunkTimer()
+    // ... etc.
+}
+```
+
+Public API of `SynchronizerMetrics` is **byte-for-byte identical**. Consumers (`ChunkConsumerTemplate`, `ChunkDataReader`, `ChunkDocumentWriter`, `DefaultChunkProcessor`, `ChunkDocumentTransformer`, `SynchronizerChunkMetricsListener`, tests) do not change.
+
+---
+
+## 4. Trade-offs
+
+### Sensitivity
+
+* Number of future metrics added to synchronizer
+* Test surface that constructs `SynchronizerMetrics` directly (currently 1 test: `DefaultChunkProcessorTest`)
+
+### Trade-off
+
+| Choice | Gain | Cost |
+|--------|------|------|
+| Two `@Component` classes | Single responsibility, registration vs recording localised | One extra Spring bean (negligible startup cost) |
+| SynchronizerMetrics holds registry reference (not MeterRegistry) | Recording is one indirection; can mock registry in tests | Indirect call cost (negligible — JVM inlines) |
+| Public API of SynchronizerMetrics unchanged | Zero consumer-side diff | None |
+
+### Risk
+
+* Indirect call (`meterRegistry.chunksReceived().increment()`) is one extra method call per recording — negligible runtime cost
+* Tests that build `SynchronizerMetrics(SimpleMeterRegistry())` must be updated to use `SynchronizerMeterRegistry(SimpleMeterRegistry())` — affects `DefaultChunkProcessorTest`
+
+### Non-Risk
+
+* Prometheus metric names unchanged (gauge/counter/timer creation logic identical)
+* Lifecycle semantics identical (both classes are `@Component` singletons, instantiated once at startup)
+* Consumer call sites unchanged
+
+---
+
+## 5. Migration
+
+1. Create `SynchronizerMeterRegistry` with the 19 meter declarations + factory methods copied verbatim
+2. Refactor `SynchronizerMetrics`:
+   - Constructor: replace `MeterRegistry` parameter with `SynchronizerMeterRegistry`
+   - Remove all 19 meter property declarations + `init {}` gauge block
+   - Update each recording method body to call `meterRegistry.x().y()`
+3. Update `DefaultChunkProcessorTest` (only test that constructs `SynchronizerMetrics` directly) to construct via `SynchronizerMeterRegistry(SimpleMeterRegistry())`
+4. Run `./gradlew :module-synchronizer:test`
+5. Run `./gradlew compileKotlin compileJava --continue`
+6. Run bootRun smoke check (per workflow-rules §10)
+
+---
+
+## 6. Test Strategy
+
+Existing tests pass unchanged (consumer behaviour preserved). Only test file modification: `DefaultChunkProcessorTest` line 27 currently constructs `SynchronizerMetrics(SimpleMeterRegistry())` — change to `SynchronizerMetrics(SynchronizerMeterRegistry(SimpleMeterRegistry()))`.
+
+No new tests required — this is a structural refactor with no behaviour change.
+
+---
+
+## 7. Acceptance Criteria
+
+- [ ] `SynchronizerMeterRegistry` separated (owns meter creation)
+- [ ] `SynchronizerMetrics` contains only recording methods (no `MeterRegistry` reference)
+- [ ] Public API of `SynchronizerMetrics` byte-for-byte identical
+- [ ] New metric addition requires editing `SynchronizerMeterRegistry` only
+- [ ] `./gradlew :module-synchronizer:test` passes
+- [ ] `./gradlew compileKotlin compileJava --continue` passes
+
+---
+
+## 8. Summary
+
+> Split `SynchronizerMetrics` into `SynchronizerMeterRegistry` (registration) + `SynchronizerMetrics` (recording). Consumers and public API unchanged. Adding a new metric touches one class.

--- a/docs/superpowers/specs/2026-06-06-1090-synchronizer-infra-extraction-design.md
+++ b/docs/superpowers/specs/2026-06-06-1090-synchronizer-infra-extraction-design.md
@@ -1,0 +1,116 @@
+# ADR-1090: Synchronizer — Complete infra extraction from DefaultChunkProcessor
+
+- Status: Accepted
+- Date: 2026-06-06
+- Owner: synchronizer
+
+## 1. Background / Problem
+
+### Background
+
+PR #1143 (commit `974efe438`) decomposed `DefaultChunkProcessor.process` into three stage classes:
+- `ChunkDataReader.read` (file read + OCID resolution)
+- `ChunkDocumentTransformer.transform` (grouped results → documents)
+- `ChunkDocumentWriter.write` (DB upsert + Redis ranking)
+
+`process()` shrank from ~40 mixed lines to ~20 orchestrator lines. The decomposition is incomplete: `process()` still calls `metrics.*` (lines 23, 25, 26, 27, 28) and a `log.info` (line 23) inline, mixing infra concerns into what should be pure orchestration.
+
+### Problem
+
+`DefaultChunkProcessor.process` is supposed to be orchestration-only ("transform → persist → metrics" per issue #1090). It still owns:
+- A `log.info` reporting grouped→document count
+- `metrics.incrementDocuments(documentCount)` / `metrics.incrementItems(itemCount)` — emit metrics about a stage's output
+- `metrics.recordChunkSize(...)` — emit combined metric
+- `metrics.recordDocumentEquipment(...)` per-prepped — emit per-item metric
+
+These are observations about what the transformer produced, not orchestration. They make `process()` look like it knows the shape of the transformer's output, which couples the orchestrator to stage internals.
+
+### Goal
+
+`DefaultChunkProcessor.process` becomes pure orchestration: call three stages, return result. No metrics, no log, no awareness of intermediate shapes.
+
+## 2. Decision
+
+> The transformer emits the per-chunk and per-document metrics, since it already owns the data shape that the metrics describe. The orchestrator calls three stage methods and returns a result.
+
+### Concretely
+
+```text
+DefaultChunkProcessor.process(input):
+    grouped   ← dataReader.read(input.objectKey)
+    transform ← transformer.transform(input.sourceRunId, input.sourceChunkId, grouped)
+    writer.write(input.sourceRunId, input.sourceChunkId, transform.prepped)
+    return ChunkProcessResult(documentCount, itemCount, input.resultCount)
+```
+
+`transform()` takes ownership of:
+- `log.info("[Synchronizer] grouped {} results into {} documents", ...)` — moved from process
+- `metrics.incrementDocuments(documentCount)` — moved from process
+- `metrics.incrementItems(itemCount)` — moved from process
+- `metrics.recordChunkSize(documentCount, itemCount)` — moved from process
+- `metrics.recordDocumentEquipment(equipmentCount)` per prepped — moved from process
+
+`writer.write` already owns the bulk-upsert timer + ranking write.
+
+`reader.read` already owns the file-read timer.
+
+`process()` becomes 5 lines (or fewer) of straight-line calls.
+
+### Why not a decorator
+
+Two options for separating metrics from stages:
+
+| Option | Trade-off |
+| --- | --- |
+| A: Push metrics into the stage that owns the data | Simple, no new abstraction, no double-dispatch. Stage classes are still focused — they grow from "do work" to "do work and report". |
+| B: Decorator (e.g. `MetricsAwareChunkProcessor` wrapping `ChunkProcessor`) | Pure separation of concerns, but metrics calls depend on the `TransformResult` shape — decorator must also know that shape. Two indirections for no functional benefit. |
+
+Option A is recommended. The stage classes are not "domain" — they already call `metrics.fileReadTimer()` / `mainUpsertTimer()`. Adding three more metric calls in the transformer does not break the separation, and it eliminates a leaky abstraction (orchestrator peeking at stage output).
+
+## 3. Trade-offs
+
+### Sensitivity
+
+- Test coverage of metric emission: the existing test (`DefaultChunkProcessorTest`) mocks stages. After this change, the transformer test must cover the metric calls. The orchestrator test simplifies (fewer mock setups).
+- Logging format: the `log.info` line is consumer-visible in production. Moving it from `process()` to `transformer.transform()` changes the logger name shown in `[Synchronizer]` — wait, no: the line already says `[Synchronizer]` literally (not the logger name), so the visible output is identical.
+
+### Trade-off
+
+| 선택 | 얻는 것 | 포기한 것 |
+| -- | ---- | ----- |
+| Push metrics into stage | Orchestrator is pure orchestration; no leaky shape; simpler test mocks | Stage classes couple to `SynchronizerMetrics` (already true for reader and writer) |
+
+### Risk
+
+- **None measurable**: the metrics output is byte-identical (same calls, same arguments, same ordering within a chunk). The log line is byte-identical. Behavior is unchanged.
+- Slight risk: if the orchestrator ever needs to do post-write work (e.g. emit a "chunk done" gauge), the orchestrator stays the right place — but that's hypothetical and YAGNI.
+
+### Non-Risk
+
+- The earlier separation risk (mixed domain/infra) is now fully resolved: orchestrator has no knowledge of stage internals.
+- The `metrics` field becomes unused on `DefaultChunkProcessor`; drop the constructor param.
+
+## 4. Result / Evidence
+
+### Metrics
+
+| Metric | Value | Notes |
+| ------ | ----: | ----- |
+| `DefaultChunkProcessor` LOC | 38 → ~20 | Remove metrics + log + constructor param |
+| `ChunkDocumentTransformer` LOC | 49 → ~55 | +6 lines for moved metrics + log |
+| Metrics calls emitted per chunk | unchanged | Same call sites, same arguments |
+| Log line emitted per chunk | unchanged | Same format, same trigger |
+
+### Observed Result
+
+After merging:
+- `DefaultChunkProcessor.process` contains only `read → transform → write → return`.
+- Constructor signature: `dataReader, transformer, writer` (no `metrics`).
+- `./gradlew :module-synchronizer:test` passes.
+- `./gradlew :module-synchronizer:compileKotlin :module-synchronizer:compileJava --continue` passes.
+- `DefaultChunkProcessorTest` still passes (mocks stages, returns canned `TransformResult`; no behavior change to verify).
+- New `ChunkDocumentTransformerTest` cases cover the moved metrics calls (or extend existing ones if a transformer test exists).
+
+## 5. Summary
+
+> Push the five remaining infra calls (one log + four metrics groups) from `DefaultChunkProcessor.process` into `ChunkDocumentTransformer.transform`, which already owns the data those calls describe. The orchestrator becomes pure 3-step orchestration.

--- a/docs/superpowers/specs/2026-06-06-1093-magic-numbers-design.md
+++ b/docs/superpowers/specs/2026-06-06-1093-magic-numbers-design.md
@@ -1,0 +1,140 @@
+# Design: Magic numbers to named constants (#1093)
+
+- Status: Accepted
+- Date: 2026-06-06
+- Owner: synchronizer / calculator / external-api / rest-controller
+
+## 1. Background / Problem
+
+### Background
+
+Issue #1093 catalogs ~25 raw numeric literals across 4 modules that obscure intent and require mental arithmetic. Examples: `5368709120` (5 GB), `134217728L` (128 MB), `3600000` (1 hour ms), `header.substring(7)` (Bearer prefix).
+
+Some of these are dead-on-arrival: the issue body refers to `CalculatorChunkProcessingCoordinator: Semaphore(2)` and "see issue #4" — that link is gone, and the value is intentional (matches HikariCP). Others are already partially constant-ized in this codebase (`JdbcBatchRetryConfig` has `Duration.ofMillis(100)` and `RetryConfig` in `RateLimitProperties` uses `Duration.ofSeconds(6)`). The work is to push remaining sites to a consistent pattern.
+
+### Problem
+
+Reading `ArtifactCleanupScheduler.kt:27` — `@Value(... max-delete-bytes-per-cycle:5368709120)` — requires the reader to convert 5368709120 to 5 GB. The codebase already uses self-documenting patterns (`Duration.ofSeconds(10)`, `RateLimitProperties.refillPeriod: Duration = Duration.ofSeconds(6)`), so the remaining raw literals are an inconsistency.
+
+### Goal
+
+Eliminate raw byte/time/count literals in the listed files. No behavioral change. Existing typed wrappers (`Duration`, `ByteSize` utilities) are preferred over `Int`/`Long` constants where possible.
+
+## 2. Decision
+
+> Three-tier constant strategy: in-file `private const val` for module-local values; module-internal `object` constants for cross-file within a module; no new shared module-common constants unless a value is genuinely cross-module.
+
+### Strategy by value type
+
+**Bytes** — Use `5L * 1024 * 1024 * 1024` style self-documenting expression, or `private const val` with `_L` suffix and a KDoc comment. Do **not** introduce a `ByteSize` value class — YAGNI, two sites in two files does not justify a shared type.
+
+**Durations** — Use the existing `Duration` type. Replace `3600000L` with `Duration.ofHours(1).toMillis()` where the surrounding code is typed `Duration`. Where the literal lives in a Spring annotation (`@Scheduled(fixedDelayString = "...")`, `@Value`), keep the raw number but add a `private const val` with the converted value and reference it from the annotation. (Spring annotations cannot reference `const val` properties, but can reference `@Value("${property:default}")` where `default` is a build-time substitution — out of scope here.)
+
+**Counts / thresholds** — Use `private const val` with a `KDoc` explaining rationale (e.g. why 5000 not 1000).
+
+**HTTP prefix length** — `header.substring(7)` → introduce `private const val BEARER_PREFIX = "Bearer "` and `header.substring(BEARER_PREFIX.length)`.
+
+**`Integer.MAX_VALUE - 100`** — already self-documenting as a phase ordering sentinel; add a comment instead of a constant.
+
+### File-by-file change set
+
+#### module-external-api
+
+| File | Change |
+| --- | --- |
+| `ArtifactCleanupScheduler.kt:27` | Default value `:5368709120` → `:5L * 1024 * 1024 * 1024` in annotation. Add comment: `// 5 GB` |
+| `SnapshotChunkingProperties.kt:18` | `134217728L` → `128L * 1024 * 1024` with KDoc `// 128 MB` |
+| `ConsumedChunkCleanupScheduler.kt:62` | Default `:3600000` → `:Duration.ofHours(1).toMillis()` (or keep raw + add `private const val` reference) |
+| `ExternalApiScheduler.kt:67` | `3_600_000` → extract `private const val LOCK_TIMEOUT_MS = 3_600_000L // 1 hour`; call site `acquireLock("daily_refresh", LOCK_TIMEOUT_MS)` |
+| `NexonExternalApiClientAdapter.kt:123` | `Duration.ofSeconds(10)` → `Duration.ofSeconds(API_TIMEOUT_SECONDS)` with `private const val API_TIMEOUT_SECONDS = 10L` + KDoc |
+| `SchedulerPhaseUtils.kt:34` | `delay(100)` → extract `private const val REFILL_BACKOFF_MS = 100L` (or keep inline + comment) |
+| `SnapshotFetchPhase.kt:213,256` | `5000`, `500`, `100` → `private const val` with KDoc |
+| `OcidLookupPhase.kt:137` | `5000` → shared const in `SchedulerPhaseUtils` object or local |
+| `RankingFetchPhase.kt:112` | `10000` → `private const val` |
+| `ChunkedSnapshotSink.kt:83` | `100, TimeUnit.MILLISECONDS` → `private const val ENQUEUE_TIMEOUT_MS = 100L` |
+
+#### module-calculator
+
+| File | Change |
+| --- | --- |
+| `CalculatorCleanupProperties.kt:10` | `5368709120` → `5L * 1024 * 1024 * 1024` with KDoc `// 5 GB` |
+| `CalculatorResultCleanupScheduler.kt:69` | `1800` → `Duration.ofMinutes(30).toSeconds()` |
+| `CalculationCache.kt:100_000` | Add `private const val CACHE_MAX_ENTRIES = 100_000` + KDoc explaining sizing |
+| `SnapshotChunkProcessor.kt:10` | Add `private const val SAMPLE_LIMIT = 10` + KDoc |
+| `CalculatorChunkProcessingCoordinator.kt:27` | `Semaphore(2)` → `private const val CONCURRENCY_PERMITS = 2` + KDoc referencing HikariCP sizing |
+
+#### module-synchronizer
+
+| File | Change |
+| --- | --- |
+| `CharacterBasicRepository.kt:14` + `EquipmentReadModelRepository.kt:17` | Both define `SUB_BATCH_SIZE = 100`. Extract to shared `object SynchronizerBatchConstants { const val SUB_BATCH_SIZE = 100 }` in same package |
+| `BasicChunkFileReader.kt:44` | `DEFAULT_BATCH_SIZE = 1000` — already named; keep |
+| `ChunkExecutionProperties` defaults | Add KDoc to existing defaults: `600`, `60`, `5`, `2` |
+
+#### module-rest-controller
+
+| File | Change |
+| --- | --- |
+| `JwtAuthInterceptor.kt:62` | `header.substring(7)` → `header.substring(BEARER_PREFIX.length)` with `private const val BEARER_PREFIX = "Bearer "` |
+| `JwtParserAdapter.kt:3600` | `3600` → `Duration.ofHours(1).toSeconds()` |
+| `BatchReadScheduler.kt:147` | `Integer.MAX_VALUE - 100` → `private const val BATCH_READ_SCHEDULER_PHASE = Integer.MAX_VALUE - 100` + KDoc explaining ordering convention |
+
+#### Cross-module (decline)
+
+| Item | Decision |
+| --- | --- |
+| `1024 * 1024` bytes→MB | Appears in 4 files (2 prod, 1 config, 1 collector). **Decline to extract.** The expression is universally understood; a `BYTES_PER_MB` constant in module-common adds an import for trivial clarity. The 3-byte repeated pattern is acceptable. |
+| `128 * 1024 * 1024` (maxUncompressedBytes) | Single site. Inline expression is self-documenting. |
+
+## 3. Trade-offs
+
+### Sensitivity
+
+- Annotation defaults (`@Value("...:5368709120")`): must keep numeric literal. Replacing with `5L * 1024 * 1024 * 1024` inside `@Value` string is allowed by Spring SpEL but the surrounding quotes make it ambiguous. **Approach: keep numeric in annotation, add a `private const val` separately, add KDoc on the field.** Two references, one source of truth.
+- `Semaphore(2)` is intentional sizing, not a magic number. Add a KDoc, not a constant.
+
+### Trade-off
+
+| 선택 | 얻는 것 | 포기한 것 |
+| -- | ---- | ----- |
+| In-file `private const val` + KDoc for each site | No new types, no cross-module coupling, minimal diff | Some repetition across modules (e.g. `5L * 1024 * 1024 * 1024` in two files) |
+| Shared `ByteSize` value class in module-common | One source of truth, type-safe arithmetic | Indirection, requires changing all sites to wrap/unwrap, overkill for 2 sites |
+| Declined to extract | No diff to small working patterns (1024*1024) | — |
+
+### Risk
+
+- **Annotation default value change** (`@Scheduled(fixedDelayString = "...":3600000)` → `...:Duration.ofHours(1).toMillis()`): the annotation is a string. Spring's `fixedDelayString` accepts a `String` of the numeric value, not a `Duration` expression. **Must keep the raw number in the annotation; extract to a `private const val` and add a comment that the annotation string mirrors the constant.** This is the only risk site.
+- Test reliance on exact ms value: search tests for `3600000` / `3600001` literals. None found in production code paths.
+
+### Non-Risk
+
+- `1024 * 1024` repeated 4 times — declining to extract is a deliberate YAGNI choice, not a missing cleanup.
+- `Semaphore(2)` is a sizing decision, not a magic number — KDoc only.
+
+## 4. Result / Evidence
+
+### Metrics
+
+| Metric | Value | Notes |
+| ------ | ----: | ----- |
+| Files touched | ~15 | Across 4 modules |
+| Raw `5368709120` literals remaining | 0 | Verify: `rg "5368709120" -g "*.kt"` |
+| Raw `134217728` literals remaining | 0 | Verify: `rg "134217728" -g "*.kt"` |
+| Raw `3600000` literals in production code | 0 | Verify: `rg "3600000" -g "*.kt" -g '!*Test.kt'` |
+| `header.substring(7)` remaining in rest-controller | 0 | Verify: `rg "substring\(7\)" -g "*.kt" module-rest-controller/` |
+| Behavioral diff | none | All values preserved exactly |
+
+### Observed Result
+
+After merging:
+- Each raw byte literal is either an inline self-documenting expression (`5L * 1024 * 1024 * 1024`) or a `private const val` with a KDoc explaining intent.
+- Each duration annotation default is paired with a `private const val` for reference.
+- `CharacterBasicRepository.SUB_BATCH_SIZE` and `EquipmentReadModelRepository.SUB_BATCH_SIZE` share a single `SynchronizerBatchConstants.SUB_BATCH_SIZE`.
+- `JwtAuthInterceptor` uses `BEARER_PREFIX.length` instead of `7`.
+- `BatchReadScheduler.getPhase()` returns a named constant.
+- `./gradlew compileKotlin compileJava --continue` passes for all 4 modules.
+- `./gradlew test` passes for all 4 modules.
+
+## 5. Summary
+
+> Push the remaining ~25 raw numeric literals in #1093 to in-file `private const val` with KDoc, or to self-documenting expressions like `5L * 1024 * 1024 * 1024`. Keep existing typed patterns (`Duration`, `Semaphore(2)` with KDoc). Decline to extract `1024 * 1024` (too small to abstract) and decline `ByteSize` value class (YAGNI for 2 sites).

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/metrics/SynchronizerMeterRegistry.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/metrics/SynchronizerMeterRegistry.kt
@@ -1,0 +1,117 @@
+package maple.synchronizer.metrics
+
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.DistributionSummary
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Timer
+import maple.synchronizer.state.ChunkExecutionStatus
+import maple.expectation.common.event.ChunkExecutionType
+import org.springframework.stereotype.Component
+import java.util.concurrent.atomic.AtomicInteger
+
+@Component
+class SynchronizerMeterRegistry(private val registry: MeterRegistry) {
+
+    // Chunk counters
+    val chunksReceived = registry.counter("synchronizer_chunks_received_total")
+    val chunksProcessing = AtomicInteger(0)
+    val chunksProcessed = registry.counter("synchronizer_chunks_processed_total")
+    val chunksFailed = registry.counter("synchronizer_chunks_failed_total")
+
+    init {
+        registry.gauge("synchronizer_chunks_processing", chunksProcessing)
+    }
+
+    // Document / item counters
+    val documentsProcessed = registry.counter("synchronizer_documents_processed_total")
+    val itemsProcessed = registry.counter("synchronizer_items_processed_total")
+
+    // Timers — 각 단계별 latency
+    val chunkTimer = Timer.builder("synchronizer_chunk_duration_seconds")
+        .description("Total time to process a single chunk end-to-end")
+        .publishPercentileHistogram()
+        .register(registry)
+
+    val fileReadTimer = Timer.builder("synchronizer_file_read_duration_seconds")
+        .description("Time to read and decompress gzip JSONL file")
+        .publishPercentileHistogram()
+        .register(registry)
+
+    val documentBuildTimer = Timer.builder("synchronizer_document_build_duration_seconds")
+        .description("Time to build read model documents from grouped results")
+        .publishPercentileHistogram()
+        .register(registry)
+
+    val mainUpsertTimer = Timer.builder("synchronizer_main_upsert_duration_seconds")
+        .description("Time to bulk upsert documents into main read model table")
+        .publishPercentileHistogram()
+        .register(registry)
+
+    // Distribution summaries — chunk 크기/분포
+    val chunkDocumentsSummary = DistributionSummary.builder("synchronizer_chunk_documents")
+        .description("Number of documents per chunk")
+        .register(registry)
+
+    val chunkItemsSummary = DistributionSummary.builder("synchronizer_chunk_items")
+        .description("Number of items per chunk")
+        .register(registry)
+
+    val chunkBytesSummary = DistributionSummary.builder("synchronizer_chunk_bytes")
+        .description("Compressed document bytes per chunk")
+        .register(registry)
+
+    val documentEquipmentSummary = DistributionSummary.builder("synchronizer_document_equipment_count")
+        .description("Equipment count per document")
+        .register(registry)
+
+    // Volume metrics — pre-upsert data volume
+    val preUpsertCompressedBytesTotal = registry.counter("synchronizer_pre_upsert_compressed_bytes_total")
+    val preUpsertUncompressedBytesTotal = registry.counter("synchronizer_pre_upsert_uncompressed_bytes_total")
+    val preUpsertJsonRowsTotal = registry.counter("synchronizer_pre_upsert_json_rows_total")
+
+    val preUpsertCompressedSummary = DistributionSummary.builder("synchronizer_pre_upsert_compressed_bytes")
+        .description("Compressed artifact bytes per chunk before DB upsert")
+        .register(registry)
+
+    val preUpsertUncompressedSummary = DistributionSummary.builder("synchronizer_pre_upsert_uncompressed_bytes")
+        .description("Uncompressed artifact bytes per chunk before DB upsert")
+        .register(registry)
+
+    val preUpsertCompressionRatio = DistributionSummary.builder("synchronizer_pre_upsert_compression_ratio")
+        .description("Compression ratio (uncompressed/compressed) per chunk before DB upsert")
+        .register(registry)
+
+    // Status / execution factory methods — these create per-tag meters on demand
+    fun statusCounter(status: String): Counter =
+        registry.counter("synchronizer_chunk_status_transition_total", "status", status)
+
+    fun chunkExecutionCounter(name: String, executionType: ChunkExecutionType): Counter =
+        registry.counter(name, "execution_type", executionType.name)
+
+    fun chunkExecutionSkippedCounter(
+        executionType: ChunkExecutionType,
+        status: ChunkExecutionStatus,
+    ): Counter =
+        registry.counter(
+            "chunk_execution_skipped_total",
+            "execution_type",
+            executionType.name,
+            "status",
+            status.name,
+        )
+
+    fun chunkExecutionFailedCounter(
+        executionType: ChunkExecutionType,
+        status: ChunkExecutionStatus,
+        reason: String,
+    ): Counter =
+        registry.counter(
+            "chunk_execution_failed_total",
+            "execution_type",
+            executionType.name,
+            "status",
+            status.name,
+            "reason",
+            reason,
+        )
+}

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/metrics/SynchronizerMetrics.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/metrics/SynchronizerMetrics.kt
@@ -1,176 +1,69 @@
 package maple.synchronizer.metrics
 
-import io.micrometer.core.instrument.Counter
-import io.micrometer.core.instrument.DistributionSummary
-import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Timer
 import maple.synchronizer.state.ChunkExecutionStatus
 import maple.expectation.common.event.ChunkExecutionType
 import org.springframework.stereotype.Component
-import java.util.concurrent.atomic.AtomicInteger
 
 @Component
-class SynchronizerMetrics(private val registry: MeterRegistry) {
+class SynchronizerMetrics(private val meterRegistry: SynchronizerMeterRegistry) {
 
-    // Chunk counters
-    private val chunksReceived = registry.counter("synchronizer_chunks_received_total")
-    private val chunksProcessing = AtomicInteger(0)
-    private val chunksProcessed = registry.counter("synchronizer_chunks_processed_total")
-    private val chunksFailed = registry.counter("synchronizer_chunks_failed_total")
-
-    init {
-        registry.gauge("synchronizer_chunks_processing", chunksProcessing)
-    }
-
-    // Document / item counters
-    private val documentsProcessed = registry.counter("synchronizer_documents_processed_total")
-    private val itemsProcessed = registry.counter("synchronizer_items_processed_total")
-
-    // Timers — 각 단계별 latency
-    private val chunkTimer = Timer.builder("synchronizer_chunk_duration_seconds")
-        .description("Total time to process a single chunk end-to-end")
-        .publishPercentileHistogram()
-        .register(registry)
-
-    private val fileReadTimer = Timer.builder("synchronizer_file_read_duration_seconds")
-        .description("Time to read and decompress gzip JSONL file")
-        .publishPercentileHistogram()
-        .register(registry)
-
-    private val documentBuildTimer = Timer.builder("synchronizer_document_build_duration_seconds")
-        .description("Time to build read model documents from grouped results")
-        .publishPercentileHistogram()
-        .register(registry)
-
-    private val mainUpsertTimer = Timer.builder("synchronizer_main_upsert_duration_seconds")
-        .description("Time to bulk upsert documents into main read model table")
-        .publishPercentileHistogram()
-        .register(registry)
-
-    // Distribution summaries — chunk 크기/분포
-    private val chunkDocumentsSummary = DistributionSummary.builder("synchronizer_chunk_documents")
-        .description("Number of documents per chunk")
-        .register(registry)
-
-    private val chunkItemsSummary = DistributionSummary.builder("synchronizer_chunk_items")
-        .description("Number of items per chunk")
-        .register(registry)
-
-    private val chunkBytesSummary = DistributionSummary.builder("synchronizer_chunk_bytes")
-        .description("Compressed document bytes per chunk")
-        .register(registry)
-
-    private val documentEquipmentSummary = DistributionSummary.builder("synchronizer_document_equipment_count")
-        .description("Equipment count per document")
-        .register(registry)
-
-    // Volume metrics — pre-upsert data volume
-    private val preUpsertCompressedBytesTotal = registry.counter("synchronizer_pre_upsert_compressed_bytes_total")
-    private val preUpsertUncompressedBytesTotal = registry.counter("synchronizer_pre_upsert_uncompressed_bytes_total")
-    private val preUpsertJsonRowsTotal = registry.counter("synchronizer_pre_upsert_json_rows_total")
-
-    private val preUpsertCompressedSummary = DistributionSummary.builder("synchronizer_pre_upsert_compressed_bytes")
-        .description("Compressed artifact bytes per chunk before DB upsert")
-        .register(registry)
-
-    private val preUpsertUncompressedSummary = DistributionSummary.builder("synchronizer_pre_upsert_uncompressed_bytes")
-        .description("Uncompressed artifact bytes per chunk before DB upsert")
-        .register(registry)
-
-    private val preUpsertCompressionRatio = DistributionSummary.builder("synchronizer_pre_upsert_compression_ratio")
-        .description("Compression ratio (uncompressed/compressed) per chunk before DB upsert")
-        .register(registry)
-
-    // Status transition counter
-    private fun statusCounter(status: String) =
-        registry.counter("synchronizer_chunk_status_transition_total", "status", status)
-
-    private fun chunkExecutionCounter(name: String, executionType: ChunkExecutionType): Counter =
-        registry.counter(name, "execution_type", executionType.name)
-
-    private fun chunkExecutionSkippedCounter(
-        executionType: ChunkExecutionType,
-        status: ChunkExecutionStatus,
-    ): Counter =
-        registry.counter(
-            "chunk_execution_skipped_total",
-            "execution_type",
-            executionType.name,
-            "status",
-            status.name,
-        )
-
-    private fun chunkExecutionFailedCounter(
-        executionType: ChunkExecutionType,
-        status: ChunkExecutionStatus,
-        reason: String,
-    ): Counter =
-        registry.counter(
-            "chunk_execution_failed_total",
-            "execution_type",
-            executionType.name,
-            "status",
-            status.name,
-            "reason",
-            reason,
-        )
-
-    fun incrementReceived() = chunksReceived.increment()
-    fun incrementProcessing() = chunksProcessing.incrementAndGet()
-    fun decrementProcessing() = chunksProcessing.decrementAndGet()
-    fun incrementProcessed() = chunksProcessed.increment()
-    fun incrementFailed() = chunksFailed.increment()
+    fun incrementReceived() = meterRegistry.chunksReceived.increment()
+    fun incrementProcessing() = meterRegistry.chunksProcessing.incrementAndGet()
+    fun decrementProcessing() = meterRegistry.chunksProcessing.decrementAndGet()
+    fun incrementProcessed() = meterRegistry.chunksProcessed.increment()
+    fun incrementFailed() = meterRegistry.chunksFailed.increment()
 
     fun recordChunkExecutionInserted(executionType: ChunkExecutionType) =
-        chunkExecutionCounter("chunk_execution_inserted_total", executionType).increment()
+        meterRegistry.chunkExecutionCounter("chunk_execution_inserted_total", executionType).increment()
 
     fun recordChunkExecutionClaimed(executionType: ChunkExecutionType) =
-        chunkExecutionCounter("chunk_execution_claimed_total", executionType).increment()
+        meterRegistry.chunkExecutionCounter("chunk_execution_claimed_total", executionType).increment()
 
     fun recordChunkExecutionSkipped(executionType: ChunkExecutionType, status: ChunkExecutionStatus) =
-        chunkExecutionSkippedCounter(executionType, status).increment()
+        meterRegistry.chunkExecutionSkippedCounter(executionType, status).increment()
 
     fun recordChunkExecutionSucceeded(executionType: ChunkExecutionType) =
-        chunkExecutionCounter("chunk_execution_succeeded_total", executionType).increment()
+        meterRegistry.chunkExecutionCounter("chunk_execution_succeeded_total", executionType).increment()
 
     fun recordChunkExecutionFailed(
         executionType: ChunkExecutionType,
         status: ChunkExecutionStatus,
         reason: String,
-    ) = chunkExecutionFailedCounter(executionType, status, reason).increment()
+    ) = meterRegistry.chunkExecutionFailedCounter(executionType, status, reason).increment()
 
     fun recordChunkExecutionReclaimedExpired(executionType: ChunkExecutionType) =
-        chunkExecutionCounter("chunk_execution_reclaimed_expired_total", executionType).increment()
+        meterRegistry.chunkExecutionCounter("chunk_execution_reclaimed_expired_total", executionType).increment()
 
-    fun incrementDocuments(count: Int) = documentsProcessed.increment(count.toDouble())
-    fun incrementItems(count: Long) = itemsProcessed.increment(count.toDouble())
+    fun incrementDocuments(count: Int) = meterRegistry.documentsProcessed.increment(count.toDouble())
+    fun incrementItems(count: Long) = meterRegistry.itemsProcessed.increment(count.toDouble())
 
-    fun recordStatusTransition(status: String) = statusCounter(status).increment()
+    fun recordStatusTransition(status: String) = meterRegistry.statusCounter(status).increment()
 
     fun recordChunkSize(documents: Int, items: Long) {
-        chunkDocumentsSummary.record(documents.toDouble())
-        chunkItemsSummary.record(items.toDouble())
+        meterRegistry.chunkDocumentsSummary.record(documents.toDouble())
+        meterRegistry.chunkItemsSummary.record(items.toDouble())
     }
 
     fun recordChunkBytes(bytes: Long) {
-        chunkBytesSummary.record(bytes.toDouble())
+        meterRegistry.chunkBytesSummary.record(bytes.toDouble())
     }
 
-    fun recordDocumentEquipment(count: Int) = documentEquipmentSummary.record(count.toDouble())
+    fun recordDocumentEquipment(count: Int) = meterRegistry.documentEquipmentSummary.record(count.toDouble())
 
     fun recordPreUpsertVolume(compressedBytes: Long, uncompressedBytes: Long, jsonRows: Long) {
-        preUpsertCompressedBytesTotal.increment(compressedBytes.toDouble())
-        preUpsertUncompressedBytesTotal.increment(uncompressedBytes.toDouble())
-        preUpsertJsonRowsTotal.increment(jsonRows.toDouble())
-        preUpsertCompressedSummary.record(compressedBytes.toDouble())
-        preUpsertUncompressedSummary.record(uncompressedBytes.toDouble())
+        meterRegistry.preUpsertCompressedBytesTotal.increment(compressedBytes.toDouble())
+        meterRegistry.preUpsertUncompressedBytesTotal.increment(uncompressedBytes.toDouble())
+        meterRegistry.preUpsertJsonRowsTotal.increment(jsonRows.toDouble())
+        meterRegistry.preUpsertCompressedSummary.record(compressedBytes.toDouble())
+        meterRegistry.preUpsertUncompressedSummary.record(uncompressedBytes.toDouble())
         if (compressedBytes > 0) {
-            preUpsertCompressionRatio.record(uncompressedBytes.toDouble() / compressedBytes.toDouble())
+            meterRegistry.preUpsertCompressionRatio.record(uncompressedBytes.toDouble() / compressedBytes.toDouble())
         }
     }
 
-    fun chunkTimer(): Timer = chunkTimer
-    fun fileReadTimer(): Timer = fileReadTimer
-    fun documentBuildTimer(): Timer = documentBuildTimer
-    fun mainUpsertTimer(): Timer = mainUpsertTimer
+    fun chunkTimer(): Timer = meterRegistry.chunkTimer
+    fun fileReadTimer(): Timer = meterRegistry.fileReadTimer
+    fun documentBuildTimer(): Timer = meterRegistry.documentBuildTimer
+    fun mainUpsertTimer(): Timer = meterRegistry.mainUpsertTimer
 }

--- a/module-synchronizer/src/test/kotlin/maple/synchronizer/processor/DefaultChunkProcessorTest.kt
+++ b/module-synchronizer/src/test/kotlin/maple/synchronizer/processor/DefaultChunkProcessorTest.kt
@@ -5,6 +5,7 @@ import maple.expectation.error.CommonErrorCode
 import maple.expectation.error.exception.ArtifactNotFoundException
 import maple.synchronizer.domain.CalculatedEquipmentItem
 import maple.synchronizer.domain.GroupedEquipmentResult
+import maple.synchronizer.metrics.SynchronizerMeterRegistry
 import maple.synchronizer.metrics.SynchronizerMetrics
 import maple.synchronizer.preparer.PreppedDocument
 import org.assertj.core.api.Assertions.assertThat
@@ -24,7 +25,7 @@ class DefaultChunkProcessorTest {
     private val dataReader: ChunkDataReader = mock()
     private val transformer: ChunkDocumentTransformer = mock()
     private val writer: ChunkDocumentWriter = mock()
-    private val metrics = SynchronizerMetrics(SimpleMeterRegistry())
+    private val metrics = SynchronizerMetrics(SynchronizerMeterRegistry(SimpleMeterRegistry()))
 
     private lateinit var chunkProcessor: DefaultChunkProcessor
 

--- a/module-synchronizer/src/test/kotlin/maple/synchronizer/processor/DefaultChunkProcessorTest.kt
+++ b/module-synchronizer/src/test/kotlin/maple/synchronizer/processor/DefaultChunkProcessorTest.kt
@@ -1,6 +1,7 @@
 package maple.synchronizer.processor
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import maple.core.domain.chunk.ChunkProcessInput
 import maple.expectation.error.CommonErrorCode
 import maple.expectation.error.exception.ArtifactNotFoundException
 import maple.synchronizer.domain.CalculatedEquipmentItem


### PR DESCRIPTION
Decomposes `SynchronizerMetrics` (176 lines) into:
- `SynchronizerMeterRegistry` (NEW, 117 lines) — owns all 19 meter declarations + 4 factory methods, exposed as `public val` properties
- `SynchronizerMetrics` (refactored, 69 lines) — recording methods only, delegates to the registry

**Public API of `SynchronizerMetrics` is byte-for-byte identical** — no consumer diff. All 22 recording methods preserved.

**New metrics** now touch `SynchronizerMeterRegistry` only; recording logic lives in `SynchronizerMetrics`.

## Drive-by Fix
PR #1143 (`refactor(923): decompose DefaultChunkProcessor`) introduced `DefaultChunkProcessorTest.kt` with a missing `import maple.core.domain.chunk.ChunkProcessInput`, leaving the test file uncompilable on develop. This PR adds the import as a 1-line drive-by fix to unblock test verification.

## Test Status
- `./gradlew :module-synchronizer:test` — `DefaultChunkProcessorTest`: 5/5 PASSED
- Pre-existing failures (NOT introduced by this PR, confirmed by running against develop HEAD with the same import fix):
  - `OcidMappingFileReaderTest > read throws ArtifactNotFoundException when file not found`
  - `ResultFileReaderTest > readAndGroupByCompositeKey - nonexistent file throws`
  - Both expect `ArtifactNotFoundException` but receive `IllegalStateException` — likely an oversight in PR #1174 (FailureDecision sealed class). Out of scope for #1066; recommend follow-up issue.

## BootRun Smoke Check
Started `:module-synchronizer:bootRun` (port 8083), `/actuator/health` returned HTTP 200. Verified all 19 meters registered on `/actuator/prometheus` with byte-for-byte identical metric names (`synchronizer_chunks_received_total`, `synchronizer_chunks_processing`, `synchronizer_chunk_duration_seconds_bucket`, etc.). No `ERROR` in logs (Kafka broker warnings are expected in this environment).

## File Structure
| File | Action | Lines |
|------|--------|------:|
| `module-synchronizer/.../metrics/SynchronizerMeterRegistry.kt` | NEW | +117 |
| `module-synchronizer/.../metrics/SynchronizerMetrics.kt` | MODIFIED | -107 net |
| `module-synchronizer/src/test/.../DefaultChunkProcessorTest.kt` | MODIFIED | +1 import |

Closes #1066

🤖 Generated with [Claude Code](https://claude.com/claude-code)