### PR TITLE
refactor(synchronizer): add ChunkPipelineOrchestrator (PR2 of #990)

### DIFF
--- a/docs/01_ADR/ADR-026-chunk-pipeline-orchestrator.md
+++ b/docs/01_ADR/ADR-026-chunk-pipeline-orchestrator.md
@@ -1,0 +1,83 @@
+# ADR-026: Chunk Pipeline Orchestrator + Thin Delegate
+
+- Status: Accepted
+- Date: 2026-06-07
+- Owner: synchronizer
+
+---
+
+## 1. Background / Problem
+
+### Background
+
+`DefaultChunkProcessor` mixes stage chain assembly with aggregate metrics in a single method. Issue #990 (PR2 of the #1143 stage-split) wants explicit stage chain assembly.
+
+### Problem
+
+- `DefaultChunkProcessor` is 38 lines today (down from 71 post-#1143), but the orchestration logic is still inline: read → transform → metrics → write.
+- Aggregate metrics (`incrementDocuments`, `incrementItems`, `recordChunkSize`, `recordDocumentEquipment`) live in the processor — they are pipeline concerns, not stage concerns.
+- Adding a new stage requires editing `DefaultChunkProcessor` directly.
+
+### Goal
+
+Extract pipeline assembly to a dedicated component. Keep behavior identical. Backward compatible with the existing `ChunkProcessor` interface consumer (`KafkaResultChunkConsumer`).
+
+---
+
+## 2. Decision
+
+> Extract pipeline assembly to `ChunkPipelineOrchestrator`. Keep `DefaultChunkProcessor` as a 1-line `@Deprecated` delegate to preserve the `ChunkProcessor` contract that `KafkaResultChunkConsumer` depends on.
+
+```text
+KafkaResultChunkConsumer → ChunkProcessor (interface) → DefaultChunkProcessor (@Deprecated delegate) → ChunkPipelineOrchestrator
+                                                                                                       ├── ChunkDataReader
+                                                                                                       ├── ChunkDocumentTransformer
+                                                                                                       ├── ChunkDocumentWriter
+                                                                                                       └── SynchronizerMetrics
+```
+
+`ChunkPipelineOrchestrator` lives in `module-synchronizer/adapter/chunk/`. It takes the three existing stage beans and `SynchronizerMetrics` as constructor dependencies. Aggregate metrics move from the processor into the orchestrator. Per-stage timers stay inside the stage classes.
+
+---
+
+## 3. Trade-offs
+
+### Sensitivity
+
+* Future stage addition frequency (target: 0/quarter, expected 1-2/quarter)
+* Number of stages in the chain (currently 3)
+* Bean wiring count for `ChunkProcessor` interface consumers
+
+### Trade-off
+
+| 선택 | 얻는 것 | 포기한 것 |
+| -- | ---- | ----- |
+| Orchestrator + thin delegate (this PR) | Backward compat, no consumer change, isolated blast radius | Two beans for one job until follow-up removal |
+| Full removal of `DefaultChunkProcessor` | One bean, single source of truth | Touches `KafkaResultChunkConsumer` and the `ChunkProcessor` interface, wider diff |
+| Port interface migration (full spec PR2) | Generic stage composition across modules | Requires all 3 stage classes to be `suspend` + change signatures |
+
+### Risk
+
+* Two beans (`DefaultChunkProcessor` + `ChunkPipelineOrchestrator`) doing the same thing for some time — mitigated by `@Deprecated` on the delegate and a follow-up removal issue.
+* Spring autowires `ChunkProcessor` → `DefaultChunkProcessor` by interface. If both are registered, ambiguity. Verified: only `DefaultChunkProcessor` implements `ChunkProcessor`, so single binding.
+* `BasicChunkIngestionService` is a separate code path (uses `fileReader.readInBatches` + `repository.bulkUpsert` + `upsertOcidFromBasicRecords`); not affected by this ADR.
+
+### Non-Risk
+
+* Stage class internals unchanged.
+* `ChunkProcessor` interface unchanged.
+* `ChunkProcessInput` / `ChunkProcessResult` / `TransformResult` types unchanged.
+* Concurrency model (Semaphore, executor) unchanged.
+* JSON serialization / metrics emission surface unchanged (same metric methods, same args).
+
+---
+
+## 4. Result / Evidence
+
+To be filled after merge: test counts, line counts, follow-up issue opened.
+
+---
+
+## 5. Summary
+
+> Add `ChunkPipelineOrchestrator` and reduce `DefaultChunkProcessor` to a 1-line `@Deprecated` delegate. Port interface migration deferred to a follow-up issue.

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/adapter/chunk/ChunkPipelineOrchestrator.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/adapter/chunk/ChunkPipelineOrchestrator.kt
@@ -1,0 +1,53 @@
+package maple.synchronizer.adapter.chunk
+
+import maple.core.domain.chunk.ChunkProcessInput
+import maple.synchronizer.metrics.SynchronizerMetrics
+import maple.synchronizer.processor.ChunkDataReader
+import maple.synchronizer.processor.ChunkDocumentTransformer
+import maple.synchronizer.processor.ChunkDocumentWriter
+import maple.synchronizer.processor.ChunkProcessResult
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+/**
+ * Pipeline orchestrator that runs the chunk stage chain in order:
+ *   read (file + ocid resolve) → transform (build + prepare) → write (upsert + ranking).
+ *
+ * Each stage is a Spring `@Component` injected as a constructor dependency. Stage-specific
+ * timers stay inside the stages; this orchestrator records only the aggregate metrics
+ * (documents, items, chunk size, per-document equipment).
+ */
+@Component
+class ChunkPipelineOrchestrator(
+    private val dataReader: ChunkDataReader,
+    private val transformer: ChunkDocumentTransformer,
+    private val writer: ChunkDocumentWriter,
+    private val metrics: SynchronizerMetrics,
+) {
+    private val log = LoggerFactory.getLogger(ChunkPipelineOrchestrator::class.java)
+
+    fun execute(input: ChunkProcessInput): ChunkProcessResult {
+        val grouped = dataReader.read(input.objectKey)
+
+        val transformResult = transformer.transform(input.sourceRunId, input.sourceChunkId, grouped)
+
+        log.info(
+            "[Synchronizer] grouped {} results into {} documents",
+            input.resultCount,
+            transformResult.documentCount,
+        )
+
+        metrics.incrementDocuments(transformResult.documentCount)
+        metrics.incrementItems(transformResult.itemCount)
+        metrics.recordChunkSize(transformResult.documentCount, transformResult.itemCount)
+        transformResult.prepped.forEach { metrics.recordDocumentEquipment(it.equipmentCount) }
+
+        writer.write(input.sourceRunId, input.sourceChunkId, transformResult.prepped)
+
+        return ChunkProcessResult(
+            documentCount = transformResult.documentCount,
+            itemCount = transformResult.itemCount,
+            jsonRowCount = input.resultCount.toLong(),
+        )
+    }
+}

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/processor/DefaultChunkProcessor.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/processor/DefaultChunkProcessor.kt
@@ -1,38 +1,24 @@
 package maple.synchronizer.processor
 
 import maple.core.domain.chunk.ChunkProcessInput
-import maple.synchronizer.metrics.SynchronizerMetrics
-import org.slf4j.LoggerFactory
+import maple.synchronizer.adapter.chunk.ChunkPipelineOrchestrator
 import org.springframework.stereotype.Component
 
+/**
+ * Thin delegate to [ChunkPipelineOrchestrator]. Retained for backward compatibility with
+ * consumers that depend on the [ChunkProcessor] interface (e.g. `KafkaResultChunkConsumer`).
+ * New stage composition should happen in the orchestrator. To be removed in a follow-up
+ * issue once the consumer migrates to inject `ChunkPipelineOrchestrator` directly.
+ */
+@Deprecated(
+    message = "Use ChunkPipelineOrchestrator directly. This delegate will be removed.",
+    replaceWith = ReplaceWith("ChunkPipelineOrchestrator", "maple.synchronizer.adapter.chunk.ChunkPipelineOrchestrator"),
+)
 @Component
 class DefaultChunkProcessor(
-    private val dataReader: ChunkDataReader,
-    private val transformer: ChunkDocumentTransformer,
-    private val writer: ChunkDocumentWriter,
-    private val metrics: SynchronizerMetrics,
+    private val orchestrator: ChunkPipelineOrchestrator,
 ) : ChunkProcessor {
 
-    private val log = LoggerFactory.getLogger(DefaultChunkProcessor::class.java)
-
-    override fun process(input: ChunkProcessInput): ChunkProcessResult {
-        val grouped = dataReader.read(input.objectKey)
-
-        val transformResult = transformer.transform(input.sourceRunId, input.sourceChunkId, grouped)
-
-        log.info("[Synchronizer] grouped {} results into {} documents", input.resultCount, transformResult.documentCount)
-
-        metrics.incrementDocuments(transformResult.documentCount)
-        metrics.incrementItems(transformResult.itemCount)
-        metrics.recordChunkSize(transformResult.documentCount, transformResult.itemCount)
-        transformResult.prepped.forEach { metrics.recordDocumentEquipment(it.equipmentCount) }
-
-        writer.write(input.sourceRunId, input.sourceChunkId, transformResult.prepped)
-
-        return ChunkProcessResult(
-            documentCount = transformResult.documentCount,
-            itemCount = transformResult.itemCount,
-            jsonRowCount = input.resultCount.toLong(),
-        )
-    }
+    override fun process(input: ChunkProcessInput): ChunkProcessResult =
+        orchestrator.execute(input)
 }

--- a/module-synchronizer/src/test/kotlin/maple/synchronizer/adapter/chunk/ChunkPipelineOrchestratorTest.kt
+++ b/module-synchronizer/src/test/kotlin/maple/synchronizer/adapter/chunk/ChunkPipelineOrchestratorTest.kt
@@ -1,0 +1,185 @@
+package maple.synchronizer.adapter.chunk
+
+import maple.core.domain.chunk.ChunkProcessInput
+import maple.synchronizer.domain.CalculatedEquipmentItem
+import maple.synchronizer.domain.GroupedEquipmentResult
+import maple.synchronizer.metrics.SynchronizerMetrics
+import maple.synchronizer.preparer.PreppedDocument
+import maple.synchronizer.processor.ChunkDataReader
+import maple.synchronizer.processor.ChunkDocumentTransformer
+import maple.synchronizer.processor.ChunkDocumentWriter
+import maple.synchronizer.processor.TransformResult
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+
+class ChunkPipelineOrchestratorTest {
+
+    private val dataReader: ChunkDataReader = mock()
+    private val transformer: ChunkDocumentTransformer = mock()
+    private val writer: ChunkDocumentWriter = mock()
+    private val metrics: SynchronizerMetrics = mock()
+
+    private lateinit var orchestrator: ChunkPipelineOrchestrator
+
+    @BeforeEach
+    fun setUp() {
+        orchestrator = ChunkPipelineOrchestrator(dataReader, transformer, writer, metrics)
+    }
+
+    @Test
+    fun `execute - happy path returns result with correct counts`() {
+        val input = testInput()
+        val grouped = listOf(testGrouped())
+        val prepped = listOf<PreppedDocument>(mock())
+        val transformResult = TransformResult(documentCount = 1, itemCount = 1, prepped = prepped)
+
+        whenever(dataReader.read(any())).thenReturn(grouped)
+        whenever(transformer.transform(any(), any(), any())).thenReturn(transformResult)
+
+        val result = orchestrator.execute(input)
+
+        assertThat(result.documentCount).isEqualTo(1)
+        assertThat(result.itemCount).isEqualTo(1)
+        assertThat(result.jsonRowCount).isEqualTo(input.resultCount.toLong())
+    }
+
+    @Test
+    fun `execute - calls stages in order read then transform then write`() {
+        val input = testInput()
+        val grouped = listOf(testGrouped())
+        val prepped = listOf<PreppedDocument>(mock())
+        whenever(dataReader.read(any())).thenReturn(grouped)
+        whenever(transformer.transform(any(), any(), any()))
+            .thenReturn(TransformResult(1, 1, prepped))
+
+        orchestrator.execute(input)
+
+        verify(dataReader).read(eq(input.objectKey))
+        verify(transformer).transform(eq(input.sourceRunId), eq(input.sourceChunkId), eq(grouped))
+        verify(writer).write(eq(input.sourceRunId), eq(input.sourceChunkId), eq(prepped))
+    }
+
+    @Test
+    fun `execute - records aggregate metrics for documents and items`() {
+        val input = testInput()
+        val grouped = listOf(testGrouped())
+        val prepped = listOf<PreppedDocument>(mock(), mock(), mock())
+        whenever(dataReader.read(any())).thenReturn(grouped)
+        whenever(transformer.transform(any(), any(), any()))
+            .thenReturn(TransformResult(documentCount = 3, itemCount = 7, prepped = prepped))
+
+        orchestrator.execute(input)
+
+        verify(metrics).incrementDocuments(3)
+        verify(metrics).incrementItems(7L)
+        verify(metrics).recordChunkSize(3, 7L)
+        verify(metrics, org.mockito.kotlin.times(3))
+            .recordDocumentEquipment(org.mockito.kotlin.any())
+    }
+
+    @Test
+    fun `execute - propagates exception from reader`() {
+        val input = testInput()
+        val ex = RuntimeException("file read failed")
+        whenever(dataReader.read(any())).thenThrow(ex)
+
+        assertThatThrownBy { orchestrator.execute(input) }.isSameAs(ex)
+    }
+
+    @Test
+    fun `execute - propagates exception from writer`() {
+        val input = testInput()
+        val grouped = listOf(testGrouped())
+        val prepped = listOf<PreppedDocument>(mock())
+        whenever(dataReader.read(any())).thenReturn(grouped)
+        whenever(transformer.transform(any(), any(), any()))
+            .thenReturn(TransformResult(1, 1, prepped))
+        val ex = RuntimeException("DB connection failed")
+        whenever(writer.write(any(), any(), any())).thenThrow(ex)
+
+        assertThatThrownBy { orchestrator.execute(input) }.isSameAs(ex)
+    }
+
+    @Test
+    fun `execute - transformer exception prevents writer and skips metrics`() {
+        val input = testInput()
+        val grouped = listOf(testGrouped())
+        val ex = RuntimeException("transform failed")
+        whenever(dataReader.read(any())).thenReturn(grouped)
+        whenever(transformer.transform(any(), any(), any())).thenThrow(ex)
+
+        val thrown = runCatching { orchestrator.execute(input) }.exceptionOrNull()
+
+        assertThat(thrown).isSameAs(ex)
+        verify(writer, org.mockito.kotlin.never()).write(any(), any(), any())
+        verify(metrics, org.mockito.kotlin.never()).incrementDocuments(any())
+        verify(metrics, org.mockito.kotlin.never()).incrementItems(any())
+        verify(metrics, org.mockito.kotlin.never()).recordChunkSize(any(), any())
+        verify(metrics, org.mockito.kotlin.never()).recordDocumentEquipment(any())
+    }
+
+    @Test
+    fun `execute - empty prepped list records zero metrics and returns zero counts`() {
+        val input = testInput()
+        val grouped = listOf(testGrouped())
+        val transformResult = TransformResult(documentCount = 0, itemCount = 0, prepped = emptyList())
+        whenever(dataReader.read(any())).thenReturn(grouped)
+        whenever(transformer.transform(any(), any(), any())).thenReturn(transformResult)
+
+        val result = orchestrator.execute(input)
+
+        assertThat(result.documentCount).isEqualTo(0)
+        assertThat(result.itemCount).isEqualTo(0L)
+        verify(metrics).incrementDocuments(0)
+        verify(metrics).incrementItems(0L)
+        verify(metrics).recordChunkSize(0, 0L)
+        verify(metrics, org.mockito.kotlin.never()).recordDocumentEquipment(any())
+        verify(writer).write(any(), any(), any())
+    }
+
+    private fun testInput(
+        objectKey: String = "run1/chunk001.jsonl.gz",
+        resultCount: Int = 1,
+    ) = ChunkProcessInput(
+        objectKey = objectKey,
+        sourceRunId = "run-1",
+        sourceChunkId = "chunk-001",
+        resultCount = resultCount,
+    )
+
+    private fun testGrouped() = GroupedEquipmentResult(
+        readKey = "oc1:1",
+        ocid = "oc1",
+        presetNo = 1,
+        items = listOf(testItem()),
+    )
+
+    private fun testItem() = CalculatedEquipmentItem(
+        ocid = "oc1",
+        presetNo = 1,
+        itemName = "Test Sword",
+        itemLevel = 160,
+        itemPart = "Weapon",
+        itemEquipmentPart = "무기",
+        potentialGrade = "레전드리",
+        potentialOptions = listOf("공격력 +12%"),
+        additionalGrade = "에픽",
+        additionalOptions = listOf("STR +9%"),
+        currentStar = 17,
+        targetStar = 22,
+        status = "SUCCESS",
+        totalCost = BigDecimal("150000000000"),
+        blackCubeCost = BigDecimal("50000000000"),
+        additionalCubeCost = BigDecimal("30000000000"),
+        starforceCost = BigDecimal("70000000000"),
+        errorMessage = null,
+    )
+}

--- a/module-synchronizer/src/test/kotlin/maple/synchronizer/processor/DefaultChunkProcessorTest.kt
+++ b/module-synchronizer/src/test/kotlin/maple/synchronizer/processor/DefaultChunkProcessorTest.kt
@@ -1,95 +1,56 @@
 package maple.synchronizer.processor
 
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import maple.core.domain.chunk.ChunkProcessInput
+import maple.synchronizer.adapter.chunk.ChunkPipelineOrchestrator
 import maple.expectation.error.CommonErrorCode
 import maple.expectation.error.exception.ArtifactNotFoundException
-import maple.synchronizer.domain.CalculatedEquipmentItem
-import maple.synchronizer.domain.GroupedEquipmentResult
-import maple.synchronizer.metrics.SynchronizerMeterRegistry
-import maple.synchronizer.metrics.SynchronizerMetrics
-import maple.synchronizer.preparer.PreppedDocument
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
-import org.mockito.kotlin.doThrow
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import java.math.BigDecimal
 
 class DefaultChunkProcessorTest {
 
-    private val dataReader: ChunkDataReader = mock()
-    private val transformer: ChunkDocumentTransformer = mock()
-    private val writer: ChunkDocumentWriter = mock()
-    private val metrics = SynchronizerMetrics(SynchronizerMeterRegistry(SimpleMeterRegistry()))
-
+    private val orchestrator: ChunkPipelineOrchestrator = mock()
     private lateinit var chunkProcessor: DefaultChunkProcessor
 
     @BeforeEach
     fun setUp() {
-        chunkProcessor = DefaultChunkProcessor(dataReader, transformer, writer, metrics)
+        chunkProcessor = DefaultChunkProcessor(orchestrator)
     }
 
     @Test
-    fun `process - happy path returns result with correct counts`() {
+    fun `process - delegates to orchestrator and returns its result`() {
         val input = testInput()
-        val grouped = listOf(GroupedEquipmentResult(readKey = "oc1:1", ocid = "oc1", presetNo = 1, items = listOf(testItem())))
-        val prepped = listOf<PreppedDocument>(mock())
-        val transformResult = TransformResult(documentCount = 1, itemCount = 1, prepped = prepped)
-
-        whenever(dataReader.read(any())).thenReturn(grouped)
-        whenever(transformer.transform(any(), any(), any())).thenReturn(transformResult)
+        val expected = ChunkProcessResult(documentCount = 5, itemCount = 9, jsonRowCount = 100L)
+        whenever(orchestrator.execute(any())).thenReturn(expected)
 
         val result = chunkProcessor.process(input)
 
-        assertThat(result.documentCount).isEqualTo(1)
-        assertThat(result.itemCount).isEqualTo(1)
-        assertThat(result.jsonRowCount).isEqualTo(input.resultCount.toLong())
+        assertThat(result).isSameAs(expected)
+        verify(orchestrator).execute(input)
     }
 
     @Test
-    fun `process - calls writer with prepped documents`() {
+    fun `process - propagates ArtifactNotFoundException from orchestrator`() {
         val input = testInput()
-        val grouped = listOf(GroupedEquipmentResult(readKey = "oc1:1", ocid = "oc1", presetNo = 1, items = listOf(testItem())))
-        val prepped = listOf<PreppedDocument>(mock())
-        val transformResult = TransformResult(documentCount = 1, itemCount = 1, prepped = prepped)
-
-        whenever(dataReader.read(any())).thenReturn(grouped)
-        whenever(transformer.transform(any(), any(), any())).thenReturn(transformResult)
-
-        chunkProcessor.process(input)
-
-        verify(writer).write(eq(input.sourceRunId), eq(input.sourceChunkId), eq(prepped))
-    }
-
-    @Test
-    fun `process - file not found propagates ArtifactNotFoundException`() {
-        val input = testInput()
-        whenever(dataReader.read(any()))
+        whenever(orchestrator.execute(any()))
             .thenThrow(ArtifactNotFoundException(CommonErrorCode.ARTIFACT_NOT_FOUND, "ResultFileReader", "/tmp/missing"))
 
         assertThatThrownBy { chunkProcessor.process(input) }
             .isInstanceOf(ArtifactNotFoundException::class.java)
             .hasMessageContaining("ResultFileReader")
-            .hasMessageContaining("/tmp/missing")
     }
 
     @Test
-    fun `process - upsert failure propagates exception`() {
+    fun `process - propagates RuntimeException from orchestrator`() {
         val input = testInput()
-        val grouped = listOf(GroupedEquipmentResult(readKey = "oc1:1", ocid = "oc1", presetNo = 1, items = listOf(testItem())))
-        val prepped = listOf<PreppedDocument>(mock())
-        val transformResult = TransformResult(documentCount = 1, itemCount = 1, prepped = prepped)
-
-        whenever(dataReader.read(any())).thenReturn(grouped)
-        whenever(transformer.transform(any(), any(), any())).thenReturn(transformResult)
-        doThrow(RuntimeException("DB connection failed"))
-            .whenever(writer).write(any(), any(), any())
+        whenever(orchestrator.execute(any())).thenThrow(RuntimeException("DB connection failed"))
 
         assertThatThrownBy { chunkProcessor.process(input) }
             .isInstanceOf(RuntimeException::class.java)
@@ -97,55 +58,20 @@ class DefaultChunkProcessorTest {
     }
 
     @Test
-    fun `process - multiple groups produce multiple documents`() {
-        val input = testInput(resultCount = 3)
-        val grouped = listOf(
-            GroupedEquipmentResult(readKey = "oc1:1", ocid = "oc1", presetNo = 1, items = listOf(testItem(ocid = "oc1"))),
-            GroupedEquipmentResult(readKey = "oc2:1", ocid = "oc2", presetNo = 1, items = listOf(testItem(ocid = "oc2"), testItem(ocid = "oc2"))),
-        )
-        val prepped = listOf<PreppedDocument>(mock(), mock())
-        val transformResult = TransformResult(documentCount = 2, itemCount = 3, prepped = prepped)
+    fun `process - calls execute exactly once per process call`() {
+        val input = testInput()
+        whenever(orchestrator.execute(any())).thenReturn(ChunkProcessResult(0, 0, 0L))
 
-        whenever(dataReader.read(any())).thenReturn(grouped)
-        whenever(transformer.transform(any(), any(), any())).thenReturn(transformResult)
+        chunkProcessor.process(input)
+        chunkProcessor.process(input)
 
-        val result = chunkProcessor.process(input)
-
-        assertThat(result.documentCount).isEqualTo(2)
-        assertThat(result.itemCount).isEqualTo(3)
+        verify(orchestrator, times(2)).execute(input)
     }
 
-    private fun testInput(
-        objectKey: String = "run1/chunk001.jsonl.gz",
-        resultCount: Int = 1,
-    ) = ChunkProcessInput(
-        objectKey = objectKey,
+    private fun testInput() = ChunkProcessInput(
+        objectKey = "run1/chunk001.jsonl.gz",
         sourceRunId = "run-1",
         sourceChunkId = "chunk-001",
-        resultCount = resultCount,
-    )
-
-    private fun testItem(
-        ocid: String = "oc1",
-        presetNo: Int = 1,
-    ) = CalculatedEquipmentItem(
-        ocid = ocid,
-        presetNo = presetNo,
-        itemName = "Test Sword",
-        itemLevel = 160,
-        itemPart = "Weapon",
-        itemEquipmentPart = "무기",
-        potentialGrade = "레전드리",
-        potentialOptions = listOf("공격력 +12%"),
-        additionalGrade = "에픽",
-        additionalOptions = listOf("STR +9%"),
-        currentStar = 17,
-        targetStar = 22,
-        status = "SUCCESS",
-        totalCost = BigDecimal("150000000000"),
-        blackCubeCost = BigDecimal("50000000000"),
-        additionalCubeCost = BigDecimal("30000000000"),
-        starforceCost = BigDecimal("70000000000"),
-        errorMessage = null,
+        resultCount = 1,
     )
 }


### PR DESCRIPTION
## Summary
- New `ChunkPipelineOrchestrator` in `module-synchronizer/adapter/chunk/` (TDD, 7 unit tests covering happy path, stage ordering, metrics, 3 exception paths, empty prepped).
- `DefaultChunkProcessor` refactored to a 1-line `@Deprecated` delegate to the orchestrator (4 delegation tests). Backward compatible with `KafkaResultChunkConsumer` (which still injects `ChunkProcessor`).
- Aggregate metrics (documents, items, chunk size, per-doc equipment) moved from processor to orchestrator.
- Stage beans (`ChunkDataReader`, `ChunkDocumentTransformer`, `ChunkDocumentWriter`) unchanged.
- ADR-026 documents the orchestrator + thin delegate pattern.

## Acceptance criteria (#990)
- [x] Pipeline stage classes independent (read, build, persist) — already true post-#1143
- [x] `DefaultChunkProcessor` is thin (1-line `@Deprecated` delegate)
- [x] Behavior unchanged — `DefaultChunkProcessorTest` proves delegation, `ChunkPipelineOrchestratorTest` proves logic, `KafkaResultChunkConsumer` integration unchanged
- [x] `./gradlew compileKotlin compileJava --continue` passes
- [x] `./gradlew :module-synchronizer:test` passes (no regression)

## Spec
`docs/superpowers/specs/2026-06-06-chunk-stage-ports-design.md` §4, §6 PR2 (partial — orchestrator only; full port interface migration deferred)

## ADR
`docs/01_ADR/ADR-026-chunk-pipeline-orchestrator.md`

## Diff summary
```
docs/01_ADR/ADR-026-chunk-pipeline-orchestrator.md                  |  83 +++++++++
.../adapter/chunk/ChunkPipelineOrchestrator.kt                      |  53 ++++++
.../processor/DefaultChunkProcessor.kt                              |  42 ++---
.../adapter/chunk/ChunkPipelineOrchestratorTest.kt                  | 185 +++++++++++++++++++++
.../processor/DefaultChunkProcessorTest.kt                          | 118 +++----------
5 files changed, 357 insertions(+), 124 deletions(-)
```

## Out of scope (follow-up issues to file)
- **Port interface migration**: `ChunkDataReader` / `ChunkDocumentTransformer` / `ChunkDocumentWriter` do NOT yet implement `module-core/.../ChunkReader` / `ChunkTransformer` / `ChunkWriter`. This is full spec PR2, separate follow-up.
- **Removing `DefaultChunkProcessor`**: kept as a 1-line `@Deprecated` delegate. Full removal = future PR that updates `KafkaResultChunkConsumer` to inject `ChunkPipelineOrchestrator` directly.

## Issue
Closes #990

🤖 Generated with [Claude Code](https://claude.com/claude-code)