### PR TITLE
fix(ext-api): track item-equipment completion in run-status via CHARACTER_BASIC_DONE

### DIFF
--- a/module-external-api/src/main/kotlin/maple/externalapi/runstatus/PipelinePhase.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/runstatus/PipelinePhase.kt
@@ -6,6 +6,7 @@ enum class PipelinePhase {
     OCID_LOOKUP,
     OCID_CACHE_REFRESH,
     CHARACTER_BASIC,
+    CHARACTER_BASIC_DONE,
     ITEM_EQUIPMENT,
     COMPLETED,
     FAILED,

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/ExternalApiScheduler.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/ExternalApiScheduler.kt
@@ -1,7 +1,6 @@
 package maple.externalapi.scheduler
 
 import maple.externalapi.cache.OcidCacheProvider
-import maple.externalapi.metrics.SchedulerMetrics
 import maple.externalapi.runstatus.PipelinePhase
 import maple.externalapi.runstatus.RunStatusTracker
 import maple.externalapi.scheduler.phase.CharacterBasicFetchPhase
@@ -31,7 +30,6 @@ class ExternalApiScheduler(
     private val characterBasicPhaseProvider: ObjectProvider<CharacterBasicFetchPhase>,
     private val itemEquipmentContinuousLoop: ItemEquipmentContinuousLoop,
     private val runStatusTracker: RunStatusTracker,
-    private val schedulerMetrics: SchedulerMetrics,
     @Value("\${external-api.schedule.run-on-startup:false}")
     private val runOnStartup: Boolean,
     @Value("\${external-api.schedule.skip-character-basic:false}")
@@ -128,12 +126,14 @@ class ExternalApiScheduler(
                         runStatusTracker.failRun(runId, ex.message ?: "unknown")
                     }
                 } else {
-                    val chunks = schedulerMetrics.drainRunChunks().toInt()
-                    val records = schedulerMetrics.drainRunRecords()
-                    runStatusTracker.getCurrentStatus()?.runId?.let { runId ->
-                        runStatusTracker.completeRun(runId, chunks, records)
-                    }
-                    log.info("[Scheduler] daily refresh completed, chunks={} records={}", chunks, records)
+                    // Char-basic finished; item-equipment runs in a SEPARATE continuous loop
+                    // (ItemEquipmentContinuousLoop) and signals run completion there. Marking
+                    // CHARACTER_BASIC_DONE here so observers (Airflow sensor, /run-status API)
+                    // can distinguish "char-basic finished, item-equipment still in flight"
+                    // from "fully completed." ItemEquipmentContinuousLoop's whenComplete
+                    // checks this phase and only then calls completeRun.
+                    runStatusTracker.transitionPhase(PipelinePhase.CHARACTER_BASIC_DONE)
+                    log.info("[Scheduler] char-basic finished, item-equipment in continuous loop")
                 }
                 releaseLock()
             }

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/ItemEquipmentContinuousLoop.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/ItemEquipmentContinuousLoop.kt
@@ -7,6 +7,8 @@ import java.util.concurrent.locks.ReentrantLock
 import maple.expectation.error.exception.DistributedLockException
 import maple.externalapi.cache.OcidCacheProvider
 import maple.externalapi.metrics.SchedulerMetrics
+import maple.externalapi.runstatus.PipelinePhase
+import maple.externalapi.runstatus.RunStatusTracker
 import maple.externalapi.scheduler.phase.ItemEquipmentFetchPhase
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
@@ -17,6 +19,12 @@ import org.springframework.stereotype.Component
  * Separated from [ExternalApiScheduler] so the scheduler can focus on the daily
  * pipeline trigger + lifecycle, and this class focuses on the long-running cycle.
  *
+ * Run-completion signal: ExternalApiScheduler transitions the run to
+ * [PipelinePhase.CHARACTER_BASIC_DONE] when char-basic ends. The first item-equipment
+ * cycle that completes AFTER that phase transition signals full run completion
+ * (sink closed, manifest + _SUCCESS marker written) via RunStatusTracker.completeRun.
+ * The phase guard prevents subsequent cycles from re-completing the same run.
+ *
  * State: one `ReentrantLock` + condition for the distributed mutex, and three
  * `AtomicBoolean`s for "loop started", "loop running", and "shutdown requested".
  */
