### PR TITLE
fix(ext-api): catch Throwable in sink writer loop so OOM/Error surfaces

### DIFF
--- a/module-external-api/src/main/kotlin/maple/externalapi/snapshot/ChunkedSnapshotSink.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/snapshot/ChunkedSnapshotSink.kt
@@ -112,7 +112,14 @@ class ChunkedSnapshotSink(
                     is SnapshotChunkRecord.CloseSignal -> return
                 }
             }
-        } catch (ex: Exception) {
+        } catch (ex: Throwable) {
+            // Catch Throwable (not Exception) so heap pressure / VM-level
+            // failures (OutOfMemoryError, StackOverflowError, etc.) are
+            // recorded in writerError instead of letting the writer thread
+            // die silently. Without this, a subsequent submit() would only
+            // see writerFuture.isDone = true and throw the vague
+            // "sink writer thread is not alive" message, losing the
+            // original cause.
             writerError.set(ex)
             accepting.set(false)
             log.error("[Sink] writer thread error: {}", ex.message, ex)

--- a/module-external-api/src/test/kotlin/maple/externalapi/snapshot/ChunkedSnapshotSinkTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/snapshot/ChunkedSnapshotSinkTest.kt
@@ -1,0 +1,115 @@
+package maple.externalapi.snapshot
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.kotlinModule
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.time.Instant
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+class ChunkedSnapshotSinkTest {
+
+    private val objectMapper = ObjectMapper().registerModule(kotlinModule())
+
+    @Test
+    fun `submit throws after writer thread dies from Error, not Exception`() {
+        // Reproduces the production symptom: writer thread dies from
+        // an Error (e.g. OOMError under heap pressure) and a subsequent
+        // submit() call observes writerFuture.isDone = true before the
+        // runWriterLoop catch can set writerError. Before the fix the
+        // submit throws a vague "writer thread is not alive" message
+        // and the original OOMError is lost. After the fix the writer
+        // catch clause widens to Throwable so the original error is
+        // propagated as "sink closed due to writer error: ...".
+
+        val appendInvoked = CountDownLatch(1)
+        val capturedBodyBytes = AtomicReference<ByteArray>()
+
+        val fileManager = mock<ChunkFileManager>()
+        whenever(fileManager.appendSuccess(any())).thenAnswer { invocation ->
+            val record = invocation.getArgument<SnapshotChunkRecord.Success>(0)
+            capturedBodyBytes.set(record.bodyBytes)
+            appendInvoked.countDown()
+            // Throw an Error (NOT Exception) — simulates heap pressure
+            // or similar unrecoverable condition. The old catch (ex: Exception)
+            // would NOT catch this and the thread would die silently.
+            throw OutOfMemoryError("simulated writer OOM")
+        }
+
+        val eventPublisher = mock<SnapshotSinkEventPublisher>()
+
+        val sink = ChunkedSnapshotSink(
+            endpoint = "item-equipment",
+            queueCapacity = 100,
+            fileManager = fileManager,
+            eventPublisher = eventPublisher,
+        )
+
+        // First submit succeeds (queue.offer, writer picks it up).
+        val body = objectMapper.writeValueAsBytes(
+            mapOf("userIgn" to "user-1", "ocid" to "ocid-1")
+        )
+        sink.submit(
+            SnapshotChunkRecord.Success(
+                key = "user-1",
+                endpoint = "item-equipment",
+                keyType = "OCID",
+                httpStatus = 200,
+                fetchedAt = Instant.parse("2026-06-11T00:00:00Z"),
+                bodyBytes = body,
+            )
+        )
+
+        // Wait for writer to start processing the first record (it will then
+        // throw OutOfMemoryError, which under the bug kills the thread
+        // silently without setting writerError or accepting=false).
+        assertTrue(
+            appendInvoked.await(2, TimeUnit.SECONDS),
+            "writer thread should have invoked fileManager.appendSuccess",
+        )
+
+        // Wait for the writer Future to be done (thread exited).
+        val writerField = ChunkedSnapshotSink::class.java.getDeclaredField("writerFuture")
+            .apply { isAccessible = true }
+        val writerFuture = writerField.get(sink) as java.util.concurrent.Future<*>
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2)
+        while (System.nanoTime() < deadline && !writerFuture.isDone) Thread.sleep(20)
+        assertTrue(writerFuture.isDone, "writer thread should have terminated")
+
+        // Second submit: under the BUG this throws
+        //   IllegalStateException("sink writer thread is not alive")
+        // because writerError stayed null (the catch never saw the OOM)
+        // and accepting stayed true. After the FIX it should throw
+        //   IllegalStateException("sink closed due to writer error: simulated writer OOM")
+        // because the writer's Throwable catch records the error and flips
+        // accepting to false.
+        val ex = assertThrows(IllegalStateException::class.java) {
+            sink.submit(
+                SnapshotChunkRecord.Success(
+                    key = "user-2",
+                    endpoint = "item-equipment",
+                    keyType = "OCID",
+                    httpStatus = 200,
+                    fetchedAt = Instant.parse("2026-06-11T00:00:00Z"),
+                    bodyBytes = objectMapper.writeValueAsBytes(
+                        mapOf("userIgn" to "user-2", "ocid" to "ocid-2")
+                    ),
+                )
+            )
+        }
+        val message = ex.message ?: ""
+        // The original OOM must surface in the message — not just a vague
+        // "writer thread is not alive". This is what the fix enables.
+        assertTrue(
+            message.contains("writer thread is not alive").not() &&
+                (message.contains("simulated writer OOM") || message.contains("sink closed due to writer error")),
+            "expected submit() to surface the underlying OOMError, got: $message",
+        )
+    }
+}


### PR DESCRIPTION
ChunkedSnapshotSink.runWriterLoop had `catch (ex: Exception)`. When the writer thread threw an `Error` (most commonly `OutOfMemoryError` under heap pressure, but also `StackOverflowError` and any `VirtualMachineError`) the catch did not fire, the thread died silently, and the next submit() could only see `writerFuture.isDone = true` and threw `IllegalStateException("sink writer thread is not alive")` — losing the original OOM and leaving the operator with no signal that the pipeline had run out of heap.

Production hit this in the last pipeline test: the daily_collection DAG went FAILED with exactly that error after 1h19m, and the log context (heap plateau at 928MB/1GB for the last 25min) strongly suggests the writer thread hit OOM while compressing/putting the current item-equipment chunk.

Widen the catch to `Throwable` so any failure inside the writer (documented or otherwise) is recorded in writerError and flips accepting to false. The next submit() then throws `"sink closed due to writer error: <original message>"` with the underlying cause as the cause chain — actionable diagnostic.

Added `ChunkedSnapshotSinkTest` with a Throwable-throwing mock to pin the contract: writer dies → writerError is set → submit throws with the original message. Without the fix the test fails (the OOM is lost); with the fix it passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)