### PR TITLE
refactor: #989 extract ChunkFileManager from ChunkedSnapshotSink

### DIFF
--- a/module-external-api/src/main/kotlin/maple/externalapi/snapshot/ChunkFileManager.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/snapshot/ChunkFileManager.kt
@@ -1,0 +1,120 @@
+package maple.externalapi.snapshot
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.slf4j.LoggerFactory
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Clock
+import java.time.Instant
+
+/**
+ * Owns every filesystem concern of a snapshot-sink run:
+ *  - chunk directory layout (chunks/, failed.jsonl, manifest.json, _SUCCESS, _RUNNING)
+ *  - the [SnapshotChunkManifest] for the run
+ *  - the active [GzipJsonlChunkWriter] and rotation
+ *  - the [SnapshotFailedRecordWriter] for failure records
+ *
+ * **Thread-affinity:** NOT thread-safe. All methods must be called from the
+ * sink's single writer thread. The class does not perform its own locking.
+ *
+ * @param runDir  the run directory (e.g. `runs/<runId>`)
+ * @param endpoint the API endpoint name (used as subdirectory)
+ * @param maxRecords max records per chunk before rotation
+ * @param maxUncompressedBytes hard cap per uncompressed chunk
+ * @param objectMapper Jackson mapper for manifest and failure lines
+ * @param clock injected clock for deterministic timestamps
+ */
+class ChunkFileManager(
+    private val runDir: Path,
+    private val endpoint: String,
+    private val maxRecords: Int,
+    private val maxUncompressedBytes: Long,
+    private val objectMapper: ObjectMapper,
+    private val clock: Clock = Clock.systemUTC(),
+) {
+    private val log = LoggerFactory.getLogger(ChunkFileManager::class.java)
+
+    val chunksDir: Path = runDir.resolve(endpoint).resolve("chunks")
+    private val failedPath: Path = runDir.resolve(endpoint).resolve("failed.jsonl")
+    private val manifestPath: Path = runDir.resolve(endpoint).resolve("manifest.json")
+    private val successPath: Path = runDir.resolve(endpoint).resolve("_SUCCESS")
+    private val runningMarker: Path = runDir.resolve("_RUNNING")
+
+    private val manifest = SnapshotChunkManifest(
+        runId = runDir.fileName.toString(),
+        endpoint = endpoint,
+        startedAt = Instant.now(clock),
+    )
+
+    private val failedWriter = SnapshotFailedRecordWriter(failedPath, objectMapper)
+    private var currentWriter: GzipJsonlChunkWriter
+    private var nextPartIndex = 2
+
+    init {
+        Files.createDirectories(chunksDir)
+        Files.createDirectories(failedPath.parent)
+        currentWriter = newChunkWriter(1)
+    }
+
+    fun appendSuccess(record: SnapshotChunkRecord.Success): ChunkStats? {
+        currentWriter.append(record)
+        manifest.totalRecords++
+        if (currentWriter.shouldRotate()) {
+            return rotateChunk()
+        }
+        return null
+    }
+
+    fun appendFailure(record: SnapshotChunkRecord.Failure) {
+        failedWriter.append(record)
+    }
+
+    fun rotateChunk(): ChunkStats? {
+        val stats = currentWriter.close()
+        if (stats.recordCount > 0) {
+            manifest.chunks.add(toEntry(stats))
+        }
+        currentWriter = newChunkWriter(nextPartIndex++)
+        return stats.takeIf { it.recordCount > 0 }
+    }
+
+    fun closeCurrentChunk(): ChunkStats? {
+        val stats = currentWriter.close()
+        if (stats.recordCount > 0) {
+            manifest.chunks.add(toEntry(stats))
+        }
+        return stats.takeIf { it.recordCount > 0 }
+    }
+
+    fun cleanupOnFailure() {
+        currentWriter.deleteTmp()
+        log.warn("[ChunkFileManager] cleaned up .tmp files after failure")
+    }
+
+    fun writeManifestAndSuccessMarker() {
+        manifest.totalFailed = failedWriter.count()
+        manifest.finishedAt = Instant.now(clock)
+        SnapshotChunkManifestWriter(manifestPath, objectMapper).write(manifest)
+        Files.writeString(successPath, "")
+    }
+
+    fun deleteRunningMarker() {
+        if (Files.exists(runningMarker)) {
+            Files.delete(runningMarker)
+        }
+    }
+
+    fun manifest(): SnapshotChunkManifest = manifest
+
+    private fun newChunkWriter(partIndex: Int): GzipJsonlChunkWriter =
+        GzipJsonlChunkWriter(chunksDir, partIndex, maxRecords, maxUncompressedBytes, objectMapper, clock)
+
+    private fun toEntry(stats: ChunkStats): ChunkEntry = ChunkEntry(
+        path = stats.path,
+        recordCount = stats.recordCount,
+        uncompressedBytes = stats.uncompressedBytes,
+        compressedBytes = stats.compressedBytes,
+        startedAt = stats.startedAt,
+        finishedAt = stats.finishedAt,
+    )
+}

