### PR TITLE
fix(ext-api): repair 5 post-merge test fixtures + RankingFetch race

### DIFF
--- a/module-external-api/src/main/kotlin/maple/externalapi/artifact/UrgentChunkArtifactWriter.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/artifact/UrgentChunkArtifactWriter.kt
@@ -26,7 +26,7 @@ class UrgentChunkArtifactWriter(
         endpointDir: String,
         record: SnapshotChunkRecord.Success,
     ): String {
-        val chunkKey = "runs/$runId/$endpointDir/chunks/part-000001"
+        val chunkKey = "runs/$runId/$endpointDir/chunks/part-000001.jsonl.gz"
         val writer = GzipJsonlChunkWriter(
             chunkKey = chunkKey,
             partIndex = 1,

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/RankingFetchPhase.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/RankingFetchPhase.kt
@@ -111,18 +111,23 @@ class RankingFetchPhase(
 
         val requestKey = "$date:$currentPage"
         return clientPort.fetch(ExternalApiProvider.NEXON, ExternalApiEndpoint.RANKING_OVERALL, requestKey)
-            .thenAcceptAsync({ bodyBytes ->
+            .thenComposeAsync({ bodyBytes ->
+                // Issue #1217 follow-up: chain the submission CF so the outer await sees it.
+                // Previously used thenAcceptAsync + inner whenComplete which was fire-and-forget —
+                // the outer chain could reach sink.close() before the submission completed,
+                // dropping the page's records. The submission is CPU-bound (Dispatchers.Default);
+                // chaining ensures backpressure: pages are not fetched faster than we can submit.
                 submitRankingEntriesAsync(sink, bodyBytes, currentPage)
-                    .whenComplete { count, ex ->
-                        if (ex == null && count != null) {
-                            fetched.addAndGet(count)
-                            metrics.recordRankingFetched(count)
-                            if (fetched.get() % 10000 == 0) {
-                                log.info("[RankingFetch] progress: fetched={}, failed={}, page={}/{}", fetched.get(), failed.get(), currentPage, maxPages)
-                            }
-                        }
-                    }
             }, workerExecutor)
+            .whenComplete { count, ex ->
+                if (ex == null && count != null) {
+                    fetched.addAndGet(count)
+                    metrics.recordRankingFetched(count)
+                    if (fetched.get() % 10000 == 0) {
+                        log.info("[RankingFetch] progress: fetched={}, failed={}, page={}/{}", fetched.get(), failed.get(), currentPage, maxPages)
+                    }
+                }
+            }
             .handle { _, ex ->
                 if (ex != null) {
                     failed.incrementAndGet()

--- a/module-external-api/src/test/kotlin/maple/externalapi/artifact/UrgentChunkArtifactWriterTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/artifact/UrgentChunkArtifactWriterTest.kt
@@ -46,7 +46,7 @@ class UrgentChunkArtifactWriterTest {
                 bodyBytes = objectMapper.writeValueAsBytes(mapOf("character_name" to "user1")),
                 key = "user1",
                 endpoint = "ranking-overall",
-                keyType = KeyType.IGN.name,
+                keyType = KeyType.USER_IGN.name,
                 httpStatus = 200,
                 fetchedAt = Instant.parse("2026-06-10T00:00:00Z"),
             ),

--- a/module-external-api/src/test/kotlin/maple/externalapi/cache/OcidCacheProviderTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/cache/OcidCacheProviderTest.kt
@@ -1,5 +1,7 @@
 package maple.externalapi.cache
 
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
@@ -7,8 +9,6 @@ import org.mockito.kotlin.whenever
 import maple.expectation.common.storage.ObjectInfo
 import maple.expectation.common.storage.ObjectStorage
 import java.time.Instant
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 class OcidCacheProviderTest {
 

--- a/module-external-api/src/test/kotlin/maple/externalapi/scheduler/ExternalApiSchedulerTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/scheduler/ExternalApiSchedulerTest.kt
@@ -2,6 +2,7 @@ package maple.externalapi.scheduler
 
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutorService
+import kotlinx.coroutines.runBlocking
 import maple.externalapi.cache.OcidCacheProvider
 import maple.externalapi.metrics.SchedulerMetrics
 import maple.externalapi.runstatus.RunStatusTracker
@@ -58,7 +59,9 @@ class ExternalApiSchedulerTest {
         // The OCID lookup phase is invoked from a runBlocking on the virtual-thread executor.
         // Wait up to 5s for the async chain to settle and capture the runKey argument.
         val runKeyCaptor = argumentCaptor<String>()
-        verify(ocidLookupPhase, timeout(5_000)).execute(any<ExecutorService>(), runKeyCaptor.capture())
+        runBlocking {
+            verify(ocidLookupPhase, timeout(5_000)).execute(any<ExecutorService>(), runKeyCaptor.capture())
+        }
         assertThat(runKeyCaptor.firstValue).isEqualTo("runs/20260610-xyz")
 
         // The runId passed to startRun is the segment after "runs/".

--- a/module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/RankingFetchPhaseTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/RankingFetchPhaseTest.kt
@@ -3,6 +3,9 @@ package maple.externalapi.scheduler.phase
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.kotlinModule
+import maple.expectation.common.event.SnapshotChunkReadyEvent
+import maple.expectation.common.event.SnapshotRunCompletedEvent
+import maple.expectation.common.event.SnapshotRunFailedEvent
 import maple.expectation.common.storage.ObjectStorage
 import maple.externalapi.domain.ExternalApiEndpoint
 import maple.externalapi.domain.ExternalApiProvider
@@ -13,9 +16,6 @@ import maple.externalapi.snapshot.SinkEventPublisher
 import maple.externalapi.snapshot.SnapshotChunkingProperties
 import maple.externalapi.snapshot.SnapshotSinkEventPublisher
 import maple.externalapi.snapshot.event.SnapshotChunkEventPublisher
-import maple.externalapi.snapshot.event.SnapshotChunkReadyEvent
-import maple.externalapi.snapshot.event.SnapshotRunCompletedEvent
-import maple.externalapi.snapshot.event.SnapshotRunFailedEvent
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any

--- a/module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/RunMarkerWriterTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/RunMarkerWriterTest.kt
@@ -1,32 +1,34 @@
 package maple.externalapi.scheduler.phase
 
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.slot
-import io.mockk.verify
 import maple.expectation.common.storage.ObjectStorage
 import maple.expectation.common.storage.PutResult
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneOffset
-import kotlin.test.assertEquals
 
 class RunMarkerWriterTest {
 
     @Test
     fun `writeRunMarker puts marker to ObjectStorage with run key prefix`() {
-        val storage = mockk<ObjectStorage>()
-        val key = slot<String>()
-        val bytes = slot<ByteArray>()
-        every { storage.put(capture(key), capture(bytes)) } returns PutResult("k", 0, null)
+        val storage = mock<ObjectStorage>()
+        val keyCaptor = argumentCaptor<String>()
+        val bytesCaptor = argumentCaptor<ByteArray>()
+        whenever(storage.put(keyCaptor.capture(), bytesCaptor.capture()))
+            .thenReturn(PutResult("k", 0L, null))
 
         val clock = Clock.fixed(Instant.parse("2026-06-10T12:00:00Z"), ZoneOffset.UTC)
         val writer = RunMarkerWriter(clock, storage)
         writer.writeRunMarker("runs/20260610-120000-abc123")
 
-        verify(exactly = 1) { storage.put(any(), any()) }
-        assertEquals("runs/20260610-120000-abc123/_RUNNING", key.captured)
-        assertEquals("2026-06-10T12:00:00Z", String(bytes.captured))
+        verify(storage).put(any<String>(), any<ByteArray>())
+        assertEquals("runs/20260610-120000-abc123/_RUNNING", keyCaptor.firstValue)
+        assertEquals("2026-06-10T12:00:00Z", String(bytesCaptor.firstValue))
     }
 }

--- a/module-external-api/src/test/kotlin/maple/externalapi/snapshot/GzipJsonlChunkWriterTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/snapshot/GzipJsonlChunkWriterTest.kt
@@ -1,6 +1,7 @@
 package maple.externalapi.snapshot
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.kotlinModule
 import maple.expectation.common.storage.ObjectStorage
 import maple.expectation.common.storage.PutResult
@@ -19,7 +20,9 @@ import java.util.zip.GZIPInputStream
 
 class GzipJsonlChunkWriterTest {
 
-    private val objectMapper = ObjectMapper().registerModule(kotlinModule())
+    private val objectMapper = ObjectMapper()
+        .registerModule(kotlinModule())
+        .registerModule(JavaTimeModule())
     private val fixedClock = Clock.fixed(Instant.parse("2026-06-10T00:00:00Z"), ZoneOffset.UTC)
 
     @Test
@@ -74,7 +77,12 @@ class GzipJsonlChunkWriterTest {
         assertThat(lines).hasSize(3)
         lines.forEach { line ->
             val node = objectMapper.readTree(line)
-            assertThat(node.has("character_name")).isTrue()
+            // Writer serializes the full SnapshotChunkRecord.Success envelope; the original
+            // bodyBytes is base64-encoded under "bodyBytes".
+            assertThat(node.has("key")).isTrue()
+            assertThat(node.has("bodyBytes")).isTrue()
+            val decoded = String(java.util.Base64.getDecoder().decode(node.get("bodyBytes").asText()))
+            assertThat(decoded).contains("\"character_name\"")
         }
     }
 }

--- a/module-external-api/src/test/kotlin/maple/externalapi/urgent/UrgentCharacterRequestConsumerTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/urgent/UrgentCharacterRequestConsumerTest.kt
@@ -7,6 +7,7 @@ import java.nio.file.Path
 import java.time.Instant
 import java.util.UUID
 import java.util.concurrent.CompletableFuture
+import maple.expectation.infrastructure.storage.LocalFsObjectStorage
 import maple.externalapi.artifact.UrgentChunkArtifactWriter
 import maple.externalapi.domain.ExternalApiEndpoint
 import maple.externalapi.domain.ExternalApiProvider
@@ -42,17 +43,19 @@ class UrgentCharacterRequestConsumerTest {
     private lateinit var objectMapper: ObjectMapper
     private lateinit var kafkaTemplate: KafkaTemplate<String, String>
     private lateinit var consumer: UrgentCharacterRequestConsumer
+    private lateinit var objectStorage: LocalFsObjectStorage
 
     @BeforeEach
     fun setUp() {
         clientPort = mock()
         objectMapper = ObjectMapper().registerKotlinModule().registerModule(JavaTimeModule())
         kafkaTemplate = mock()
+        objectStorage = LocalFsObjectStorage(basePath = tempDir.toString(), meterRegistry = null)
 
         val ocidResponseParser = UrgentOcidResponseParser(objectMapper)
         val chunkArtifactWriter = UrgentChunkArtifactWriter(
-            storeBasePath = tempDir.toString(),
             objectMapper = objectMapper,
+            objectStorage = objectStorage,
         )
         val eventPublisher = UrgentEventPublisher(
             kafkaTemplate = kafkaTemplate,
@@ -129,15 +132,25 @@ class UrgentCharacterRequestConsumerTest {
         val endpoints = chunkEvents.map { it["endpoint"].asText() }.toSet()
         assertThat(endpoints).containsExactlyInAnyOrder("character-basic", "item-equipment")
 
-        // Verify chunk files exist on disk (consumer creates tempDir/runs/urgent-xxx/...)
-        val runsDir = tempDir.resolve("runs").toFile()
-        assertThat(runsDir.exists()).isTrue()
-        val urgentDirs = runsDir.listFiles()?.filter { it.isDirectory && it.name.startsWith("urgent-") }
-        assertThat(urgentDirs).isNotEmpty
+        // Verify chunk objects exist in ObjectStorage (consumer creates runs/urgent-xxx/...).
+        // The consume() call returns synchronously but the underlying fetch + publish chain is async;
+        // poll for the keys to appear (the kafkaTemplate.send verification above already waits 5s).
+        val urgentKeys = awaitKeys("runs/", "urgent-", ".jsonl.gz", expected = 2, timeoutMs = 5_000)
+        assertThat(urgentKeys).hasSize(2)
+    }
 
-        val runDir = urgentDirs!!.first()
-        val chunksFiles = runDir.walkTopDown().filter { it.extension == "gz" }.toList()
-        assertThat(chunksFiles).hasSize(2)
+    private fun awaitKeys(prefix: String, mustContain: String, suffix: String, expected: Int, timeoutMs: Long): List<String> {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            val keys = objectStorage.listByPrefix(prefix)
+                .map { it.key }
+                .filter { it.contains(mustContain) && it.endsWith(suffix) }
+            if (keys.size >= expected) return keys
+            Thread.sleep(50)
+        }
+        return objectStorage.listByPrefix(prefix)
+            .map { it.key }
+            .filter { it.contains(mustContain) && it.endsWith(suffix) }
     }
 
     @Test
@@ -176,8 +189,7 @@ class UrgentCharacterRequestConsumerTest {
         assertThat(notFoundEvent["userIgn"].asText()).isEqualTo(userIgn)
         assertThat(notFoundEvent["reason"].asText()).isEqualTo("OCID_NOT_FOUND")
 
-        // No chunk files created
-        val runsDir = tempDir.resolve("runs").toFile()
-        assertThat(runsDir.exists()).isFalse()
+        // No chunk objects created
+        assertThat(objectStorage.listByPrefix("runs/")).isEmpty()
     }
 }


### PR DESCRIPTION
## Summary

Two followups from PR #1228 (raw path → MinIO migration):

1. **5 pre-existing test files** had compile errors after the migration signature changes. Fixed.
2. **`RankingFetchPhase` fire-and-forget race condition** discovered by `DataflowContractTest` (Task 14) — the per-page submission CF was not awaited by the outer chain, allowing `sink.close()` to fire before page 1 records were submitted.

Plus 2 small production fixes uncovered while fixing the tests:
- `UrgentChunkArtifactWriter` was passing `chunkKey` without `.jsonl.gz` extension; `GzipJsonlChunkWriter.Stats.path` uses `substringAfterLast('/')` so the return value came back without the suffix.
- `GzipJsonlChunkWriterTest` didn't register `JavaTimeModule`, and the writer serializes the full `SnapshotChunkRecord.Success` envelope (bodyBytes is base64-encoded) — assertions corrected.

## Files changed (9)

**Tests (7):**
- `UrgentChunkArtifactWriterTest.kt` — `KeyType.IGN` → `USER_IGN`
- `OcidCacheProviderTest.kt` — `kotlin.test` → JUnit assertions
- `ExternalApiSchedulerTest.kt` — wrap `verify(...).execute(...)` in `runBlocking` (suspend)
- `RankingFetchPhaseTest.kt` — fix event class FQNs (`maple.expectation.common.event.*`)
- `RunMarkerWriterTest.kt` — convert `mockk` + `kotlin.test` → `mockito-kotlin` + JUnit
- `UrgentCharacterRequestConsumerTest.kt` — real `LocalFsObjectStorage`, await async chain via `listByPrefix` poll, fix chunk key suffix
- `GzipJsonlChunkWriterTest.kt` — `JavaTimeModule` + assert `bodyBytes` is base64-encoded

**Production (2):**
- `UrgentChunkArtifactWriter.kt` — include `.jsonl.gz` in `chunkKey`
- `RankingFetchPhase.kt` — `thenAcceptAsync` + inner `whenComplete` (fire-and-forget) → `thenComposeAsync` + outer `whenComplete` (awaited). Submission errors now propagate to the outer `handle` and get recorded as failures.

## Test plan

- [x] `./gradlew :module-external-api:test` — BUILD SUCCESSFUL
- [x] `./gradlew :module-cleanup:test` — BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)