### PR TITLE
fix(ext-api): stream OCID mapping writes to MinIO instead of buffering

### DIFF
--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/OcidLookupPhase.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/OcidLookupPhase.kt
@@ -11,20 +11,23 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.yield
 import kotlinx.coroutines.future.await
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.yield
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
-import java.io.ByteArrayOutputStream
 import java.io.BufferedInputStream
 import java.io.BufferedOutputStream
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
 import java.time.Instant
-import java.util.Collections
 import java.util.UUID
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.atomic.AtomicInteger
@@ -39,9 +42,17 @@ import java.util.zip.GZIPOutputStream
  * Caller (ExternalApiScheduler) 는 `runBlocking { ocidLookupPhase.execute(workerExecutor, runKey) }` (multi-threaded VT, short-lived).
  *
  * <p>VS2 migration (Task 7): input chunks and output OCID mapping are read/written via
- * [ObjectStorage] using string keys. `runKey: String` replaces the prior `runDir: Path` argument.
+ * [ObjectStorage] using string keys. `runKey: String` replaces the prior `runDir: Path` argumento.
  * The `nexonAuthClient` is held for future callers (per-key authentication); the current
  * per-IGN lookup path goes through [ExternalApiClientPort].
+ *
+ * <p>Streaming write: each successful mapping is pushed to a [Channel] and consumed by a
+ * single writer coroutine that pipes bytes into a GZIPOutputStream wrapping
+ * [ObjectStorage.putStream]. The previous implementation accumulated all 600K+ entries in a
+ * `MutableList<String>` until the end of the phase — that held ~120MB of JSON strings in heap
+ * for the entire OCID run and pushed the JVM over its 1GB ceiling when combined with other
+ * in-flight state. Streaming keeps the heap footprint bounded to the pipe buffer (64KB) plus
+ * the GZIPOutputStream internal buffer.
  */
 @Component
 @ConditionalOnProperty(name = ["external-api.schedule.enabled"], havingValue = "true")
