### PR TITLE
fix(ext-api): add authCharacterFetchExecutor bean (Closes #1206)

### DIFF
--- a/module-external-api/src/main/kotlin/maple/externalapi/auth/AuthExecutorConfig.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/auth/AuthExecutorConfig.kt
@@ -1,0 +1,45 @@
+package maple.externalapi.auth
+
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import java.util.concurrent.Executor
+
+/**
+ * Auth executor configuration (Issue #1206).
+ *
+ * <p>AuthCharacterFetchConsumer 의 `@Qualifier("authCharacterFetchExecutor")` 인자 wired.
+ * 별도 platform thread pool — Kafka listener 의 dispatch 와 분리.
+ *
+ * <p>Thread type: <b>platform thread</b> (not VT). RunBlocking(Dispatchers.Default) 으로 VT carrier
+ * block 위험 회피 (#1128 precedent, Issue #1208 follow-up).
+ *
+ * <h3>Sizing (per #1128 sizing principles)</h3>
+ * <ul>
+ *   <li>core: 2 (low-volume, auth API call 만)</li>
+ *   <li>max: 4 (1:2 ratio per P2-25)</li>
+ *   <li>queue: 100</li>
+ * </ul>
+ */
+@Configuration
+class AuthExecutorConfig {
+
+    private val log = LoggerFactory.getLogger(AuthExecutorConfig::class.java)
+
+    @Bean(name = ["authCharacterFetchExecutor"])
+    fun authCharacterFetchExecutor(): Executor {
+        val executor = ThreadPoolTaskExecutor()
+        executor.corePoolSize = 2
+        executor.maxPoolSize = 4
+        executor.queueCapacity = 100
+        executor.setThreadNamePrefix("auth-character-fetch-")
+        executor.setAllowCoreThreadTimeOut(true)
+        executor.setKeepAliveSeconds(30)
+        executor.setWaitForTasksToCompleteOnShutdown(true)
+        executor.setAwaitTerminationSeconds(30)
+        executor.initialize()
+        log.info("[AuthExecutorConfig] authCharacterFetchExecutor initialized: core=2, max=4, queue=100")
+        return executor
+    }
+}


### PR DESCRIPTION
Issue #1206: AuthCharacterFetchConsumer 의 @Qualifier("authCharacterFetchExecutor")
인자 wired. bean 정의 누락 → Spring startup fail 위험.

Create AuthExecutorConfig (module-external-api):
- Platform thread pool (core=2, max=4, queue=100, 1:2 ratio)
- Not VT: RunBlocking(Dispatchers.Default) for JSON serialize
  (#1128 precedent, #1208 follow-up mitigation)
- Thread name prefix: auth-character-fetch-

Closes #1206