--- a/module-external-api/src/main/kotlin/maple/externalapi/snapshot/ChunkedSnapshotSink.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/snapshot/ChunkedSnapshotSink.kt
@@ -1,11 +1,7 @@
 package maple.externalapi.snapshot
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import org.slf4j.LoggerFactory
-import java.nio.file.Files
 import java.nio.file.Path
-import java.time.Clock
-import java.time.Instant
 import java.util.concurrent.ArrayBlockingQueue
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
@@ -17,42 +13,18 @@ import java.util.concurrent.atomic.AtomicReference
 class ChunkedSnapshotSink(
     private val runDir: Path,
     private val endpoint: String,
-    private val maxRecords: Int,
-    private val maxUncompressedBytes: Long,
     private val queueCapacity: Int,
-    private val objectMapper: ObjectMapper,
+    private val fileManager: ChunkFileManager,
     private val eventPublisher: SnapshotSinkEventPublisher,
     private val writerExecutor: ExecutorService = Executors.newSingleThreadExecutor { runnable ->
         Thread.ofPlatform().name("snapshot-writer-$endpoint").unstarted(runnable)
     },
-    private val clock: Clock = Clock.systemUTC(),
 ) {
     private val log = LoggerFactory.getLogger(ChunkedSnapshotSink::class.java)
-
-    private val chunksDir: Path = runDir.resolve(endpoint).resolve("chunks")
-    private val failedPath: Path = runDir.resolve(endpoint).resolve("failed.jsonl")
-    private val manifestPath: Path = runDir.resolve(endpoint).resolve("manifest.json")
-    private val successPath: Path = runDir.resolve(endpoint).resolve("_SUCCESS")
 
     private val queue = ArrayBlockingQueue<SnapshotChunkRecord>(queueCapacity)
     private val accepting = AtomicBoolean(true)
     private val writerError = AtomicReference<Throwable?>(null)
-
-    private val manifest = SnapshotChunkManifest(
-        runId = runDir.fileName.toString(),
-        endpoint = endpoint,
-        startedAt = Instant.now(clock),
-    )
-
-    private val failedWriter = SnapshotFailedRecordWriter(failedPath, objectMapper)
-    private var currentWriter: GzipJsonlChunkWriter
-    private var nextPartIndex = 2
-
-    init {
-        Files.createDirectories(chunksDir)
-        Files.createDirectories(failedPath.parent)
-        currentWriter = newChunkWriter(1)
-    }
 
     private val writerFuture: Future<*> = writerExecutor.submit {
         runWriterLoop()
@@ -99,31 +71,19 @@ class ChunkedSnapshotSink(
         }
 
         val err = writerError.get()
+        val manifest = fileManager.manifest()
         if (err != null) {
-            cleanupOnFailure()
+            fileManager.cleanupOnFailure()
             eventPublisher.publishRunFailed(manifest, endpoint, err.message ?: "unknown")
             throw RuntimeException("writer thread failed: ${err.message}", err)
         }
 
-        // close current chunk
-        closeCurrentChunk()
-
-        // close failed writer
-        manifest.totalFailed = failedWriter.count()
-
-        // write manifest
-        manifest.finishedAt = Instant.now(clock)
-        val manifestWriter = SnapshotChunkManifestWriter(manifestPath, objectMapper)
-        manifestWriter.write(manifest)
-
-        // create _SUCCESS
-        Files.writeString(successPath, "")
-
-        // Remove run-level _RUNNING marker (if exists)
-        val runningMarker = runDir.resolve("_RUNNING")
-        if (Files.exists(runningMarker)) {
-            Files.delete(runningMarker)
+        // close current chunk and write manifest + _SUCCESS marker
+        fileManager.closeCurrentChunk()?.let { stats ->
+            eventPublisher.publishChunkReady(stats, manifest.runId, endpoint)
         }
+        fileManager.writeManifestAndSuccessMarker()
+        fileManager.deleteRunningMarker()
 
         log.info(
             "[Sink] closed: endpoint={}, chunks={}, records={}, failed={}",
@@ -140,7 +100,7 @@ class ChunkedSnapshotSink(
                 val record = queue.take()
                 when (record) {
                     is SnapshotChunkRecord.Success -> handleSuccess(record)
-                    is SnapshotChunkRecord.Failure -> failedWriter.append(record)
+                    is SnapshotChunkRecord.Failure -> fileManager.appendFailure(record)
                     is SnapshotChunkRecord.CloseSignal -> return
                 }
             }
@@ -153,15 +113,13 @@ class ChunkedSnapshotSink(
 
     private fun handleSuccess(record: SnapshotChunkRecord.Success) {
         try {
-            currentWriter.append(record)
-            manifest.totalRecords++
-
-            if (currentWriter.shouldRotate()) {
-                rotateChunk()
+            val stats = fileManager.appendSuccess(record)
+            if (stats != null) {
+                eventPublisher.publishChunkReady(stats, fileManager.manifest().runId, endpoint)
             }
         } catch (ex: Exception) {
             log.warn("[Sink] invalid bodyBytes for key={}, treating as failure: {}", record.key, ex.message)
-            failedWriter.append(
+            fileManager.appendFailure(
                 SnapshotChunkRecord.Failure(
                     key = record.key,
                     endpoint = record.endpoint,
@@ -173,45 +131,4 @@ class ChunkedSnapshotSink(
             )
         }
     }
-
-    private fun rotateChunk() {
-        val stats = currentWriter.close()
-        if (stats.recordCount > 0) {
-            val entry = ChunkEntry(
-                path = stats.path,
-                recordCount = stats.recordCount,
-                uncompressedBytes = stats.uncompressedBytes,
-                compressedBytes = stats.compressedBytes,
-                startedAt = stats.startedAt,
-                finishedAt = stats.finishedAt,
-            )
-            manifest.chunks.add(entry)
-            eventPublisher.publishChunkReady(stats, manifest.runId, endpoint)
-        }
-        currentWriter = newChunkWriter(nextPartIndex++)
-    }
-
-    private fun closeCurrentChunk() {
-        val stats = currentWriter.close()
-        if (stats.recordCount > 0) {
-            val entry = ChunkEntry(
-                path = stats.path,
-                recordCount = stats.recordCount,
-                uncompressedBytes = stats.uncompressedBytes,
-                compressedBytes = stats.compressedBytes,
-                startedAt = stats.startedAt,
-                finishedAt = stats.finishedAt,
-            )
-            manifest.chunks.add(entry)
-            eventPublisher.publishChunkReady(stats, manifest.runId, endpoint)
-        }
-    }
-
-    private fun cleanupOnFailure() {
-        currentWriter.deleteTmp()
-        log.warn("[Sink] cleaned up .tmp files after failure")
-    }
-
-    private fun newChunkWriter(partIndex: Int): GzipJsonlChunkWriter =
-        GzipJsonlChunkWriter(chunksDir, partIndex, maxRecords, maxUncompressedBytes, objectMapper, clock)
 }

--- a/module-external-api/src/main/kotlin/maple/externalapi/snapshot/EndpointSinkFactory.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/snapshot/EndpointSinkFactory.kt
@@ -42,19 +42,24 @@ class EndpointSinkFactory(
         publisher: SnapshotChunkEventPublisher,
     ): ChunkedSnapshotSink {
         val endpointConfig = chunkingProperties.configFor(endpoint)
-        return ChunkedSnapshotSink(
+        val fileManager = ChunkFileManager(
             runDir = runDir,
             endpoint = endpoint,
             maxRecords = endpointConfig.maxRecords,
             maxUncompressedBytes = endpointConfig.maxUncompressedBytes,
-            queueCapacity = chunkingProperties.queueCapacity,
             objectMapper = objectMapper,
+            clock = clock,
+        )
+        return ChunkedSnapshotSink(
+            runDir = runDir,
+            endpoint = endpoint,
+            queueCapacity = chunkingProperties.queueCapacity,
+            fileManager = fileManager,
             eventPublisher = SnapshotSinkEventPublisher(
                 eventPublisher = SinkEventPublisher(publisher),
                 volumeMetrics = volumeMetrics,
                 clock = clock,
             ),
-            clock = clock,
         )
     }
 }


### PR DESCRIPTION
## Summary

- Issue #989: extract file I/O + chunk rotation from ChunkedSnapshotSink into new ChunkFileManager class
- Sink reduces from 217 → 134 lines (-38%), holds only queue + writer thread + event-publisher calls
- Manager owns chunks dir, failed.jsonl, manifest.json, _SUCCESS, _RUNNING, and the active chunk writer
- Pure mechanical refactor; no behavior change

## Files

- New: `module-external-api/.../snapshot/ChunkFileManager.kt` (120 lines)
- Modified: `ChunkedSnapshotSink.kt` (-78 lines)
- Modified: `EndpointSinkFactory.kt` (+5 lines)

## Verification

- `./gradlew :module-external-api:compileKotlin` → BUILD SUCCESSFUL
- `./gradlew :module-external-api:compileJava` → BUILD SUCCESSFUL (NO-SOURCE)
- `./gradlew :module-external-api:test` → BUILD SUCCESSFUL (4 test classes)
- `./gradlew test` (full suite) → BUILD SUCCESSFUL (67 actionable tasks)
- Server runtime: `:module-external-api:bootRun` started in 15.6s, `/actuator/health` → 200
- 4 chunks written to disk (5000 records each, compressionRatio ~9.1) — matches pre-refactor behavior
- 0 ERRORs in app log (Kafka WARNs are environmental — no local broker, pre-existing)

## Spec

- `docs/superpowers/specs/2026-06-07-989-chunk-file-manager-extraction-design.md`

## Note on baseline

This branch is based on `ae4bc4a62` (`#1191`: BatchProgress + EndpointSinkFactory), which is the
current develop tip at the time of creation. `RankingSnapshotSinkFactory` (referenced in the
original spec) was deleted by `#1191` and replaced by `EndpointSinkFactory`. The 3 phase files
(`CharacterBasicFetchPhase`, `ItemEquipmentFetchPhase`, `RankingFetchPhase`) no longer construct
sinks directly — only `EndpointSinkFactory` needed to be updated to construct the new
`ChunkFileManager`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)