### PR TITLE
fix(ext-api): re-enable character-basic and item-equipment phases

### DIFF
--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/ExternalApiScheduler.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/ExternalApiScheduler.kt
@@ -4,6 +4,7 @@ import maple.externalapi.cache.OcidCacheProvider
 import maple.externalapi.metrics.SchedulerMetrics
 import maple.externalapi.runstatus.PipelinePhase
 import maple.externalapi.runstatus.RunStatusTracker
+import maple.externalapi.scheduler.phase.CharacterBasicFetchPhase
 import maple.externalapi.scheduler.phase.OcidLookupPhase
 import maple.externalapi.scheduler.phase.RankingFetchPhase
 import maple.expectation.infrastructure.lifecycle.ManagedLifecycle
@@ -27,6 +28,8 @@ class ExternalApiScheduler(
     private val ocidLookupPhase: OcidLookupPhase,
     private val ocidCacheProvider: OcidCacheProvider,
     private val rankingFetchPhaseProvider: ObjectProvider<RankingFetchPhase>,
+    private val characterBasicPhaseProvider: ObjectProvider<CharacterBasicFetchPhase>,
+    private val itemEquipmentContinuousLoop: ItemEquipmentContinuousLoop,
     private val runStatusTracker: RunStatusTracker,
     private val schedulerMetrics: SchedulerMetrics,
     @Value("\${external-api.schedule.run-on-startup:false}")
@@ -48,7 +51,7 @@ class ExternalApiScheduler(
             log.info("[Scheduler] run-on-startup enabled, triggering daily refresh")
             triggerDailyRefresh(null)
         }
-        executor.submit { runItemEquipmentLoop() }
+        itemEquipmentContinuousLoop.startItemEquipmentLoopOnce()
     }
 
     @Scheduled(cron = "\${external-api.schedule.daily-cron:0 0 3 * * *}")
@@ -101,11 +104,22 @@ class ExternalApiScheduler(
                 }
             }
             .thenCompose {
-                // TODO(#1217 pre-existing): re-enable character basic / item equipment
-                // fetches when SnapshotFetchPhase is reintroduced. For now, only OCID
-                // lookup runs as part of the daily refresh.
                 ocidCacheProvider.refresh()
-                CompletableFuture.completedFuture(null)
+                runStatusTracker.transitionPhase(PipelinePhase.CHARACTER_BASIC)
+                val charBasicPhase = characterBasicPhaseProvider.ifAvailable
+                if (charBasicPhase == null) {
+                    log.warn("[Scheduler] character-basic phase not enabled, skipping")
+                    CompletableFuture.completedFuture(null)
+                } else {
+                    val ocidCache = ocidCacheProvider.current()
+                    if (ocidCache.isEmpty()) {
+                        log.warn("[Scheduler] OCID cache empty after OCID lookup, skipping character-basic")
+                        CompletableFuture.completedFuture(null)
+                    } else {
+                        log.info("[Scheduler] starting character-basic fetch ({} entries)", ocidCache.size)
+                        charBasicPhase.execute(executor, ocidCache)
+                    }
+                }
             }
             .whenComplete { _, ex ->
                 if (ex != null) {
@@ -122,48 +136,6 @@ class ExternalApiScheduler(
                     log.info("[Scheduler] daily refresh completed, chunks={} records={}", chunks, records)
                 }
                 releaseLock()
-            }
-    }
-
-    private fun runItemEquipmentLoop() {
-        log.info("[Scheduler] ITEM_EQUIPMENT continuous loop started")
-        runItemEquipmentCycle()
-    }
-
-    private fun runItemEquipmentCycle() {
-        if (shutdown.get()) {
-            log.info("[Scheduler] ITEM_EQUIPMENT continuous loop stopped")
-            return
-        }
-
-        val entries = ocidCacheProvider.current().entries.toList()
-        if (entries.isEmpty()) {
-            log.warn("[Scheduler] OCID cache empty, waiting 30s")
-            executor.submit {
-                Thread.sleep(java.time.Duration.ofSeconds(30))
-                ocidCacheProvider.refresh()
-                runItemEquipmentCycle()
-            }
-            return
-        }
-
-        if (!acquireLock(120_000)) {
-            executor.submit {
-                Thread.sleep(java.time.Duration.ofSeconds(5))
-                runItemEquipmentCycle()
-            }
-            return
-        }
-
-        CompletableFuture.completedFuture(null)
-            // TODO(#1217 pre-existing): re-enable item equipment fetch when
-            // SnapshotFetchPhase is reintroduced.
-            .whenComplete { _, ex ->
-                if (ex != null) {
-                    log.error("[Scheduler] ITEM_EQUIPMENT cycle failed", ex)
-                }
-                releaseLock()
-                executor.submit { runItemEquipmentCycle() }
             }
     }
 