@@ -25,6 +33,7 @@ class ItemEquipmentContinuousLoop(
     private val itemEquipmentFetchPhase: ItemEquipmentFetchPhase,
     private val ocidCacheProvider: OcidCacheProvider,
     private val schedulerMetrics: SchedulerMetrics,
+    private val runStatusTracker: RunStatusTracker,
     @Qualifier("externalApiSchedulerExecutor") private val executor: ExecutorService,
 ) {
     private val log = LoggerFactory.getLogger(ItemEquipmentContinuousLoop::class.java)
@@ -79,6 +88,23 @@ class ItemEquipmentContinuousLoop(
             .whenComplete { _, ex ->
                 if (ex != null) {
                     log.error("[Scheduler] ITEM_EQUIPMENT cycle failed", ex)
+                } else {
+                    // Cycle finished cleanly (sink closed, manifest + _SUCCESS written).
+                    // If char-basic has already finished for the current run, this cycle
+                    // represents run completion. Guarded by phase to make it idempotent —
+                    // subsequent cycles see COMPLETED and skip the completeRun call.
+                    val current = runStatusTracker.getCurrentStatus()
+                    if (current != null &&
+                        current.phase == PipelinePhase.CHARACTER_BASIC_DONE
+                    ) {
+                        val chunks = schedulerMetrics.drainRunChunks().toInt()
+                        val records = schedulerMetrics.drainRunRecords()
+                        runStatusTracker.completeRun(current.runId, chunks, records)
+                        log.info(
+                            "[Scheduler] run completed, runId={} chunks={} records={}",
+                            current.runId, chunks, records,
+                        )
+                    }
                 }
                 releaseLock()
                 executor.submit { runItemEquipmentCycle() }

--- a/module-external-api/src/test/kotlin/maple/externalapi/artifact/UrgentChunkArtifactWriterTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/artifact/UrgentChunkArtifactWriterTest.kt
@@ -17,9 +17,11 @@ import org.mockito.kotlin.whenever
 import java.time.Instant
 
 /**
- * Migration Task 8: writer must put a single chunk at
- * `runs/{runId}/{endpointDir}/chunks/part-000001.jsonl.gz` and return
- * that key (not a local filesystem path).
+ * Migration Task 8: writer must put a single chunk under
+ * `runs/{runId}/{endpointDir}/chunks/` and return that key (not a local
+ * filesystem path). The part suffix is a UUID, not a counter — this prevents
+ * concurrent urgent writes for the same runId/endpoint from clobbering each
+ * other on the same key.
  */
 class UrgentChunkArtifactWriterTest {
 
@@ -28,7 +30,7 @@ class UrgentChunkArtifactWriterTest {
         .registerModule(JavaTimeModule())
 
     @Test
-    fun `writeChunk returns runs slash runId slash endpoint slash chunks slash part key and puts to ObjectStorage`() {
+    fun `writeChunk returns runs slash runId slash endpoint slash chunks slash part uuid key and puts to ObjectStorage`() {
         val storage = mock<ObjectStorage>()
         val keyCaptor = argumentCaptor<String>()
         val bytesCaptor = argumentCaptor<ByteArray>()
@@ -52,7 +54,7 @@ class UrgentChunkArtifactWriterTest {
             ),
         )
 
-        assertThat(key).isEqualTo("runs/abc/ranking-overall/chunks/part-000001.jsonl.gz")
+        assertThat(key).matches("^runs/abc/ranking-overall/chunks/part-[0-9a-f-]{36}\\.jsonl\\.gz$")
         assertThat(keyCaptor.firstValue).isEqualTo(key)
         assertThat(bytesCaptor.firstValue).isNotEmpty
         verify(storage).put(any<String>(), any<ByteArray>())

--- a/module-external-api/src/test/kotlin/maple/externalapi/runstatus/RunStatusTrackerTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/runstatus/RunStatusTrackerTest.kt
@@ -58,6 +58,20 @@ class RunStatusTrackerTest {
     }
 
     @Test
+    fun `CHARACTER_BASIC_DONE is non-terminal`() {
+        // Regression: the new intermediate phase must NOT be reported as terminal
+        // by the run-status API; otherwise /api/internal/run-status shows
+        // terminal=true while ITEM_EQUIPMENT is still in flight.
+        tracker.startRun("run-1")
+        tracker.transitionPhase(PipelinePhase.CHARACTER_BASIC)
+        tracker.transitionPhase(PipelinePhase.CHARACTER_BASIC_DONE)
+
+        val status = tracker.getCurrentStatus()!!
+        assertThat(status.phase).isEqualTo(PipelinePhase.CHARACTER_BASIC_DONE)
+        assertThat(status.isTerminal).isFalse()
+    }
+
+    @Test
     fun `getLastCompletedRun returns most recent completed`() {
         tracker.startRun("run-1")
         tracker.completeRun("run-1", 10, 1000L)

--- a/module-external-api/src/test/kotlin/maple/externalapi/scheduler/ExternalApiSchedulerTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/scheduler/ExternalApiSchedulerTest.kt
@@ -4,7 +4,7 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutorService
 import kotlinx.coroutines.runBlocking
 import maple.externalapi.cache.OcidCacheProvider
-import maple.externalapi.metrics.SchedulerMetrics
+import maple.externalapi.runstatus.PipelinePhase
 import maple.externalapi.runstatus.RunStatusTracker
 import maple.externalapi.scheduler.phase.CharacterBasicFetchPhase
 import maple.externalapi.scheduler.phase.OcidLookupPhase
@@ -13,6 +13,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.timeout
 import org.mockito.kotlin.verify
@@ -24,6 +25,11 @@ import org.springframework.beans.factory.ObjectProvider
  * [RankingFetchPhase.execute] as a runKey String (e.g. "runs/20260610-xyz"),
  * strip the "runs/" prefix to obtain the runId, and pass the full runKey
  * (not the runId) downstream to [OcidLookupPhase.execute].
+ *
+ * Run-status wiring: when char-basic ends, ExternalApiScheduler must transition
+ * to [PipelinePhase.CHARACTER_BASIC_DONE] — NOT [PipelinePhase.COMPLETED] — because
+ * item-equipment runs in a SEPARATE continuous loop
+ * ([ItemEquipmentContinuousLoop]) and signals full completion from there.
  */
 class ExternalApiSchedulerTest {
 
@@ -38,9 +44,6 @@ class ExternalApiSchedulerTest {
 
         val ocidCache = mock<OcidCacheProvider>()
         val runStatusTracker = mock<RunStatusTracker>()
-        val schedulerMetrics = mock<SchedulerMetrics>()
-        whenever(schedulerMetrics.drainRunChunks()).thenReturn(0L)
-        whenever(schedulerMetrics.drainRunRecords()).thenReturn(0L)
 
         val rankingProvider = mock<ObjectProvider<RankingFetchPhase>>()
         whenever(rankingProvider.ifAvailable).thenReturn(rankingPhase)
@@ -57,7 +60,6 @@ class ExternalApiSchedulerTest {
             characterBasicPhaseProvider = charBasicProvider,
             itemEquipmentContinuousLoop = itemEquipmentLoop,
             runStatusTracker = runStatusTracker,
-            schedulerMetrics = schedulerMetrics,
             runOnStartup = false,
             skipCharacterBasic = false,
         )
@@ -74,5 +76,62 @@ class ExternalApiSchedulerTest {
 
         // The runId passed to startRun is the segment after "runs/".
         verify(runStatusTracker, timeout(5_000)).startRun("20260610-xyz")
+    }
+
+    @Test
+    fun `triggerDailyRefresh transitions to CHARACTER_BASIC_DONE not COMPLETED after char-basic`() {
+        // Regression test for the bug where /api/internal/run-status showed
+        // terminal=true while ITEM_EQUIPMENT was still running in
+        // ItemEquipmentContinuousLoop. The fix is: ExternalApiScheduler signals
+        // char-basic end via CHARACTER_BASIC_DONE; the continuous loop signals
+        // full completion via completeRun.
+
+        val rankingPhase = mock<RankingFetchPhase>()
+        whenever(rankingPhase.execute(any<ExecutorService>()))
+            .thenReturn(CompletableFuture.completedFuture("runs/run-cb-done"))
+
+        val ocidLookupPhase = mock<OcidLookupPhase>()
+        runBlocking {
+            whenever(ocidLookupPhase.execute(any<ExecutorService>(), any<String>()))
+                .thenReturn(Unit)
+        }
+
+        val ocidCache = mock<OcidCacheProvider>()
+        whenever(ocidCache.current()).thenReturn(emptyMap())
+
+        val runStatusTracker = mock<RunStatusTracker>()
+
+        val rankingProvider = mock<ObjectProvider<RankingFetchPhase>>()
+        whenever(rankingProvider.ifAvailable).thenReturn(rankingPhase)
+
+        val charBasicProvider = mock<ObjectProvider<CharacterBasicFetchPhase>>()
+        // Char-basic returns an empty OCID cache to short-circuit the inner block,
+        // so the whenComplete fires and we can assert the phase transition.
+        whenever(charBasicProvider.ifAvailable).thenReturn(null)
+
+        val itemEquipmentLoop = mock<ItemEquipmentContinuousLoop>()
+
+        val scheduler = ExternalApiScheduler(
+            ocidLookupPhase = ocidLookupPhase,
+            ocidCacheProvider = ocidCache,
+            rankingFetchPhaseProvider = rankingProvider,
+            characterBasicPhaseProvider = charBasicProvider,
+            itemEquipmentContinuousLoop = itemEquipmentLoop,
+            runStatusTracker = runStatusTracker,
+            runOnStartup = false,
+            skipCharacterBasic = false,
+        )
+
+        scheduler.triggerDailyRefresh(null)
+
+        // The chain reaches whenComplete → transitionPhase(CHARACTER_BASIC_DONE).
+        // The bug would call completeRun() here instead, which we explicitly do NOT want.
+        verify(runStatusTracker, timeout(5_000))
+            .transitionPhase(PipelinePhase.CHARACTER_BASIC_DONE)
+        verify(runStatusTracker, timeout(1_000).times(0)).completeRun(
+            org.mockito.kotlin.any<String>(),
+            org.mockito.kotlin.any<Int>(),
+            org.mockito.kotlin.any<Long>(),
+        )
     }
 }

--- a/module-external-api/src/test/kotlin/maple/externalapi/snapshot/SnapshotSinkEventPublisherTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/snapshot/SnapshotSinkEventPublisherTest.kt
@@ -34,7 +34,10 @@ class SnapshotSinkEventPublisherTest {
         whenever(sinkEventPublisher.publishChunkReady(any())).thenReturn(CompletableFuture.completedFuture(null))
 
         val stats = ChunkStats(
-            path = "chunks/part-000001.jsonl.gz",
+            // GzipJsonlChunkWriter.close() stores `chunkKey.substringAfterLast('/')`
+            // in stats.path — i.e. the filename only. The publisher prepends the
+            // `runs/{runId}/{endpoint}/chunks/` segment.
+            path = "part-000001.jsonl.gz",
             partIndex = 1,
             recordCount = 42,
             uncompressedBytes = 1000L,


### PR DESCRIPTION
## Summary
- Add `PipelinePhase.CHARACTER_BASIC_DONE` as intermediate (non-terminal) state
- `ExternalApiScheduler` transitions to `CHARACTER_BASIC_DONE` after char-basic ends (instead of `completeRun`)
- `ItemEquipmentContinuousLoop` checks `current.phase == CHARACTER_BASIC_DONE` on each cycle's `whenComplete` and calls `completeRun` only once per run (idempotent guard)
- Remove unused `SchedulerMetrics` injection from `ExternalApiScheduler` (moved to continuous loop)
- Fix 2 pre-existing test failures (outdated expectations):
  - `SnapshotSinkEventPublisherTest`: `stats.path` is filename-only, not `/chunks/`-prefixed
  - `UrgentChunkArtifactWriterTest`: urgent part name is UUID, not counter

## Why
`/api/internal/run-status.current` reported `terminal=true` while ITEM_EQUIPMENT was still running. The char-basic chain's `whenComplete` fired `completeRun`, but item-equipment lives in a separate continuous loop that never reported back. Airflow sensor saw the stale terminal flag and marked runs as `failed` even when the pipeline succeeded.

## Test plan
- [x] `./gradlew :module-external-api:test` — 60/60 pass
- [x] New regression test: `CHARACTER_BASIC_DONE is non-terminal` in `RunStatusTrackerTest`
- [x] New regression test: scheduler calls `transitionPhase(CHARACTER_BASIC_DONE)`, never `completeRun`, in `ExternalApiSchedulerTest`
- [ ] Runtime: rebuild + restart + verify `/api/internal/run-status` transitions correctly through `RANKING_FETCH` → `OCID_LOOKUP` → `CHARACTER_BASIC` → `CHARACTER_BASIC_DONE` → `COMPLETED` (or `FAILED`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)