### PR TITLE
refactor(1073): extract CalculationDispatchService (step 1/2)

### DIFF
--- a/docs/superpowers/plans/2026-06-06-1073-calculation-dispatch-extraction.md
+++ b/docs/superpowers/plans/2026-06-06-1073-calculation-dispatch-extraction.md
@@ -1,0 +1,722 @@
+# Issue 1073 — CalculationDispatchService Extraction Implementation Plan (step 1/2)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract 6 PGMQ-dispatch methods from `CalculationJobService` into a new `CalculationDispatchService`. `CalculationJobService` delegates to it. Zero behavioral change.
+
+**Architecture:** Create `CalculationDispatchService` (3 deps: `jobPort`, `pgmqClient`, `snapshotRepository`) with the 6 dispatch methods copied verbatim from `CalculationJobService`. Refactor `CalculationJobService` to swap `pgmqClient` for `dispatchService` and turn the 6 methods into 1-line delegates. Existing 4 caller files unchanged. Existing 5 `retryExternalApiJob` tests pass via delegation path. New `CalculationDispatchServiceTest` adds direct unit-test coverage for all 6 methods.
+
+**Tech Stack:** Kotlin, Spring `@Service` + `@Transactional`, JUnit5 + Mockito-Kotlin.
+
+**Branch:** `refactor/1073-calculation-dispatch-extraction` (already created from `origin/develop`). PR base: `develop`.
+
+**Spec:** `docs/superpowers/specs/2026-06-06-1073-calculation-dispatch-service-design.md`
+
+---
+
+## File structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `module-infra/.../job/CalculationDispatchService.kt` | CREATE | 6 dispatch methods (verbatim from `CalculationJobService`) |
+| `module-infra/.../job/CalculationJobService.kt` | MODIFY | Remove `pgmqClient` field, add `dispatchService` field, 6 methods → 1-line delegates |
+| `module-infra/.../test/.../job/CalculationDispatchServiceTest.kt` | CREATE | Unit tests for 6 dispatch methods |
+| `module-infra/.../test/.../job/CalculationJobServiceTest.kt` | MODIFY | Constructor: swap `pgmqClient` mock for `dispatchService` mock |
+
+All production files under `module-infra/src/main/kotlin/maple/expectation/infrastructure/job/`. All test files under `module-infra/src/test/kotlin/maple/expectation/infrastructure/job/`.
+
+---
+
+## Task 1: Verify worktree branch
+
+**Files:** none (verification only)
+
+- [ ] **Step 1.1: Confirm branch**
+
+Run: `git -C /home/maple/probabilistic-valuation-engine-worktrees/1073-calculation-dispatch-extraction branch --show-current`
+Expected: `refactor/1073-calculation-dispatch-extraction`
+
+- [ ] **Step 1.2: Confirm clean state**
+
+Run: `git -C /home/maple/probabilistic-valuation-engine-worktrees/1073-calculation-dispatch-extraction status --short`
+Expected: empty output (clean)
+
+---
+
+## Task 2: Create `CalculationDispatchService` (TDD)
+
+**Files:**
+- Create: `module-infra/src/main/kotlin/maple/expectation/infrastructure/job/CalculationDispatchService.kt`
+- Create: `module-infra/src/test/kotlin/maple/expectation/infrastructure/job/CalculationDispatchServiceTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `module-infra/src/test/kotlin/maple/expectation/infrastructure/job/CalculationDispatchServiceTest.kt`:
+
+```kotlin
+package maple.expectation.infrastructure.job
+
+import java.util.UUID
+import maple.expectation.core.model.job.CalculationJob
+import maple.expectation.core.model.job.CalculationJobStatus
+import maple.expectation.core.port.out.CalculationJobPort
+import maple.expectation.infrastructure.queue.QueueNames
+import maple.expectation.infrastructure.persistence.entity.CalculationSnapshotEntity
+import maple.expectation.infrastructure.persistence.repository.CalculationSnapshotRepository
+import maple.expectation.infrastructure.pgmq.CalculationCompletedPayload
+import maple.expectation.infrastructure.pgmq.CalculationRequestedPayload
+import maple.expectation.infrastructure.pgmq.ExternalApiJobPayload
+import maple.expectation.infrastructure.pgmq.PgmqClient
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@ExtendWith(MockitoExtension::class)
+class CalculationDispatchServiceTest {
+
+    @Mock lateinit var jobPort: CalculationJobPort
+    @Mock lateinit var pgmqClient: PgmqClient
+    @Mock lateinit var snapshotRepository: CalculationSnapshotRepository
+
+    private lateinit var service: CalculationDispatchService
+
+    @BeforeEach
+    fun setUp() {
+        service = CalculationDispatchService(jobPort, pgmqClient, snapshotRepository)
+    }
+
+    // ===== retryOcidResolvingJob =====
+
+    @Test
+    fun `retryOcidResolvingJob sends external API payload when retry increments`() {
+        val job = job()
+        whenever(jobPort.incrementRetryForOcid(job.jobId, "OCID_RESOLVE_TIMEOUT")).thenReturn(true)
+
+        val result = service.retryOcidResolvingJob(job.jobId, job.userIgn, job.presetNo)
+
+        assertThat(result).isTrue()
+        verify(pgmqClient).send(QueueNames.EXTERNAL_API, ExternalApiJobPayload(job.jobId.toString(), job.userIgn, job.presetNo))
+    }
+
+    @Test
+    fun `retryOcidResolvingJob does not send when retry fails`() {
+        val job = job()
+        whenever(jobPort.incrementRetryForOcid(job.jobId, "OCID_RESOLVE_TIMEOUT")).thenReturn(false)
+
+        val result = service.retryOcidResolvingJob(job.jobId, job.userIgn, job.presetNo)
+
+        assertThat(result).isFalse()
+        verify(pgmqClient, never()).send(eq(QueueNames.EXTERNAL_API), any<ExternalApiJobPayload>())
+    }
+
+    // ===== retryApiRequestedJob =====
+
+    @Test
+    fun `retryApiRequestedJob sends external API payload when retry increments`() {
+        val job = job()
+        whenever(jobPort.incrementRetry(job.jobId, "EXTERNAL_API_TIMEOUT")).thenReturn(true)
+
+        val result = service.retryApiRequestedJob(job.jobId, job.userIgn, job.presetNo)
+
+        assertThat(result).isTrue()
+        verify(pgmqClient).send(QueueNames.EXTERNAL_API, ExternalApiJobPayload(job.jobId.toString(), job.userIgn, job.presetNo))
+    }
+
+    // ===== dispatchToExternalApi =====
+
+    @Test
+    fun `dispatchToExternalApi sends payload when transition succeeds`() {
+        val job = job()
+        whenever(jobPort.transitionStatus(job.jobId, CalculationJobStatus.REQUESTED, CalculationJobStatus.OCID_RESOLVING)).thenReturn(true)
+
+        service.dispatchToExternalApi(job.jobId, job.userIgn, job.presetNo)
+
+        verify(pgmqClient).send(QueueNames.EXTERNAL_API, ExternalApiJobPayload(job.jobId.toString(), job.userIgn, job.presetNo))
+    }
+
+    @Test
+    fun `dispatchToExternalApi does not send when transition fails`() {
+        val job = job()
+        whenever(jobPort.transitionStatus(job.jobId, CalculationJobStatus.REQUESTED, CalculationJobStatus.OCID_RESOLVING)).thenReturn(false)
+
+        service.dispatchToExternalApi(job.jobId, job.userIgn, job.presetNo)
+
+        verify(pgmqClient, never()).send(eq(QueueNames.EXTERNAL_API), any<ExternalApiJobPayload>())
+    }
+
+    // ===== dispatchCalculationCompleted =====
+
+    @Test
+    fun `dispatchCalculationCompleted sends to CALCULATION_COMPLETED queue`() {
+        val payload = CalculationCompletedPayload(jobId = "job-1")
+
+        service.dispatchCalculationCompleted(payload)
+
+        verify(pgmqClient).send(QueueNames.CALCULATION_COMPLETED, payload)
+    }
+
+    // ===== saveInputSnapshotAndDispatchCalculation =====
+
+    @Test
+    fun `saveInputSnapshotAndDispatchCalculation saves snapshot and dispatches when mark ready succeeds`() {
+        val job = job()
+        val entity = mock<CalculationSnapshotEntity>()
+        whenever(entity.snapshotId).thenReturn(UUID.randomUUID())
+        val payload = CalculationRequestedPayload(jobId = job.jobId.toString())
+        whenever(jobPort.markSnapshotReady(job.jobId, entity.snapshotId, CalculationJobStatus.API_REQUESTED)).thenReturn(true)
+
+        val result = service.saveInputSnapshotAndDispatchCalculation(entity, job.jobId, entity.snapshotId, payload)
+
+        assertThat(result).isTrue()
+        verify(snapshotRepository).save(entity)
+        verify(jobPort).markSnapshotReady(job.jobId, entity.snapshotId, CalculationJobStatus.API_REQUESTED)
+        verify(pgmqClient).send(QueueNames.CALCULATION_REQUESTED, payload)
+    }
+
+    @Test
+    fun `saveInputSnapshotAndDispatchCalculation does not dispatch when mark ready fails`() {
+        val job = job()
+        val entity = mock<CalculationSnapshotEntity>()
+        whenever(entity.snapshotId).thenReturn(UUID.randomUUID())
+        val payload = CalculationRequestedPayload(jobId = job.jobId.toString())
+        whenever(jobPort.markSnapshotReady(job.jobId, entity.snapshotId, CalculationJobStatus.API_REQUESTED)).thenReturn(false)
+
+        val result = service.saveInputSnapshotAndDispatchCalculation(entity, job.jobId, entity.snapshotId, payload)
+
+        assertThat(result).isFalse()
+        verify(snapshotRepository).save(entity)
+        verify(pgmqClient, never()).send(eq(QueueNames.CALCULATION_REQUESTED), any())
+    }
+
+    // ===== retryExternalApiJob =====
+
+    @Test
+    fun `retryExternalApiJob increments OCID retry when job is OCID_RESOLVING`() {
+        val job = job(status = CalculationJobStatus.OCID_RESOLVING)
+        whenever(jobPort.findJobById(job.jobId)).thenReturn(job)
+        whenever(jobPort.incrementRetryForOcid(job.jobId, "OCID_RESOLVE_ERROR")).thenReturn(true)
+
+        val result = service.retryExternalApiJob(job.jobId, "OCID_RESOLVE_ERROR")
+
+        assertThat(result).isTrue()
+        verify(jobPort).incrementRetryForOcid(job.jobId, "OCID_RESOLVE_ERROR")
+        verify(pgmqClient).send(QueueNames.EXTERNAL_API, ExternalApiJobPayload(job.jobId.toString(), job.userIgn, job.presetNo))
+    }
+
+    @Test
+    fun `retryExternalApiJob marks exhausted job failed when retries exceeded`() {
+        val job = job(status = CalculationJobStatus.API_REQUESTED, retryCount = 3, maxRetries = 3)
+        whenever(jobPort.findJobById(job.jobId)).thenReturn(job)
+
+        val result = service.retryExternalApiJob(job.jobId)
+
+        assertThat(result).isTrue()
+        verify(jobPort).markFailed(job.jobId, "EXTERNAL_API_ERROR", "Max retries exceeded")
+        verify(pgmqClient, never()).send(eq(QueueNames.EXTERNAL_API), any<ExternalApiJobPayload>())
+    }
+
+    @Test
+    fun `retryExternalApiJob returns false for non-processable job status`() {
+        val job = job(status = CalculationJobStatus.COMPLETED)
+        whenever(jobPort.findJobById(job.jobId)).thenReturn(job)
+
+        val result = service.retryExternalApiJob(job.jobId)
+
+        assertThat(result).isFalse()
+        verify(jobPort, never()).markFailed(eq(job.jobId), any(), any())
+        verify(pgmqClient, never()).send(eq(QueueNames.EXTERNAL_API), any<ExternalApiJobPayload>())
+    }
+
+    private fun job(
+        status: CalculationJobStatus = CalculationJobStatus.REQUESTED,
+        ocid: String? = null,
+        retryCount: Int = 0,
+        maxRetries: Int = 3,
+    ) = CalculationJob(
+        jobId = UUID.randomUUID(),
+        ocid = ocid,
+        userIgn = "test-character",
+        presetNo = 1,
+        status = status,
+        retryCount = retryCount,
+        maxRetries = maxRetries,
+    )
+
+    private fun <T> mock(): T = org.mockito.kotlin.mock()
+}
+```
+
+> **NOTE:** The `private fun <T> mock(): T = org.mockito.kotlin.mock()` helper is a workaround for `org.mockito.kotlin.mock<T>()` reified inline fun not being callable from non-inline contexts with a nullable receiver. If the test file already has imports for mockito-kotlin and the existing pattern in the codebase uses `@Mock lateinit var`, prefer that. The above is a safe fallback.
+
+> **NOTE:** Verify exact constructor signatures of `CalculationJob`, `CalculationCompletedPayload`, `CalculationRequestedPayload`, `ExternalApiJobPayload`, `CalculationSnapshotEntity` by reading their files. Adjust if any fields differ.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+cd /home/maple/probabilistic-valuation-engine-worktrees/1073-calculation-dispatch-extraction
+./gradlew :module-infra:test --tests "maple.expectation.infrastructure.job.CalculationDispatchServiceTest" --continue 2>&1 | tail -15
+```
+Expected: COMPILATION FAILURE (`CalculationDispatchService` not found)
+
+- [ ] **Step 3: Create the dispatch service implementation**
+
+Create `module-infra/src/main/kotlin/maple/expectation/infrastructure/job/CalculationDispatchService.kt`:
+
+```kotlin
+package maple.expectation.infrastructure.job
+
+import java.util.UUID
+import maple.expectation.core.model.job.CalculationJobStatus
+import maple.expectation.core.port.out.CalculationJobPort
+import maple.expectation.infrastructure.queue.QueueNames
+import maple.expectation.infrastructure.persistence.entity.CalculationSnapshotEntity
+import maple.expectation.infrastructure.persistence.repository.CalculationSnapshotRepository
+import maple.expectation.infrastructure.pgmq.CalculationCompletedPayload
+import maple.expectation.infrastructure.pgmq.CalculationRequestedPayload
+import maple.expectation.infrastructure.pgmq.ExternalApiJobPayload
+import maple.expectation.infrastructure.pgmq.PgmqClient
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class CalculationDispatchService(
+    private val jobPort: CalculationJobPort,
+    private val pgmqClient: PgmqClient,
+    private val snapshotRepository: CalculationSnapshotRepository,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Transactional(value = "transactionManager", readOnly = false)
+    fun retryOcidResolvingJob(jobId: UUID, userIgn: String, presetNo: Int): Boolean {
+        val incremented = jobPort.incrementRetryForOcid(jobId, "OCID_RESOLVE_TIMEOUT")
+        if (incremented) {
+            pgmqClient.send(QueueNames.EXTERNAL_API, ExternalApiJobPayload(jobId.toString(), userIgn, presetNo))
+        }
+        return incremented
+    }
+
+    @Transactional(value = "transactionManager", readOnly = false)
+    fun retryApiRequestedJob(jobId: UUID, userIgn: String, presetNo: Int): Boolean {
+        val incremented = jobPort.incrementRetry(jobId, "EXTERNAL_API_TIMEOUT")
+        if (incremented) {
+            pgmqClient.send(QueueNames.EXTERNAL_API, ExternalApiJobPayload(jobId.toString(), userIgn, presetNo))
+        }
+        return incremented
+    }
+
+    @Transactional(value = "transactionManager", readOnly = false)
+    fun dispatchToExternalApi(jobId: UUID, userIgn: String, presetNo: Int) {
+        val transitioned = jobPort.transitionStatus(
+            jobId,
+            CalculationJobStatus.REQUESTED,
+            CalculationJobStatus.OCID_RESOLVING,
+        )
+        if (!transitioned) {
+            log.warn("[jobId={}] Cannot transition to OCID_RESOLVING", jobId)
+            return
+        }
+
+        pgmqClient.send(QueueNames.EXTERNAL_API, ExternalApiJobPayload(jobId.toString(), userIgn, presetNo))
+        log.info("[jobId={}] Dispatched to consolidated external API pipeline", jobId)
+    }
+
+    @Transactional(value = "transactionManager", readOnly = false)
+    fun dispatchCalculationCompleted(payload: CalculationCompletedPayload) {
+        pgmqClient.send(QueueNames.CALCULATION_COMPLETED, payload)
+        log.info("[jobId={}] Calculation completed payload dispatched", payload.jobId)
+    }
+
+    @Transactional(value = "transactionManager", readOnly = false)
+    fun saveInputSnapshotAndDispatchCalculation(
+        snapshotEntity: CalculationSnapshotEntity,
+        jobId: UUID,
+        snapshotId: UUID,
+        payload: CalculationRequestedPayload,
+    ): Boolean {
+        snapshotRepository.save(snapshotEntity)
+        val ready = jobPort.markSnapshotReady(jobId, snapshotId, CalculationJobStatus.API_REQUESTED)
+        if (!ready) {
+            log.warn("[jobId={}] Cannot mark SNAPSHOT_READY before calculation dispatch", jobId)
+            return false
+        }
+        pgmqClient.send(QueueNames.CALCULATION_REQUESTED, payload)
+        log.info("[jobId={}] Calculation requested", jobId)
+        return true
+    }
+
+    @Transactional(value = "transactionManager", readOnly = false)
+    fun retryExternalApiJob(jobId: UUID, errorCode: String = "EXTERNAL_API_ERROR"): Boolean {
+        val job = jobPort.findJobById(jobId) ?: return false
+        if (job.retryCount >= job.maxRetries) {
+            jobPort.markFailed(jobId, errorCode, "Max retries exceeded")
+            log.warn("[jobId={}] External API failed after {} retries", jobId, job.retryCount)
+            return true
+        }
+        val incremented = when (job.status) {
+            CalculationJobStatus.OCID_RESOLVING -> jobPort.incrementRetryForOcid(jobId, errorCode)
+            CalculationJobStatus.API_REQUESTED,
+            CalculationJobStatus.RETRYING,
+            -> jobPort.incrementRetry(jobId, errorCode)
+            CalculationJobStatus.REQUESTED -> jobPort.transitionStatus(
+                jobId,
+                CalculationJobStatus.REQUESTED,
+                CalculationJobStatus.OCID_RESOLVING,
+            )
+            else -> false
+        }
+        if (!incremented) {
+            log.warn("[jobId={}] External API retry not scheduled from state {}", jobId, job.status)
+            return false
+        }
+        pgmqClient.send(QueueNames.EXTERNAL_API, ExternalApiJobPayload(job.jobId.toString(), job.userIgn, job.presetNo))
+        log.info("[jobId={}] External API retry scheduled (attempt {})", jobId, job.retryCount + 1)
+        return true
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+```bash
+cd /home/maple/probabilistic-valuation-engine-worktrees/1073-calculation-dispatch-extraction
+./gradlew :module-infra:test --tests "maple.expectation.infrastructure.job.CalculationDispatchServiceTest" --continue 2>&1 | tail -15
+```
+Expected: PASS (10 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine-worktrees/1073-calculation-dispatch-extraction
+git add module-infra/src/main/kotlin/maple/expectation/infrastructure/job/CalculationDispatchService.kt
+git add module-infra/src/test/kotlin/maple/expectation/infrastructure/job/CalculationDispatchServiceTest.kt
+git commit -m "refactor(1073): extract CalculationDispatchService with 6 dispatch methods"
+```
+
+---
+
+## Task 3: Refactor `CalculationJobService` to delegate
+
+**Files:**
+- Modify: `module-infra/src/main/kotlin/maple/expectation/infrastructure/job/CalculationJobService.kt`
+
+- [ ] **Step 1: Update imports**
+
+Remove the now-unused PGMQ imports from `CalculationJobService.kt`:
+- `maple.expectation.infrastructure.queue.QueueNames` (no longer used directly)
+- `maple.expectation.infrastructure.pgmq.ExternalApiJobPayload` (no longer used directly)
+- `maple.expectation.infrastructure.pgmq.CalculationRequestedPayload` (no longer used directly)
+- `maple.expectation.infrastructure.pgmq.CalculationCompletedPayload` (no longer used directly)
+
+Keep: `PgmqClient` import will be removed in the next step (constructor change).
+
+- [ ] **Step 2: Update constructor**
+
+Replace the constructor with:
+
+```kotlin
+@Service
+class CalculationJobService(
+    private val jobPort: CalculationJobPort,
+    private val eventAppender: DomainEventAppender,
+    private val ocidResolveTopic: OcidResolveTopic,
+    private val nexonApiRequestTopic: NexonApiRequestTopic,
+    private val nexonApiResponseTopic: NexonApiResponseTopic,
+    private val snapshotRepository: CalculationSnapshotRepository,
+    private val dispatchService: CalculationDispatchService,
+) {
+```
+
+Changes:
+- Remove `pgmqClient: PgmqClient` field
+- Add `dispatchService: CalculationDispatchService` field (last position)
+- Remove the `import maple.expectation.infrastructure.pgmq.PgmqClient` line
+
+- [ ] **Step 3: Replace 6 method bodies with delegates**
+
+Delete the 6 method bodies (lines 147-244 in the original file):
+- `retryOcidResolvingJob`
+- `retryApiRequestedJob`
+- `dispatchToExternalApi`
+- `saveInputSnapshotAndDispatchCalculation` (lines 193-209, the dispatch-specific one — not to be confused with `saveInputSnapshotAndMarkReady` which stays)
+- `dispatchCalculationCompleted`
+- `retryExternalApiJob`
+
+Replace each with a 1-line delegate:
+
+```kotlin
+    fun retryOcidResolvingJob(jobId: UUID, userIgn: String, presetNo: Int): Boolean =
+        dispatchService.retryOcidResolvingJob(jobId, userIgn, presetNo)
+
+    fun retryApiRequestedJob(jobId: UUID, userIgn: String, presetNo: Int): Boolean =
+        dispatchService.retryApiRequestedJob(jobId, userIgn, presetNo)
+
+    fun dispatchToExternalApi(jobId: UUID, userIgn: String, presetNo: Int) {
+        dispatchService.dispatchToExternalApi(jobId, userIgn, presetNo)
+    }
+
+    fun dispatchCalculationCompleted(payload: CalculationCompletedPayload) {
+        dispatchService.dispatchCalculationCompleted(payload)
+    }
+
+    fun saveInputSnapshotAndDispatchCalculation(
+        snapshotEntity: CalculationSnapshotEntity,
+        jobId: UUID,
+        snapshotId: UUID,
+        payload: CalculationRequestedPayload,
+    ): Boolean = dispatchService.saveInputSnapshotAndDispatchCalculation(snapshotEntity, jobId, snapshotId, payload)
+
+    fun retryExternalApiJob(jobId: UUID, errorCode: String = "EXTERNAL_API_ERROR"): Boolean =
+        dispatchService.retryExternalApiJob(jobId, errorCode)
+```
+
+**Important**: 
+- `dispatchToExternalApi`, `dispatchCalculationCompleted`, and `saveInputSnapshotAndDispatchCalculation` reference types (`CalculationCompletedPayload`, `CalculationRequestedPayload`) that are still imported. Keep those imports — they're needed for the delegate signatures.
+- The `// ===== Consolidated Pipeline Methods (ExternalApiWorker) =====` section comment is removed since the 6 methods are now delegates (not consolidated pipeline methods).
+
+- [ ] **Step 4: Compile check**
+
+Run:
+```bash
+cd /home/maple/probabilistic-valuation-engine-worktrees/1073-calculation-dispatch-extraction
+./gradlew :module-infra:compileKotlin --continue 2>&1 | tail -10
+```
+Expected: BUILD SUCCESSFUL. (No test compilation since the test file still uses the old constructor — we'll fix in next task.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine-worktrees/1073-calculation-dispatch-extraction
+git add module-infra/src/main/kotlin/maple/expectation/infrastructure/job/CalculationJobService.kt
+git commit -m "refactor(1073): make CalculationJobService delegate to CalculationDispatchService"
+```
+
+---
+
+## Task 4: Update `CalculationJobServiceTest` constructor
+
+**Files:**
+- Modify: `module-infra/src/test/kotlin/maple/expectation/infrastructure/job/CalculationJobServiceTest.kt`
+
+- [ ] **Step 1: Update imports**
+
+Remove unused imports:
+- `maple.expectation.infrastructure.pgmq.ExternalApiJobPayload` (still used in `verify(pgmqClient).send(...)` calls — keep)
+- Actually, `ExternalApiJobPayload` IS used in `verify(pgmqClient).send(...)` — keep
+- `PgmqClient` is no longer a field mock — remove the import only if unused
+- `QueueNames` is still used in verify calls — keep
+
+Looking at the test: `@Mock lateinit var pgmqClient: PgmqClient` is declared but will become unused since `CalculationJobService` no longer has `pgmqClient` (delegated). The test still verifies `pgmqClient.send(...)` because the mock delegate's effect is observed through the real `pgmqClient` mock? No — when `CalculationJobService.retryExternalApiJob(...)` delegates to `dispatchService.retryExternalApiJob(...)`, the real `pgmqClient` in `dispatchService` is invoked. The test's `pgmqClient` mock is now unused.
+
+**Decision:** Keep the existing 5 tests. Replace `@Mock lateinit var pgmqClient: PgmqClient` with `@Mock lateinit var dispatchService: CalculationDispatchService`. Update the `setUp` to pass `dispatchService` instead of `pgmqClient`. The verify calls need to change to verify `dispatchService.retryExternalApiJob(...)` instead of `pgmqClient.send(...)`.
+
+- [ ] **Step 2: Update mock fields and constructor**
+
+Replace the test file's `@Mock` declarations and `setUp` block:
+
+```kotlin
+    @Mock lateinit var jobPort: CalculationJobPort
+
+    @Mock lateinit var eventAppender: DomainEventAppender
+
+    @Mock lateinit var dispatchService: CalculationDispatchService
+
+    @Mock lateinit var ocidResolveTopic: OcidResolveTopic
+
+    @Mock lateinit var nexonApiRequestTopic: NexonApiRequestTopic
+
+    @Mock lateinit var nexonApiResponseTopic: NexonApiResponseTopic
+
+    @Mock lateinit var snapshotRepository: CalculationSnapshotRepository
+
+    private lateinit var service: CalculationJobService
+
+    @BeforeEach
+    fun setUp() {
+        service = CalculationJobService(
+            jobPort = jobPort,
+            eventAppender = eventAppender,
+            ocidResolveTopic = ocidResolveTopic,
+            nexonApiRequestTopic = nexonApiRequestTopic,
+            nexonApiResponseTopic = nexonApiResponseTopic,
+            snapshotRepository = snapshotRepository,
+            dispatchService = dispatchService,
+        )
+    }
+```
+
+- [ ] **Step 3: Update test method verify calls**
+
+The 5 `retryExternalApiJob` tests need their `verify(pgmqClient).send(...)` calls changed to `verify(dispatchService).retryExternalApiJob(...)`. The delegation path means the test now verifies the call was forwarded.
+
+Replace the test methods' verify calls:
+
+For each of the 5 existing tests (`retryExternalApiJob increments OCID retry when job is resolving OCID`, etc.):
+- `verify(pgmqClient).send(QueueNames.EXTERNAL_API, ExternalApiJobPayload(...))` → `verify(dispatchService).retryExternalApiJob(job.jobId, ...)` (with appropriate error code argument)
+
+Use Mockito-Kotlin argument matchers. The exact pattern depends on the test's call:
+
+**Test 1** (`increments OCID retry when job is resolving OCID`):
+- Calls `service.retryExternalApiJob(job.jobId, "OCID_RESOLVE_ERROR")`
+- Asserts `result == true`
+- Original verifies: `verify(jobPort).incrementRetryForOcid(...)` and `verify(pgmqClient).send(...)`
+- New verifies: `verify(jobPort).incrementRetryForOcid(...)` and `verify(dispatchService).retryExternalApiJob(job.jobId, "OCID_RESOLVE_ERROR")`
+
+**Test 2** (`increments API retry when job is API requested`):
+- Calls `service.retryExternalApiJob(job.jobId)` (default error code = "EXTERNAL_API_ERROR")
+- New verifies: `verify(dispatchService).retryExternalApiJob(job.jobId)` — default argument
+
+**Test 3** (`stores provided API error code`):
+- Calls `service.retryExternalApiJob(job.jobId, "NEXON_RATE_LIMITED")`
+- New verifies: `verify(dispatchService).retryExternalApiJob(job.jobId, "NEXON_RATE_LIMITED")`
+
+**Test 4** (`increments API retry when job is retrying`):
+- Calls `service.retryExternalApiJob(job.jobId)` (default)
+- New verifies: `verify(dispatchService).retryExternalApiJob(job.jobId)`
+
+**Test 5** (`marks exhausted job failed and archives current message`):
+- Calls `service.retryExternalApiJob(job.jobId)` (default)
+- New verifies: `verify(dispatchService).retryExternalApiJob(job.jobId)` — and the result of that delegation is what makes `markFailed` happen inside `dispatchService`. This test now passes if `markFailed` is NOT called on `jobPort` (because the actual `markFailed` is inside `dispatchService`, which is mocked). The test's assertion of `result == true` still holds.
+- **This test's intent changes** — it now verifies that the delegate is called and returns `true`. The "marks exhausted job failed" assertion is no longer verifiable on `jobPort` because the real logic is in the mocked `dispatchService`.
+
+**Test 6** (if exists — `returns false for non external API processable job`):
+- Calls `service.retryExternalApiJob(job.jobId)`
+- New verifies: `verify(dispatchService).retryExternalApiJob(job.jobId)`
+- The `result == false` assertion still holds if the mock returns false (Mockito returns false by default for Boolean methods).
+
+> **NOTE**: The original test file has 5 tests (lines 60-138). The 5th test (`returns false for non external API processable job`) at line 127 needs the same update. If there are more tests below line 138 in the file that weren't shown, update them too with the same pattern.
+
+After updating, the test file verifies: **`CalculationJobService` correctly delegates `retryExternalApiJob` to `CalculationDispatchService`**. The real `retryExternalApiJob` behavior is tested in `CalculationDispatchServiceTest` (Task 2).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+```bash
+cd /home/maple/probabilistic-valuation-engine-worktrees/1073-calculation-dispatch-extraction
+./gradlew :module-infra:test --tests "maple.expectation.infrastructure.job.CalculationJobServiceTest" --continue 2>&1 | tail -15
+```
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine-worktrees/1073-calculation-dispatch-extraction
+git add module-infra/src/test/kotlin/maple/expectation/infrastructure/job/CalculationJobServiceTest.kt
+git commit -m "refactor(1073): update CalculationJobServiceTest for delegation"
+```
+
+---
+
+## Task 5: Compile + test gates
+
+**Files:** none (verification only)
+
+- [ ] **Step 5.1: Compile module-infra**
+
+Run:
+```bash
+cd /home/maple/probabilistic-valuation-engine-worktrees/1073-calculation-dispatch-extraction
+./gradlew :module-infra:compileKotlin compileJava --continue 2>&1 | tail -10
+```
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 5.2: Run module-infra unit tests**
+
+Run:
+```bash
+cd /home/maple/probabilistic-valuation-engine-worktrees/1073-calculation-dispatch-extraction
+./gradlew :module-infra:test --continue 2>&1 | tail -10
+```
+Expected: BUILD SUCCESSFUL (all tests pass — both `CalculationJobServiceTest` and `CalculationDispatchServiceTest`).
+
+- [ ] **Step 5.3: Full repo compile (sanity)**
+
+Run:
+```bash
+cd /home/maple/probabilistic-valuation-engine-worktrees/1073-calculation-dispatch-extraction
+./gradlew compileKotlin compileJava --continue 2>&1 | tail -10
+```
+Expected: BUILD SUCCESSFUL.
+
+---
+
+## Task 6: PR
+
+**Files:** none
+
+- [ ] **Step 6.1: Push branch**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine-worktrees/1073-calculation-dispatch-extraction
+git push -u origin refactor/1073-calculation-dispatch-extraction
+```
+
+- [ ] **Step 6.2: Create PR**
+
+```bash
+gh pr create \
+  --base develop \
+  --head refactor/1073-calculation-dispatch-extraction \
+  --title "refactor(1073): extract CalculationDispatchService (step 1/2)" \
+  --body "$(cat <<'EOF'
+## Summary
+Extract 6 PGMQ-dispatch methods from `CalculationJobService` into a new `CalculationDispatchService` (step 1 of 2). `CalculationJobService` delegates to the new service via 1-line wrappers.
+
+## Files
+- Created: `job/CalculationDispatchService.kt` (3 deps, 6 methods) + tests (10 cases)
+- Modified: `job/CalculationJobService.kt` — swap `pgmqClient` for `dispatchService`, 6 methods → delegates
+- Modified: `test/.../CalculationJobServiceTest.kt` — mock `dispatchService` instead of `pgmqClient`, verify delegation
+
+## Behavior
+Zero behavioral change. Method signatures unchanged. 4 caller files unchanged:
+- `CalculationJobTimeoutScanner` — calls `retryOcidResolvingJob`/`retryApiRequestedJob`
+- `CalculationRequestedWorker` — calls `dispatchCalculationCompleted`
+- `AbstractExpectationCalcWorker` — calls `dispatchToExternalApi`
+- `ExternalApiWorker` — calls `saveInputSnapshotAndDispatchCalculation`/`retryExternalApiJob`
+
+## Step 2 (out of scope, future PR)
+- Migrate callers to inject `CalculationDispatchService` directly
+- Remove delegation methods from `CalculationJobService`
+
+## Verification
+- [x] `./gradlew :module-infra:compileKotlin compileJava --continue` passes
+- [x] `./gradlew :module-infra:test` passes
+- [x] `./gradlew compileKotlin compileJava --continue` passes (full repo)
+- [x] 5 existing `CalculationJobServiceTest` tests pass (via delegation)
+- [x] 10 new `CalculationDispatchServiceTest` tests pass
+
+Closes #1073
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 6.3: Verify PR exists**
+
+Run:
+```bash
+gh pr view --json number,url,title,state | jq '{number, url, title, state}'
+```
+Expected: state `OPEN`.
+
+---
+
+## Acceptance criteria
+
+From #1073:
+- [x] New `CalculationDispatchService` created with 6 dispatch methods (Task 2)
+- [x] `CalculationJobService` delegates to `CalculationDispatchService` (Task 3)
+- [x] `./gradlew compileKotlin compileJava --continue` passes (Task 5)
+- [x] `./gradlew test` passes (Task 5)
+- [x] No behavioral change (Tasks 2-4, all method bodies moved verbatim)

--- a/docs/superpowers/specs/2026-06-06-1073-calculation-dispatch-service-design.md
+++ b/docs/superpowers/specs/2026-06-06-1073-calculation-dispatch-service-design.md
@@ -1,0 +1,216 @@
+# Issue 1073 — CalculationDispatchService Extraction Design (step 1/2)
+
+- Status: Accepted
+- Date: 2026-06-06
+- Owner: zbnerd
+- Spec: [#1073](https://github.com/zbnerd/probabilistic-valuation-engine/issues/1073)
+- Branch: `refactor/1073-calculation-dispatch-extraction`
+
+---
+
+## 1. Background / Problem
+
+### Background
+
+`module-infra/.../job/CalculationJobService.kt` is **245 lines** with **7 constructor fields** and **16 methods**. It mixes 4 orchestration concerns:
+
+1. **Job lifecycle creation / lookup** — `createJob`, `createOrFindActiveJob`
+2. **Status transition + event append** — `requestOcidResolve`, `resolveOcidAndEnqueueApiData`, `markSnapshotReady`, `markSnapshotReadyInternal`
+3. **Failure handling** — `handleApiFailure`, `handleOcidFailure`
+4. **PGMQ dispatch** — `retryOcidResolvingJob`, `retryApiRequestedJob`, `dispatchToExternalApi`, `dispatchCalculationCompleted`, `saveInputSnapshotAndDispatchCalculation`, `retryExternalApiJob`
+
+The **6 dispatch methods** use only `jobPort` + `pgmqClient` and never touch `eventAppender`, the topic fields, or `snapshotRepository` (except `saveInputSnapshotAndDispatchCalculation` which also writes to `snapshotRepository`). They form the cleanest extraction boundary.
+
+This is **step 1 of 2**. Step 2 (out of scope for this PR) will update external callers (`CalculationJobTimeoutScanner`, `CalculationRequestedWorker`, `AbstractExpectationCalcWorker`, `ExternalApiWorker`) to depend on `CalculationDispatchService` directly and remove the delegation in `CalculationJobService`.
+
+### Problem
+
+`CalculationJobService` violates Single Responsibility — one service manages job CRUD, status transitions, failure handling, and message dispatch. Each concern has different deps and change cadence, but they share one god class. The 6 dispatch methods are the natural first extraction because they have minimal coupling (only `jobPort` + `pgmqClient` + `snapshotRepository` for one method).
+
+### Goal
+
+Extract the 6 PGMQ-dispatch methods into a new `CalculationDispatchService`. `CalculationJobService` delegates to it. Zero behavioral change. All existing tests pass.
+
+---
+
+## 2. Decision
+
+> Create `CalculationDispatchService` containing the 6 PGMQ-dispatch methods verbatim from `CalculationJobService`. `CalculationJobService` removes `pgmqClient`, adds `dispatchService: CalculationDispatchService`, and turns the 6 methods into 1-line delegates.
+
+### Component map (after)
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  CalculationJobService (delegator)                                   │
+│    ├── CalculationJobPort         (shared, retained)                 │
+│    ├── DomainEventAppender        (unchanged)                        │
+│    ├── OcidResolveTopic           (unchanged)                        │
+│    ├── NexonApiRequestTopic       (unchanged)                        │
+│    ├── NexonApiResponseTopic      (unchanged)                        │
+│    ├── CalculationSnapshotRepository (unchanged)                     │
+│    └── CalculationDispatchService (NEW — delegate target)            │
+└──────────────────────────────────────────────────────────────────────┘
+                    │
+                    ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│  CalculationDispatchService (NEW)                                    │
+│    ├── CalculationJobPort                                             │
+│    └── PgmqClient                                                     │
+│    Methods:                                                           │
+│    - retryOcidResolvingJob                                            │
+│    - retryApiRequestedJob                                             │
+│    - dispatchToExternalApi                                            │
+│    - dispatchCalculationCompleted                                     │
+│    - saveInputSnapshotAndDispatchCalculation                          │
+│    - retryExternalApiJob                                              │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+### Method mapping
+
+| Source (`CalculationJobService`) | Target (`CalculationDispatchService`) | Body |
+|---|---|---|
+| `retryOcidResolvingJob` | same name, same signature | Verbatim copy |
+| `retryApiRequestedJob` | same name, same signature | Verbatim copy |
+| `dispatchToExternalApi` | same name, same signature | Verbatim copy |
+| `dispatchCalculationCompleted` | same name, same signature | Verbatim copy |
+| `saveInputSnapshotAndDispatchCalculation` | same name, same signature | Verbatim copy (also uses `snapshotRepository`) |
+| `retryExternalApiJob` | same name, same signature | Verbatim copy |
+
+After the move, `CalculationJobService` keeps each of the 6 methods as a 1-line delegate:
+```kotlin
+fun retryExternalApiJob(jobId: UUID, errorCode: String = "EXTERNAL_API_ERROR"): Boolean =
+    dispatchService.retryExternalApiJob(jobId, errorCode)
+```
+
+---
+
+## 3. Trade-offs
+
+### Sensitivity
+
+- **`@Transactional` propagation** — all 6 dispatch methods carry `@Transactional(value = "transactionManager", readOnly = false)`. The annotation must move to `CalculationDispatchService` methods (the delegator's `@Transactional` on a 1-line call is a no-op when the call site isn't proxied — Spring AOP doesn't proxy self-invocations). Verification: existing tests don't observe transaction behavior, so behavior is unchanged either way.
+- **`pgmqClient` field ownership** — only the 6 dispatch methods reference `pgmqClient`. After extraction, `CalculationJobService` no longer needs it.
+- **`snapshotRepository` ownership** — `saveInputSnapshotAndDispatchCalculation` references it. Either move `snapshotRepository` to `CalculationDispatchService` (preferred — single-concern) or share it. Per principle of single-concern, move it to the dispatch service.
+- **Test mocks** — `CalculationJobServiceTest` mocks `pgmqClient` and `snapshotRepository`. After the move, these mocks become unused for the dispatch path (still used for `markSnapshotReady`, `saveSnapshotAndMarkReady`, `saveInputSnapshotAndMarkReady` which stay in `CalculationJobService`).
+
+### Trade-off
+
+| Choice | Gained | Given up |
+|---|---|---|
+| Delegation pattern (per issue) | No caller changes; step 2 will be trivial | Two methods with the same name temporarily |
+| `snapshotRepository` moves to dispatch service | Single-concern per service | Slightly larger new service (3 deps) |
+| Keep existing `CalculationJobServiceTest` unchanged | Minimal diff, tests pass via delegation path | Tests verify delegation, not real logic |
+| New `CalculationDispatchServiceTest` | Direct coverage of new service | Slight test count growth |
+
+### Risk
+
+- **`@Transactional` boundary change** — the dispatcher methods now have their own proxy boundary. Behavior is unchanged because the inner logic is identical and no caller relies on propagation through the delegate. (The delegate's `@Transactional` would be ineffective anyway due to AOP self-invocation, so this is actually a correctness improvement.)
+- **Constructor signature change** — `CalculationJobService` constructor changes (pgmqClient → dispatchService). Caller changes: NONE (Spring auto-wires). Test changes: `CalculationJobServiceTest` constructor must pass `dispatchService` (mock).
+
+### Non-Risk
+
+- Method signatures unchanged → all 4 caller files (`CalculationJobTimeoutScanner`, `CalculationRequestedWorker`, `AbstractExpectationCalcWorker`, `ExternalApiWorker`) need no changes.
+- 5 existing `retryExternalApiJob` tests in `CalculationJobServiceTest` continue to work — they call `service.retryExternalApiJob(...)` which delegates. The test would verify delegation behavior (and indirectly the real logic via the mock chain), which is acceptable for step 1.
+
+---
+
+## 4. Result / Evidence
+
+### Metrics
+
+| Metric | Before | After | Notes |
+|---|---:|---:|---|
+| `CalculationJobService.kt` lines | 245 | ~150 | After extracting 6 methods (logic moved verbatim, delegators are 1-liners) |
+| `CalculationJobService` constructor fields | 7 | 7 | Swap: `-pgmqClient, +dispatchService` |
+| `CalculationJobService` methods | 16 | 16 | 10 stay, 6 become delegates |
+| New components | 0 | 1 | `CalculationDispatchService` |
+| New test file | 0 | 1 | `CalculationDispatchServiceTest` |
+| Caller changes | — | 0 | Step 2 (out of scope) |
+
+### Verification commands
+
+```bash
+./gradlew :module-infra:compileKotlin compileJava --continue
+./gradlew :module-infra:test
+```
+
+### Runtime verification (per project workflow)
+
+Per `.claude/rules/workflow-rules.md` §10, runtime server check is required before merge. Since this refactor has no behavioral change, the verification focuses on observing the same job lifecycle logs in the synchronizer pipeline.
+
+---
+
+## 5. Summary
+
+> Extract `CalculationJobService`'s 6 PGMQ-dispatch methods into a new `CalculationDispatchService`. `CalculationJobService` delegates to the new service (step 1 of 2 — step 2 will remove the delegation and migrate callers).
+
+---
+
+## Appendix A — File structure
+
+```
+module-infra/src/main/kotlin/maple/expectation/infrastructure/job/
+├── CalculationJobService.kt        (MODIFIED — 6 methods become delegates)
+└── CalculationDispatchService.kt   (NEW — 6 methods verbatim from above)
+
+module-infra/src/test/kotlin/maple/expectation/infrastructure/job/
+├── CalculationJobServiceTest.kt    (MODIFIED — swap pgmqClient mock for dispatchService mock)
+└── CalculationDispatchServiceTest.kt (NEW — focused unit tests for 6 methods)
+```
+
+## Appendix B — Key signatures
+
+```kotlin
+// CalculationDispatchService.kt
+@Service
+class CalculationDispatchService(
+    private val jobPort: CalculationJobPort,
+    private val pgmqClient: PgmqClient,
+    private val snapshotRepository: CalculationSnapshotRepository,
+) {
+    @Transactional(value = "transactionManager", readOnly = false)
+    fun retryOcidResolvingJob(jobId: UUID, userIgn: String, presetNo: Int): Boolean { ... }
+
+    @Transactional(value = "transactionManager", readOnly = false)
+    fun retryApiRequestedJob(jobId: UUID, userIgn: String, presetNo: Int): Boolean { ... }
+
+    @Transactional(value = "transactionManager", readOnly = false)
+    fun dispatchToExternalApi(jobId: UUID, userIgn: String, presetNo: Int) { ... }
+
+    @Transactional(value = "transactionManager", readOnly = false)
+    fun dispatchCalculationCompleted(payload: CalculationCompletedPayload) { ... }
+
+    @Transactional(value = "transactionManager", readOnly = false)
+    fun saveInputSnapshotAndDispatchCalculation(
+        snapshotEntity: CalculationSnapshotEntity,
+        jobId: UUID,
+        snapshotId: UUID,
+        payload: CalculationRequestedPayload,
+    ): Boolean { ... }
+
+    @Transactional(value = "transactionManager", readOnly = false)
+    fun retryExternalApiJob(jobId: UUID, errorCode: String = "EXTERNAL_API_ERROR"): Boolean { ... }
+}
+```
+
+```kotlin
+// CalculationJobService.kt — refactored (sketch)
+@Service
+class CalculationJobService(
+    private val jobPort: CalculationJobPort,
+    private val eventAppender: DomainEventAppender,
+    private val ocidResolveTopic: OcidResolveTopic,
+    private val nexonApiRequestTopic: NexonApiRequestTopic,
+    private val nexonApiResponseTopic: NexonApiResponseTopic,
+    private val snapshotRepository: CalculationSnapshotRepository,
+    private val dispatchService: CalculationDispatchService,
+) {
+    // ... 10 unchanged methods ...
+
+    fun retryExternalApiJob(jobId: UUID, errorCode: String = "EXTERNAL_API_ERROR"): Boolean =
+        dispatchService.retryExternalApiJob(jobId, errorCode)
+
+    // ... 5 more 1-line delegates ...
+}
+```

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/job/CalculationDispatchService.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/job/CalculationDispatchService.kt
@@ -1,0 +1,111 @@
+package maple.expectation.infrastructure.job
+
+import java.util.UUID
+import maple.expectation.core.model.job.CalculationJobStatus
+import maple.expectation.core.port.out.CalculationJobPort
+import maple.expectation.infrastructure.persistence.entity.CalculationSnapshotEntity
+import maple.expectation.infrastructure.persistence.repository.CalculationSnapshotRepository
+import maple.expectation.infrastructure.pgmq.CalculationCompletedPayload
+import maple.expectation.infrastructure.pgmq.CalculationRequestedPayload
+import maple.expectation.infrastructure.pgmq.ExternalApiJobPayload
+import maple.expectation.infrastructure.pgmq.PgmqClient
+import maple.expectation.infrastructure.queue.QueueNames
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class CalculationDispatchService(
+    private val jobPort: CalculationJobPort,
+    private val pgmqClient: PgmqClient,
+    private val snapshotRepository: CalculationSnapshotRepository,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Transactional(value = "transactionManager", readOnly = false)
+    fun retryOcidResolvingJob(jobId: UUID, userIgn: String, presetNo: Int): Boolean {
+        val incremented = jobPort.incrementRetryForOcid(jobId, "OCID_RESOLVE_TIMEOUT")
+        if (incremented) {
+            pgmqClient.send(QueueNames.EXTERNAL_API, ExternalApiJobPayload(jobId.toString(), userIgn, presetNo))
+        }
+        return incremented
+    }
+
+    @Transactional(value = "transactionManager", readOnly = false)
+    fun retryApiRequestedJob(jobId: UUID, userIgn: String, presetNo: Int): Boolean {
+        val incremented = jobPort.incrementRetry(jobId, "EXTERNAL_API_TIMEOUT")
+        if (incremented) {
+            pgmqClient.send(QueueNames.EXTERNAL_API, ExternalApiJobPayload(jobId.toString(), userIgn, presetNo))
+        }
+        return incremented
+    }
+
+    @Transactional(value = "transactionManager", readOnly = false)
+    fun dispatchToExternalApi(jobId: UUID, userIgn: String, presetNo: Int) {
+        val transitioned = jobPort.transitionStatus(
+            jobId,
+            CalculationJobStatus.REQUESTED,
+            CalculationJobStatus.OCID_RESOLVING,
+        )
+        if (!transitioned) {
+            log.warn("[jobId={}] Cannot transition to OCID_RESOLVING", jobId)
+            return
+        }
+
+        pgmqClient.send(QueueNames.EXTERNAL_API, ExternalApiJobPayload(jobId.toString(), userIgn, presetNo))
+        log.info("[jobId={}] Dispatched to consolidated external API pipeline", jobId)
+    }
+
+    @Transactional(value = "transactionManager", readOnly = false)
+    fun dispatchCalculationCompleted(payload: CalculationCompletedPayload) {
+        pgmqClient.send(QueueNames.CALCULATION_COMPLETED, payload)
+        log.info("[jobId={}] Calculation completed payload dispatched", payload.jobId)
+    }
+
+    @Transactional(value = "transactionManager", readOnly = false)
+    fun saveInputSnapshotAndDispatchCalculation(
+        snapshotEntity: CalculationSnapshotEntity,
+        jobId: UUID,
+        snapshotId: UUID,
+        payload: CalculationRequestedPayload,
+    ): Boolean {
+        snapshotRepository.save(snapshotEntity)
+        val ready = jobPort.markSnapshotReady(jobId, snapshotId, CalculationJobStatus.API_REQUESTED)
+        if (!ready) {
+            log.warn("[jobId={}] Cannot mark SNAPSHOT_READY before calculation dispatch", jobId)
+            return false
+        }
+        pgmqClient.send(QueueNames.CALCULATION_REQUESTED, payload)
+        log.info("[jobId={}] Calculation requested", jobId)
+        return true
+    }
+
+    @Transactional(value = "transactionManager", readOnly = false)
+    fun retryExternalApiJob(jobId: UUID, errorCode: String = "EXTERNAL_API_ERROR"): Boolean {
+        val job = jobPort.findJobById(jobId) ?: return false
+        if (job.retryCount >= job.maxRetries) {
+            jobPort.markFailed(jobId, errorCode, "Max retries exceeded")
+            log.warn("[jobId={}] External API failed after {} retries", jobId, job.retryCount)
+            return true
+        }
+        val incremented = when (job.status) {
+            CalculationJobStatus.OCID_RESOLVING -> jobPort.incrementRetryForOcid(jobId, errorCode)
+            CalculationJobStatus.API_REQUESTED,
+            CalculationJobStatus.RETRYING,
+            -> jobPort.incrementRetry(jobId, errorCode)
+            CalculationJobStatus.REQUESTED -> jobPort.transitionStatus(
+                jobId,
+                CalculationJobStatus.REQUESTED,
+                CalculationJobStatus.OCID_RESOLVING,
+            )
+            else -> false
+        }
+        if (!incremented) {
+            log.warn("[jobId={}] External API retry not scheduled from state {}", jobId, job.status)
+            return false
+        }
+        pgmqClient.send(QueueNames.EXTERNAL_API, ExternalApiJobPayload(job.jobId.toString(), job.userIgn, job.presetNo))
+        log.info("[jobId={}] External API retry scheduled (attempt {})", jobId, job.retryCount + 1)
+        return true
+    }
+}

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/job/CalculationJobService.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/job/CalculationJobService.kt
@@ -5,7 +5,6 @@ import maple.expectation.core.model.job.CalculationJob
 import maple.expectation.core.model.job.CalculationJobClaim
 import maple.expectation.core.model.job.CalculationJobStatus
 import maple.expectation.core.port.out.CalculationJobPort
-import maple.expectation.infrastructure.queue.QueueNames
 import maple.expectation.core.port.out.mq.DomainEventAppender
 import maple.expectation.infrastructure.mq.event.NexonApiRequestEventFactory
 import maple.expectation.infrastructure.mq.event.NexonApiResponseEventFactory
@@ -17,8 +16,6 @@ import maple.expectation.infrastructure.persistence.entity.CalculationSnapshotEn
 import maple.expectation.infrastructure.persistence.repository.CalculationSnapshotRepository
 import maple.expectation.infrastructure.pgmq.CalculationCompletedPayload
 import maple.expectation.infrastructure.pgmq.CalculationRequestedPayload
-import maple.expectation.infrastructure.pgmq.ExternalApiJobPayload
-import maple.expectation.infrastructure.pgmq.PgmqClient
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -27,11 +24,11 @@ import org.springframework.transaction.annotation.Transactional
 class CalculationJobService(
     private val jobPort: CalculationJobPort,
     private val eventAppender: DomainEventAppender,
-    private val pgmqClient: PgmqClient,
     private val ocidResolveTopic: OcidResolveTopic,
     private val nexonApiRequestTopic: NexonApiRequestTopic,
     private val nexonApiResponseTopic: NexonApiResponseTopic,
     private val snapshotRepository: CalculationSnapshotRepository,
+    private val dispatchService: CalculationDispatchService,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -141,42 +138,6 @@ class CalculationJobService(
         }
     }
 
-    // ===== Consolidated Pipeline Methods (ExternalApiWorker) =====
-
-    @Transactional(value = "transactionManager", readOnly = false)
-    fun retryOcidResolvingJob(jobId: UUID, userIgn: String, presetNo: Int): Boolean {
-        val incremented = jobPort.incrementRetryForOcid(jobId, "OCID_RESOLVE_TIMEOUT")
-        if (incremented) {
-            pgmqClient.send(QueueNames.EXTERNAL_API, ExternalApiJobPayload(jobId.toString(), userIgn, presetNo))
-        }
-        return incremented
-    }
-
-    @Transactional(value = "transactionManager", readOnly = false)
-    fun retryApiRequestedJob(jobId: UUID, userIgn: String, presetNo: Int): Boolean {
-        val incremented = jobPort.incrementRetry(jobId, "EXTERNAL_API_TIMEOUT")
-        if (incremented) {
-            pgmqClient.send(QueueNames.EXTERNAL_API, ExternalApiJobPayload(jobId.toString(), userIgn, presetNo))
-        }
-        return incremented
-    }
-
-    @Transactional(value = "transactionManager", readOnly = false)
-    fun dispatchToExternalApi(jobId: UUID, userIgn: String, presetNo: Int) {
-        val transitioned = jobPort.transitionStatus(
-            jobId,
-            CalculationJobStatus.REQUESTED,
-            CalculationJobStatus.OCID_RESOLVING,
-        )
-        if (!transitioned) {
-            log.warn("[jobId={}] Cannot transition to OCID_RESOLVING", jobId)
-            return
-        }
-
-        pgmqClient.send(QueueNames.EXTERNAL_API, ExternalApiJobPayload(jobId.toString(), userIgn, presetNo))
-        log.info("[jobId={}] Dispatched to consolidated external API pipeline", jobId)
-    }
-
     @Transactional(value = "transactionManager", readOnly = false)
     fun resolveOcidInPlace(jobId: UUID, ocid: String): Boolean = jobPort.resolveOcidAndTransition(jobId, ocid)
 
@@ -190,56 +151,27 @@ class CalculationJobService(
         return jobPort.markSnapshotReady(jobId, snapshotId, CalculationJobStatus.API_REQUESTED)
     }
 
-    @Transactional(value = "transactionManager", readOnly = false)
+    fun retryOcidResolvingJob(jobId: UUID, userIgn: String, presetNo: Int): Boolean =
+        dispatchService.retryOcidResolvingJob(jobId, userIgn, presetNo)
+
+    fun retryApiRequestedJob(jobId: UUID, userIgn: String, presetNo: Int): Boolean =
+        dispatchService.retryApiRequestedJob(jobId, userIgn, presetNo)
+
+    fun dispatchToExternalApi(jobId: UUID, userIgn: String, presetNo: Int) {
+        dispatchService.dispatchToExternalApi(jobId, userIgn, presetNo)
+    }
+
+    fun dispatchCalculationCompleted(payload: CalculationCompletedPayload) {
+        dispatchService.dispatchCalculationCompleted(payload)
+    }
+
     fun saveInputSnapshotAndDispatchCalculation(
         snapshotEntity: CalculationSnapshotEntity,
         jobId: UUID,
         snapshotId: UUID,
         payload: CalculationRequestedPayload,
-    ): Boolean {
-        snapshotRepository.save(snapshotEntity)
-        val ready = jobPort.markSnapshotReady(jobId, snapshotId, CalculationJobStatus.API_REQUESTED)
-        if (!ready) {
-            log.warn("[jobId={}] Cannot mark SNAPSHOT_READY before calculation dispatch", jobId)
-            return false
-        }
-        pgmqClient.send(QueueNames.CALCULATION_REQUESTED, payload)
-        log.info("[jobId={}] Calculation requested", jobId)
-        return true
-    }
+    ): Boolean = dispatchService.saveInputSnapshotAndDispatchCalculation(snapshotEntity, jobId, snapshotId, payload)
 
-    @Transactional(value = "transactionManager", readOnly = false)
-    fun dispatchCalculationCompleted(payload: CalculationCompletedPayload) {
-        pgmqClient.send(QueueNames.CALCULATION_COMPLETED, payload)
-        log.info("[jobId={}] Calculation completed payload dispatched", payload.jobId)
-    }
-
-    @Transactional(value = "transactionManager", readOnly = false)
-    fun retryExternalApiJob(jobId: UUID, errorCode: String = "EXTERNAL_API_ERROR"): Boolean {
-        val job = jobPort.findJobById(jobId) ?: return false
-        if (job.retryCount >= job.maxRetries) {
-            jobPort.markFailed(jobId, errorCode, "Max retries exceeded")
-            log.warn("[jobId={}] External API failed after {} retries", jobId, job.retryCount)
-            return true
-        }
-        val incremented = when (job.status) {
-            CalculationJobStatus.OCID_RESOLVING -> jobPort.incrementRetryForOcid(jobId, errorCode)
-            CalculationJobStatus.API_REQUESTED,
-            CalculationJobStatus.RETRYING,
-            -> jobPort.incrementRetry(jobId, errorCode)
-            CalculationJobStatus.REQUESTED -> jobPort.transitionStatus(
-                jobId,
-                CalculationJobStatus.REQUESTED,
-                CalculationJobStatus.OCID_RESOLVING,
-            )
-            else -> false
-        }
-        if (!incremented) {
-            log.warn("[jobId={}] External API retry not scheduled from state {}", jobId, job.status)
-            return false
-        }
-        pgmqClient.send(QueueNames.EXTERNAL_API, ExternalApiJobPayload(job.jobId.toString(), job.userIgn, job.presetNo))
-        log.info("[jobId={}] External API retry scheduled (attempt {})", jobId, job.retryCount + 1)
-        return true
-    }
+    fun retryExternalApiJob(jobId: UUID, errorCode: String = "EXTERNAL_API_ERROR"): Boolean =
+        dispatchService.retryExternalApiJob(jobId, errorCode)
 }

--- a/module-infra/src/test/kotlin/maple/expectation/infrastructure/job/CalculationDispatchServiceTest.kt
+++ b/module-infra/src/test/kotlin/maple/expectation/infrastructure/job/CalculationDispatchServiceTest.kt
@@ -1,0 +1,207 @@
+package maple.expectation.infrastructure.job
+
+import java.util.UUID
+import maple.expectation.core.model.job.CalculationJob
+import maple.expectation.core.model.job.CalculationJobStatus
+import maple.expectation.core.port.out.CalculationJobPort
+import maple.expectation.infrastructure.persistence.entity.CalculationSnapshotEntity
+import maple.expectation.infrastructure.persistence.repository.CalculationSnapshotRepository
+import maple.expectation.infrastructure.pgmq.CalculationCompletedPayload
+import maple.expectation.infrastructure.pgmq.CalculationRequestedPayload
+import maple.expectation.infrastructure.pgmq.ExternalApiJobPayload
+import maple.expectation.infrastructure.pgmq.PgmqClient
+import maple.expectation.infrastructure.queue.QueueNames
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@ExtendWith(MockitoExtension::class)
+class CalculationDispatchServiceTest {
+
+    @Mock lateinit var jobPort: CalculationJobPort
+    @Mock lateinit var pgmqClient: PgmqClient
+    @Mock lateinit var snapshotRepository: CalculationSnapshotRepository
+
+    private lateinit var service: CalculationDispatchService
+
+    @BeforeEach
+    fun setUp() {
+        service = CalculationDispatchService(jobPort, pgmqClient, snapshotRepository)
+    }
+
+    @Test
+    fun `retryOcidResolvingJob sends external API payload when retry increments`() {
+        val job = job()
+        whenever(jobPort.incrementRetryForOcid(job.jobId, "OCID_RESOLVE_TIMEOUT")).thenReturn(true)
+
+        val result = service.retryOcidResolvingJob(job.jobId, job.userIgn, job.presetNo)
+
+        assertThat(result).isTrue()
+        verify(pgmqClient).send(QueueNames.EXTERNAL_API, ExternalApiJobPayload(job.jobId.toString(), job.userIgn, job.presetNo))
+    }
+
+    @Test
+    fun `retryOcidResolvingJob does not send when retry fails`() {
+        val job = job()
+        whenever(jobPort.incrementRetryForOcid(job.jobId, "OCID_RESOLVE_TIMEOUT")).thenReturn(false)
+
+        val result = service.retryOcidResolvingJob(job.jobId, job.userIgn, job.presetNo)
+
+        assertThat(result).isFalse()
+        verify(pgmqClient, never()).send(eq(QueueNames.EXTERNAL_API), any<ExternalApiJobPayload>())
+    }
+
+    @Test
+    fun `retryApiRequestedJob sends external API payload when retry increments`() {
+        val job = job()
+        whenever(jobPort.incrementRetry(job.jobId, "EXTERNAL_API_TIMEOUT")).thenReturn(true)
+
+        val result = service.retryApiRequestedJob(job.jobId, job.userIgn, job.presetNo)
+
+        assertThat(result).isTrue()
+        verify(pgmqClient).send(QueueNames.EXTERNAL_API, ExternalApiJobPayload(job.jobId.toString(), job.userIgn, job.presetNo))
+    }
+
+    @Test
+    fun `dispatchToExternalApi sends payload when transition succeeds`() {
+        val job = job()
+        whenever(jobPort.transitionStatus(job.jobId, CalculationJobStatus.REQUESTED, CalculationJobStatus.OCID_RESOLVING)).thenReturn(true)
+
+        service.dispatchToExternalApi(job.jobId, job.userIgn, job.presetNo)
+
+        verify(pgmqClient).send(QueueNames.EXTERNAL_API, ExternalApiJobPayload(job.jobId.toString(), job.userIgn, job.presetNo))
+    }
+
+    @Test
+    fun `dispatchToExternalApi does not send when transition fails`() {
+        val job = job()
+        whenever(jobPort.transitionStatus(job.jobId, CalculationJobStatus.REQUESTED, CalculationJobStatus.OCID_RESOLVING)).thenReturn(false)
+
+        service.dispatchToExternalApi(job.jobId, job.userIgn, job.presetNo)
+
+        verify(pgmqClient, never()).send(eq(QueueNames.EXTERNAL_API), any<ExternalApiJobPayload>())
+    }
+
+    @Test
+    fun `dispatchCalculationCompleted sends to CALCULATION_COMPLETED queue`() {
+        val payload = makeCompletedPayload(jobId = "job-1")
+
+        service.dispatchCalculationCompleted(payload)
+
+        verify(pgmqClient).send(QueueNames.CALCULATION_COMPLETED, payload)
+    }
+
+    @Test
+    fun `saveInputSnapshotAndDispatchCalculation saves snapshot and dispatches when mark ready succeeds`() {
+        val job = job()
+        val entity = makeSnapshotEntity(jobId = job.jobId)
+        val payload = makeRequestedPayload(jobId = job.jobId.toString(), userIgn = job.userIgn, presetNo = job.presetNo)
+        whenever(jobPort.markSnapshotReady(job.jobId, entity.snapshotId, CalculationJobStatus.API_REQUESTED)).thenReturn(true)
+
+        val result = service.saveInputSnapshotAndDispatchCalculation(entity, job.jobId, entity.snapshotId, payload)
+
+        assertThat(result).isTrue()
+        verify(snapshotRepository).save(entity)
+        verify(jobPort).markSnapshotReady(job.jobId, entity.snapshotId, CalculationJobStatus.API_REQUESTED)
+        verify(pgmqClient).send(QueueNames.CALCULATION_REQUESTED, payload)
+    }
+
+    @Test
+    fun `saveInputSnapshotAndDispatchCalculation does not dispatch when mark ready fails`() {
+        val job = job()
+        val entity = makeSnapshotEntity(jobId = job.jobId)
+        val payload = makeRequestedPayload(jobId = job.jobId.toString(), userIgn = job.userIgn, presetNo = job.presetNo)
+        whenever(jobPort.markSnapshotReady(job.jobId, entity.snapshotId, CalculationJobStatus.API_REQUESTED)).thenReturn(false)
+
+        val result = service.saveInputSnapshotAndDispatchCalculation(entity, job.jobId, entity.snapshotId, payload)
+
+        assertThat(result).isFalse()
+        verify(snapshotRepository).save(entity)
+        verify(pgmqClient, never()).send(eq(QueueNames.CALCULATION_REQUESTED), any<CalculationRequestedPayload>())
+    }
+
+    @Test
+    fun `retryExternalApiJob increments OCID retry when job is OCID_RESOLVING`() {
+        val job = job(status = CalculationJobStatus.OCID_RESOLVING)
+        whenever(jobPort.findJobById(job.jobId)).thenReturn(job)
+        whenever(jobPort.incrementRetryForOcid(job.jobId, "OCID_RESOLVE_ERROR")).thenReturn(true)
+
+        val result = service.retryExternalApiJob(job.jobId, "OCID_RESOLVE_ERROR")
+
+        assertThat(result).isTrue()
+        verify(jobPort).incrementRetryForOcid(job.jobId, "OCID_RESOLVE_ERROR")
+        verify(pgmqClient).send(QueueNames.EXTERNAL_API, ExternalApiJobPayload(job.jobId.toString(), job.userIgn, job.presetNo))
+    }
+
+    @Test
+    fun `retryExternalApiJob marks exhausted job failed when retries exceeded`() {
+        val job = job(status = CalculationJobStatus.API_REQUESTED, retryCount = 3, maxRetries = 3)
+        whenever(jobPort.findJobById(job.jobId)).thenReturn(job)
+
+        val result = service.retryExternalApiJob(job.jobId)
+
+        assertThat(result).isTrue()
+        verify(jobPort).markFailed(job.jobId, "EXTERNAL_API_ERROR", "Max retries exceeded")
+        verify(pgmqClient, never()).send(eq(QueueNames.EXTERNAL_API), any<ExternalApiJobPayload>())
+    }
+
+    @Test
+    fun `retryExternalApiJob returns false for non-processable job status`() {
+        val job = job(status = CalculationJobStatus.COMPLETED)
+        whenever(jobPort.findJobById(job.jobId)).thenReturn(job)
+
+        val result = service.retryExternalApiJob(job.jobId)
+
+        assertThat(result).isFalse()
+        verify(jobPort, never()).markFailed(eq(job.jobId), any(), any())
+        verify(pgmqClient, never()).send(eq(QueueNames.EXTERNAL_API), any<ExternalApiJobPayload>())
+    }
+
+    private fun job(
+        status: CalculationJobStatus = CalculationJobStatus.REQUESTED,
+        ocid: String? = null,
+        retryCount: Int = 0,
+        maxRetries: Int = 3,
+    ) = CalculationJob(
+        jobId = UUID.randomUUID(),
+        ocid = ocid,
+        userIgn = "test-character",
+        presetNo = 1,
+        status = status,
+        retryCount = retryCount,
+        maxRetries = maxRetries,
+    )
+
+    private fun makeSnapshotEntity(jobId: UUID) = CalculationSnapshotEntity(
+        jobId = jobId,
+        objectKey = "test-key",
+        expiresAt = java.time.Instant.now().plusSeconds(60),
+    )
+
+    private fun makeCompletedPayload(jobId: String) = CalculationCompletedPayload(
+        jobId = jobId,
+        characterId = "char-1",
+        characterClass = "WARRIOR",
+        presetNo = 1,
+        gzipData = ByteArray(0),
+        hash = "hash-1",
+        originalSize = 0,
+        compressedSize = 0,
+    )
+
+    private fun makeRequestedPayload(jobId: String, userIgn: String, presetNo: Int) = CalculationRequestedPayload(
+        jobId = jobId,
+        userIgn = userIgn,
+        presetNo = presetNo,
+        characterId = "char-1",
+        characterClass = "WARRIOR",
+    )
+}

--- a/module-infra/src/test/kotlin/maple/expectation/infrastructure/job/CalculationJobServiceTest.kt
+++ b/module-infra/src/test/kotlin/maple/expectation/infrastructure/job/CalculationJobServiceTest.kt
@@ -1,26 +1,18 @@
 package maple.expectation.infrastructure.job
 
 import java.util.UUID
-import maple.expectation.core.model.job.CalculationJob
-import maple.expectation.core.model.job.CalculationJobStatus
 import maple.expectation.core.port.out.CalculationJobPort
-import maple.expectation.infrastructure.queue.QueueNames
 import maple.expectation.core.port.out.mq.DomainEventAppender
 import maple.expectation.infrastructure.mq.pgmq.topic.NexonApiRequestTopic
 import maple.expectation.infrastructure.mq.pgmq.topic.NexonApiResponseTopic
 import maple.expectation.infrastructure.mq.pgmq.topic.OcidResolveTopic
 import maple.expectation.infrastructure.persistence.repository.CalculationSnapshotRepository
-import maple.expectation.infrastructure.pgmq.ExternalApiJobPayload
-import maple.expectation.infrastructure.pgmq.PgmqClient
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
-import org.mockito.kotlin.any
-import org.mockito.kotlin.eq
-import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -31,7 +23,7 @@ class CalculationJobServiceTest {
 
     @Mock lateinit var eventAppender: DomainEventAppender
 
-    @Mock lateinit var pgmqClient: PgmqClient
+    @Mock lateinit var dispatchService: CalculationDispatchService
 
     @Mock lateinit var ocidResolveTopic: OcidResolveTopic
 
@@ -48,107 +40,22 @@ class CalculationJobServiceTest {
         service = CalculationJobService(
             jobPort = jobPort,
             eventAppender = eventAppender,
-            pgmqClient = pgmqClient,
             ocidResolveTopic = ocidResolveTopic,
             nexonApiRequestTopic = nexonApiRequestTopic,
             nexonApiResponseTopic = nexonApiResponseTopic,
             snapshotRepository = snapshotRepository,
+            dispatchService = dispatchService,
         )
     }
 
     @Test
-    fun `retryExternalApiJob increments OCID retry when job is resolving OCID`() {
-        val job = job(status = CalculationJobStatus.OCID_RESOLVING)
-        whenever(jobPort.findJobById(job.jobId)).thenReturn(job)
-        whenever(jobPort.incrementRetryForOcid(job.jobId, "OCID_RESOLVE_ERROR")).thenReturn(true)
+    fun `retryExternalApiJob delegates to dispatchService`() {
+        val jobId = UUID.randomUUID()
+        whenever(dispatchService.retryExternalApiJob(jobId, "TEST_ERROR")).thenReturn(true)
 
-        val result = service.retryExternalApiJob(job.jobId, "OCID_RESOLVE_ERROR")
-
-        assertThat(result).isTrue()
-        verify(jobPort).incrementRetryForOcid(job.jobId, "OCID_RESOLVE_ERROR")
-        verify(jobPort, never()).incrementRetry(eq(job.jobId), any())
-        verify(pgmqClient).send(QueueNames.EXTERNAL_API, ExternalApiJobPayload(job.jobId.toString(), job.userIgn, job.presetNo))
-    }
-
-    @Test
-    fun `retryExternalApiJob increments API retry when job is API requested`() {
-        val job = job(status = CalculationJobStatus.API_REQUESTED, ocid = "ocid-1")
-        whenever(jobPort.findJobById(job.jobId)).thenReturn(job)
-        whenever(jobPort.incrementRetry(job.jobId, "EXTERNAL_API_ERROR")).thenReturn(true)
-
-        val result = service.retryExternalApiJob(job.jobId)
+        val result = service.retryExternalApiJob(jobId, "TEST_ERROR")
 
         assertThat(result).isTrue()
-        verify(jobPort).incrementRetry(job.jobId, "EXTERNAL_API_ERROR")
-        verify(jobPort, never()).incrementRetryForOcid(eq(job.jobId), any())
-        verify(pgmqClient).send(QueueNames.EXTERNAL_API, ExternalApiJobPayload(job.jobId.toString(), job.userIgn, job.presetNo))
+        verify(dispatchService).retryExternalApiJob(jobId, "TEST_ERROR")
     }
-
-    @Test
-    fun `retryExternalApiJob stores provided API error code`() {
-        val job = job(status = CalculationJobStatus.API_REQUESTED, ocid = "ocid-1")
-        whenever(jobPort.findJobById(job.jobId)).thenReturn(job)
-        whenever(jobPort.incrementRetry(job.jobId, "NEXON_RATE_LIMITED")).thenReturn(true)
-
-        val result = service.retryExternalApiJob(job.jobId, "NEXON_RATE_LIMITED")
-
-        assertThat(result).isTrue()
-        verify(jobPort).incrementRetry(job.jobId, "NEXON_RATE_LIMITED")
-        verify(pgmqClient).send(QueueNames.EXTERNAL_API, ExternalApiJobPayload(job.jobId.toString(), job.userIgn, job.presetNo))
-    }
-
-    @Test
-    fun `retryExternalApiJob increments API retry when job is retrying`() {
-        val job = job(status = CalculationJobStatus.RETRYING, ocid = "ocid-1", retryCount = 1)
-        whenever(jobPort.findJobById(job.jobId)).thenReturn(job)
-        whenever(jobPort.incrementRetry(job.jobId, "EXTERNAL_API_ERROR")).thenReturn(true)
-
-        val result = service.retryExternalApiJob(job.jobId)
-
-        assertThat(result).isTrue()
-        verify(jobPort).incrementRetry(job.jobId, "EXTERNAL_API_ERROR")
-        verify(jobPort, never()).incrementRetryForOcid(eq(job.jobId), any())
-        verify(pgmqClient).send(QueueNames.EXTERNAL_API, ExternalApiJobPayload(job.jobId.toString(), job.userIgn, job.presetNo))
-    }
-
-    @Test
-    fun `retryExternalApiJob marks exhausted job failed and archives current message`() {
-        val job = job(status = CalculationJobStatus.API_REQUESTED, retryCount = 3, maxRetries = 3)
-        whenever(jobPort.findJobById(job.jobId)).thenReturn(job)
-
-        val result = service.retryExternalApiJob(job.jobId)
-
-        assertThat(result).isTrue()
-        verify(jobPort).markFailed(job.jobId, "EXTERNAL_API_ERROR", "Max retries exceeded")
-        verify(pgmqClient, never()).send(eq(QueueNames.EXTERNAL_API), any<ExternalApiJobPayload>())
-    }
-
-    @Test
-    fun `retryExternalApiJob returns false for non external API processable job`() {
-        val job = job(status = CalculationJobStatus.COMPLETED)
-        whenever(jobPort.findJobById(job.jobId)).thenReturn(job)
-
-        val result = service.retryExternalApiJob(job.jobId)
-
-        assertThat(result).isFalse()
-        verify(jobPort, never()).incrementRetry(eq(job.jobId), any())
-        verify(jobPort, never()).incrementRetryForOcid(eq(job.jobId), any())
-        verify(jobPort, never()).markFailed(eq(job.jobId), any(), any())
-        verify(pgmqClient, never()).send(eq(QueueNames.EXTERNAL_API), any<ExternalApiJobPayload>())
-    }
-
-    private fun job(
-        status: CalculationJobStatus,
-        ocid: String? = null,
-        retryCount: Int = 0,
-        maxRetries: Int = 3,
-    ) = CalculationJob(
-        jobId = UUID.randomUUID(),
-        ocid = ocid,
-        userIgn = "test-character",
-        presetNo = 1,
-        status = status,
-        retryCount = retryCount,
-        maxRetries = maxRetries,
-    )
 }


### PR DESCRIPTION
## Summary
Extract 6 PGMQ-dispatch methods from `CalculationJobService` into a new `CalculationDispatchService` (step 1 of 2). `CalculationJobService` delegates to the new service via 1-line wrappers.

## Files
- Created: `job/CalculationDispatchService.kt` (3 deps, 6 methods with `@Transactional`) + tests (11 cases)
- Modified: `job/CalculationJobService.kt` — swap `pgmqClient` for `dispatchService`; 6 methods become 1-line delegates (no `@Transactional` per grill-me correction)
- Modified: `test/.../CalculationJobServiceTest.kt` — 5 old `retryExternalApiJob` tests deleted, replaced with 1 delegation test; `pgmqClient` mock swapped for `dispatchService` mock

## Behavior
Zero behavioral change. All 6 method bodies moved verbatim (logic identical to original). 4 caller files unchanged:
- `CalculationJobTimeoutScanner` — calls `retryOcidResolvingJob` / `retryApiRequestedJob`
- `CalculationRequestedWorker` — calls `dispatchCalculationCompleted`
- `AbstractExpectationCalcWorker` — calls `dispatchToExternalApi`
- `ExternalApiWorker` — calls `saveInputSnapshotAndDispatchCalculation` / `retryExternalApiJob`

## Notes
- **Field count**: 7 fields in `CalculationJobService` (was 7 — swapped `pgmqClient` for `dispatchService`). The issue text says "6 fields" but the delegation pattern requires the new field; spec §1 acknowledges this.
- **`@Transactional` placement**: 6 methods have it on the dispatch service only. Delegator methods omit it (self-invocation would make it a no-op anyway, and removing it prevents confusion).
- **Test count**: 11 in `CalculationDispatchServiceTest` (one more than plan's 10 — extra coverage on `retryExternalApiJob` non-processable path).

## Step 2 (out of scope, future PR)
- Migrate callers to inject `CalculationDispatchService` directly
- Remove delegation methods from `CalculationJobService`

## Verification
- [x] `./gradlew :module-infra:compileKotlin compileJava --continue` passes
- [x] `./gradlew :module-infra:test` passes
- [x] `./gradlew compileKotlin compileJava --continue` passes (full repo)
- [x] All 6 dispatch methods verified byte-identical to original
- [x] All 4 caller files unchanged (verified via `git diff`)

Closes #1073

🤖 Generated with [Claude Code](https://claude.com/claude-code)