@@ -193,5 +165,6 @@ class ExternalApiScheduler(
         log.info("[Scheduler] shutdown requested")
         shutdown.set(true)
         executor.close()
+        itemEquipmentContinuousLoop.stop()
     }
 }

--- a/module-external-api/src/test/kotlin/maple/externalapi/scheduler/ExternalApiSchedulerTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/scheduler/ExternalApiSchedulerTest.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.runBlocking
 import maple.externalapi.cache.OcidCacheProvider
 import maple.externalapi.metrics.SchedulerMetrics
 import maple.externalapi.runstatus.RunStatusTracker
+import maple.externalapi.scheduler.phase.CharacterBasicFetchPhase
 import maple.externalapi.scheduler.phase.OcidLookupPhase
 import maple.externalapi.scheduler.phase.RankingFetchPhase
 import org.assertj.core.api.Assertions.assertThat
@@ -44,10 +45,17 @@ class ExternalApiSchedulerTest {
         val rankingProvider = mock<ObjectProvider<RankingFetchPhase>>()
         whenever(rankingProvider.ifAvailable).thenReturn(rankingPhase)
 
+        val charBasicProvider = mock<ObjectProvider<CharacterBasicFetchPhase>>()
+        whenever(charBasicProvider.ifAvailable).thenReturn(null)
+
+        val itemEquipmentLoop = mock<ItemEquipmentContinuousLoop>()
+
         val scheduler = ExternalApiScheduler(
             ocidLookupPhase = ocidLookupPhase,
             ocidCacheProvider = ocidCache,
             rankingFetchPhaseProvider = rankingProvider,
+            characterBasicPhaseProvider = charBasicProvider,
+            itemEquipmentContinuousLoop = itemEquipmentLoop,
             runStatusTracker = runStatusTracker,
             schedulerMetrics = schedulerMetrics,
             runOnStartup = false,


### PR DESCRIPTION
Issue #1217 left the char-basic + item-equipment phases disabled in `ExternalApiScheduler.triggerDailyRefresh` with a TODO marker. The phases themselves were fixed in PR #1230 (ObjectStorage wiring) but the scheduler never re-wired them.

## Changes
- Inject `ItemEquipmentContinuousLoop`; `onStartup()` calls its `startItemEquipmentLoopOnce()` instead of the dead local stub.
- Inject `ObjectProvider<CharacterBasicFetchPhase>`; OCID → CHARACTER_BASIC is now part of the daily refresh chain. Skips if OCID cache is empty or the phase bean is not enabled.
- Track `PipelinePhase.CHARACTER_BASIC` via `RunStatusTracker.transitionPhase`.
- Drop the dead `runItemEquipmentLoop` / `runItemEquipmentCycle` methods + 2 TODO(#1217) markers.
- `stopLifecycle()` now also stops the continuous loop.
- `ExternalApiSchedulerTest` updated to wire the new params (char-basic mocked as null so it skips in the test).

## Verification
- `./gradlew :module-external-api:compileKotlin` — OK
- `./gradlew :module-external-api:compileTestKotlin` — OK
- `./gradlew :module-external-api:test --tests ExternalApiSchedulerTest` — PASSED (7.3s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)