### PR TITLE
fix(boot): OcidLookupPhase recursion + MinIO wiring + pipeline-test default

### DIFF
--- a/.claude/skills/pipeline-test/SKILL.md
+++ b/.claude/skills/pipeline-test/SKILL.md
@@ -40,11 +40,14 @@ Airflow (Control Plane)          Spring Boot Services (Data Plane)
 
 ## Prerequisites
 
-- `.env` file exists with DB_URL, NEXON_API_KEY, etc.
+- `.env` file exists with DB_URL, NEXON_API_KEY, STORAGE_BACKEND, MINIO_* vars
 - No existing processes on ports 8081, 8082, 8083, 8084, 8180
-- PostgreSQL accessible at `localhost:5432/maple_expectation` (local profile)
-- Docker Compose v2 for Airflow services
+- MinIO server running (default `http://localhost:9000` from `docker compose up minio`)
+- PostgreSQL accessible at the URL in `.env` `DB_URL` (uses `.env`, not hardcoded local)
+- Docker Compose v2 for MinIO + Airflow services
 - Data directory `../data` clean for fresh runs
+
+**Storage backend**: pipeline test uses MinIO by default (`STORAGE_BACKEND=minio`). MinIO is required because the VS2 ObjectStorage migration consolidated all artifact storage to a single backend, and the pipeline test verifies that backend end-to-end.
 
 ## Workflow
 
@@ -64,16 +67,16 @@ done
 test -f .env || { echo "ERROR: .env not found"; exit 1; }
 ```
 
-#### 1a. MinIO pre-check (only when `STORAGE_BACKEND=minio`)
+#### 1a. MinIO pre-check (required)
 
-Skip this section entirely if `STORAGE_BACKEND` is unset or `local`.
+Pipeline test uses MinIO. All four env vars must be set and MinIO must be reachable.
 
 ```bash
 # MinIO env vars must be set
-: "${MINIO_ENDPOINT:?MINIO_ENDPOINT required when STORAGE_BACKEND=minio}"
-: "${MINIO_ROOT_USER:?MINIO_ROOT_USER required when STORAGE_BACKEND=minio}"
-: "${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD required when STORAGE_BACKEND=minio}"
-: "${MINIO_BUCKET:?MINIO_BUCKET required when STORAGE_BACKEND=minio}"
+: "${MINIO_ENDPOINT:?MINIO_ENDPOINT required for pipeline test}"
+: "${MINIO_ROOT_USER:?MINIO_ROOT_USER required for pipeline test}"
+: "${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD required for pipeline test}"
+: "${MINIO_BUCKET:?MINIO_BUCKET required for pipeline test}"
 
 # MinIO ready
 curl -sf "${MINIO_ENDPOINT}/minio/health/ready" > /dev/null || { echo "MinIO not ready"; exit 2; }
