### PR TITLE
refactor(rest-controller): #1081 decompose ReadModelQueryService.batchQuery

### DIFF
--- a/docs/superpowers/plans/2026-06-06-1081-readmodel-query-decomposition.md
+++ b/docs/superpowers/plans/2026-06-06-1081-readmodel-query-decomposition.md
@@ -1,0 +1,523 @@
+# ReadModelQueryService.batchQuery Decomposition Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Split `ReadModelQueryService.batchQuery` into three single-purpose units (`ReadModelRowQuery`, `StalenessCheck`, `ReadModelDocumentExtractor`) and reduce `batchQuery` to a 5-line orchestrator.
+
+**Architecture:** Pure objects for SQL building and staleness partition; `@Component` for the gzip + JSON + fallback extractor. The service keeps DI for `NamedParameterJdbcTemplate` and the new `ReadModelDocumentExtractor`, and orchestrates the three helpers in a flat `forEach`. No new module dependencies.
+
+**Tech Stack:** Kotlin 1.9, Spring Boot 3, Jackson, JUnit 5 + `org.mockito.kotlin`, SLF4J, Gradle (Kotlin DSL).
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|------|----------------|--------|
+| `module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelRowQuery.kt` | Build dynamic SQL + `MapSqlParameterSource` from a request map | Create |
+| `module-rest-controller/src/test/kotlin/maple/restcontroller/read/ReadModelRowQueryTest.kt` | Unit tests for SQL/params | Create |
+| `module-rest-controller/src/main/kotlin/maple/restcontroller/read/StalenessCheck.kt` | Pure function that partitions rows by `updated_at` | Create |
+| `module-rest-controller/src/test/kotlin/maple/restcontroller/read/StalenessCheckTest.kt` | Unit tests for partition logic | Create |
+| `module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelDocumentExtractor.kt` | gzip + JSON tree + DB-row fallback → `V6ExpectationResponse` | Create |
+| `module-rest-controller/src/test/kotlin/maple/restcontroller/read/ReadModelDocumentExtractorTest.kt` | Unit tests for extract with fallback paths | Create |
+| `module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelQueryService.kt` | Slim to orchestration only | Modify |
+
+---
+
+## Task 1: Create `ReadModelRowQuery` with test (TDD)
+
+**Files:**
+- Create: `module-rest-controller/src/test/kotlin/maple/restcontroller/read/ReadModelRowQueryTest.kt`
+- Create: `module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelRowQuery.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `module-rest-controller/src/test/kotlin/maple/restcontroller/read/ReadModelRowQueryTest.kt`:
+
+```kotlin
+package maple.restcontroller.read
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
+
+class ReadModelRowQueryTest {
+    @Test
+    fun `build returns empty predicate and empty params for empty requests`() {
+        val (sql, params) = ReadModelRowQuery.build(emptyMap())
+
+        assertTrue(
+            sql.contains("FROM character_equipment_read_model"),
+            "expected SELECT in: $sql",
+        )
+        assertTrue(
+            sql.contains("WHERE ()"),
+            "expected empty predicate placeholder in: $sql",
+        )
+        // No values added.
+        assertEquals(0, params.parameterNames.size)
+    }
+
+    @Test
+    fun `build produces OR-chained pair predicates and indexed params`() {
+        val (sql, params) = ReadModelRowQuery.build(
+            mapOf("f***l" to 1, "s***d" to 2),
+        )
+
+        assertTrue(
+            sql.contains("(user_ign = :userIgn0 AND preset_no = :presetNo0)"),
+            "missing first predicate in: $sql",
+        )
+        assertTrue(
+            sql.contains("(user_ign = :userIgn1 AND preset_no = :presetNo1)"),
+            "missing second predicate in: $sql",
+        )
+        assertTrue(
+            sql.contains(") OR ("),
+            "missing OR between predicates in: $sql",
+        )
+        assertEquals(setOf("userIgn0", "presetNo0", "userIgn1", "presetNo1"), params.parameterNames.toSet())
+        assertEquals("f***l", params.getValue("userIgn0"))
+        assertEquals(1, params.getValue("presetNo0"))
+        assertEquals("s***d", params.getValue("userIgn1"))
+        assertEquals(2, params.getValue("presetNo1"))
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :module-rest-controller:test --tests "maple.restcontroller.read.ReadModelRowQueryTest" -i`
+Expected: COMPILATION FAILURE — `Unresolved reference: ReadModelRowQuery`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelRowQuery.kt`:
+
+```kotlin
+package maple.restcontroller.read
+
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
+
+object ReadModelRowQuery {
+    fun build(requests: Map<String, Int>): Pair<String, MapSqlParameterSource> {
+        val params = MapSqlParameterSource()
+        val predicates = requests.entries.mapIndexed { i, (userIgn, presetNo) ->
+            params
+                .addValue("userIgn$i", userIgn)
+                .addValue("presetNo$i", presetNo)
+            "(user_ign = :userIgn$i AND preset_no = :presetNo$i)"
+        }.joinToString(" OR ")
+
+        val sql = """
+            SELECT user_ign, preset_no, document, total_cost, equipment_count, calculated_at, updated_at
+            FROM character_equipment_read_model
+            WHERE ($predicates)
+              AND user_ign IS NOT NULL
+        """.trimIndent()
+        return sql to params
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :module-rest-controller:test --tests "maple.restcontroller.read.ReadModelRowQueryTest" -i`
+Expected: PASS — 2 tests, 0 failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelRowQuery.kt \
+        module-rest-controller/src/test/kotlin/maple/restcontroller/read/ReadModelRowQueryTest.kt
+git commit -m "feat(rest-controller): add ReadModelRowQuery SQL/params builder"
+```
+
+---
+
+## Task 2: Create `StalenessCheck` with test (TDD)
+
+**Files:**
+- Create: `module-rest-controller/src/test/kotlin/maple/restcontroller/read/StalenessCheckTest.kt`
+- Create: `module-rest-controller/src/main/kotlin/maple/restcontroller/read/StalenessCheck.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `module-rest-controller/src/test/kotlin/maple/restcontroller/read/StalenessCheckTest.kt`:
+
+```kotlin
+package maple.restcontroller.read
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import java.sql.Timestamp
+import java.time.Instant
+
+class StalenessCheckTest {
+    private val now = Instant.parse("2026-06-06T12:00:00Z")
+    private val threshold = now.minusSeconds(60)
+
+    @Test
+    fun `partitionStale with null minimumUpdatedAt returns all rows and zero stale`() {
+        val rows = listOf(
+            mapOf<String, Any?>("updated_at" to Timestamp.from(now)),
+            mapOf<String, Any?>("updated_at" to Timestamp.from(Instant.EPOCH)),
+        )
+
+        val (fresh, stale) = StalenessCheck.partitionStale(rows, null)
+
+        assertEquals(2, fresh.size)
+        assertEquals(0, stale)
+    }
+
+    @Test
+    fun `partitionStale separates fresh from stale and counts them`() {
+        val freshRow = mapOf<String, Any?>("updated_at" to Timestamp.from(now))
+        val staleRow = mapOf<String, Any?>("updated_at" to Timestamp.from(Instant.EPOCH))
+
+        val (fresh, stale) = StalenessCheck.partitionStale(listOf(freshRow, staleRow), threshold)
+
+        assertEquals(1, fresh.size)
+        assertEquals(freshRow, fresh[0])
+        assertEquals(1, stale)
+    }
+
+    @Test
+    fun `partitionStale treats missing updated_at as epoch and flags stale`() {
+        val rowWithout = mapOf<String, Any?>("user_ign" to "f***l")
+
+        val (fresh, stale) = StalenessCheck.partitionStale(listOf(rowWithout), threshold)
+
+        assertTrue(fresh.isEmpty())
+        assertEquals(1, stale)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :module-rest-controller:test --tests "maple.restcontroller.read.StalenessCheckTest" -i`
+Expected: COMPILATION FAILURE — `Unresolved reference: StalenessCheck`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `module-rest-controller/src/main/kotlin/maple/restcontroller/read/StalenessCheck.kt`:
+
+```kotlin
+package maple.restcontroller.read
+
+import java.sql.Timestamp
+import java.time.Instant
+
+object StalenessCheck {
+    fun partitionStale(
+        rows: List<Map<String, Any?>>,
+        minimumUpdatedAt: Instant?,
+    ): Pair<List<Map<String, Any?>>, Int> {
+        if (minimumUpdatedAt == null) return rows to 0
+        val fresh = mutableListOf<Map<String, Any?>>()
+        var stale = 0
+        rows.forEach { row ->
+            val updatedAt = (row["updated_at"] as? Timestamp)?.toInstant() ?: Instant.EPOCH
+            if (updatedAt.isBefore(minimumUpdatedAt)) stale++ else fresh.add(row)
+        }
+        return fresh to stale
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :module-rest-controller:test --tests "maple.restcontroller.read.StalenessCheckTest" -i`
+Expected: PASS — 3 tests, 0 failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add module-rest-controller/src/main/kotlin/maple/restcontroller/read/StalenessCheck.kt \
+        module-rest-controller/src/test/kotlin/maple/restcontroller/read/StalenessCheckTest.kt
+git commit -m "feat(rest-controller): add StalenessCheck pure partition function"
+```
+
+---
+
+## Task 3: Create `ReadModelDocumentExtractor` with test (TDD)
+
+**Files:**
+- Create: `module-rest-controller/src/test/kotlin/maple/restcontroller/read/ReadModelDocumentExtractorTest.kt`
+- Create: `module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelDocumentExtractor.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `module-rest-controller/src/test/kotlin/maple/restcontroller/read/ReadModelDocumentExtractorTest.kt`:
+
+```kotlin
+package maple.restcontroller.read
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import maple.expectation.util.GzipUtils
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import java.math.BigDecimal
+import java.sql.Timestamp
+import java.time.Instant
+
+class ReadModelDocumentExtractorTest {
+    private val objectMapper = ObjectMapper()
+    private val extractor = ReadModelDocumentExtractor(objectMapper)
+
+    @Test
+    fun `extract prefers JSON fields over DB row fallback`() {
+        val json = """
+            {
+              "presetNo": 7,
+              "summary": { "totalCost": 1234.5, "equipmentCount": 3 },
+              "metadata": { "calculatedAt": "2026-06-06T11:00:00Z" },
+              "equipment": [ { "name": "x" } ]
+            }
+        """.trimIndent()
+        val compressed = GzipUtils.compress(json.toByteArray())
+        val row = mapOf<String, Any?>(
+            "user_ign" to "f***l",
+            "preset_no" to 1,
+            "total_cost" to BigDecimal("999.0"),
+            "equipment_count" to 0,
+            "calculated_at" to Timestamp.from(Instant.parse("2026-01-01T00:00:00Z")),
+        )
+
+        val out = extractor.extract("f***l", compressed, row)
+
+        assertEquals("f***l", out.userIgn)
+        assertEquals(7, out.presetNo)
+        assertEquals(BigDecimal("1234.5"), out.totalCost)
+        assertEquals(3, out.equipmentCount)
+        assertEquals(1, out.equipment.size)
+        assertEquals(Instant.parse("2026-06-06T11:00:00Z"), out.calculatedAt)
+    }
+
+    @Test
+    fun `extract falls back to DB row when JSON omits fields`() {
+        val json = """{"equipment": []}"""
+        val compressed = GzipUtils.compress(json.toByteArray())
+        val row = mapOf<String, Any?>(
+            "user_ign" to "s***d",
+            "preset_no" to 42,
+            "total_cost" to BigDecimal("500.0"),
+            "equipment_count" to 4,
+            "calculated_at" to Timestamp.from(Instant.parse("2026-05-01T00:00:00Z")),
+        )
+
+        val out = extractor.extract("s***d", compressed, row)
+
+        assertEquals(42, out.presetNo)
+        assertEquals(BigDecimal("500.0"), out.totalCost)
+        assertEquals(4, out.equipmentCount)
+        assertEquals(Instant.parse("2026-05-01T00:00:00Z"), out.calculatedAt)
+        assertTrue(out.equipment.isEmpty())
+    }
+
+    @Test
+    fun `extract returns defaults when both JSON and row lack a field`() {
+        val json = """{}"""
+        val compressed = GzipUtils.compress(json.toByteArray())
+        val row = mapOf<String, Any?>(
+            "user_ign" to "t***d",
+            "preset_no" to 1,
+        )
+
+        val out = extractor.extract("t***d", compressed, row)
+
+        assertEquals(BigDecimal.ZERO, out.totalCost)
+        assertEquals(0, out.equipmentCount)
+        assertNotNull(out.calculatedAt)
+    }
+}
+```
+
+> **Note for the executing subagent:** Discover the actual `GzipUtils` method name (`compress` / `gzip` / `encode`) and `V6ExpectationResponse` constructor parameter names from the existing `ReadModelQueryService.kt` (lines 70-83) and `maple.expectation.util.GzipUtils` source. If the gzip helper has a different name, swap it in. If `V6ExpectationResponse` parameters differ, adjust the test assertions to use the real constructor. Do NOT change the response shape — only adapt the test.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :module-rest-controller:test --tests "maple.restcontroller.read.ReadModelDocumentExtractorTest" -i`
+Expected: COMPILATION FAILURE — `Unresolved reference: ReadModelDocumentExtractor` (and possibly the `GzipUtils.compress` name).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelDocumentExtractor.kt`:
+
+```kotlin
+package maple.restcontroller.read
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import maple.expectation.util.GzipUtils
+import org.springframework.stereotype.Component
+import java.math.BigDecimal
+import java.sql.Timestamp
+import java.time.Instant
+
+@Component
+class ReadModelDocumentExtractor(
+    private val objectMapper: ObjectMapper,
+) {
+    fun extract(
+        userIgn: String,
+        compressed: ByteArray,
+        row: Map<String, Any?>,
+    ): V6ExpectationResponse {
+        val json = GzipUtils.decompress(compressed)
+        val tree = objectMapper.readTree(json)
+
+        val equipmentNode = tree["equipment"]
+        @Suppress("UNCHECKED_CAST")
+        val equipment: List<Map<String, Any?>> = if (equipmentNode != null && !equipmentNode.isNull) {
+            objectMapper.readValue(
+                equipmentNode.toString(),
+                objectMapper.typeFactory.constructCollectionType(List::class.java, Map::class.java),
+            ) as List<Map<String, Any?>>
+        } else emptyList()
+
+        return V6ExpectationResponse(
+            userIgn = userIgn,
+            presetNo = tree["presetNo"]?.asInt() ?: (row["preset_no"] as Number).toInt(),
+            totalCost = tree["summary"]?.get("totalCost")?.decimalValue()
+                ?: row["total_cost"] as? BigDecimal
+                ?: BigDecimal.ZERO,
+            equipmentCount = tree["summary"]?.get("equipmentCount")?.asInt()
+                ?: (row["equipment_count"] as? Number)?.toInt()
+                ?: 0,
+            equipment = equipment,
+            calculatedAt = tree["metadata"]?.get("calculatedAt")?.asText()?.let(Instant::parse)
+                ?: (row["calculated_at"] as? Timestamp)?.toInstant()
+                ?: Instant.now(),
+        )
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :module-rest-controller:test --tests "maple.restcontroller.read.ReadModelDocumentExtractorTest" -i`
+Expected: PASS — 3 tests, 0 failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelDocumentExtractor.kt \
+        module-rest-controller/src/test/kotlin/maple/restcontroller/read/ReadModelDocumentExtractorTest.kt
+git commit -m "feat(rest-controller): add ReadModelDocumentExtractor (gzip + JSON + fallback)"
+```
+
+---
+
+## Task 4: Slim `ReadModelQueryService.batchQuery` to orchestration
+
+**Files:**
+- Modify: `module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelQueryService.kt`
+
+- [ ] **Step 1: Inject extractor and rewrite `batchQuery`**
+
+Replace the entire contents of `module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelQueryService.kt` with:
+
+```kotlin
+package maple.restcontroller.read
+
+import org.slf4j.LoggerFactory
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import java.time.Duration
+import java.time.Instant
+
+class ReadModelQueryService(
+    private val jdbc: NamedParameterJdbcTemplate,
+    private val documentExtractor: ReadModelDocumentExtractor,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    /**
+     * @param requests userIgn -> presetNo mapping
+     * @return userIgn -> V6ExpectationResponse for hits only
+     */
+    fun batchQuery(
+        requests: Map<String, Int>,
+        maxAge: Duration? = null,
+    ): Map<String, V6ExpectationResponse> {
+        if (requests.isEmpty()) return emptyMap()
+
+        val (sql, params) = ReadModelRowQuery.build(requests)
+        val raw = jdbc.queryForList(sql, params)
+        val minimumUpdatedAt = maxAge?.let { Instant.now().minus(it) }
+        val (fresh, stale) = StalenessCheck.partitionStale(raw, minimumUpdatedAt)
+
+        val result = LinkedHashMap<String, V6ExpectationResponse>(fresh.size)
+        fresh.forEach { row ->
+            val userIgn = row["user_ign"].toString()
+            result[userIgn] = documentExtractor.extract(userIgn, row["document"] as ByteArray, row)
+        }
+        log.debug("Read model query: requested={}, hits={}, stale={}", requests.size, result.size, stale)
+        return result
+    }
+}
+```
+
+Drop the unused imports (`GzipUtils`, `MapSqlParameterSource`, `BigDecimal`, `Timestamp`, `ObjectMapper`). Keep `Duration` and `Instant`.
+
+- [ ] **Step 2: Compile + run module tests**
+
+Run: `./gradlew :module-rest-controller:compileKotlin :module-rest-controller:compileJava --continue && ./gradlew :module-rest-controller:test -i`
+Expected: BUILD SUCCESSFUL — all 8 new tests pass (2 + 3 + 3) and existing tests continue to pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelQueryService.kt
+git commit -m "refactor(rest-controller): ReadModelQueryService.batchQuery is orchestration only"
+```
+
+---
+
+## Task 5: Final verification — full module build and test
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Compile entire project**
+
+Run: `./gradlew compileKotlin compileJava --continue`
+Expected: BUILD SUCCESSFUL — no errors across all modules.
+
+- [ ] **Step 2: Run rest-controller test suite**
+
+Run: `./gradlew :module-rest-controller:test -i`
+Expected: BUILD SUCCESSFUL — all tests pass, including 8 new tests added in Tasks 1, 2, 3.
+
+- [ ] **Step 3: Sanity-check service file size**
+
+Run: `wc -l module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelQueryService.kt`
+Expected: roughly 35 lines (down from 88), the body of `batchQuery` is roughly 10 lines.
+
+- [ ] **Step 4: Verify no inline gzip / SQL composition remains**
+
+Run: `grep -n "GzipUtils\\|objectMapper.readTree\\|MapSqlParameterSource\\|queryForList" module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelQueryService.kt || echo "no matches"`
+Expected: `no matches` — all of those are now in the helpers, not the service.
+
+- [ ] **Step 5: Commit any verification artefacts (none expected)**
+
+If everything is clean, no further commit is needed. If verification surfaces a stray reference, fix it and commit as a follow-up.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §2.A `ReadModelRowQuery` → Task 1. Covered.
+- §2.B `StalenessCheck` → Task 2. Covered.
+- §2.C `ReadModelDocumentExtractor` → Task 3. Covered.
+- §2.D Slimmed `batchQuery` → Task 4. Covered.
+- §2 acceptance criteria (`:module-rest-controller:test` + `compileKotlin/compileJava`) → Task 5. Covered.
+
+**Placeholder scan:** No "TBD" or "implement later" markers. Task 3 Step 1 contains an explicit note that the executing subagent must verify the `GzipUtils` method name and `V6ExpectationResponse` constructor from source — this is intentional, not a real placeholder. All other step 3 / 1 code blocks are complete.
+
+**Type consistency:** `ReadModelRowQuery.build(requests: Map<String, Int>): Pair<String, MapSqlParameterSource>` used in both Task 1 test and Task 4 service. `StalenessCheck.partitionStale(rows: List<Map<String, Any?>>, minimumUpdatedAt: Instant?): Pair<List<Map<String, Any?>>, Int>` used in both Task 2 test and Task 4 service. `ReadModelDocumentExtractor.extract(userIgn: String, compressed: ByteArray, row: Map<String, Any?>): V6ExpectationResponse` used in both Task 3 test and Task 4 service. Consistent.

--- a/docs/superpowers/plans/2026-06-06-1081-readmodel-query-decomposition.md
+++ b/docs/superpowers/plans/2026-06-06-1081-readmodel-query-decomposition.md
@@ -39,24 +39,18 @@ package maple.restcontroller.read
 
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 
 class ReadModelRowQueryTest {
     @Test
-    fun `build returns empty predicate and empty params for empty requests`() {
-        val (sql, params) = ReadModelRowQuery.build(emptyMap())
-
-        assertTrue(
-            sql.contains("FROM character_equipment_read_model"),
-            "expected SELECT in: $sql",
-        )
-        assertTrue(
-            sql.contains("WHERE ()"),
-            "expected empty predicate placeholder in: $sql",
-        )
-        // No values added.
-        assertEquals(0, params.parameterNames.size)
+    fun `build throws on empty requests to avoid WHERE () syntax error`() {
+        val ex = assertThrows(IllegalArgumentException::class.java) {
+            ReadModelRowQuery.build(emptyMap())
+        }
+        // No SQL or params are produced.
+        assertTrue(ex.message!!.contains("requests"), "message: ${ex.message}")
     }
 
     @Test
@@ -102,6 +96,7 @@ import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 
 object ReadModelRowQuery {
     fun build(requests: Map<String, Int>): Pair<String, MapSqlParameterSource> {
+        require(requests.isNotEmpty()) { "ReadModelRowQuery.build requires non-empty requests" }
         val params = MapSqlParameterSource()
         val predicates = requests.entries.mapIndexed { i, (userIgn, presetNo) ->
             params

--- a/docs/superpowers/plans/2026-06-06-batch-read-orchestration-extraction.md
+++ b/docs/superpowers/plans/2026-06-06-batch-read-orchestration-extraction.md
@@ -1599,16 +1599,19 @@ class ExpectationV6Controller(
     fun getExpectation(
         @PathVariable @ValidUserIgn userIgn: String,
         @RequestParam(defaultValue = "1") presetNo: Int,
-    ): ResponseEntity<*> {
+    ): DeferredResult<ResponseEntity<*>> {
         log.debug("V6 read request userIgn={} presetNo={}", maskIgn(userIgn), presetNo)
         val deferred = DeferredResult<ResponseEntity<*>>(properties.requestTimeoutMs)
         val result: EnqueueResult = facade.enqueue(userIgn, presetNo, deferred)
-        // Map the synchronous outcome. If the facade returns Accepted, the
-        // controller responds with 202 + status snapshot. If Rejected (buffer
-        // full), the controller responds with 503.
-        val response = ReadResponseMapper.toResponseEntity(result, properties.statusRetryAfterSeconds)
-        // If accepted, also wire deferred timeout (facade installed it).
-        return response
+        if (result is EnqueueResult.Rejected) {
+            // Synchronous rejection — set 503 on the deferred immediately.
+            // Accepted case: leave the deferred for the scheduler (200/404) or
+            // the timeout callback (202) to resolve.
+            deferred.setResult(
+                ReadResponseMapper.toResponseEntity(result, properties.statusRetryAfterSeconds)
+            )
+        }
+        return deferred
     }
 
     @GetMapping("/{userIgn}/status")
@@ -1638,27 +1641,12 @@ class ExpectationV6Controller(
 }
 ```
 
-**Note on the controller redesign**: the prior controller returned `DeferredResult<ResponseEntity<*>>` and never set a result — the deferred was set asynchronously by the scheduler. The new design returns a `ResponseEntity<*>` directly for the synchronous case (`Accepted → 202` or `Rejected → 503`). The deferred still exists for timeout / completion lifecycle but is no longer returned to the client. The timeout callback installed by the facade no longer fires because the response has been sent.
+**Note**: This preserves the original async wire behavior. The client receives:
+- `503` synchronously when the buffer is full (`Rejected`)
+- `200` / `404` if the scheduler finds the data within `requestTimeoutMs`
+- `202` if neither happens within `requestTimeoutMs` (timeout callback)
 
-If the previous behavior of "200 OK with the eventual result" must be preserved (where the client blocks on the deferred for up to `requestTimeoutMs` to receive 200, 404, or 202), the controller must return `DeferredResult` and call `deferred.setResult(response)` after `enqueue` returns. Restore the original `DeferredResult`-returning signature:
-
-```kotlin
-@GetMapping("/{userIgn}/expectation")
-fun getExpectation(
-    @PathVariable @ValidUserIgn userIgn: String,
-    @RequestParam(defaultValue = "1") presetNo: Int,
-): DeferredResult<ResponseEntity<*>> {
-    log.debug("V6 read request userIgn={} presetNo={}", maskIgn(userIgn), presetNo)
-    val deferred = DeferredResult<ResponseEntity<*>>(properties.requestTimeoutMs)
-    val result: EnqueueResult = facade.enqueue(userIgn, presetNo, deferred)
-    val mapped = ReadResponseMapper.toResponseEntity(result, properties.statusRetryAfterSeconds)
-    // If facade gave us a synchronous response (Accepted/Rejected), set it on the deferred.
-    deferred.setResult(mapped)
-    return deferred
-}
-```
-
-This preserves the asynchronous wire shape (the client still waits up to `requestTimeoutMs`) while the controller owns the HTTP-shape decision. **Use this version in the file.** The tests in Step 1 expect 202 status which is consistent with `Accepted` mapping.
+The controller owns the synchronous 503 decision via the typed `EnqueueResult`; the scheduler owns the 200/404 path; the facade-installed timeout owns the 202 path.
 
 - [ ] **Step 5: Run all controller tests to verify they pass**
 

--- a/docs/superpowers/plans/2026-06-06-batch-read-orchestration-extraction.md
+++ b/docs/superpowers/plans/2026-06-06-batch-read-orchestration-extraction.md
@@ -1,0 +1,1736 @@
+# V6 Read Orchestration Extraction (#1082) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove `ResponseEntity` construction from `BatchReadScheduler`, `BatchResolver`, and `ExpectationReadFacade`; introduce sealed `ReadOutcome` / `EnqueueResult` types and a single `ReadResponseMapper` as the canonical HTTP-shape converter.
+
+**Architecture:** Sealed types carry the meaning of a read resolution from the orchestration layer up to the controller. A single `ReadResponseMapper` (object) owns every `ResponseEntity` construction for the V6 read flow. `InflightRequestRegistry` gains an `applyOutcome(key, ReadOutcome)` method that internally maps outcomes to responses and applies them to deferreds.
+
+**Tech Stack:** Kotlin, Spring Boot, JUnit 5, Mockito-Kotlin, AssertJ, MockMvc.
+
+---
+
+## File Structure
+
+**Create:**
+- `module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadOutcome.kt` — sealed interface (Ready/NotFound/DeferredForTimeout)
+- `module-rest-controller/src/main/kotlin/maple/restcontroller/read/EnqueueResult.kt` — sealed interface (Accepted/Rejected)
+- `module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadResponseMapper.kt` — object with two methods: `toResponseEntity(ReadOutcome)` and `toResponseEntity(EnqueueResult, V6ReadProperties)` and `toResponseEntity(UrgentReadStatusResponse)`
+- `module-rest-controller/src/test/kotlin/maple/restcontroller/read/ReadOutcomeTest.kt`
+- `module-rest-controller/src/test/kotlin/maple/restcontroller/read/EnqueueResultTest.kt`
+- `module-rest-controller/src/test/kotlin/maple/restcontroller/read/ReadResponseMapperTest.kt`
+- `module-rest-controller/src/test/kotlin/maple/restcontroller/read/BatchResolverTest.kt`
+- `module-rest-controller/src/test/kotlin/maple/restcontroller/read/BatchReadSchedulerOutcomeTest.kt`
+- `module-rest-controller/src/test/kotlin/maple/restcontroller/read/InflightRequestRegistryApplyOutcomeTest.kt`
+- `module-rest-controller/src/test/kotlin/maple/restcontroller/controller/ExpectationV6ControllerEnqueueTest.kt`
+
+**Modify:**
+- `module-rest-controller/src/main/kotlin/maple/restcontroller/read/BatchResolver.kt` — return `Map<String, ReadOutcome>` (userIgn → outcome); no `ResponseEntity`.
+- `module-rest-controller/src/main/kotlin/maple/restcontroller/read/BatchReadScheduler.kt` — wire `BatchResolver` → `registry.applyOutcome` instead of inline `setResult`; remove `urgentPublisher` publish from the scheduler? No: BatchResolver still calls urgentPublisher (infrastructure concern). Scheduler delegates resolution, registry applies.
+- `module-rest-controller/src/main/kotlin/maple/restcontroller/read/ExpectationReadFacade.kt` — return `EnqueueResult`; remove `ResponseEntity` references. `deferred.setErrorResult` / `deferred.setResult` are removed; the controller wires the deferred lifecycle with mapper.
+- `module-rest-controller/src/main/kotlin/maple/restcontroller/read/InflightRequestRegistry.kt` — add `applyOutcome(userIgn, presetNo, ReadOutcome)` method that uses `ReadResponseMapper` to convert and `deferred.setResult(...)` internally.
+- `module-rest-controller/src/main/kotlin/maple/restcontroller/controller/ExpectationV6Controller.kt` — map `EnqueueResult` to 202 or 503. `deferred.onTimeout` uses `ReadResponseMapper`.
+- `module-rest-controller/src/main/kotlin/maple/restcontroller/config/V6ReadConfig.kt` — wire `BatchResolver` bean and pass into `BatchReadScheduler`. Remove `urgentPublisherProvider` from `BatchReadScheduler` (move to `BatchResolver`).
+- `module-rest-controller/src/test/kotlin/maple/restcontroller/read/ExpectationReadFacadeTest.kt` — update tests to assert typed `EnqueueResult`.
+- `module-rest-controller/src/test/kotlin/maple/restcontroller/controller/ExpectationV6ControllerTest.kt` — update tests to assert controller maps `EnqueueResult` to HTTP.
+
+**Delete:** None. (Prior `BatchResolver` from `refactor-batch-2` is replaced; worktree is fresh from `develop`.)
+
+---
+
+## Task 1: Add `ReadOutcome` sealed type
+
+**Files:**
+- Create: `module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadOutcome.kt`
+- Create: `module-rest-controller/src/test/kotlin/maple/restcontroller/read/ReadOutcomeTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+```kotlin
+// module-rest-controller/src/test/kotlin/maple/restcontroller/read/ReadOutcomeTest.kt
+package maple.restcontroller.read
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Instant
+
+class ReadOutcomeTest {
+
+    @Test
+    fun `Ready carries V6ExpectationResponse and is recognized as terminal`() {
+        val resp = V6ExpectationResponse(
+            userIgn = "진격캐넌", presetNo = 1,
+            totalCost = BigDecimal("100"), equipmentCount = 1,
+            equipment = emptyList(), calculatedAt = Instant.parse("2026-01-01T00:00:00Z"),
+        )
+        val outcome: ReadOutcome = ReadOutcome.Ready(resp)
+        assertThat(outcome.response).isEqualTo(resp)
+    }
+
+    @Test
+    fun `NotFound is a singleton object with no payload`() {
+        val a: ReadOutcome = ReadOutcome.NotFound
+        val b: ReadOutcome = ReadOutcome.NotFound
+        assertThat(a).isSameAs(b)
+    }
+
+    @Test
+    fun `DeferredForTimeout is a singleton object with no payload`() {
+        val a: ReadOutcome = ReadOutcome.DeferredForTimeout
+        val b: ReadOutcome = ReadOutcome.DeferredForTimeout
+        assertThat(a).isSameAs(b)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+cd /home/maple/probabilistic-valuation-engine
+./gradlew :module-rest-controller:test --tests "maple.restcontroller.read.ReadOutcomeTest" --continue
+```
+Expected: FAIL with "Unresolved reference: ReadOutcome".
+
+- [ ] **Step 3: Write minimal implementation**
+
+```kotlin
+// module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadOutcome.kt
+package maple.restcontroller.read
+
+sealed interface ReadOutcome {
+    data class Ready(val response: V6ExpectationResponse) : ReadOutcome
+    data object NotFound : ReadOutcome
+    data object DeferredForTimeout : ReadOutcome
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+```bash
+cd /home/maple/probabilistic-valuation-engine
+./gradlew :module-rest-controller:test --tests "maple.restcontroller.read.ReadOutcomeTest" --continue
+```
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine
+git add module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadOutcome.kt \
+        module-rest-controller/src/test/kotlin/maple/restcontroller/read/ReadOutcomeTest.kt
+git -c user.email=claude@anthropic.com -c user.name="Claude" commit -m "feat(rest): add ReadOutcome sealed type for read resolution"
+```
+
+---
+
+## Task 2: Add `EnqueueResult` sealed type
+
+**Files:**
+- Create: `module-rest-controller/src/main/kotlin/maple/restcontroller/read/EnqueueResult.kt`
+- Create: `module-rest-controller/src/test/kotlin/maple/restcontroller/read/EnqueueResultTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+```kotlin
+// module-rest-controller/src/test/kotlin/maple/restcontroller/read/EnqueueResultTest.kt
+package maple.restcontroller.read
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class EnqueueResultTest {
+
+    @Test
+    fun `Accepted carries the initial status snapshot`() {
+        val snap = UrgentReadStatusResponse(
+            state = UrgentReadState.Unknown,
+            userIgn = "진격캐넌",
+            statusUrl = "/api/v6/characters/진격캐넌/status?presetNo=1",
+            queuePositionApprox = null,
+            estimatedWaitSeconds = null,
+            retryAfterSeconds = 3L,
+        )
+        val result: EnqueueResult = EnqueueResult.Accepted(snap)
+        assertThat(result.status).isEqualTo(snap)
+    }
+
+    @Test
+    fun `Rejected carries a retryAfterSeconds value`() {
+        val result: EnqueueResult = EnqueueResult.Rejected(retryAfterSeconds = 1L)
+        assertThat(result.retryAfterSeconds).isEqualTo(1L)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+cd /home/maple/probabilistic-valuation-engine
+./gradlew :module-rest-controller:test --tests "maple.restcontroller.read.EnqueueResultTest" --continue
+```
+Expected: FAIL with "Unresolved reference: EnqueueResult".
+
+- [ ] **Step 3: Write minimal implementation**
+
+```kotlin
+// module-rest-controller/src/main/kotlin/maple/restcontroller/read/EnqueueResult.kt
+package maple.restcontroller.read
+
+sealed interface EnqueueResult {
+    data class Accepted(val status: UrgentReadStatusResponse) : EnqueueResult
+    data class Rejected(val retryAfterSeconds: Long) : EnqueueResult
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+```bash
+cd /home/maple/probabilistic-valuation-engine
+./gradlew :module-rest-controller:test --tests "maple.restcontroller.read.EnqueueResultTest" --continue
+```
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine
+git add module-rest-controller/src/main/kotlin/maple/restcontroller/read/EnqueueResult.kt \
+        module-rest-controller/src/test/kotlin/maple/restcontroller/read/EnqueueResultTest.kt
+git -c user.email=claude@anthropic.com -c user.name="Claude" commit -m "feat(rest): add EnqueueResult sealed type for synchronous facade outcome"
+```
+
+---
+
+## Task 3: Add `ReadResponseMapper`
+
+**Files:**
+- Create: `module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadResponseMapper.kt`
+- Create: `module-rest-controller/src/test/kotlin/maple/restcontroller/read/ReadResponseMapperTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+```kotlin
+// module-rest-controller/src/test/kotlin/maple/restcontroller/read/ReadResponseMapperTest.kt
+package maple.restcontroller.read
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import java.math.BigDecimal
+import java.time.Instant
+
+class ReadResponseMapperTest {
+
+    private val mapper = ReadResponseMapper
+    private val resp = V6ExpectationResponse(
+        userIgn = "진격캐넌", presetNo = 1,
+        totalCost = BigDecimal("100"), equipmentCount = 1,
+        equipment = emptyList(), calculatedAt = Instant.parse("2026-01-01T00:00:00Z"),
+    )
+
+    @Test
+    fun `Ready maps to 200 OK with body`() {
+        val entity = mapper.toResponseEntity(ReadOutcome.Ready(resp))
+        assertThat(entity.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(entity.body).isEqualTo(resp)
+    }
+
+    @Test
+    fun `NotFound maps to 404 with X-Error-Reason header`() {
+        val entity = mapper.toResponseEntity(ReadOutcome.NotFound)
+        assertThat(entity.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
+        assertThat(entity.headers["X-Error-Reason"]).containsExactly("character-not-found")
+    }
+
+    @Test
+    fun `DeferredForTimeout maps to 202 with Location, Retry-After, and status body`() {
+        val status = UrgentReadStatusResponse(
+            state = UrgentReadState.Pending(queuePositionApprox = 2L, estimatedWaitSeconds = 5L),
+            userIgn = "진격캐넌",
+            statusUrl = "/api/v6/characters/진격캐넌/status?presetNo=1",
+            queuePositionApprox = 2L,
+            estimatedWaitSeconds = 5L,
+            retryAfterSeconds = 3L,
+        )
+        val entity = mapper.toResponseEntity(ReadOutcome.DeferredForTimeout, status, retryAfterSeconds = 3L)
+        assertThat(entity.statusCode).isEqualTo(HttpStatus.ACCEPTED)
+        assertThat(entity.headers["Location"]).containsExactly(status.statusUrl)
+        assertThat(entity.headers["Retry-After"]).containsExactly("3")
+        assertThat(entity.body).isEqualTo(status)
+    }
+
+    @Test
+    fun `Accepted EnqueueResult maps to 202 with status body`() {
+        val status = UrgentReadStatusResponse(
+            state = UrgentReadState.Unknown,
+            userIgn = "진격캐넌",
+            statusUrl = "/api/v6/characters/진격캐넌/status?presetNo=1",
+            queuePositionApprox = null,
+            estimatedWaitSeconds = null,
+            retryAfterSeconds = 3L,
+        )
+        val entity = mapper.toResponseEntity(EnqueueResult.Accepted(status), retryAfterSeconds = 3L)
+        assertThat(entity.statusCode).isEqualTo(HttpStatus.ACCEPTED)
+        assertThat(entity.body).isEqualTo(status)
+    }
+
+    @Test
+    fun `Rejected EnqueueResult maps to 503 with Retry-After header`() {
+        val entity = mapper.toResponseEntity(EnqueueResult.Rejected(retryAfterSeconds = 1L))
+        assertThat(entity.statusCode).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE)
+        assertThat(entity.headers["Retry-After"]).containsExactly("1")
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+cd /home/maple/probabilistic-valuation-engine
+./gradlew :module-rest-controller:test --tests "maple.restcontroller.read.ReadResponseMapperTest" --continue
+```
+Expected: FAIL with "Unresolved reference: ReadResponseMapper".
+
+- [ ] **Step 3: Write minimal implementation**
+
+```kotlin
+// module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadResponseMapper.kt
+package maple.restcontroller.read
+
+import org.springframework.http.ResponseEntity
+
+object ReadResponseMapper {
+
+    fun toResponseEntity(outcome: ReadOutcome): ResponseEntity<*> = when (outcome) {
+        is ReadOutcome.Ready -> ResponseEntity.ok(outcome.response)
+        ReadOutcome.NotFound -> ResponseEntity.status(404)
+            .header("X-Error-Reason", "character-not-found")
+            .build<Any>()
+        ReadOutcome.DeferredForTimeout -> error("DeferredForTimeout requires status payload; use 3-arg overload")
+    }
+
+    fun toResponseEntity(
+        outcome: ReadOutcome.DeferredForTimeout,
+        status: UrgentReadStatusResponse,
+        retryAfterSeconds: Long,
+    ): ResponseEntity<*> = ResponseEntity.accepted()
+        .header("Location", status.statusUrl)
+        .header("Retry-After", retryAfterSeconds.toString())
+        .body(status)
+
+    fun toResponseEntity(
+        result: EnqueueResult,
+        retryAfterSeconds: Long,
+    ): ResponseEntity<*> = when (result) {
+        is EnqueueResult.Accepted -> toResponseEntity(ReadOutcome.DeferredForTimeout, result.status, retryAfterSeconds)
+        is EnqueueResult.Rejected -> ResponseEntity.status(503)
+            .header("Retry-After", result.retryAfterSeconds.toString())
+            .build<Any>()
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+```bash
+cd /home/maple/probabilistic-valuation-engine
+./gradlew :module-rest-controller:test --tests "maple.restcontroller.read.ReadResponseMapperTest" --continue
+```
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine
+git add module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadResponseMapper.kt \
+        module-rest-controller/src/test/kotlin/maple/restcontroller/read/ReadResponseMapperTest.kt
+git -c user.email=claude@anthropic.com -c user.name="Claude" commit -m "feat(rest): add ReadResponseMapper for V6 read HTTP shape"
+```
+
+---
+
+## Task 4: Extend `InflightRequestRegistry` with `applyOutcome`
+
+**Files:**
+- Modify: `module-rest-controller/src/main/kotlin/maple/restcontroller/read/InflightRequestRegistry.kt`
+- Create: `module-rest-controller/src/test/kotlin/maple/restcontroller/read/InflightRequestRegistryApplyOutcomeTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+```kotlin
+// module-rest-controller/src/test/kotlin/maple/restcontroller/read/InflightRequestRegistryApplyOutcomeTest.kt
+package maple.restcontroller.read
+
+import maple.restcontroller.read.ReadResponseMapper
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.context.request.async.DeferredResult
+import java.math.BigDecimal
+import java.time.Instant
+
+class InflightRequestRegistryApplyOutcomeTest {
+
+    private val registry = InflightRequestRegistry()
+
+    private fun newDeferred(): DeferredResult<ResponseEntity<*>> = DeferredResult()
+
+    private val readyResp = V6ExpectationResponse(
+        userIgn = "진격캐넌", presetNo = 1,
+        totalCost = BigDecimal("100"), equipmentCount = 1,
+        equipment = emptyList(), calculatedAt = Instant.parse("2026-01-01T00:00:00Z"),
+    )
+
+    @Test
+    fun `applyOutcome Ready sets 200 OK on registered deferreds and removes them`() {
+        val d1 = newDeferred(); val d2 = newDeferred()
+        registry.register("진격캐넌", 1, d1)
+        registry.register("진격캐넌", 1, d2)
+
+        registry.applyOutcome("진격캐넌", 1, ReadOutcome.Ready(readyResp))
+
+        assertThat(d1.result).isNotNull
+        assertThat(d2.result).isNotNull
+        assertThat((d1.result as ResponseEntity<*>).statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(registry.size()).isEqualTo(0)
+    }
+
+    @Test
+    fun `applyOutcome NotFound sets 404 with X-Error-Reason header`() {
+        val d = newDeferred()
+        registry.register("nope", 1, d)
+
+        registry.applyOutcome("nope", 1, ReadOutcome.NotFound)
+
+        val entity = d.result as ResponseEntity<*>
+        assertThat(entity.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
+        assertThat(entity.headers["X-Error-Reason"]).containsExactly("character-not-found")
+    }
+
+    @Test
+    fun `applyOutcome DeferredForTimeout with status sets 202 and removes deferreds`() {
+        val d = newDeferred()
+        registry.register("slow", 1, d)
+        val status = UrgentReadStatusResponse(
+            state = UrgentReadState.Unknown, userIgn = "slow",
+            statusUrl = "/api/v6/characters/slow/status?presetNo=1",
+            queuePositionApprox = null, estimatedWaitSeconds = null, retryAfterSeconds = 3L,
+        )
+
+        registry.applyOutcome("slow", 1, ReadOutcome.DeferredForTimeout, status, retryAfterSeconds = 3L)
+
+        val entity = d.result as ResponseEntity<*>
+        assertThat(entity.statusCode).isEqualTo(HttpStatus.ACCEPTED)
+        assertThat(entity.headers["Location"]).containsExactly(status.statusUrl)
+        assertThat(registry.size()).isEqualTo(0)
+    }
+
+    @Test
+    fun `applyOutcome with no registered deferreds is a no-op`() {
+        registry.applyOutcome("absent", 1, ReadOutcome.Ready(readyResp))
+        // No exception, registry stays empty.
+        assertThat(registry.size()).isEqualTo(0)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+cd /home/maple/probabilistic-valuation-engine
+./gradlew :module-rest-controller:test --tests "maple.restcontroller.read.InflightRequestRegistryApplyOutcomeTest" --continue
+```
+Expected: FAIL with "Unresolved reference: applyOutcome".
+
+- [ ] **Step 3: Modify `InflightRequestRegistry`**
+
+Replace entire file content with:
+
+```kotlin
+// module-rest-controller/src/main/kotlin/maple/restcontroller/read/InflightRequestRegistry.kt
+package maple.restcontroller.read
+
+import maple.restcontroller.read.ReadResponseMapper
+import org.springframework.http.ResponseEntity
+import org.springframework.web.context.request.async.DeferredResult
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArrayList
+
+class InflightRequestRegistry {
+
+    private val registry = ConcurrentHashMap<String, CopyOnWriteArrayList<DeferredResult<ResponseEntity<*>>>>()
+
+    fun register(userIgn: String, presetNo: Int, deferred: DeferredResult<ResponseEntity<*>>): Boolean {
+        val list = registry.computeIfAbsent(key(userIgn, presetNo)) { CopyOnWriteArrayList() }
+        list.add(deferred)
+        return list.size == 1
+    }
+
+    fun getAndRemove(userIgn: String, presetNo: Int): List<DeferredResult<ResponseEntity<*>>> {
+        return registry.remove(key(userIgn, presetNo)) ?: emptyList()
+    }
+
+    fun cleanup(userIgn: String, presetNo: Int, deferred: DeferredResult<ResponseEntity<*>>) {
+        registry.computeIfPresent(key(userIgn, presetNo)) { _, list ->
+            list.remove(deferred)
+            if (list.isEmpty()) null else list
+        }
+    }
+
+    fun size(): Int = registry.size
+
+    /**
+     * Apply a typed [ReadOutcome] to all deferreds registered for [userIgn]/[presetNo].
+     * Internally converts the outcome to a `ResponseEntity` via [ReadResponseMapper]
+     * and calls `deferred.setResult(...)`. Deferreds are removed.
+     *
+     * For [ReadOutcome.DeferredForTimeout], [status] must be supplied.
+     */
+    fun applyOutcome(userIgn: String, presetNo: Int, outcome: ReadOutcome) {
+        applyOutcome(userIgn, presetNo, outcome, status = null, retryAfterSeconds = 0L)
+    }
+
+    fun applyOutcome(
+        userIgn: String,
+        presetNo: Int,
+        outcome: ReadOutcome,
+        status: UrgentReadStatusResponse?,
+        retryAfterSeconds: Long,
+    ) {
+        val deferreds = getAndRemove(userIgn, presetNo)
+        if (deferreds.isEmpty()) return
+        val entity: ResponseEntity<*> = when (outcome) {
+            is ReadOutcome.Ready -> ReadResponseMapper.toResponseEntity(outcome)
+            ReadOutcome.NotFound -> ReadResponseMapper.toResponseEntity(outcome)
+            ReadOutcome.DeferredForTimeout -> {
+                requireNotNull(status) { "DeferredForTimeout requires status payload" }
+                ReadResponseMapper.toResponseEntity(outcome, status, retryAfterSeconds)
+            }
+        }
+        deferreds.forEach { it.setResult(entity) }
+    }
+
+    fun failAll(response: ResponseEntity<*>) {
+        registry.keys.toList().forEach { userIgn ->
+            val deferreds = registry.remove(userIgn)
+            deferreds?.forEach { deferred ->
+                deferred.setErrorResult(response)
+            }
+        }
+    }
+
+    private fun key(userIgn: String, presetNo: Int): String = "$userIgn:$presetNo"
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+```bash
+cd /home/maple/probabilistic-valuation-engine
+./gradlew :module-rest-controller:test --tests "maple.restcontroller.read.InflightRequestRegistryApplyOutcomeTest" --continue
+```
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine
+git add module-rest-controller/src/main/kotlin/maple/restcontroller/read/InflightRequestRegistry.kt \
+        module-rest-controller/src/test/kotlin/maple/restcontroller/read/InflightRequestRegistryApplyOutcomeTest.kt
+git -c user.email=claude@anthropic.com -c user.name="Claude" commit -m "feat(rest): InflightRequestRegistry.applyOutcome routes via mapper"
+```
+
+---
+
+## Task 5: Refactor `BatchResolver` to return outcomes
+
+**Files:**
+- Modify: `module-rest-controller/src/main/kotlin/maple/restcontroller/read/BatchResolver.kt`
+- Create: `module-rest-controller/src/test/kotlin/maple/restcontroller/read/BatchResolverTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+```kotlin
+// module-rest-controller/src/test/kotlin/maple/restcontroller/read/BatchResolverTest.kt
+package maple.restcontroller.read
+
+import maple.expectation.util.StringMaskingUtils
+import maple.restcontroller.config.V6ReadProperties
+import maple.restcontroller.metrics.V6ReadMetrics
+import maple.restcontroller.urgent.UrgentCharacterRequest
+import maple.restcontroller.urgent.UrgentTriggerPublisher
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+import java.time.Duration
+import java.time.Instant
+
+class BatchResolverTest {
+
+    private val cacheService: ReadModelCacheService = mock()
+    private val registry: InflightRequestRegistry = mock()
+    private val queryService: ReadModelQueryService = mock()
+    private val urgentPublisher: UrgentTriggerPublisher = mock()
+    private val properties = V6ReadProperties().apply { readModelFreshnessSeconds = 1800 }
+    private val metrics = V6ReadMetrics(SimpleMeterRegistry(), mock<LocalRequestBuffer>(relaxed = true), mock<InflightRequestRegistry>(relaxed = true))
+    private val resolver = BatchResolver(cacheService, registry, queryService, urgentPublisher, properties, metrics)
+
+    private val resp = V6ExpectationResponse(
+        userIgn = "캐릭터", presetNo = 1,
+        totalCost = BigDecimal("100"), equipmentCount = 1,
+        equipment = emptyList(), calculatedAt = Instant.parse("2026-01-01T00:00:00Z"),
+    )
+
+    @Test
+    fun `cache hit returns Ready outcome and applies via registry`() {
+        whenever(cacheService.multiGet(mapOf("캐릭터" to 1)))
+            .returns(mapOf("캐릭터" to resp) to emptyMap())
+        val req = ReadRequest(userIgn = "캐릭터", presetNo = 1)
+
+        val outcomes = resolver.resolveBatch(listOf(req))
+
+        assertThat(outcomes).containsExactly("캐릭터:1" to ReadOutcome.Ready(resp))
+        verify(registry).applyOutcome("캐릭터", 1, ReadOutcome.Ready(resp))
+    }
+
+    @Test
+    fun `db hit returns Ready outcome and writes cache`() {
+        whenever(cacheService.multiGet(mapOf("캐릭터" to 1)))
+            .returns(emptyMap<V6ExpectationResponse>() to mapOf("캐릭터" to 1))
+        whenever(queryService.batchQuery(mapOf("캐릭터" to 1), any<Duration>()))
+            .returns(mapOf("캐릭터" to resp))
+
+        val outcomes = resolver.resolveBatch(listOf(ReadRequest("캐릭터", 1)))
+
+        assertThat(outcomes).containsExactly("캐릭터:1" to ReadOutcome.Ready(resp))
+        verify(cacheService).multiPut(mapOf("캐릭터" to resp))
+        verify(registry).applyOutcome("캐릭터", 1, ReadOutcome.Ready(resp))
+    }
+
+    @Test
+    fun `db miss + negative cache returns NotFound outcome`() {
+        whenever(cacheService.multiGet(mapOf("캐릭터" to 1)))
+            .returns(emptyMap<V6ExpectationResponse>() to mapOf("캐릭터" to 1))
+        whenever(queryService.batchQuery(mapOf("캐릭터" to 1), any<Duration>()))
+            .returns(emptyMap())
+        whenever(cacheService.getNegativeCache("캐릭터")).returns(true)
+
+        val outcomes = resolver.resolveBatch(listOf(ReadRequest("캐릭터", 1)))
+
+        assertThat(outcomes).containsExactly("캐릭터:1" to ReadOutcome.NotFound)
+        verify(registry).applyOutcome("캐릭터", 1, ReadOutcome.NotFound)
+        verify(urgentPublisher, never()).publish(any())
+    }
+
+    @Test
+    fun `db miss + no negative cache + fresh urgent SETNX returns DeferredForTimeout and publishes urgent`() {
+        whenever(cacheService.multiGet(mapOf("캐릭터" to 1)))
+            .returns(emptyMap<V6ExpectationResponse>() to mapOf("캐릭터" to 1))
+        whenever(queryService.batchQuery(mapOf("캐릭터" to 1), any<Duration>()))
+            .returns(emptyMap())
+        whenever(cacheService.getNegativeCache("캐릭터")).returns(false)
+        whenever(cacheService.tryMarkUrgentPending("캐릭터")).returns(true)
+
+        val outcomes = resolver.resolveBatch(listOf(ReadRequest("캐릭터", 1)))
+
+        assertThat(outcomes).containsExactly("캐릭터:1" to ReadOutcome.DeferredForTimeout)
+        verify(urgentPublisher).publish(UrgentCharacterRequest(userIgn = "캐릭터", presetNo = 1))
+        // No applyOutcome: deferred is left to timeout in registry.
+        verify(registry, never()).applyOutcome(any<String>(), any<Int>(), any<ReadOutcome>())
+    }
+
+    @Test
+    fun `db miss + already urgent pending returns DeferredForTimeout and does not republish`() {
+        whenever(cacheService.multiGet(mapOf("캐릭터" to 1)))
+            .returns(emptyMap<V6ExpectationResponse>() to mapOf("캐릭터" to 1))
+        whenever(queryService.batchQuery(mapOf("캐릭터" to 1), any<Duration>()))
+            .returns(emptyMap())
+        whenever(cacheService.getNegativeCache("캐릭터")).returns(false)
+        whenever(cacheService.tryMarkUrgentPending("캐릭터")).returns(false)
+
+        val outcomes = resolver.resolveBatch(listOf(ReadRequest("캐릭터", 1)))
+
+        assertThat(outcomes).containsExactly("캐릭터:1" to ReadOutcome.DeferredForTimeout)
+        verify(urgentPublisher, never()).publish(any())
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+cd /home/maple/probabilistic-valuation-engine
+./gradlew :module-rest-controller:test --tests "maple.restcontroller.read.BatchResolverTest" --continue
+```
+Expected: FAIL — current `BatchResolver.resolveBatch` returns `Int` and has a different signature. The test will fail at compile time on signature mismatch or assertThat shape.
+
+- [ ] **Step 3: Modify `BatchResolver`**
+
+Replace entire file with:
+
+```kotlin
+// module-rest-controller/src/main/kotlin/maple/restcontroller/read/BatchResolver.kt
+package maple.restcontroller.read
+
+import maple.expectation.util.StringMaskingUtils.maskIgn
+import maple.restcontroller.config.V6ReadProperties
+import maple.restcontroller.metrics.V6ReadMetrics
+import maple.restcontroller.urgent.UrgentCharacterRequest
+import maple.restcontroller.urgent.UrgentTriggerPublisher
+import org.slf4j.LoggerFactory
+import java.time.Duration
+
+class BatchResolver(
+    private val cacheService: ReadModelCacheService,
+    private val registry: InflightRequestRegistry,
+    private val queryService: ReadModelQueryService,
+    private val urgentPublisher: UrgentTriggerPublisher?,
+    private val properties: V6ReadProperties,
+    private val metrics: V6ReadMetrics,
+) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    /**
+     * Resolve a batch by orchestrating Redis / DB / Kafka, returning a map of
+     * `"$userIgn:$presetNo" -> ReadOutcome` and applying terminal outcomes
+     * (Ready, NotFound) to registered deferreds via [InflightRequestRegistry.applyOutcome].
+     *
+     * `DeferredForTimeout` outcomes are returned but NOT applied — the deferred
+     * remains in the registry and the controller's timeout callback will resolve it.
+     */
+    fun resolveBatch(batch: List<ReadRequest>): Map<String, ReadOutcome> {
+        if (batch.isEmpty()) return emptyMap()
+
+        val requests = batch.associate { it.userIgn to it.presetNo }
+        val outcomes = mutableMapOf<String, ReadOutcome>()
+
+        // 1. Redis cache lookup — split hits / misses
+        val (cacheHits, cacheMisses) = cacheService.multiGet(requests)
+
+        // 2. Cache hits → Ready
+        cacheHits.forEach { (userIgn, response) ->
+            metrics.recordHit()
+            metrics.recordRedisHit()
+            registry.applyOutcome(userIgn, response.presetNo, ReadOutcome.Ready(response))
+            outcomes["$userIgn:${response.presetNo}"] = ReadOutcome.Ready(response)
+        }
+
+        // 3. DB batch query for cache misses
+        if (cacheMisses.isNotEmpty()) {
+            val dbResults = queryService.batchQuery(
+                cacheMisses,
+                Duration.ofSeconds(properties.readModelFreshnessSeconds),
+            )
+
+            // 4. Write DB results to Redis cache
+            cacheService.multiPut(dbResults)
+
+            // 5. Resolve miss deferreds
+            cacheMisses.forEach { (userIgn, presetNo) ->
+                val response = dbResults[userIgn]
+                if (response != null) {
+                    metrics.recordHit()
+                    metrics.recordDbHit()
+                    registry.applyOutcome(userIgn, presetNo, ReadOutcome.Ready(response))
+                    outcomes["$userIgn:$presetNo"] = ReadOutcome.Ready(response)
+                } else {
+                    metrics.recordMiss("read_model_empty")
+                    if (cacheService.getNegativeCache(userIgn)) {
+                        registry.applyOutcome(userIgn, presetNo, ReadOutcome.NotFound)
+                        outcomes["$userIgn:$presetNo"] = ReadOutcome.NotFound
+                        return@forEach
+                    }
+                    if (urgentPublisher != null && cacheService.tryMarkUrgentPending(userIgn)) {
+                        urgentPublisher.publish(UrgentCharacterRequest(userIgn = userIgn, presetNo = presetNo))
+                        metrics.urgentTriggerTotal.increment()
+                        log.info("Triggered urgent pipeline: userIgn={}", maskIgn(userIgn))
+                    }
+                    // Deferred stays — controller timeout will resolve it.
+                    outcomes["$userIgn:$presetNo"] = ReadOutcome.DeferredForTimeout
+                }
+            }
+        }
+
+        return outcomes
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+```bash
+cd /home/maple/probabilistic-valuation-engine
+./gradlew :module-rest-controller:test --tests "maple.restcontroller.read.BatchResolverTest" --continue
+```
+Expected: PASS (5 tests). If any existing test references the old signature, fix it in subsequent tasks (next test file).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine
+git add module-rest-controller/src/main/kotlin/maple/restcontroller/read/BatchResolver.kt \
+        module-rest-controller/src/test/kotlin/maple/restcontroller/read/BatchResolverTest.kt
+git -c user.email=claude@anthropic.com -c user.name="Claude" commit -m "refactor(rest): BatchResolver returns ReadOutcome map, no ResponseEntity"
+```
+
+---
+
+## Task 6: Refactor `BatchReadScheduler` to delegate to `BatchResolver`
+
+**Files:**
+- Modify: `module-rest-controller/src/main/kotlin/maple/restcontroller/read/BatchReadScheduler.kt`
+- Create: `module-rest-controller/src/test/kotlin/maple/restcontroller/read/BatchReadSchedulerOutcomeTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+```kotlin
+// module-rest-controller/src/test/kotlin/maple/restcontroller/read/BatchReadSchedulerOutcomeTest.kt
+package maple.restcontroller.read
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import maple.restcontroller.config.V6ReadProperties
+import maple.restcontroller.metrics.V6ReadMetrics
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.context.request.async.DeferredResult
+import java.math.BigDecimal
+import java.time.Instant
+
+class BatchReadSchedulerOutcomeTest {
+
+    private val buffer: LocalRequestBuffer = mock()
+    private val registry: InflightRequestRegistry = InflightRequestRegistry()
+    private val cacheService: ReadModelCacheService = mock()
+    private val queryService: ReadModelQueryService = mock()
+    private val resolver = BatchResolver(cacheService, registry, queryService, null, V6ReadProperties(), V6ReadMetrics(SimpleMeterRegistry(), mock<LocalRequestBuffer>(relaxed = true), mock<InflightRequestRegistry>(relaxed = true)))
+    private val properties = V6ReadProperties().apply {
+        maxBatchSize = 200
+        shutdownDrainTimeoutSeconds = 5
+    }
+    private val metrics = V6ReadMetrics(SimpleMeterRegistry(), mock<LocalRequestBuffer>(relaxed = true), mock<InflightRequestRegistry>(relaxed = true))
+    private val scheduler = BatchReadScheduler(buffer, resolver, metrics, properties)
+
+    private val resp = V6ExpectationResponse(
+        userIgn = "캐릭터", presetNo = 1,
+        totalCost = BigDecimal("100"), equipmentCount = 1,
+        equipment = emptyList(), calculatedAt = Instant.parse("2026-01-01T00:00:00Z"),
+    )
+
+    @Test
+    fun `scheduledDrain drains buffer and delegates to resolver`() {
+        whenever(buffer.drain(200)).thenReturn(listOf(ReadRequest("캐릭터", 1)))
+        whenever(cacheService.multiGet(mapOf("캐릭터" to 1)))
+            .returns(mapOf("캐릭터" to resp) to emptyMap())
+
+        scheduler.start()
+        scheduler.scheduledDrain()
+
+        // The deferred registered against "캐릭터:1" should now have a 200 response.
+        // (We register one in this test, then resolver.applyOutcome sets the result.)
+        // Verify indirect effect: buffer drain was called, no ResponseEntity built in scheduler.
+        verify(buffer).drain(200)
+    }
+
+    @Test
+    fun `stop drains remaining requests and fails deferreds with 503`() {
+        val deferred = DeferredResult<ResponseEntity<*>>()
+        registry.register("pending", 1, deferred)
+        whenever(buffer.drain(200)).thenReturn(emptyList())
+        whenever(buffer.isEmpty()).thenReturn(false, true)
+
+        scheduler.stop()
+
+        // After stop, remaining deferred must be resolved with 503.
+        val entity = deferred.result
+        assertThat(entity).isNotNull
+        assertThat((entity as ResponseEntity<*>).statusCode).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+cd /home/maple/probabilistic-valuation-engine
+./gradlew :module-rest-controller:test --tests "maple.restcontroller.read.BatchReadSchedulerOutcomeTest" --continue
+```
+Expected: FAIL — current `BatchReadScheduler` constructor doesn't accept a `BatchResolver`.
+
+- [ ] **Step 3: Modify `BatchReadScheduler`**
+
+Replace entire file with:
+
+```kotlin
+// module-rest-controller/src/main/kotlin/maple/restcontroller/read/BatchReadScheduler.kt
+package maple.restcontroller.read
+
+import maple.restcontroller.config.V6ReadProperties
+import maple.restcontroller.metrics.V6ReadMetrics
+import org.slf4j.LoggerFactory
+import org.springframework.context.SmartLifecycle
+import org.springframework.http.ResponseEntity
+import org.springframework.scheduling.annotation.Scheduled
+import java.util.concurrent.TimeUnit
+
+class BatchReadScheduler(
+    private val buffer: LocalRequestBuffer,
+    private val resolver: BatchResolver,
+    private val metrics: V6ReadMetrics,
+    private val properties: V6ReadProperties,
+) : SmartLifecycle {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Volatile
+    private var running = false
+
+    override fun start() {
+        running = true
+        log.info("BatchReadScheduler started")
+    }
+
+    override fun stop() {
+        stop { }
+    }
+
+    override fun stop(callback: Runnable) {
+        running = false
+        log.info("BatchReadScheduler stopping — draining remaining requests")
+
+        buffer.stopAccepting()
+
+        val deadlineNanos = System.nanoTime() +
+            TimeUnit.SECONDS.toNanos(properties.shutdownDrainTimeoutSeconds)
+
+        val serviceUnavailable = ResponseEntity.status(503)
+            .header("Retry-After", "1")
+            .build<Any>()
+
+        var drained = 0
+        while (!buffer.isEmpty() && System.nanoTime() < deadlineNanos) {
+            val batch = buffer.drain(properties.maxBatchSize)
+            resolver.resolveBatch(batch)
+            drained += batch.size
+        }
+
+        buffer.failAllPending()
+
+        log.info("BatchReadScheduler stopped — drained={}", drained)
+        callback.run()
+    }
+
+    override fun isRunning(): Boolean = running
+
+    override fun getPhase(): Int = Integer.MAX_VALUE - 100
+
+    override fun isAutoStartup(): Boolean = true
+
+    @Scheduled(fixedDelayString = "\${expectation.v6.batch-window-ms:10}")
+    fun scheduledDrain() {
+        if (!running) return
+        val batch = buffer.drain(properties.maxBatchSize)
+        if (batch.isEmpty()) return
+
+        val sample = io.micrometer.core.instrument.Timer.start()
+        resolver.resolveBatch(batch)
+        sample.stop(metrics.batchLatency)
+    }
+}
+```
+
+Note: shutdown 503 has been moved to be the responsibility of the registry (`registry.failAll` already does this in old code). For now we removed the `failAll` call from shutdown — instead `buffer.failAllPending` clears the buffer and any deferreds that already had their registry entry stay registered and will hit their `requestTimeoutMs` to become 202. The original `registry.failAll(serviceUnavailable)` line is removed for the same reason `enqueue` will no longer 503-respond by itself; the controller's `Rejected` path now handles 503 from the synchronous side. **This is an explicit behavior change** documented in the spec's "Trade-offs / Risk" — drain on shutdown now relies on the buffer failing pending entries; outstanding deferreds (registered in the registry but not in the buffer) are timed out by the container via `requestTimeoutMs`. If the prior code's `failAll` behavior must be preserved, re-add a `registry.failAll(503)` call in `stop()`.
+
+The cleanest move is to keep the old `failAll` semantics on shutdown. Adjust the new file's `stop()` as follows:
+
+```kotlin
+override fun stop(callback: Runnable) {
+    running = false
+    log.info("BatchReadScheduler stopping — draining remaining requests")
+
+    buffer.stopAccepting()
+
+    val deadlineNanos = System.nanoTime() +
+        TimeUnit.SECONDS.toNanos(properties.shutdownDrainTimeoutSeconds)
+
+    val serviceUnavailable = ResponseEntity.status(503)
+        .header("Retry-After", "1")
+        .build<Any>()
+
+    var drained = 0
+    while (!buffer.isEmpty() && System.nanoTime() < deadlineNanos) {
+        val batch = buffer.drain(properties.maxBatchSize)
+        resolver.resolveBatch(batch)
+        drained += batch.size
+    }
+
+    // The registry holds deferreds that are still in-flight. We don't have a direct
+    // handle to the registry here, so we use the existing local `registry` reference
+    // — add it to the constructor.
+    ...
+}
+```
+
+To preserve failAll behavior, add `registry: InflightRequestRegistry` to the constructor and call `registry.failAll(serviceUnavailable)`. **Update Task 6 Step 3 above to use this final shape:**
+
+```kotlin
+// module-rest-controller/src/main/kotlin/maple/restcontroller/read/BatchReadScheduler.kt
+package maple.restcontroller.read
+
+import maple.restcontroller.config.V6ReadProperties
+import maple.restcontroller.metrics.V6ReadMetrics
+import org.slf4j.LoggerFactory
+import org.springframework.context.SmartLifecycle
+import org.springframework.http.ResponseEntity
+import org.springframework.scheduling.annotation.Scheduled
+import java.util.concurrent.TimeUnit
+
+class BatchReadScheduler(
+    private val buffer: LocalRequestBuffer,
+    private val registry: InflightRequestRegistry,
+    private val resolver: BatchResolver,
+    private val metrics: V6ReadMetrics,
+    private val properties: V6ReadProperties,
+) : SmartLifecycle {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Volatile
+    private var running = false
+
+    override fun start() {
+        running = true
+        log.info("BatchReadScheduler started")
+    }
+
+    override fun stop() {
+        stop { }
+    }
+
+    override fun stop(callback: Runnable) {
+        running = false
+        log.info("BatchReadScheduler stopping — draining remaining requests")
+
+        buffer.stopAccepting()
+
+        val deadlineNanos = System.nanoTime() +
+            TimeUnit.SECONDS.toNanos(properties.shutdownDrainTimeoutSeconds)
+
+        var drained = 0
+        while (!buffer.isEmpty() && System.nanoTime() < deadlineNanos) {
+            val batch = buffer.drain(properties.maxBatchSize)
+            resolver.resolveBatch(batch)
+            drained += batch.size
+        }
+
+        // Resolve any remaining deferreds with 503 — same as before.
+        val serviceUnavailable = ResponseEntity.status(503)
+            .header("Retry-After", "1")
+            .build<Any>()
+        registry.failAll(serviceUnavailable)
+        buffer.failAllPending()
+
+        log.info("BatchReadScheduler stopped — drained={}", drained)
+        callback.run()
+    }
+
+    override fun isRunning(): Boolean = running
+
+    override fun getPhase(): Int = Integer.MAX_VALUE - 100
+
+    override fun isAutoStartup(): Boolean = true
+
+    @Scheduled(fixedDelayString = "\${expectation.v6.batch-window-ms:10}")
+    fun scheduledDrain() {
+        if (!running) return
+        val batch = buffer.drain(properties.maxBatchSize)
+        if (batch.isEmpty()) return
+
+        val sample = io.micrometer.core.instrument.Timer.start()
+        resolver.resolveBatch(batch)
+        sample.stop(metrics.batchLatency)
+    }
+}
+```
+
+The test in Step 1 expects `BatchReadScheduler(buffer, resolver, metrics, properties)`. Update the test to use the new constructor with registry: `BatchReadScheduler(buffer, registry, resolver, metrics, properties)`.
+
+- [ ] **Step 4: Update Step 1 test to match new constructor**
+
+In `BatchReadSchedulerOutcomeTest.kt`, replace the line:
+
+```kotlin
+private val scheduler = BatchReadScheduler(buffer, resolver, metrics, properties)
+```
+
+with:
+
+```kotlin
+private val scheduler = BatchReadScheduler(buffer, registry, resolver, metrics, properties)
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run:
+```bash
+cd /home/maple/probabilistic-valuation-engine
+./gradlew :module-rest-controller:test --tests "maple.restcontroller.read.BatchReadSchedulerOutcomeTest" --continue
+```
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine
+git add module-rest-controller/src/main/kotlin/maple/restcontroller/read/BatchReadScheduler.kt \
+        module-rest-controller/src/test/kotlin/maple/restcontroller/read/BatchReadSchedulerOutcomeTest.kt
+git -c user.email=claude@anthropic.com -c user.name="Claude" commit -m "refactor(rest): BatchReadScheduler delegates to BatchResolver, no ResponseEntity"
+```
+
+---
+
+## Task 7: Update `V6ReadConfig` to wire `BatchResolver`
+
+**Files:**
+- Modify: `module-rest-controller/src/main/kotlin/maple/restcontroller/config/V6ReadConfig.kt`
+
+- [ ] **Step 1: Modify the `batchReadScheduler` and add `batchResolver` beans**
+
+Replace the `batchReadScheduler` bean block with:
+
+```kotlin
+@Bean
+fun batchResolver(
+    cacheService: ReadModelCacheService,
+    registry: InflightRequestRegistry,
+    queryService: ReadModelQueryService,
+    urgentPublisherProvider: ObjectProvider<UrgentTriggerPublisher>,
+    v6ReadMetrics: V6ReadMetrics,
+): BatchResolver = BatchResolver(
+    cacheService, registry, queryService,
+    urgentPublisherProvider.ifAvailable,
+    v6ReadMetrics, properties,
+)
+
+@Bean
+fun batchReadScheduler(
+    buffer: LocalRequestBuffer,
+    registry: InflightRequestRegistry,
+    resolver: BatchResolver,
+    v6ReadMetrics: V6ReadMetrics,
+): BatchReadScheduler = BatchReadScheduler(
+    buffer, registry, resolver, v6ReadMetrics, properties,
+)
+```
+
+(Remove the `queryService: ReadModelQueryService` and `cacheService: ReadModelCacheService` and `urgentPublisherProvider: ObjectProvider<UrgentTriggerPublisher>` parameters from `batchReadScheduler`.)
+
+- [ ] **Step 2: Compile**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine
+./gradlew :module-rest-controller:compileKotlin :module-rest-controller:compileJava --continue
+```
+Expected: compile success.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine
+git add module-rest-controller/src/main/kotlin/maple/restcontroller/config/V6ReadConfig.kt
+git -c user.email=claude@anthropic.com -c user.name="Claude" commit -m "refactor(rest): wire BatchResolver bean in V6ReadConfig"
+```
+
+---
+
+## Task 8: Refactor `ExpectationReadFacade` to return `EnqueueResult`
+
+**Files:**
+- Modify: `module-rest-controller/src/main/kotlin/maple/restcontroller/read/ExpectationReadFacade.kt`
+- Modify: `module-rest-controller/src/test/kotlin/maple/restcontroller/read/ExpectationReadFacadeTest.kt`
+
+- [ ] **Step 1: Update the existing test for typed return**
+
+Replace `ExpectationReadFacadeTest.kt` with:
+
+```kotlin
+// module-rest-controller/src/test/kotlin/maple/restcontroller/read/ExpectationReadFacadeTest.kt
+package maple.restcontroller.read
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import maple.restcontroller.config.V6ReadProperties
+import maple.restcontroller.metrics.V6ReadMetrics
+import maple.restcontroller.popular.PopularCharacterService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.http.ResponseEntity
+import org.springframework.web.context.request.async.DeferredResult
+
+class ExpectationReadFacadeTest {
+
+    private val meterRegistry = SimpleMeterRegistry()
+    private lateinit var buffer: LocalRequestBuffer
+    private lateinit var registry: InflightRequestRegistry
+    private lateinit var metrics: V6ReadMetrics
+    private lateinit var facade: ExpectationReadFacade
+    private lateinit var cacheService: ReadModelCacheService
+    private lateinit var popularCharacterService: PopularCharacterService
+    private lateinit var properties: V6ReadProperties
+
+    @BeforeEach
+    fun setup() {
+        buffer = LocalRequestBuffer(100)
+        registry = InflightRequestRegistry()
+        metrics = V6ReadMetrics(meterRegistry, buffer, registry)
+        cacheService = mock()
+        popularCharacterService = mock()
+        properties = V6ReadProperties().apply { statusRetryAfterSeconds = 1L }
+        facade = ExpectationReadFacade(registry, buffer, metrics, cacheService, popularCharacterService, properties)
+    }
+
+    private fun enqueue(ign: String, presetNo: Int = 1): Pair<EnqueueResult, DeferredResult<ResponseEntity<*>>> {
+        val deferred = DeferredResult<ResponseEntity<*>>()
+        val result = facade.enqueue(ign, presetNo, deferred)
+        return result to deferred
+    }
+
+    @Test
+    fun `enqueue dedup miss returns Accepted and offers to buffer`() {
+        val (result, _) = enqueue("진격캐넌")
+
+        assertThat(result).isInstanceOf(EnqueueResult.Accepted::class.java)
+        assertThat(buffer.size()).isEqualTo(1)
+        assertThat(meterRegistry.counter("v6_dedup_miss_total").count()).isEqualTo(1.0)
+        assertThat(meterRegistry.counter("v6_request_total").count()).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `enqueue dedup hit returns Accepted and does not add to buffer`() {
+        enqueue("진격캐넌")
+        val (result, _) = enqueue("진격캐넌")
+
+        assertThat(result).isInstanceOf(EnqueueResult.Accepted::class.java)
+        assertThat(buffer.size()).isEqualTo(1)
+        assertThat(meterRegistry.counter("v6_dedup_hit_total").count()).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `enqueue returns Rejected when buffer is full`() {
+        val smallBuffer = LocalRequestBuffer(1)
+        val smallMetrics = V6ReadMetrics(SimpleMeterRegistry(), smallBuffer, registry)
+        val fullFacade = ExpectationReadFacade(
+            registry, smallBuffer, smallMetrics, cacheService, popularCharacterService, properties,
+        )
+
+        val d1 = DeferredResult<ResponseEntity<*>>()
+        val r1 = fullFacade.enqueue("a", 1, d1)
+
+        val d2 = DeferredResult<ResponseEntity<*>>()
+        val r2 = fullFacade.enqueue("b", 1, d2)
+
+        assertThat(r1).isInstanceOf(EnqueueResult.Accepted::class.java)
+        assertThat(r2).isInstanceOf(EnqueueResult.Rejected::class.java)
+        assertThat((r2 as EnqueueResult.Rejected).retryAfterSeconds).isEqualTo(1L)
+        assertThat(smallMetrics.bufferRejectedTotal.count()).isEqualTo(1.0)
+        // Cleanup should have removed the rejected deferred from registry.
+        assertThat(registry.size()).isEqualTo(1)
+    }
+
+    @Test
+    fun `different userIgns both return Accepted and are buffered`() {
+        enqueue("a")
+        enqueue("b")
+
+        assertThat(buffer.size()).isEqualTo(2)
+        assertThat(registry.size()).isEqualTo(2)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+cd /home/maple/probabilistic-valuation-engine
+./gradlew :module-rest-controller:test --tests "maple.restcontroller.read.ExpectationReadFacadeTest" --continue
+```
+Expected: FAIL — `enqueue` returns `Unit` in current code.
+
+- [ ] **Step 3: Refactor `ExpectationReadFacade`**
+
+Replace entire file with:
+
+```kotlin
+// module-rest-controller/src/main/kotlin/maple/restcontroller/read/ExpectationReadFacade.kt
+package maple.restcontroller.read
+
+import maple.expectation.util.StringMaskingUtils.maskIgn
+import maple.restcontroller.config.V6ReadProperties
+import maple.restcontroller.metrics.V6ReadMetrics
+import maple.restcontroller.popular.PopularCharacterService
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.web.context.request.async.DeferredResult
+
+class ExpectationReadFacade(
+    private val registry: InflightRequestRegistry,
+    private val buffer: RequestBuffer,
+    private val metrics: V6ReadMetrics,
+    private val cacheService: ReadModelCacheService,
+    private val popularCharacterService: PopularCharacterService,
+    private val properties: V6ReadProperties,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    /**
+     * Enqueue a read request. Returns a typed [EnqueueResult] describing the
+     * synchronous outcome. The caller (controller) is responsible for translating
+     * the result into HTTP and for installing the deferred timeout / completion
+     * callbacks that produce 202 / 503 responses.
+     */
+    fun enqueue(
+        userIgn: String,
+        presetNo: Int,
+        deferred: DeferredResult<ResponseEntity<*>>,
+    ): EnqueueResult {
+        popularCharacterService.recordV6ExpectationRequest(userIgn)
+        metrics.requestTotal.increment()
+        val firstRequest = registry.register(userIgn, presetNo, deferred)
+        if (firstRequest) {
+            metrics.dedupMissTotal.increment()
+            if (!buffer.offer(ReadRequest(userIgn = userIgn, presetNo = presetNo))) {
+                metrics.bufferRejectedTotal.increment()
+                registry.cleanup(userIgn, presetNo, deferred)
+                log.warn("Buffer full, rejecting request userIgn={}", maskIgn(userIgn))
+                return EnqueueResult.Rejected(retryAfterSeconds = 1L)
+            }
+            log.debug("Buffered read request userIgn={}", maskIgn(userIgn))
+        } else {
+            metrics.dedupHitTotal.increment()
+            log.debug("Dedup hit for userIgn={}", maskIgn(userIgn))
+        }
+
+        deferred.onTimeout {
+            metrics.timeoutTotal.increment()
+            deferred.setResult(
+                ReadResponseMapper.toResponseEntity(
+                    ReadOutcome.DeferredForTimeout,
+                    cacheService.status(userIgn, presetNo),
+                    properties.statusRetryAfterSeconds,
+                )
+            )
+        }
+        deferred.onCompletion {
+            registry.cleanup(userIgn, presetNo, deferred)
+        }
+        return EnqueueResult.Accepted(status = cacheService.status(userIgn, presetNo))
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+```bash
+cd /home/maple/probabilistic-valuation-engine
+./gradlew :module-rest-controller:test --tests "maple.restcontroller.read.ExpectationReadFacadeTest" --continue
+```
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine
+git add module-rest-controller/src/main/kotlin/maple/restcontroller/read/ExpectationReadFacade.kt \
+        module-rest-controller/src/test/kotlin/maple/restcontroller/read/ExpectationReadFacadeTest.kt
+git -c user.email=claude@anthropic.com -c user.name="Claude" commit -m "refactor(rest): ExpectationReadFacade.enqueue returns EnqueueResult"
+```
+
+---
+
+## Task 9: Refactor `ExpectationV6Controller` to map `EnqueueResult` to HTTP
+
+**Files:**
+- Modify: `module-rest-controller/src/main/kotlin/maple/restcontroller/controller/ExpectationV6Controller.kt`
+- Modify: `module-rest-controller/src/test/kotlin/maple/restcontroller/controller/ExpectationV6ControllerTest.kt`
+- Create: `module-rest-controller/src/test/kotlin/maple/restcontroller/controller/ExpectationV6ControllerEnqueueTest.kt`
+
+- [ ] **Step 1: Update the existing `ExpectationV6ControllerTest.kt`**
+
+The existing test only checks 200 status and buffer state. The behavior change is now that the controller responds with **202 Accepted** (not 200) because `enqueue` returns `EnqueueResult.Accepted` which the controller maps to a 202. Update assertions to match.
+
+Replace the file with:
+
+```kotlin
+// module-rest-controller/src/test/kotlin/maple/restcontroller/controller/ExpectationV6ControllerTest.kt
+package maple.restcontroller.controller
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import maple.restcontroller.advice.RestControllerExceptionHandler
+import maple.restcontroller.config.V6ReadProperties
+import maple.restcontroller.metrics.V6ReadMetrics
+import maple.restcontroller.popular.PopularCharacterService
+import maple.restcontroller.read.*
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.springframework.http.HttpStatus
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+
+class ExpectationV6ControllerTest {
+
+    private lateinit var mockMvc: MockMvc
+    private lateinit var buffer: LocalRequestBuffer
+    private lateinit var registry: InflightRequestRegistry
+    private lateinit var facade: ExpectationReadFacade
+    private lateinit var cacheService: ReadModelCacheService
+    private lateinit var popularCharacterService: PopularCharacterService
+    private lateinit var queryService: ReadModelQueryService
+    private val properties = V6ReadProperties().apply {
+        requestTimeoutMs = 100
+        queueCapacity = 10
+        maxBatchSize = 200
+        batchWindowMs = 10
+        shutdownDrainTimeoutSeconds = 5
+        statusRetryAfterSeconds = 1L
+    }
+
+    @BeforeEach
+    fun setup() {
+        buffer = LocalRequestBuffer(properties.queueCapacity)
+        registry = InflightRequestRegistry()
+        val metrics = V6ReadMetrics(SimpleMeterRegistry(), buffer, registry)
+        cacheService = mock()
+        popularCharacterService = mock()
+        queryService = mock()
+        facade = ExpectationReadFacade(registry, buffer, metrics, cacheService, popularCharacterService, properties)
+
+        mockMvc = MockMvcBuilders
+            .standaloneSetup(ExpectationV6Controller(facade, properties, cacheService, queryService))
+            .setControllerAdvice(RestControllerExceptionHandler())
+            .build()
+    }
+
+    @Test
+    fun `should buffer valid request and return 202 Accepted`() {
+        mockMvc.perform(get("/api/v6/characters/{userIgn}/expectation", "진격캐넌")
+            .param("presetNo", "1"))
+            .andExpect(status().isAccepted)
+
+        assertThat(buffer.size()).isEqualTo(1)
+        assertThat(registry.size()).isEqualTo(1)
+    }
+
+    @Test
+    fun `should use default presetNo when not specified`() {
+        mockMvc.perform(get("/api/v6/characters/{userIgn}/expectation", "진격캐넌"))
+            .andExpect(status().isAccepted)
+
+        assertThat(buffer.size()).isEqualTo(1)
+    }
+
+    @Test
+    fun `should deduplicate concurrent requests for same ign`() {
+        mockMvc.perform(get("/api/v6/characters/{userIgn}/expectation", "진격캐넌"))
+        mockMvc.perform(get("/api/v6/characters/{userIgn}/expectation", "진격캐넌"))
+
+        assertThat(buffer.size()).isEqualTo(1)
+    }
+
+    @Test
+    fun `should buffer multiple different igns`() {
+        mockMvc.perform(get("/api/v6/characters/{userIgn}/expectation", "user1"))
+        mockMvc.perform(get("/api/v6/characters/{userIgn}/expectation", "user2"))
+
+        assertThat(buffer.size()).isEqualTo(2)
+    }
+}
+```
+
+- [ ] **Step 2: Add the synchronous 503 path test**
+
+```kotlin
+// module-rest-controller/src/test/kotlin/maple/restcontroller/controller/ExpectationV6ControllerEnqueueTest.kt
+package maple.restcontroller.controller
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import maple.restcontroller.advice.RestControllerExceptionHandler
+import maple.restcontroller.config.V6ReadProperties
+import maple.restcontroller.metrics.V6ReadMetrics
+import maple.restcontroller.popular.PopularCharacterService
+import maple.restcontroller.read.*
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.header
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+
+class ExpectationV6ControllerEnqueueTest {
+
+    private lateinit var mockMvc: MockMvc
+    private lateinit var registry: InflightRequestRegistry
+    private lateinit var cacheService: ReadModelCacheService
+    private lateinit var popularCharacterService: PopularCharacterService
+    private lateinit var queryService: ReadModelQueryService
+    private val properties = V6ReadProperties().apply {
+        requestTimeoutMs = 100
+        queueCapacity = 1
+        maxBatchSize = 200
+        batchWindowMs = 10
+        shutdownDrainTimeoutSeconds = 5
+        statusRetryAfterSeconds = 1L
+    }
+
+    @BeforeEach
+    fun setup() {
+        registry = InflightRequestRegistry()
+        val buffer = LocalRequestBuffer(properties.queueCapacity)
+        val metrics = V6ReadMetrics(SimpleMeterRegistry(), buffer, registry)
+        cacheService = mock()
+        popularCharacterService = mock()
+        queryService = mock()
+        val facade = ExpectationReadFacade(registry, buffer, metrics, cacheService, popularCharacterService, properties)
+
+        mockMvc = MockMvcBuilders
+            .standaloneSetup(ExpectationV6Controller(facade, properties, cacheService, queryService))
+            .setControllerAdvice(RestControllerExceptionHandler())
+            .build()
+    }
+
+    @Test
+    fun `returns 503 with Retry-After when buffer is full`() {
+        // Fill the single-slot buffer.
+        mockMvc.perform(get("/api/v6/characters/{userIgn}/expectation", "user1"))
+        // Second request must overflow → 503.
+        mockMvc.perform(get("/api/v6/characters/{userIgn}/expectation", "user2"))
+            .andExpect(status().isServiceUnavailable)
+            .andExpect(header().string("Retry-After", "1"))
+    }
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run:
+```bash
+cd /home/maple/probabilistic-valuation-engine
+./gradlew :module-rest-controller:test --tests "maple.restcontroller.controller.ExpectationV6ControllerTest" --continue
+./gradlew :module-rest-controller:test --tests "maple.restcontroller.controller.ExpectationV6ControllerEnqueueTest" --continue
+```
+Expected: FAIL — current controller still calls `facade.enqueue(...)` ignoring return; no mapping to 202/503.
+
+- [ ] **Step 4: Modify `ExpectationV6Controller`**
+
+Replace entire file with:
+
+```kotlin
+// module-rest-controller/src/main/kotlin/maple/restcontroller/controller/ExpectationV6Controller.kt
+package maple.restcontroller.controller
+
+import maple.expectation.util.StringMaskingUtils.maskIgn
+import maple.restcontroller.config.V6ReadProperties
+import maple.restcontroller.read.EnqueueResult
+import maple.restcontroller.read.ExpectationReadFacade
+import maple.restcontroller.read.ReadModelCacheService
+import maple.restcontroller.read.ReadModelQueryService
+import maple.restcontroller.read.ReadResponseMapper
+import maple.restcontroller.read.UrgentReadState
+import maple.restcontroller.validation.ValidUserIgn
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.http.ResponseEntity
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.context.request.async.DeferredResult
+import java.time.Duration
+
+@RestController
+@RequestMapping("/api/v6/characters")
+@Validated
+@ConditionalOnProperty(name = ["expectation.v6.enabled"], havingValue = "true")
+class ExpectationV6Controller(
+    private val facade: ExpectationReadFacade,
+    private val properties: V6ReadProperties,
+    private val cacheService: ReadModelCacheService,
+    private val queryService: ReadModelQueryService,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @GetMapping("/{userIgn}/expectation")
+    fun getExpectation(
+        @PathVariable @ValidUserIgn userIgn: String,
+        @RequestParam(defaultValue = "1") presetNo: Int,
+    ): ResponseEntity<*> {
+        log.debug("V6 read request userIgn={} presetNo={}", maskIgn(userIgn), presetNo)
+        val deferred = DeferredResult<ResponseEntity<*>>(properties.requestTimeoutMs)
+        val result: EnqueueResult = facade.enqueue(userIgn, presetNo, deferred)
+        // Map the synchronous outcome. If the facade returns Accepted, the
+        // controller responds with 202 + status snapshot. If Rejected (buffer
+        // full), the controller responds with 503.
+        val response = ReadResponseMapper.toResponseEntity(result, properties.statusRetryAfterSeconds)
+        // If accepted, also wire deferred timeout (facade installed it).
+        return response
+    }
+
+    @GetMapping("/{userIgn}/status")
+    fun getStatus(
+        @PathVariable @ValidUserIgn userIgn: String,
+        @RequestParam(defaultValue = "1") presetNo: Int,
+    ): ResponseEntity<*> {
+        val current = cacheService.status(userIgn, presetNo)
+        val status = if (current.state.shouldTryDb()) {
+            val dbResult = queryService.batchQuery(
+                mapOf(userIgn to presetNo),
+                Duration.ofSeconds(properties.readModelFreshnessSeconds),
+            )
+            if (dbResult.isNotEmpty()) {
+                cacheService.multiPut(dbResult)
+                cacheService.status(userIgn, presetNo)
+            } else {
+                current
+            }
+        } else {
+            current
+        }
+        return ResponseEntity.ok()
+            .header("Retry-After", status.retryAfterSeconds.toString())
+            .body(status)
+    }
+}
+```
+
+**Note on the controller redesign**: the prior controller returned `DeferredResult<ResponseEntity<*>>` and never set a result — the deferred was set asynchronously by the scheduler. The new design returns a `ResponseEntity<*>` directly for the synchronous case (`Accepted → 202` or `Rejected → 503`). The deferred still exists for timeout / completion lifecycle but is no longer returned to the client. The timeout callback installed by the facade no longer fires because the response has been sent.
+
+If the previous behavior of "200 OK with the eventual result" must be preserved (where the client blocks on the deferred for up to `requestTimeoutMs` to receive 200, 404, or 202), the controller must return `DeferredResult` and call `deferred.setResult(response)` after `enqueue` returns. Restore the original `DeferredResult`-returning signature:
+
+```kotlin
+@GetMapping("/{userIgn}/expectation")
+fun getExpectation(
+    @PathVariable @ValidUserIgn userIgn: String,
+    @RequestParam(defaultValue = "1") presetNo: Int,
+): DeferredResult<ResponseEntity<*>> {
+    log.debug("V6 read request userIgn={} presetNo={}", maskIgn(userIgn), presetNo)
+    val deferred = DeferredResult<ResponseEntity<*>>(properties.requestTimeoutMs)
+    val result: EnqueueResult = facade.enqueue(userIgn, presetNo, deferred)
+    val mapped = ReadResponseMapper.toResponseEntity(result, properties.statusRetryAfterSeconds)
+    // If facade gave us a synchronous response (Accepted/Rejected), set it on the deferred.
+    deferred.setResult(mapped)
+    return deferred
+}
+```
+
+This preserves the asynchronous wire shape (the client still waits up to `requestTimeoutMs`) while the controller owns the HTTP-shape decision. **Use this version in the file.** The tests in Step 1 expect 202 status which is consistent with `Accepted` mapping.
+
+- [ ] **Step 5: Run all controller tests to verify they pass**
+
+Run:
+```bash
+cd /home/maple/probabilistic-valuation-engine
+./gradlew :module-rest-controller:test --tests "maple.restcontroller.controller.*" --continue
+```
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine
+git add module-rest-controller/src/main/kotlin/maple/restcontroller/controller/ExpectationV6Controller.kt \
+        module-rest-controller/src/test/kotlin/maple/restcontroller/controller/ExpectationV6ControllerTest.kt \
+        module-rest-controller/src/test/kotlin/maple/restcontroller/controller/ExpectationV6ControllerEnqueueTest.kt
+git -c user.email=claude@anthropic.com -c user.name="Claude" commit -m "refactor(rest): controller maps EnqueueResult to ResponseEntity"
+```
+
+---
+
+## Task 10: Final compile + test + PR
+
+- [ ] **Step 1: Compile**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine
+./gradlew :module-rest-controller:compileKotlin :module-rest-controller:compileJava --continue
+```
+Expected: compile success.
+
+- [ ] **Step 2: Run full test suite for the module**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine
+./gradlew :module-rest-controller:test --continue
+```
+Expected: all tests pass.
+
+- [ ] **Step 3: Acceptance-criteria grep self-check**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine
+grep -n "ResponseEntity" module-rest-controller/src/main/kotlin/maple/restcontroller/read/BatchReadScheduler.kt || echo "OK: no ResponseEntity in BatchReadScheduler"
+grep -n "ResponseEntity" module-rest-controller/src/main/kotlin/maple/restcontroller/read/BatchResolver.kt || echo "OK: no ResponseEntity in BatchResolver"
+grep -n "ResponseEntity" module-rest-controller/src/main/kotlin/maple/restcontroller/read/ExpectationReadFacade.kt || echo "OK: no ResponseEntity in ExpectationReadFacade"
+```
+Expected: 3 `OK:` lines. (The `ResponseEntity` reference in `ExpectationReadFacade` from the `deferred` type parameter `DeferredResult<ResponseEntity<*>>` is OK; check by `grep "ResponseEntity\\.\|ResponseEntity\\b"` to see the construction sites.)
+
+Refined check:
+```bash
+grep -nE "ResponseEntity\.(ok|status|accepted|build)" \
+  module-rest-controller/src/main/kotlin/maple/restcontroller/read/BatchReadScheduler.kt \
+  module-rest-controller/src/main/kotlin/maple/restcontroller/read/BatchResolver.kt \
+  module-rest-controller/src/main/kotlin/maple/restcontroller/read/ExpectationReadFacade.kt \
+  || echo "OK: no inline ResponseEntity construction in service layer"
+```
+
+- [ ] **Step 4: Push branch and open PR against `develop`**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine
+git push -u origin HEAD
+gh pr create --base develop --head "$(git rev-parse --abbrev-ref HEAD)" \
+  --title "refactor(rest): extract HTTP response from V6 read orchestration (#1082)" \
+  --body "Closes #1082. Sealed ReadOutcome + ReadResponseMapper centralize HTTP shape; BatchReadScheduler / BatchResolver / ExpectationReadFacade no longer construct ResponseEntity. Controller maps EnqueueResult to 202/503."
+```
+
+- [ ] **Step 5: Wait for CI**
+
+```bash
+gh pr checks --watch
+```
+Expected: all checks green.

--- a/docs/superpowers/specs/2026-06-06-1081-readmodel-query-decomposition-design.md
+++ b/docs/superpowers/specs/2026-06-06-1081-readmodel-query-decomposition-design.md
@@ -1,0 +1,235 @@
+# Design: Rest-Controller ReadModelQueryService.batchQuery decomposition (issue #1081)
+
+- Status: Accepted
+- Date: 2026-06-06
+- Owner: zbnerd
+- Issue: #1081
+- Note: extends the "parse → delegate → orchestration" discipline to the read-model query layer. Same surgical pattern as #1088.
+
+---
+
+## 1. Background / Problem
+
+### Background
+
+`ReadModelQueryService.batchQuery` (module-rest-controller, lines 23-87) is a 65-line method that mixes three structurally different concerns inside one `forEach` body:
+
+1. **SQL/DB layer** (lines 29-44): dynamic `OR`-chained pair-predicate construction, `MapSqlParameterSource` population, `NamedParameterJdbcTemplate.queryForList` call.
+2. **JSON / deserialization layer** (lines 56-68): gzip decompression via `GzipUtils`, `ObjectMapper.readTree` traversal, equipment-list re-serialization, field extraction.
+3. **Business / domain layer** (lines 46-83): staleness filtering (`updatedAt` vs `minimumUpdatedAt`), JSON-first-with-DB-fallback field resolution (`summary.totalCost` else `total_cost`).
+
+The three layers run in series but are interleaved. The DB row, the JSON tree, and the domain response all share the same closure.
+
+### Problem
+
+- SQL composition is hidden inside a method whose name says nothing about SQL.
+- JSON tree walking + domain fallback is repeated inline; the fallback rule (`json ?? row["col"]`) is implicit.
+- Staleness logic is a one-line predicate that cannot be unit-tested without mocking `NamedParameterJdbcTemplate` and serializing gzip bytes.
+- `batchQuery` reads as one long procedure instead of an orchestrator over named steps.
+
+### Goal
+
+Split `batchQuery` into three named units, each with a single testable concern, and reduce `batchQuery` to a 5-line orchestrator.
+
+---
+
+## 2. Decision
+
+Three new types, one slimmed consumer.
+
+### A) `ReadModelRowQuery` (object)
+
+Pure builder for the dynamic SQL + parameter source. No Spring, no I/O.
+
+```kotlin
+object ReadModelRowQuery {
+    fun build(requests: Map<String, Int>): Pair<String, MapSqlParameterSource> {
+        val params = MapSqlParameterSource()
+        val predicates = requests.entries.mapIndexed { i, (userIgn, presetNo) ->
+            params
+                .addValue("userIgn$i", userIgn)
+                .addValue("presetNo$i", presetNo)
+            "(user_ign = :userIgn$i AND preset_no = :presetNo$i)"
+        }.joinToString(" OR ")
+
+        val sql = """
+            SELECT user_ign, preset_no, document, total_cost, equipment_count, calculated_at, updated_at
+            FROM character_equipment_read_model
+            WHERE ($predicates)
+              AND user_ign IS NOT NULL
+        """.trimIndent()
+        return sql to params
+    }
+}
+```
+
+### B) `StalenessCheck` (object, pure)
+
+Pure function over the row list. No dependencies.
+
+```kotlin
+object StalenessCheck {
+    fun partitionStale(
+        rows: List<Map<String, Any?>>,
+        minimumUpdatedAt: Instant?,
+    ): Pair<List<Map<String, Any?>>, Int> {
+        if (minimumUpdatedAt == null) return rows to 0
+        val fresh = mutableListOf<Map<String, Any?>>()
+        var stale = 0
+        rows.forEach { row ->
+            val updatedAt = (row["updated_at"] as? Timestamp)?.toInstant() ?: Instant.EPOCH
+            if (updatedAt.isBefore(minimumUpdatedAt)) stale++ else fresh.add(row)
+        }
+        return fresh to stale
+    }
+}
+```
+
+### C) `ReadModelDocumentExtractor` (`@Component`)
+
+Wraps gzip + JSON tree + domain fallback. Takes the row + the compressed document, returns a `V6ExpectationResponse`. JSON-first with DB-row fallback lives here.
+
+```kotlin
+@Component
+class ReadModelDocumentExtractor(
+    private val objectMapper: ObjectMapper,
+) {
+    fun extract(userIgn: String, compressed: ByteArray, row: Map<String, Any?>): V6ExpectationResponse {
+        val json = GzipUtils.decompress(compressed)
+        val tree = objectMapper.readTree(json)
+
+        val equipmentNode = tree["equipment"]
+        @Suppress("UNCHECKED_CAST")
+        val equipment: List<Map<String, Any?>> = if (equipmentNode != null && !equipmentNode.isNull) {
+            objectMapper.readValue(
+                equipmentNode.toString(),
+                objectMapper.typeFactory.constructCollectionType(List::class.java, Map::class.java),
+            ) as List<Map<String, Any?>>
+        } else emptyList()
+
+        return V6ExpectationResponse(
+            userIgn = userIgn,
+            presetNo = tree["presetNo"]?.asInt() ?: (row["preset_no"] as Number).toInt(),
+            totalCost = tree["summary"]?.get("totalCost")?.decimalValue()
+                ?: row["total_cost"] as? BigDecimal
+                ?: BigDecimal.ZERO,
+            equipmentCount = tree["summary"]?.get("equipmentCount")?.asInt()
+                ?: (row["equipment_count"] as? Number)?.toInt()
+                ?: 0,
+            equipment = equipment,
+            calculatedAt = tree["metadata"]?.get("calculatedAt")?.asText()?.let(Instant::parse)
+                ?: (row["calculated_at"] as? Timestamp)?.toInstant()
+                ?: Instant.now(),
+        )
+    }
+}
+```
+
+### D) Slimmed `batchQuery`
+
+```kotlin
+fun batchQuery(
+    requests: Map<String, Int>,
+    maxAge: Duration? = null,
+): Map<String, V6ExpectationResponse> {
+    if (requests.isEmpty()) return emptyMap()
+
+    val (sql, params) = ReadModelRowQuery.build(requests)
+    val raw = jdbc.queryForList(sql, params)
+    val minimumUpdatedAt = maxAge?.let { Instant.now().minus(it) }
+    val (fresh, stale) = StalenessCheck.partitionStale(raw, minimumUpdatedAt)
+
+    val result = LinkedHashMap<String, V6ExpectationResponse>(fresh.size)
+    fresh.forEach { row ->
+        val userIgn = row["user_ign"].toString()
+        result[userIgn] = extractor.extract(userIgn, row["document"] as ByteArray, row)
+    }
+    log.debug("Read model query: requested={}, hits={}, stale={}", requests.size, result.size, stale)
+    return result
+}
+```
+
+`batchQuery` now reads as: guard, build SQL, run SQL, partition, extract, log.
+
+---
+
+## 3. Trade-offs
+
+### Sensitivity
+
+- **JSON schema:** `equipmentNode` / `summary.totalCost` / `metadata.calculatedAt` field names are baked into the extractor. A schema change requires an extractor update. Same as before — no change in coupling.
+- **DB column shape:** `user_ign`, `preset_no`, `document`, `total_cost`, `equipment_count`, `calculated_at`, `updated_at`. These are still referenced in `ReadModelRowQuery` (SQL) and `StalenessCheck` (`updated_at`). Splitting spreads the column-name knowledge across two files, but each file references only the columns it needs (`StalenessCheck` only `updated_at`).
+- **Test coverage:** `StalenessCheck` and `ReadModelRowQuery` are now directly unit-testable. The orchestrator test stays in `ReadModelQueryService`.
+
+### Trade-off
+
+| Choice | Gain | Cost |
+|--------|------|------|
+| `ReadModelRowQuery` as `object` (not `@Component`) | No DI, pure function, trivial test | One global point of access; OK for stateless builder |
+| `StalenessCheck` as pure function | No mocking, table-driven test | Returns `Pair<list, count>` — slight API awkwardness vs. two collections |
+| `ReadModelDocumentExtractor` as `@Component` | Spring-injected `ObjectMapper`, follows project convention | One extra bean |
+| Keep `ByteArray` extraction + DB fallback in `extract` | Single source of fallback rule | Method is ~25 lines; manageable |
+| Skip introducing a `Document`-shaped value object | YAGNI — current shape is row + bytes, no new type | None |
+
+### Risk
+
+- **Staleness semantics drift:** The original code increments `stale++` and `return@forEach` for stale rows, then logs `hits = result.size` and `stale = stale`. The new `partitionStale` + `forEach` produces the same counts (verified by re-reading the loop). The log line at the end is unchanged.
+- **Parameter binding order:** `MapSqlParameterSource` accepts out-of-order `addValue` calls; the SQL refers to `:userIgn$i` / `:presetNo$i` and the order inside the builder matches the index. No risk of mis-binding.
+- **Empty request path:** `if (requests.isEmpty()) return emptyMap()` is preserved verbatim.
+- **`ObjectMapper` reuse:** `ReadModelDocumentExtractor` is a `@Component`; the existing primary `ObjectMapper` is injected. No new `ObjectMapper()`.
+- **Pair return from `partitionStale`:** Slightly less ergonomic than two collections. Acceptable — the call site consumes both immediately.
+
+### Non-Risk
+
+- DB schema: unchanged.
+- Wire format: unchanged.
+- `V6ExpectationResponse` shape: unchanged.
+- Spring DI: only one new `@Component`. No new `@Configuration` or wiring.
+- Module boundary (`module-rest-controller`): all new classes stay inside the module.
+
+---
+
+## 4. Result / Evidence
+
+### Metrics
+
+| Metric | Value | Notes |
+|--------|------:|-------|
+| `batchQuery` line count | 65 → ~20 | Orchestrator only |
+| Inline gzip + JSON tree in `batchQuery` | Yes → No | Moved to `ReadModelDocumentExtractor.extract` |
+| Inline dynamic SQL in `batchQuery` | Yes → No | Moved to `ReadModelRowQuery.build` |
+| Inline staleness check in `batchQuery` | Yes → No | Moved to `StalenessCheck.partitionStale` |
+| New top-level types | 3 | `ReadModelRowQuery`, `StalenessCheck`, `ReadModelDocumentExtractor` |
+| New unit tests | ~6 | SQL string snapshot, partition no-maxAge, partition with-maxAge, partition empty, extract happy, extract fallback |
+| `batchQuery` cyclomatic complexity | ~7 → ~3 | `forEach` is now one body line per row |
+
+### Observed Result
+
+Post-implementation:
+- `ReadModelQueryService.batchQuery` reads top-to-bottom: empty-guard → build SQL → run → partition → forEach{extract} → log → return
+- `ReadModelRowQuery.build` is independently testable as a string + param-source snapshot
+- `StalenessCheck.partitionStale` is independently testable with a synthetic `List<Map<String, Any?>>`
+- `ReadModelDocumentExtractor.extract` is independently testable with a hand-crafted gzip byte array
+- All existing `module-rest-controller` tests still pass
+- `./gradlew :module-rest-controller:test` passes
+- `./gradlew :module-rest-controller:compileKotlin :module-rest-controller:compileJava --continue` passes
+
+---
+
+## 5. Summary
+
+> Split `ReadModelQueryService.batchQuery` into three single-purpose units — `ReadModelRowQuery` (SQL), `StalenessCheck` (pure), `ReadModelDocumentExtractor` (gzip + JSON + fallback) — and reduce `batchQuery` to a 5-line orchestrator.
+
+---
+
+## 6. Implementation Outline (reference for writing-plans)
+
+1. Create `ReadModelRowQuery` (`module-rest-controller/.../read/ReadModelRowQuery.kt`) as a `Kotlin object` with `build(requests: Map<String, Int>): Pair<String, MapSqlParameterSource>`.
+2. Create `StalenessCheck` (`module-rest-controller/.../read/StalenessCheck.kt`) as a `Kotlin object` with `partitionStale(rows, minimumUpdatedAt): Pair<List<Map<String, Any?>>, Int>`.
+3. Create `ReadModelDocumentExtractor` (`module-rest-controller/.../read/ReadModelDocumentExtractor.kt`) as a `@Component` with `extract(userIgn, compressed, row): V6ExpectationResponse`.
+4. Inject `ReadModelDocumentExtractor` into `ReadModelQueryService`. Rewrite `batchQuery` to use all three helpers.
+5. Add unit tests:
+   - `ReadModelRowQueryTest`: 0 / 1 / N requests, snapshot SQL string + non-empty params
+   - `StalenessCheckTest`: null `minimumUpdatedAt` (no filter, stale=0), mixed fresh+stale rows, all stale, all fresh
+   - `ReadModelDocumentExtractorTest`: happy path (JSON has all fields, fallback unused), JSON-missing presetNo falls back to row, gzip decompression failure
+6. Run `./gradlew :module-rest-controller:test` and `./gradlew :module-rest-controller:compileKotlin :module-rest-controller:compileJava --continue`.

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/config/V6ReadConfig.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/config/V6ReadConfig.kt
@@ -47,8 +47,8 @@ class V6ReadConfig(
     @Bean
     fun readModelQueryService(
         jdbc: NamedParameterJdbcTemplate,
-        objectMapper: ObjectMapper
-    ): ReadModelQueryService = ReadModelQueryService(jdbc, objectMapper)
+        documentExtractor: ReadModelDocumentExtractor,
+    ): ReadModelQueryService = ReadModelQueryService(jdbc, documentExtractor)
 
     @Bean
     fun readModelCacheService(

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelDocumentExtractor.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelDocumentExtractor.kt
@@ -1,0 +1,46 @@
+package maple.restcontroller.read
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import maple.expectation.util.GzipUtils
+import org.springframework.stereotype.Component
+import java.math.BigDecimal
+import java.sql.Timestamp
+import java.time.Instant
+
+@Component
+class ReadModelDocumentExtractor(
+    private val objectMapper: ObjectMapper,
+) {
+    fun extract(
+        userIgn: String,
+        compressed: ByteArray,
+        row: Map<String, Any?>,
+    ): V6ExpectationResponse {
+        val json = GzipUtils.decompress(compressed)
+        val tree = objectMapper.readTree(json)
+
+        val equipmentNode = tree["equipment"]
+        @Suppress("UNCHECKED_CAST")
+        val equipment: List<Map<String, Any?>> = if (equipmentNode != null && !equipmentNode.isNull) {
+            objectMapper.readValue(
+                equipmentNode.toString(),
+                objectMapper.typeFactory.constructCollectionType(List::class.java, Map::class.java),
+            ) as List<Map<String, Any?>>
+        } else emptyList()
+
+        return V6ExpectationResponse(
+            userIgn = userIgn,
+            presetNo = tree["presetNo"]?.asInt() ?: (row["preset_no"] as Number).toInt(),
+            totalCost = tree["summary"]?.get("totalCost")?.decimalValue()
+                ?: row["total_cost"] as? BigDecimal
+                ?: BigDecimal.ZERO,
+            equipmentCount = tree["summary"]?.get("equipmentCount")?.asInt()
+                ?: (row["equipment_count"] as? Number)?.toInt()
+                ?: 0,
+            equipment = equipment,
+            calculatedAt = tree["metadata"]?.get("calculatedAt")?.asText()?.let(Instant::parse)
+                ?: (row["calculated_at"] as? Timestamp)?.toInstant()
+                ?: Instant.now(),
+        )
+    }
+}

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelQueryService.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelQueryService.kt
@@ -1,18 +1,13 @@
 package maple.restcontroller.read
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import maple.expectation.util.GzipUtils
 import org.slf4j.LoggerFactory
-import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
-import java.math.BigDecimal
-import java.sql.Timestamp
 import java.time.Duration
 import java.time.Instant
 
 class ReadModelQueryService(
     private val jdbc: NamedParameterJdbcTemplate,
-    private val objectMapper: ObjectMapper,
+    private val documentExtractor: ReadModelDocumentExtractor,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -26,61 +21,17 @@ class ReadModelQueryService(
     ): Map<String, V6ExpectationResponse> {
         if (requests.isEmpty()) return emptyMap()
 
-        val params = MapSqlParameterSource()
-        val pairPredicates = requests.entries.mapIndexed { index, (userIgn, presetNo) ->
-            params
-                .addValue("userIgn$index", userIgn)
-                .addValue("presetNo$index", presetNo)
-            "(user_ign = :userIgn$index AND preset_no = :presetNo$index)"
-        }.joinToString(" OR ")
-
-        val sql = """
-            SELECT user_ign, preset_no, document, total_cost, equipment_count, calculated_at, updated_at
-            FROM character_equipment_read_model
-            WHERE ($pairPredicates)
-              AND user_ign IS NOT NULL
-        """.trimIndent()
-
-        val rows = jdbc.queryForList(sql, params)
-        val result = LinkedHashMap<String, V6ExpectationResponse>()
+        val built = ReadModelRowQuery.build(requests)
+        val raw = jdbc.queryForList(built.first, built.second)
         val minimumUpdatedAt = maxAge?.let { Instant.now().minus(it) }
-        var stale = 0
-        rows.forEach { row ->
-            val updatedAt = (row["updated_at"] as? Timestamp)?.toInstant() ?: Instant.EPOCH
-            if (minimumUpdatedAt != null && updatedAt.isBefore(minimumUpdatedAt)) {
-                stale++
-                return@forEach
-            }
+        val partitioned = StalenessCheck.partitionStale(raw, minimumUpdatedAt)
+        val fresh = partitioned.first
+        val stale = partitioned.second
 
+        val result = LinkedHashMap<String, V6ExpectationResponse>(fresh.size)
+        fresh.forEach { row ->
             val userIgn = row["user_ign"].toString()
-            val compressed = row["document"] as ByteArray
-            val json = GzipUtils.decompress(compressed)
-            val tree = objectMapper.readTree(json)
-            val equipmentNode = tree["equipment"]
-            val equipment = if (equipmentNode != null && !equipmentNode.isNull) {
-                @Suppress("UNCHECKED_CAST")
-                objectMapper.readValue(
-                    equipmentNode.toString(),
-                    objectMapper.typeFactory.constructCollectionType(List::class.java, Map::class.java),
-                ) as List<Map<String, Any?>>
-            } else {
-                emptyList()
-            }
-
-            result[userIgn] = V6ExpectationResponse(
-                userIgn = userIgn,
-                presetNo = tree["presetNo"]?.asInt() ?: (row["preset_no"] as Number).toInt(),
-                totalCost = tree["summary"]?.get("totalCost")?.decimalValue()
-                    ?: row["total_cost"] as? BigDecimal
-                    ?: BigDecimal.ZERO,
-                equipmentCount = tree["summary"]?.get("equipmentCount")?.asInt()
-                    ?: (row["equipment_count"] as? Number)?.toInt()
-                    ?: 0,
-                equipment = equipment,
-                calculatedAt = tree["metadata"]?.get("calculatedAt")?.asText()?.let(Instant::parse)
-                    ?: (row["calculated_at"] as? Timestamp)?.toInstant()
-                    ?: Instant.now(),
-            )
+            result[userIgn] = documentExtractor.extract(userIgn, row["document"] as ByteArray, row)
         }
         log.debug("Read model query: requested={}, hits={}, stale={}", requests.size, result.size, stale)
         return result

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelRowQuery.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/read/ReadModelRowQuery.kt
@@ -1,0 +1,24 @@
+package maple.restcontroller.read
+
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
+
+object ReadModelRowQuery {
+    fun build(requests: Map<String, Int>): Pair<String, MapSqlParameterSource> {
+        require(requests.isNotEmpty()) { "ReadModelRowQuery.build requires non-empty requests" }
+        val params = MapSqlParameterSource()
+        val predicates = requests.entries.mapIndexed { i, (userIgn, presetNo) ->
+            params
+                .addValue("userIgn$i", userIgn)
+                .addValue("presetNo$i", presetNo)
+            "(user_ign = :userIgn$i AND preset_no = :presetNo$i)"
+        }.joinToString(" OR ")
+
+        val sql = """
+            SELECT user_ign, preset_no, document, total_cost, equipment_count, calculated_at, updated_at
+            FROM character_equipment_read_model
+            WHERE ($predicates)
+              AND user_ign IS NOT NULL
+        """.trimIndent()
+        return sql to params
+    }
+}

--- a/module-rest-controller/src/main/kotlin/maple/restcontroller/read/StalenessCheck.kt
+++ b/module-rest-controller/src/main/kotlin/maple/restcontroller/read/StalenessCheck.kt
@@ -1,0 +1,20 @@
+package maple.restcontroller.read
+
+import java.sql.Timestamp
+import java.time.Instant
+
+object StalenessCheck {
+    fun partitionStale(
+        rows: List<Map<String, Any?>>,
+        minimumUpdatedAt: Instant?,
+    ): Pair<List<Map<String, Any?>>, Int> {
+        if (minimumUpdatedAt == null) return rows to 0
+        val fresh = mutableListOf<Map<String, Any?>>()
+        var stale = 0
+        rows.forEach { row ->
+            val updatedAt = (row["updated_at"] as? Timestamp)?.toInstant() ?: Instant.EPOCH
+            if (updatedAt.isBefore(minimumUpdatedAt)) stale++ else fresh.add(row)
+        }
+        return fresh to stale
+    }
+}

--- a/module-rest-controller/src/test/kotlin/maple/restcontroller/read/ReadModelDocumentExtractorTest.kt
+++ b/module-rest-controller/src/test/kotlin/maple/restcontroller/read/ReadModelDocumentExtractorTest.kt
@@ -1,0 +1,82 @@
+package maple.restcontroller.read
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import maple.expectation.util.GzipUtils
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import java.math.BigDecimal
+import java.sql.Timestamp
+import java.time.Instant
+
+class ReadModelDocumentExtractorTest {
+    private val objectMapper = ObjectMapper()
+    private val extractor = ReadModelDocumentExtractor(objectMapper)
+
+    @Test
+    fun `extract prefers JSON fields over DB row fallback`() {
+        val json = """
+            {
+              "presetNo": 7,
+              "summary": { "totalCost": 1234.5, "equipmentCount": 3 },
+              "metadata": { "calculatedAt": "2026-06-06T11:00:00Z" },
+              "equipment": [ { "name": "x" } ]
+            }
+        """.trimIndent()
+        val compressed = GzipUtils.compress(json.toByteArray())
+        val row = mapOf<String, Any?>(
+            "user_ign" to "f***l",
+            "preset_no" to 1,
+            "total_cost" to BigDecimal("999.0"),
+            "equipment_count" to 0,
+            "calculated_at" to Timestamp.from(Instant.parse("2026-01-01T00:00:00Z")),
+        )
+
+        val out = extractor.extract("f***l", compressed, row)
+
+        assertEquals("f***l", out.userIgn)
+        assertEquals(7, out.presetNo)
+        assertEquals(BigDecimal("1234.5"), out.totalCost)
+        assertEquals(3, out.equipmentCount)
+        assertEquals(1, out.equipment.size)
+        assertEquals(Instant.parse("2026-06-06T11:00:00Z"), out.calculatedAt)
+    }
+
+    @Test
+    fun `extract falls back to DB row when JSON omits fields`() {
+        val json = """{"equipment": []}"""
+        val compressed = GzipUtils.compress(json.toByteArray())
+        val row = mapOf<String, Any?>(
+            "user_ign" to "s***d",
+            "preset_no" to 42,
+            "total_cost" to BigDecimal("500.0"),
+            "equipment_count" to 4,
+            "calculated_at" to Timestamp.from(Instant.parse("2026-05-01T00:00:00Z")),
+        )
+
+        val out = extractor.extract("s***d", compressed, row)
+
+        assertEquals(42, out.presetNo)
+        assertEquals(BigDecimal("500.0"), out.totalCost)
+        assertEquals(4, out.equipmentCount)
+        assertEquals(Instant.parse("2026-05-01T00:00:00Z"), out.calculatedAt)
+        assertTrue(out.equipment.isEmpty())
+    }
+
+    @Test
+    fun `extract returns defaults when both JSON and row lack a field`() {
+        val json = """{}"""
+        val compressed = GzipUtils.compress(json.toByteArray())
+        val row = mapOf<String, Any?>(
+            "user_ign" to "t***d",
+            "preset_no" to 1,
+        )
+
+        val out = extractor.extract("t***d", compressed, row)
+
+        assertEquals(BigDecimal.ZERO, out.totalCost)
+        assertEquals(0, out.equipmentCount)
+        assertNotNull(out.calculatedAt)
+    }
+}

--- a/module-rest-controller/src/test/kotlin/maple/restcontroller/read/ReadModelQueryServiceTest.kt
+++ b/module-rest-controller/src/test/kotlin/maple/restcontroller/read/ReadModelQueryServiceTest.kt
@@ -16,7 +16,8 @@ class ReadModelQueryServiceTest {
 
     private val jdbc: NamedParameterJdbcTemplate = mock()
     private val objectMapper = ObjectMapper()
-    private val service = ReadModelQueryService(jdbc, objectMapper)
+    private val documentExtractor = ReadModelDocumentExtractor(objectMapper)
+    private val service = ReadModelQueryService(jdbc, documentExtractor)
 
     @Test
     fun `should return empty map for empty requests`() {

--- a/module-rest-controller/src/test/kotlin/maple/restcontroller/read/ReadModelRowQueryTest.kt
+++ b/module-rest-controller/src/test/kotlin/maple/restcontroller/read/ReadModelRowQueryTest.kt
@@ -1,0 +1,47 @@
+package maple.restcontroller.read
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
+
+class ReadModelRowQueryTest {
+    @Test
+    fun `build throws on empty requests to avoid WHERE () syntax error`() {
+        val ex = assertThrows(IllegalArgumentException::class.java) {
+            ReadModelRowQuery.build(emptyMap())
+        }
+        assertTrue(ex.message!!.contains("requests"), "message: ${ex.message}")
+    }
+
+    @Test
+    fun `build produces OR-chained pair predicates and indexed params`() {
+        val result = ReadModelRowQuery.build(
+            mapOf("f***l" to 1, "s***d" to 2),
+        )
+        val sql = result.first
+        val params = result.second
+
+        assertTrue(
+            sql.contains("(user_ign = :userIgn0 AND preset_no = :presetNo0)"),
+            "missing first predicate in: $sql",
+        )
+        assertTrue(
+            sql.contains("(user_ign = :userIgn1 AND preset_no = :presetNo1)"),
+            "missing second predicate in: $sql",
+        )
+        assertTrue(
+            sql.contains(") OR ("),
+            "missing OR between predicates in: $sql",
+        )
+        assertEquals(
+            setOf("userIgn0", "presetNo0", "userIgn1", "presetNo1"),
+            params.parameterNames.toSet(),
+        )
+        assertEquals("f***l", params.getValue("userIgn0"))
+        assertEquals(1, params.getValue("presetNo0"))
+        assertEquals("s***d", params.getValue("userIgn1"))
+        assertEquals(2, params.getValue("presetNo1"))
+    }
+}

--- a/module-rest-controller/src/test/kotlin/maple/restcontroller/read/StalenessCheckTest.kt
+++ b/module-rest-controller/src/test/kotlin/maple/restcontroller/read/StalenessCheckTest.kt
@@ -1,0 +1,53 @@
+package maple.restcontroller.read
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import java.sql.Timestamp
+import java.time.Instant
+
+class StalenessCheckTest {
+    private val now = Instant.parse("2026-06-06T12:00:00Z")
+    private val threshold = now.minusSeconds(60)
+
+    @Test
+    fun `partitionStale with null minimumUpdatedAt returns all rows and zero stale`() {
+        val rows = listOf(
+            mapOf<String, Any?>("updated_at" to Timestamp.from(now)),
+            mapOf<String, Any?>("updated_at" to Timestamp.from(Instant.EPOCH)),
+        )
+
+        val result = StalenessCheck.partitionStale(rows, null)
+        val fresh = result.first
+        val stale = result.second
+
+        assertEquals(2, fresh.size)
+        assertEquals(0, stale)
+    }
+
+    @Test
+    fun `partitionStale separates fresh from stale and counts them`() {
+        val freshRow = mapOf<String, Any?>("updated_at" to Timestamp.from(now))
+        val staleRow = mapOf<String, Any?>("updated_at" to Timestamp.from(Instant.EPOCH))
+
+        val result = StalenessCheck.partitionStale(listOf(freshRow, staleRow), threshold)
+        val fresh = result.first
+        val stale = result.second
+
+        assertEquals(1, fresh.size)
+        assertEquals(freshRow, fresh[0])
+        assertEquals(1, stale)
+    }
+
+    @Test
+    fun `partitionStale treats missing updated_at as epoch and flags stale`() {
+        val rowWithout = mapOf<String, Any?>("user_ign" to "f***l")
+
+        val result = StalenessCheck.partitionStale(listOf(rowWithout), threshold)
+        val fresh = result.first
+        val stale = result.second
+
+        assertTrue(fresh.isEmpty())
+        assertEquals(1, stale)
+    }
+}


### PR DESCRIPTION
## Summary
- Extract `ReadModelRowQuery` (object): dynamic SQL + `MapSqlParameterSource` builder
- Extract `StalenessCheck` (object, pure): `partitionStale` with null-guard
- Extract `ReadModelDocumentExtractor` (`@Component`): gzip + JSON tree + DB-row fallback
- Slim `ReadModelQueryService.batchQuery` to a 5-step orchestrator
- Wire `ReadModelDocumentExtractor` into `V6ReadConfig` bean factory
- Update `ReadModelQueryServiceTest` to construct a real `ReadModelDocumentExtractor`

`ReadModelQueryService.batchQuery` is now: empty-guard → build SQL → query → partition → forEach{extract} → log.

## Files
**New**
- `module-rest-controller/.../read/ReadModelRowQuery.kt` + test (2 tests)
- `module-rest-controller/.../read/StalenessCheck.kt` + test (3 tests)
- `module-rest-controller/.../read/ReadModelDocumentExtractor.kt` + test (3 tests)

**Modified**
- `ReadModelQueryService.kt` (88 → 39 lines, −55%)
- `V6ReadConfig.kt` (bean factory wiring)
- `ReadModelQueryServiceTest.kt` (constructor update; real extractor over mock for higher coverage)

## Test plan
- [x] `./gradlew :module-rest-controller:test` — all PASS (5 existing + 8 new = 13)
- [x] `./gradlew :module-rest-controller:compileKotlin :module-rest-controller:compileJava --continue` — BUILD SUCCESSFUL
- [x] No inline `GzipUtils` / `readTree` / `MapSqlParameterSource` in `ReadModelQueryService` (only `jdbc.queryForList` remains, by design)
- [x] `built.first` / `built.second` used to avoid `component1()` ambiguity in `Pair<String, MapSqlParameterSource>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)