@@ -78,7 +89,7 @@ class OcidLookupPhase(
 
         log.info("[Scheduler] ========== OCID lookup start ==========")
         log.info(
-            "[Scheduler] config: total={}, rate={}/s, batchSize={}, store=ObjectStorage",
+            "[Scheduler] config: total={}, rate={}/s, batchSize={}, store=ObjectStorage (streaming)",
             igns.size, ocidLookupPermitsPerSecond, batchSize,
         )
 
@@ -86,23 +97,57 @@ class OcidLookupPhase(
         val successCount = AtomicInteger(0)
         val failCount = AtomicInteger(0)
         val lastProgressLog = AtomicInteger(0)
-        val results: MutableList<String> = Collections.synchronizedList(mutableListOf())
-
-        processBatch(
-            workerExecutor = workerExecutor,
-            rateLimiter = rateLimiter,
-            runKey = runKey,
-            igns = igns,
-            processed = 0,
-            successCount = successCount,
-            failCount = failCount,
-            lastProgressLog = lastProgressLog,
-            results = results,
-            start = start,
-        )
-
         val runId = runKey.removePrefix("runs/").substringBefore('/')
-        writeMappingGzipped(mappingDir, results, runId)
+        val key = "$mappingDir/ocid-mapping-$runId.jsonl.gz"
+
+        // Channel + writer coroutine: producers (per-ign fetch) send strings,
+        // a single consumer coroutine gzips + puts to ObjectStorage as bytes flow.
+        // Channel.BUFFERED applies backpressure when the writer can't keep up.
+        val resultsChannel = Channel<String>(Channel.BUFFERED)
+
+        // Pipe: producer writes to pipeOut (GZIPOutputStream), consumer reads
+        // from pipeIn (ObjectStorage.putStream). Buffer of 64KB caps JVM heap
+        // use from the pipe itself.
+        val pipeOut = PipedOutputStream()
+        val pipeIn = PipedInputStream(pipeOut, 65_536)
+
+        coroutineScope {
+            val putJob = async(Dispatchers.IO) { objectStorage.putStream(key, pipeIn) }
+
+            val writerJob = launch(Dispatchers.IO) {
+                val gz = GZIPOutputStream(BufferedOutputStream(pipeOut))
+                try {
+                    for (entry in resultsChannel) {
+                        gz.write(entry.toByteArray())
+                        gz.write('\n'.code)
+                    }
+                } finally {
+                    runCatching { gz.close() }
+                    runCatching { pipeOut.close() }
+                }
+            }
+
+            processBatch(
+                workerExecutor = workerExecutor,
+                rateLimiter = rateLimiter,
+                runKey = runKey,
+                igns = igns,
+                processed = 0,
+                successCount = successCount,
+                failCount = failCount,
+                lastProgressLog = lastProgressLog,
+                resultsSink = resultsChannel,
+                start = start,
+            )
+
+            resultsChannel.close()
+            writerJob.join()
+            putJob.await()
+        }
+        log.info(
+            "[Scheduler] streamed {} OCID mappings to {} (heap-bounded via pipe)",
+            successCount.get(), key,
+        )
         SchedulerPhaseUtils.logSummary(
             "OCID lookup",
             igns.size,
@@ -116,8 +161,8 @@ class OcidLookupPhase(
                 eventId = UUID.randomUUID().toString(),
                 runId = runId,
                 endpoint = "ocid-lookup",
-                manifestPath = "$mappingDir/ocid-mapping-$runId.jsonl.gz",
-                totalRecords = results.size,
+                manifestPath = key,
+                totalRecords = successCount.get(),
                 totalFailed = failCount.get(),
                 chunkCount = 1,
                 startedAt = start,
@@ -153,19 +198,6 @@ class OcidLookupPhase(
         log.info("[Scheduler] deleted {} old OCID mapping objects in {}/", total, mappingDir)
     }
 
-    private fun writeMappingGzipped(mappingDir: String, results: List<String>, runId: String) {
-        val out = ByteArrayOutputStream()
-        GZIPOutputStream(BufferedOutputStream(out)).use { gz ->
-            for (r in results) {
-                gz.write(r.toByteArray())
-                gz.write('\n'.code)
-            }
-        }
-        val key = "$mappingDir/ocid-mapping-$runId.jsonl.gz"
-        objectStorage.put(key, out.toByteArray())
-        log.info("[Scheduler] wrote {} OCID mappings to {} ({} bytes)", results.size, key, out.size())
-    }
-
     /**
      * Iterative batch processor. async + awaitAll for parallel CPU offload.
      * Each `async` runs on caller dispatcher (IO from runBlocking → no explicit = inherited).
@@ -184,15 +216,13 @@ class OcidLookupPhase(
         successCount: AtomicInteger,
         failCount: AtomicInteger,
         lastProgressLog: AtomicInteger,
-        results: MutableList<String>,
+        resultsSink: SendChannel<String>,
         start: Instant,
     ) {
         var current = processed
         while (current < igns.size) {
             val permits = SchedulerPhaseUtils.acquirePermits(rateLimiter, batchSize, igns.size - current)
             if (permits == 0) {
-                // bucket drained — yield to dispatcher so other coroutines run,
-                // then retry on next iteration (no artificial delay)
                 yield()
                 continue
             }
@@ -201,7 +231,7 @@ class OcidLookupPhase(
             coroutineScope {
                 chunk.map { ign ->
                     async(Dispatchers.IO) {
-                        fetchAndCollectOcidAsync(ign, workerExecutor, successCount, failCount, results)
+                        fetchAndCollectOcidAsync(ign, workerExecutor, successCount, failCount, resultsSink)
                     }
                 }.awaitAll()
             }
@@ -221,13 +251,15 @@ class OcidLookupPhase(
 
     /**
      * Per-ign OCID fetch + JSON parse/serialize. HTTP call on IO, CPU offload via withContext(Default).
+     * Each successful mapping is sent to [resultsSink] for streaming write — no
+     * in-memory accumulation.
      */
     private suspend fun fetchAndCollectOcidAsync(
         ign: String,
         workerExecutor: ExecutorService,
         successCount: AtomicInteger,
         failCount: AtomicInteger,
-        results: MutableList<String>,
+        resultsSink: SendChannel<String>,
     ) {
         try {
             val data = withContext(Dispatchers.IO) {
@@ -251,7 +283,7 @@ class OcidLookupPhase(
             }
 
             if (ocid != null && json != null) {
-                results.add(json)
+                resultsSink.send(json)
                 successCount.incrementAndGet()
             }
         } catch (ex: Exception) {

--- a/module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/OcidLookupPhaseTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/OcidLookupPhaseTest.kt
@@ -6,22 +6,24 @@ import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import maple.expectation.common.storage.ObjectInfo
 import maple.expectation.common.storage.ObjectStorage
 import maple.expectation.common.storage.PutResult
 import maple.expectation.infrastructure.external.NexonAuthClient
-import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
+import java.io.InputStream
 import java.time.Instant
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executors
+import java.util.zip.GZIPInputStream
 
 class OcidLookupPhaseTest {
 
     @Test
-    fun `execute writes OCID mapping gzipped to ObjectStorage under ocid-mapping key`() {
+    fun `execute streams OCID mapping gzipped to ObjectStorage under ocid-mapping key`() {
         val storage = mock<ObjectStorage>()
         val nexonClient = mock<NexonAuthClient>()
         val objectMapper = ObjectMapper().registerModule(kotlinModule())
@@ -29,7 +31,6 @@ class OcidLookupPhaseTest {
         whenever(storage.listByPrefix(any())).thenReturn(listOf(
             ObjectInfo("runs/abc/ranking-overall/chunks/part-000001.jsonl.gz", 100, Instant.now())
         ))
-        // Chunk files are gzipped JSONL on disk; produce a gzipped fixture.
         val chunkBytes = run {
             val out = java.io.ByteArrayOutputStream()
             java.util.zip.GZIPOutputStream(out).use { gz ->
@@ -40,7 +41,6 @@ class OcidLookupPhaseTest {
         whenever(storage.getStream("runs/abc/ranking-overall/chunks/part-000001.jsonl.gz"))
             .thenReturn(chunkBytes.inputStream())
 
-        // clientPort is used for the per-IGN OCID lookup. Stub it to return an ocid JSON for each IGN.
         val clientPort = mock<maple.externalapi.port.out.ExternalApiClientPort>()
         whenever(clientPort.fetch(any(), any(), any())).thenAnswer { invocation ->
             val ign = invocation.getArgument<String>(2)
@@ -48,10 +48,16 @@ class OcidLookupPhaseTest {
             CompletableFuture.completedFuture(payload.toByteArray())
         }
 
-        val mappingKeyCaptor = argumentCaptor<String>()
-        val mappingBytesCaptor = argumentCaptor<ByteArray>()
-        whenever(storage.put(mappingKeyCaptor.capture(), mappingBytesCaptor.capture()))
-            .thenReturn(PutResult("k", 0, null))
+        // Collect streamed bytes (replaces the previous put() call). This
+        // is exactly the path MinioObjectStorage.putStream takes: it drains
+        // the input to a temp file, then puts that file to S3.
+        val collectedBytes = java.util.concurrent.atomic.AtomicReference<ByteArray>()
+        whenever(storage.putStream(any(), any())).thenAnswer { invocation ->
+            val input = invocation.getArgument<InputStream>(1)
+            val bytes = input.readBytes()
+            collectedBytes.set(bytes)
+            PutResult(invocation.getArgument<String>(0), bytes.size.toLong(), null)
+        }
 
         val phase = OcidLookupPhase(
             clientPort = clientPort,
@@ -70,6 +76,9 @@ class OcidLookupPhaseTest {
             )
         }
 
+        // Verify the streaming putStream was called with the right key.
+        val mappingKeyCaptor = argumentCaptor<String>()
+        verify(storage).putStream(mappingKeyCaptor.capture(), any())
         val mappingKey = mappingKeyCaptor.firstValue
         assertNotNull(mappingKey)
         assertTrue(
@@ -81,10 +90,12 @@ class OcidLookupPhaseTest {
             "expected mapping key to end with '.jsonl.gz' but was '$mappingKey'",
         )
 
-        // Verify the captured bytes are a valid gzip stream
-        val captured = mappingBytesCaptor.firstValue
-        assertTrue(captured.isNotEmpty(), "mapping bytes should not be empty")
-        val decompressed = java.util.zip.GZIPInputStream(captured.inputStream())
+        // The streamed bytes should be a non-empty valid gzip containing the
+        // expected userIgn/ocid pairs.
+        val bytes = collectedBytes.get()
+        assertNotNull(bytes, "putStream should have been called")
+        assertTrue(bytes!!.isNotEmpty(), "streamed bytes should not be empty")
+        val decompressed = GZIPInputStream(bytes.inputStream())
             .bufferedReader().readText()
         assertTrue(
             decompressed.contains("user1") && decompressed.contains("ocid-for-user1"),


### PR DESCRIPTION
The previous implementation accumulated every successful mapping (`{"userIgn":"...","ocid":"..."}` JSON, ~200B) in a single `results: MutableList<String>` and only flushed to MinIO at the end of the OCID phase via a single `objectStorage.put(key, ByteArray)`. For a 600K-entry run that held ~120MB of strings in heap for the entire OCID phase (~25 min) and pushed the JVM over its 1GB heap ceiling when combined with the in-flight batch state and the item-equipment continuous loop's parallel processing. The 2.5h run died with OutOfMemoryError mid-OCID at run minute 25.

Stream each mapping to a Channel; a single writer coroutine consumes the channel and gzips + writes to ObjectStorage via putStream. The heap footprint is bounded to the pipe buffer (64KB) plus the GZIPOutputStream internal buffer — the 120MB string list is gone.

Reader (OcidCacheProvider) is unchanged: it picks the latest object via listByPrefix + maxByOrNull(lastModified), so a single streaming write to the same key continues to produce the same final artifact.

## Verification
- `./gradlew :module-external-api:compileKotlin` — OK
- `./gradlew :module-external-api:test --tests OcidLookupPhaseTest` — 1/1 PASSED (5.2s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)