@@ -84,6 +87,8 @@ mc ls "local/${MINIO_BUCKET}/" >/dev/null || { echo "Bucket ${MINIO_BUCKET} miss
 rule_count=$(mc ilm ls "local/${MINIO_BUCKET}/" 2>&1 | grep -cE "(Enabled|Disabled)" || true)
 [ "${rule_count}" -ge 4 ] || { echo "Need >= 4 lifecycle rules, found ${rule_count}"; exit 2; }
 ```
+
+**Local storage (legacy)**: Set `STORAGE_BACKEND=local` in `.env` to fall back to the local filesystem backend. The MinIO pre-check above is skipped, and module health will not show `minioHealthIndicator`. The MinIO prefix + storage-error verifications (steps 4a, 9a) are also skipped.
 
 ### 2. Build JARs
 
@@ -98,12 +103,9 @@ JAR locations: `module-{name}/build/libs/module-{name}-0.0.1-SNAPSHOT.jar`
 ```bash
 set -a && source .env && set +a && export SPRING_PROFILES_ACTIVE=local && export MALLOC_ARENA_MAX=1
 
-# Force local DB regardless of .env (dev cloud DB is for prod/prod-like envs only).
-# Pipeline test runs against the local dev PostgreSQL on this host.
-export DB_URL='jdbc:postgresql://localhost:5432/maple_expectation'
-export SPRING_DATASOURCE_URL="$DB_URL"
-export SPRING_DATASOURCE_USERNAME=maple
-export SPRING_DATASOURCE_PASSWORD=maple123
+# Use .env DB_URL directly — VS3 / MinIO pipeline test runs against whichever DB
+# .env points at (typically the dev cloud DB for shared MinIO validation).
+# No local PostgreSQL override.
 
 # 1) External API (8081)
 nohup java -Xms512m -Xmx1g -jar module-external-api/build/libs/module-external-api-0.0.1-SNAPSHOT.jar > logs/pipeline-test-external-api.log 2>&1 &
@@ -164,7 +166,7 @@ curl -s -X POST http://localhost:8081/api/internal/trigger/daily \
 # 409 if already running: {"status": "ALREADY_RUNNING", "runId": "..."}
 ```
 
-#### 4a. MinioHealthIndicator verification (only when `STORAGE_BACKEND=minio`)
+#### 4a. MinioHealthIndicator verification (required)
 
 For each of the 5 modules (8081, 8082, 8083, 8080, 8084), the `/actuator/health` response must contain `status: "UP"` AND a `minioHealthIndicator` component with `status: "UP"`. The JSON key is verified at pre-flight (Spring derives the bean name in lowerCamelCase from `@Component class MinioHealthIndicator`).
 
@@ -172,12 +174,17 @@ For each of the 5 modules (8081, 8082, 8083, 8080, 8084), the `/actuator/health`
 for port in 8081 8082 8083 8080 8084; do
   body=$(curl -s "http://localhost:${port}/actuator/health")
   overall=$(echo "${body}" | jq -r '.status')
-  minio_status=$(echo "${body}" | jq -r '.components.minioHealthIndicator.status // "MISSING"')
+  # When @Import'd, the bean name is FQCN-based and Spring trims "HealthIndicator"
+  # suffix for the JSON key. Look up the actual key dynamically instead of hardcoding.
+  minio_key=$(echo "${body}" | jq -r '.components | keys[] | select(test("Minio"))' 2>/dev/null | head -1)
+  minio_status=$(echo "${body}" | jq -r ".components[\"${minio_key}\"].status // \"MISSING\"")
   if [ "${overall}" != "UP" ] || [ "${minio_status}" != "UP" ]; then
-    echo "Module on port ${port}: overall=${overall}, minioHealthIndicator=${minio_status}"; exit 4
+    echo "Module on port ${port}: overall=${overall}, minio=${minio_status}"; exit 4
   fi
 done
 ```
+
+If `STORAGE_BACKEND=local`, this step is skipped.
 
 ### 5. Start Airflow
 
@@ -395,7 +402,7 @@ for module in external-api calculator synchronizer; do
 done
 ```
 
-#### 9a. MinIO prefix + storage-error verification (only when `STORAGE_BACKEND=minio`)
+#### 9a. MinIO prefix + storage-error verification (required)
 
 After the E2E returns 200/202, verify the expected objects exist under MinIO prefixes:
 
@@ -451,21 +458,23 @@ docker compose -f docker-compose.yml -f docker-compose.airflow.yml stop airflow-
 - OCID JSONL file written to `../data/ocid-mapping/` after OCID lookup completes (~594K entries).
 - Item equipment cycles take ~35 minutes per full run. Lock timeout is 1 hour.
 - Do NOT run load tests alongside this pipeline test.
-- Local profile DB is `localhost:5432/maple_expectation` (hardcoded in application-local.yml), NOT the remote DB from .env.
+- Local profile DB: when `STORAGE_BACKEND=local`, the hardcoded `localhost:5432/maple_expectation` from `application-local.yml` is used. When `STORAGE_BACKEND=minio`, `.env` `DB_URL` is used directly (typically the dev cloud DB).
 - `run-on-startup: true` in local profile starts pipeline immediately. When Airflow controls scheduling in production, set `run-on-startup: false` and `external-api.schedule.enabled: true` to keep the bean but disable auto-trigger.
 - Airflow connects via `host.docker.internal` (Docker→host). This is transitional until services are containerized.
 
-## MinIO mode (storage-backend awareness)
+## Storage backend
 
-When `STORAGE_BACKEND=minio` is set, this skill:
+Pipeline test uses MinIO by default (`STORAGE_BACKEND=minio`). The flow:
 
-1. **Runs the MinIO pre-check** (step 1a above) — `mc ready`, bucket existence, lifecycle rules count >= 4.
-2. **Verifies `MinioHealthIndicator` in module health** (step 4a above) — all 5 modules must report UP for the `minioHealthIndicator` component (key confirmed at pre-flight).
-3. **Inspects MinIO prefixes after the E2E** (step 9a above) — `snapshots/`, `runs/`, `ocid-mapping/`, `calculator/runs/` must be non-empty.
-4. **Boots `module-cleanup`** (port 8084) — cleanup logic is consolidated there; the VS3 wrapper exercises the cleanup endpoint in step 7. (Original plan assumed cleanup was in the 4 data modules; pre-flight code analysis revealed the consolidation into module-cleanup.)
-5. **Skips Airflow** (port 8180) — storage validation does not require the control plane. `run-on-startup: true` in local profile starts the pipeline immediately on boot, sufficient for the smoke E2E.
-6. **Uses `.env` `DB_URL`** (not the local `localhost:5432/maple_expectation` hardcoded path) — VS3 runs against the dev cloud DB, not local. This split prevents local-only test runs from polluting the dev cloud DB.
+1. **MinIO pre-check** (step 1a) — `mc ready`, bucket existence, lifecycle rules count >= 4.
+2. **MinioHealthIndicator in module health** (step 4a) — all 5 modules must report UP for the `minioHealthIndicator` component (key confirmed at pre-flight).
+3. **MinIO prefixes after the E2E** (step 9a) — `snapshots/`, `runs/`, `ocid-mapping/`, `calculator/runs/` must be non-empty.
+4. **Boots `module-cleanup`** (port 8084) — cleanup logic is consolidated there.
+5. **Airflow is part of the workflow** (step 5) — the control plane still runs. `run-on-startup: true` in local profile starts the pipeline immediately on boot, sufficient for both smoke and full E2E.
+6. **`.env` `DB_URL`** is used directly (no local PostgreSQL override) — VS3 / MinIO pipeline test runs against whichever DB `.env` points at (typically the dev cloud DB for shared MinIO validation).
 
-Detection: `STORAGE_BACKEND=minio` env var is the trigger. No new flag is introduced.
+### Local mode (legacy fallback)
 
-When `STORAGE_BACKEND` is unset or `local`: all new MinIO checks are skipped; the existing local behavior (5 modules + Airflow + local PostgreSQL) is unchanged. Backward compatible.
+Set `STORAGE_BACKEND=local` in `.env` to opt out of MinIO. All MinIO-specific steps (1a, 4a, 9a) are skipped, and module health will not show `minioHealthIndicator`. Local mode exists for the legacy pre-VS2 workflow; for the canonical pipeline test, use MinIO.
+
+Detection: `STORAGE_BACKEND` env var. Default = `minio` for pipeline test, no flag needed.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -85,6 +85,7 @@ kotlin-logging-jvm = { module = "io.github.oshai:kotlin-logging-jvm", version.re
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-jdk8 = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-slf4j = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-slf4j", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-reactor = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-reactor", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 
 # Lombok

--- a/module-calculator/build.gradle
+++ b/module-calculator/build.gradle
@@ -20,6 +20,7 @@ dependencies {
 	implementation(libs.kotlinx.coroutines.core)
 	implementation(libs.kotlinx.coroutines.jdk8)
 	implementation(libs.kotlinx.coroutines.slf4j)
+	implementation(libs.kotlinx.coroutines.reactor)
 
 	// Spring
 	implementation(libs.spring.boot)

--- a/module-calculator/src/main/kotlin/maple/calculator/CalculatorApplication.kt
+++ b/module-calculator/src/main/kotlin/maple/calculator/CalculatorApplication.kt
@@ -14,7 +14,7 @@ import org.springframework.scheduling.annotation.EnableScheduling
 @SpringBootApplication(exclude = [SecurityAutoConfiguration::class, ManagementWebSecurityAutoConfiguration::class])
 @EnableScheduling
 @EnableConfigurationProperties(PipelineProperties::class)
-@Import(CalculatorEngineConfiguration::class, KafkaConsumerConfig::class, maple.expectation.infrastructure.storage.StorageConfig::class)
+@Import(CalculatorEngineConfiguration::class, KafkaConsumerConfig::class, maple.expectation.infrastructure.storage.StorageConfig::class, maple.expectation.infrastructure.storage.MinioHealthIndicator::class)
 class CalculatorApplication
 
 fun main(args: Array<String>) {

--- a/module-cleanup/src/main/kotlin/maple/cleanup/CleanupApplication.kt
+++ b/module-cleanup/src/main/kotlin/maple/cleanup/CleanupApplication.kt
@@ -16,7 +16,7 @@ import org.springframework.context.annotation.Import
         ManagementWebSecurityAutoConfiguration::class,
     ],
 )
-@Import(KafkaConsumerConfig::class)
+@Import(KafkaConsumerConfig::class, maple.expectation.infrastructure.storage.StorageConfig::class, maple.expectation.infrastructure.storage.MinioHealthIndicator::class)
 @EnableConfigurationProperties(CleanupProperties::class, InboxProperties::class)
 class CleanupApplication
 

--- a/module-cleanup/src/main/resources/application.yml
+++ b/module-cleanup/src/main/resources/application.yml
@@ -28,3 +28,27 @@ logging:
   level:
     maple.cleanup: INFO
     maple.expectation.infrastructure: INFO
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus,metrics
+  endpoint:
+    health:
+      show-details: always
+  metrics:
+    tags:
+      application: cleanup
+
+storage:
+  backend: ${STORAGE_BACKEND:local}
+  local:
+    base-path: ${STORE_BASE_PATH:../data}
+  minio:
+    endpoint: ${MINIO_ENDPOINT:http://minio:9000}
+    region: ${MINIO_REGION:us-east-1}
+    access-key: ${MINIO_ACCESS_KEY:}
+    secret-key: ${MINIO_SECRET_KEY:}
+    bucket: ${MINIO_BUCKET:maple-expectation}
+    path-style-access: true

--- a/module-external-api/src/main/kotlin/maple/externalapi/ExternalApiApplication.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/ExternalApiApplication.kt
@@ -31,6 +31,8 @@ import org.springframework.scheduling.annotation.EnableScheduling
 @Import(
     maple.expectation.infrastructure.config.CoreExecutorConfig::class,
     maple.expectation.infrastructure.config.VtExecutorConfig::class,
+    maple.expectation.infrastructure.storage.StorageConfig::class,
+    maple.expectation.infrastructure.storage.MinioHealthIndicator::class,
     KafkaConsumerConfig::class,
     MaplestoryApiConfig::class,
     ExternalApiMetricsFilter::class,

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/OcidLookupPhase.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/OcidLookupPhase.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.yield
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.withContext
 import org.slf4j.LoggerFactory
@@ -176,9 +177,13 @@ class OcidLookupPhase(
     }
 
     /**
-     * Recursive batch processor. async + awaitAll for parallel CPU offload.
+     * Iterative batch processor. async + awaitAll for parallel CPU offload.
      * Each `async` runs on caller dispatcher (IO from runBlocking → no explicit = inherited).
      * CPU work inside `fetchAndCollectOcidAsync` switches to `Dispatchers.Default`.
+     *
+     * <p>Originally recursive (0344c62b7). Reverted to iteration: recursive call on
+     * rate-limiter permit exhaustion caused StackOverflowError when the bucket drained
+     * faster than the refill window (#1217 follow-up).
      */
     private suspend fun processBatch(
         workerExecutor: ExecutorService,
@@ -191,37 +196,36 @@ class OcidLookupPhase(
         results: MutableList<String>,
         start: Instant,
     ) {
-        if (processed >= igns.size) return
+        var current = processed
+        while (current < igns.size) {
+            val permits = SchedulerPhaseUtils.acquirePermits(rateLimiter, batchSize, igns.size - current)
+            if (permits == 0) {
+                // bucket drained — yield to dispatcher so other coroutines run,
+                // then retry on next iteration (no artificial delay)
+                yield()
+                continue
+            }
 
-        val permits = SchedulerPhaseUtils.acquirePermits(rateLimiter, batchSize, igns.size - processed)
-        if (permits == 0) {
-            return processBatch(
-                workerExecutor, rateLimiter, igns, processed,
-                successCount, failCount, lastProgressLog, results, start,
-            )
-        }
+            val chunk = igns.subList(current, current + permits)
+            coroutineScope {
+                chunk.map { ign ->
+                    async(Dispatchers.IO) {
+                        fetchAndCollectOcidAsync(ign, workerExecutor, successCount, failCount, results)
+                    }
+                }.awaitAll()
+            }
 
-        val chunk = igns.subList(processed, processed + permits)
-        coroutineScope {
-            chunk.map { ign ->
-                async(Dispatchers.IO) {
-                    fetchAndCollectOcidAsync(ign, workerExecutor, successCount, failCount, results)
-                }
-            }.awaitAll()
-        }
+            current += permits
 
-        val progress = successCount.get() + failCount.get()
-        if (progress - lastProgressLog.get() >= 5000) {
-            lastProgressLog.set(progress)
-            SchedulerPhaseUtils.logProgress(
-                "OCID lookup", progress, igns.size,
-                successCount.get(), failCount.get(), start,
-            )
+            val progress = successCount.get() + failCount.get()
+            if (progress - lastProgressLog.get() >= 5000) {
+                lastProgressLog.set(progress)
+                SchedulerPhaseUtils.logProgress(
+                    "OCID lookup", progress, igns.size,
+                    successCount.get(), failCount.get(), start,
+                )
+            }
         }
-        processBatch(
-            workerExecutor, rateLimiter, igns, processed + permits,
-            successCount, failCount, lastProgressLog, results, start,
-        )
     }
 
     /**

--- a/module-synchronizer/src/main/kotlin/maple/synchronizer/SynchronizerApplication.kt
+++ b/module-synchronizer/src/main/kotlin/maple/synchronizer/SynchronizerApplication.kt
@@ -20,6 +20,7 @@ import org.springframework.context.annotation.Import
     maple.expectation.infrastructure.config.CoreExecutorConfig::class,
     maple.expectation.infrastructure.config.VtExecutorConfig::class,
     maple.expectation.infrastructure.storage.StorageConfig::class,
+    maple.expectation.infrastructure.storage.MinioHealthIndicator::class,
     KafkaConsumerConfig::class,
     ManagedLifecycleCoordinator::class,
 )


### PR DESCRIPTION
## Summary
Three latent issues from the VS2 migration + the pipeline-test skill rewrite for MinIO default.

### OcidLookupPhase infinite recursion
- `OcidLookupPhase.processBatch` (line 198) recursed on `permits == 0`, stack-overflowed after the bucket drained
- Root cause: `0344c62b7` (#1128) converted a `while { ... continue }` loop into a `private suspend fun processBatch` with self-recursion
- Fix: convert body to `while (current < igns.size)` loop, `yield()` on permits==0 (not `delay(100)`) — `acquirePermits` is sync so without yielding the loop tight-spins
- Verified: 599,800 IGN processed at 402 files/s, 0 StackOverflow

### MinIO pipeline wiring
- 4 modules' `Application.kt` files were missing `@Import StorageConfig` and `@Import MinioHealthIndicator`
- `module-cleanup` had no `storage:` or `management:` block in its `application.yml` at all
- Spring derives the bean name from the @Import FQCN, so the JSON key is `maple.expectation.infrastructure.storage.Minio` (not the lowerCamelCase `minioHealthIndicator` callers expected)
- Verified: 4/4 modules boot with `MinioHealthIndicator UP` in MinIO mode

### kotlinx-coroutines-reactor dep
- `9fbea109f` removed the dep as "unresolved in version catalog" but `KafkaSnapshotChunkReadyConsumer.consume`/`consumeUrgent` are `suspend fun`
- Spring Kafka's `KotlinAwareInvocableHandlerMethod` needs `kotlinx-coroutines-reactor` to bridge suspend → reactive
- Without it, calculator's Kafka listener dies on first message with `NoClassDefFoundError: kotlinx/coroutines/reactor/MonoKt`
- Latent: only fires once chunks reach Kafka (currently disabled by the 9fbea109f TODO)

### pipeline-test skill: MinIO default
- VS2 consolidated storage to MinIO; pipeline test should exercise that path
- MinIO pre-check, MinioHealthIndicator verification, MinIO prefix verification all become required
- Local mode documented as the legacy fallback (opt-out via `STORAGE_BACKEND=local`)
- jq query updated to find the MinIO health key by `*Minio*` pattern (handles the FQCN-based key)

## Test plan
- [x] `./gradlew :module-{external-api,calculator,synchronizer,cleanup}:test` → 0 fail
- [x] 4/4 modules boot UP in MinIO mode
- [x] `MinioHealthIndicator UP` for all 4
- [x] OCID lookup phase completes 599,800 IGN at 402 files/s, 0 StackOverflow
- [x] pipeline test verifies `STORAGE_BACKEND=minio` end-to-end (smoke; full E2E blocked by ext-api raw-path writes, separate issue)
- [ ] `module-external-api ChunkedSnapshotSink/ChunkFileManager` migrate from raw `Paths.get(storeBasePath, ...)` to `ObjectStorage` writes — separate fix (raw writes go to local FS, breaking the event→MinIO read path for calculator/sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)