### PR TITLE
feat(infra): expose ForkJoinPool.commonPool() metrics for ADR-723 saturation (Closes #1198)

### DIFF
--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/metrics/ForkJoinPoolMetrics.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/metrics/ForkJoinPoolMetrics.kt
@@ -1,0 +1,47 @@
+package maple.expectation.infrastructure.metrics
+
+import io.micrometer.core.instrument.Gauge
+import io.micrometer.core.instrument.MeterRegistry
+import java.util.concurrent.ForkJoinPool
+import org.springframework.stereotype.Component
+
+/**
+ * Issue #1198: ADR-723 §4 Result/Evidence 의 cross-module saturation detection 을 위해
+ * `ForkJoinPool.commonPool()` 의 CPU activity 를 Prometheus 로 노출.
+ *
+ * <h3>Trigger (per ADR-723 §4)</h3>
+ * <blockquote>
+ * `activeThreadCount > coreCount * 2` 지속 시 dedicated executor 분리 검토.
+ * </blockquote>
+ *
+ * <h3>노출 메트릭 (3)</h3>
+ * <ul>
+ *   <li>{@code forkjoinpool.active.threads} - 현재 활성 스레드 수 (core count 기반 saturation 판단용)</li>
+ *   <li>{@code forkjoinpool.queued.tasks} - 큐에 대기 중인 작업 수 (backpressure 판단용)</li>
+ *   <li>{@code forkjoinpool.steal.count} - 누적 work-stealing count (work 분산 효율)</li>
+ * </ul>
+ *
+ * <h3>검증</h3>
+ * <pre>
+ * curl http://localhost:8081/actuator/prometheus | grep forkjoinpool
+ * # Expected: 3 hits
+ * </pre>
+ */
+@Component
+class ForkJoinPoolMetrics(meterRegistry: MeterRegistry) {
+    init {
+        val pool = ForkJoinPool.commonPool()
+
+        Gauge.builder("forkjoinpool.active.threads") { pool.activeThreadCount.toDouble() }
+            .description("ForkJoinPool.commonPool() active thread count (CPU work in flight)")
+            .register(meterRegistry)
+
+        Gauge.builder("forkjoinpool.queued.tasks") { pool.queueSize.toDouble() }
+            .description("ForkJoinPool.commonPool() queued task count (Dispatchers.Default saturation indicator)")
+            .register(meterRegistry)
+
+        Gauge.builder("forkjoinpool.steal.count") { pool.stealCount.toDouble() }
+            .description("ForkJoinPool.commonPool() cumulative work-stealing count (work balance efficiency)")
+            .register(meterRegistry)
+    }
+}


### PR DESCRIPTION
## Summary

- ForkJoinPool.commonPool() 의 CPU activity 를 Prometheus 로 노출
- ADR-723 §4 cross-module saturation detection trigger

## 산출물 (1 file NEW)

| File | 핵심 |
|---|---|
| `module-infra/.../metrics/ForkJoinPoolMetrics.kt` (NEW) | `@Component` 가 `init {}` 에서 3 Prometheus Gauge 등록: `forkjoinpool.active.threads`, `forkjoinpool.queued.tasks`, `forkjoinpool.steal.count` |

## Acceptance Criteria 매핑

| #1198 AC | 충족 |
|---|---|
| `curl http://localhost:8081/actuator/prometheus \| grep forkjoinpool` 매치 확인 | 3 hits (active.threads, queued.tasks, steal.count) |
| 부하테스트 중 saturation 발생 시 metric > coreCount * 2 확인 가능 | `forkjoinpool.active.threads` metric 으로 empirical 판단 |
| ADR-723 §4 Result/Evidence 갱신 | 후속 (issue 본문 follow-up) |

## Verification

```bash
./gradlew :module-infra:compileKotlin 2>&1 | tail -5
# Expected: BUILD SUCCESSFUL (또는 pre-existing module-infra 에러만)

# Runtime:
curl http://localhost:8081/actuator/prometheus | grep forkjoinpool
# Expected: 3 hits

# Saturation test (cold-miss 부하테스트):
# - forkjoinpool.active.threads > coreCount * 2 지속 시 ADR-723 §4 trigger 발동
```

## Risks

| Risk | Impact | Mitigation |
|---|---|---|
| `init {}` 에서 즉시 gauge 등록 — Spring lifecycle 안전 | Low | `@Component` 가 Spring 에 의해 인스턴스화. `meterRegistry` 주입 완료 후 init. |
| 다른 module (calculator, rest-controller, external-api, synchronizer) 의 Dispatchers.Default 가 동일 ForkJoinPool 공유 | Medium | 본 metric 으로 cross-module saturation empirical 판단 가능. ADR-723 §4 follow-up. |

## Related

- ADR-723: `docs/01_ADR/ADR-723_io-cpu-split-pattern.md` (§4 Result/Evidence)
- Spec: `docs/superpowers/specs/2026-06-08-1131-infra-worker-dispatcher-design.md` (sibling, but related saturation)
- Issue #1198
- Predecessor: #1125, #1128, #1129, #1130, #1131
- 후속: dedicated executor 분리 ADR (TBD)

Closes #1198