### PR TITLE
fix(ext-api): backport OOM + startRun fixes to release-0.6.12

### DIFF
--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/ExternalApiScheduler.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/ExternalApiScheduler.kt
@@ -6,6 +6,7 @@ import maple.externalapi.runstatus.RunStatusTracker
 import maple.externalapi.scheduler.phase.CharacterBasicFetchPhase
 import maple.externalapi.scheduler.phase.OcidLookupPhase
 import maple.externalapi.scheduler.phase.RankingFetchPhase
+import maple.externalapi.scheduler.phase.RunIdGenerator
 import maple.expectation.infrastructure.lifecycle.ManagedLifecycle
 import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
@@ -30,6 +31,7 @@ class ExternalApiScheduler(
     private val characterBasicPhaseProvider: ObjectProvider<CharacterBasicFetchPhase>,
     private val itemEquipmentContinuousLoop: ItemEquipmentContinuousLoop,
     private val runStatusTracker: RunStatusTracker,
+    private val runIdGenerator: RunIdGenerator,
     @Value("\${external-api.schedule.run-on-startup:false}")
     private val runOnStartup: Boolean,
     @Value("\${external-api.schedule.skip-character-basic:false}")
@@ -76,15 +78,23 @@ class ExternalApiScheduler(
             return
         }
 
-        log.info("[Scheduler] starting ranking fetch phase")
-        rankingPhase.execute(executor)
+        // Generate the runId here, BEFORE the async chain starts, so the
+        // run-status tracker transitions to RANKING_FETCH for the new run
+        // immediately. Previously this happened inside the .handle callback
+        // of ranking.execute(), which meant a new pipeline cycle would leave
+        // the previous run's FAILED status visible on /api/internal/run-status
+        // until ranking.fetch completed — and any failure before that
+        // (e.g. ItemEquipmentContinuousLoop picking up a fresh OCID mapping
+        // written by a sibling process) would never transition the tracker
+        // at all. See bug repro in commit a4f380f1d.
+        val runId = runIdGenerator.newRunId()
+        runStatusTracker.startRun(runId)
+
+        log.info("[Scheduler] starting ranking fetch phase: runId={}", runId)
+        rankingPhase.execute(executor, runId)
             .handle { runKey, ex ->
                 if (ex != null) {
                     log.error("[Scheduler] ranking fetch failed, cannot proceed with OCID lookup", ex)
-                } else if (runKey != null) {
-                    // runKey is "runs/<runId>"; extract runId for the status tracker.
-                    val runId = runKey.removePrefix("runs/")
-                    runStatusTracker.startRun(runId)
                 }
                 runKey
             }

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/ItemEquipmentContinuousLoop.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/ItemEquipmentContinuousLoop.kt
@@ -10,6 +10,7 @@ import maple.externalapi.metrics.SchedulerMetrics
 import maple.externalapi.runstatus.PipelinePhase
 import maple.externalapi.runstatus.RunStatusTracker
 import maple.externalapi.scheduler.phase.ItemEquipmentFetchPhase
+import maple.externalapi.scheduler.phase.RunIdGenerator
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
@@ -34,6 +35,7 @@ class ItemEquipmentContinuousLoop(
     private val ocidCacheProvider: OcidCacheProvider,
     private val schedulerMetrics: SchedulerMetrics,
     private val runStatusTracker: RunStatusTracker,
+    private val runIdGenerator: RunIdGenerator,
     @Qualifier("externalApiSchedulerExecutor") private val executor: ExecutorService,
 ) {
     private val log = LoggerFactory.getLogger(ItemEquipmentContinuousLoop::class.java)
@@ -83,8 +85,17 @@ class ItemEquipmentContinuousLoop(
         }
         schedulerMetrics.incrementLockAcquired("item_equipment")
 
+        // Generate a per-cycle runId and tell the run-status tracker. The
+        // item-equipment loop runs indefinitely across multiple "runs" of
+        // ranking→ocid→character-basic (each of which writes a fresh OCID
+        // mapping file). Without this, the previous run's FAILED status
+        // would stay on /api/internal/run-status even though a brand-new
+        // cycle is in flight under a new runId.
+        val cycleRunId = runIdGenerator.newRunId()
+        runStatusTracker.startRun(cycleRunId)
+
         CompletableFuture.completedFuture(null)
-            .thenCompose { itemEquipmentFetchPhase.execute(executor, entries) }
+            .thenCompose { itemEquipmentFetchPhase.execute(executor, entries, cycleRunId) }
             .whenComplete { _, ex ->
                 if (ex != null) {
                     log.error("[Scheduler] ITEM_EQUIPMENT cycle failed", ex)

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/ItemEquipmentFetchPhase.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/ItemEquipmentFetchPhase.kt
@@ -38,19 +38,17 @@ class ItemEquipmentFetchPhase(
     @Value("\${external-api.batch-size:1000}")
     private val batchSize: Int,
     private val clock: Clock = Clock.systemUTC(),
-    private val runIdGenerator: RunIdGenerator,
     private val runMarkerWriter: RunMarkerWriter,
     private val schedulerProgressLogger: SchedulerProgressLogger,
 ) {
     private val log = LoggerFactory.getLogger(ItemEquipmentFetchPhase::class.java)
 
-    fun execute(workerExecutor: ExecutorService, entries: List<Map.Entry<String, String>>): CompletableFuture<Unit> {
+    fun execute(workerExecutor: ExecutorService, entries: List<Map.Entry<String, String>>, runId: String): CompletableFuture<Unit> {
         if (entries.isEmpty()) {
             log.warn("[Scheduler] OCID cache empty, skipping item-equipment")
             return CompletableFuture.completedFuture(Unit)
         }
 
-        val runId = runIdGenerator.newRunId()
         val chunkConfig = chunkingProperties.configFor("item-equipment")
         val runKey = "runs/$runId/item-equipment"
         runMarkerWriter.writeRunMarker(runKey)

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/RankingFetchPhase.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/RankingFetchPhase.kt
@@ -48,8 +48,7 @@ class RankingFetchPhase(
 ) {
     private val log = LoggerFactory.getLogger(RankingFetchPhase::class.java)
 
-    fun execute(workerExecutor: ExecutorService): CompletableFuture<String> {
-        val runId = SchedulerPhaseUtils.newRunId()
+    fun execute(workerExecutor: ExecutorService, runId: String): CompletableFuture<String> {
         val date = LocalDate.now().minusDays(1).format(DateTimeFormatter.ISO_LOCAL_DATE)
         val runKey = "runs/$runId"
         val endpointConfig = chunkingProperties.configFor("ranking-overall")

--- a/module-external-api/src/main/kotlin/maple/externalapi/snapshot/GzipJsonlChunkWriter.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/snapshot/GzipJsonlChunkWriter.kt
@@ -2,9 +2,12 @@ package maple.externalapi.snapshot
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import maple.expectation.common.storage.ObjectStorage
-import java.io.ByteArrayOutputStream
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
 import java.time.Clock
 import java.time.Instant
+import java.util.UUID
 import java.util.zip.GZIPOutputStream
 
 data class ChunkStats(
@@ -19,8 +22,22 @@ data class ChunkStats(
 
 /**
  * Streams SnapshotChunkRecord.Success entries into a gzipped JSONL object
- * stored in ObjectStorage under `chunkKey`. No local temp file; bytes are
- * accumulated in a ByteArrayOutputStream and put on close().
+ * stored in ObjectStorage under `chunkKey`.
+ *
+ * Gzip output is written to a temp file on disk (not an in-memory
+ * [java.io.ByteArrayOutputStream]) so the writer thread's heap footprint
+ * stays bounded by the deflater window (~32KB) regardless of
+ * [maxUncompressedBytes]. The previous heap-buffered design OOM'd the
+ * 1GB-heap writer thread at `maxUncompressedBytes=128MB` because the
+ * intermediate buffer plus `ByteArrayOutputStream.toByteArray()` reached
+ * ~256MB before `objectStorage.put` was called.
+ *
+ * On close(), the temp file is streamed to storage via
+ * [ObjectStorage.putStream] and deleted. The two backends
+ * ([maple.expectation.infrastructure.storage.LocalFsObjectStorage],
+ * [maple.expectation.infrastructure.storage.MinioObjectStorage]) both
+ * spool to a temp file internally, so net disk usage during a chunk
+ * rotation is at most two copies of the chunk briefly.
  */
 class GzipJsonlChunkWriter(
     private val chunkKey: String,
@@ -31,8 +48,16 @@ class GzipJsonlChunkWriter(
     private val objectStorage: ObjectStorage,
     private val clock: Clock = Clock.systemUTC(),
 ) {
-    private val buffer = ByteArrayOutputStream()
-    private val gzipped = GZIPOutputStream(buffer)
+    private val tempFile: Path = Files.createTempFile(
+        "gzip-chunk-${UUID.randomUUID()}-part-${partIndex.toString().padStart(6, '0')}-",
+        ".jsonl.gz.tmp",
+    )
+    private val fileOut = Files.newOutputStream(
+        tempFile,
+        StandardOpenOption.WRITE,
+        StandardOpenOption.TRUNCATE_EXISTING,
+    )
+    private val gzipped = GZIPOutputStream(fileOut)
     private var recordCount: Int = 0
     private var uncompressedBytes: Long = 0
     private val startedAt: Instant = Instant.now(clock)
@@ -50,15 +75,23 @@ class GzipJsonlChunkWriter(
         recordCount >= maxRecords || uncompressedBytes >= maxUncompressedBytes
 
     fun close(): ChunkStats {
-        gzipped.close()
-        val compressedBytes = buffer.toByteArray()
-        objectStorage.put(chunkKey, compressedBytes)
+        var putSize: Long = 0L
+        try {
+            gzipped.close()
+            fileOut.close()
+            Files.newInputStream(tempFile).use { input ->
+                val result = objectStorage.putStream(chunkKey, input)
+                putSize = result.size
+            }
+        } finally {
+            Files.deleteIfExists(tempFile)
+        }
         return ChunkStats(
             partIndex = partIndex,
             path = chunkKey.substringAfterLast('/'),
             recordCount = recordCount,
             uncompressedBytes = uncompressedBytes,
-            compressedBytes = compressedBytes.size.toLong(),
+            compressedBytes = putSize,
             startedAt = startedAt,
             finishedAt = Instant.now(clock),
         )

--- a/module-external-api/src/test/kotlin/maple/externalapi/artifact/UrgentChunkArtifactWriterTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/artifact/UrgentChunkArtifactWriterTest.kt
@@ -14,6 +14,7 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.io.ByteArrayInputStream
 import java.time.Instant
 
 /**
@@ -33,9 +34,17 @@ class UrgentChunkArtifactWriterTest {
     fun `writeChunk returns runs slash runId slash endpoint slash chunks slash part uuid key and puts to ObjectStorage`() {
         val storage = mock<ObjectStorage>()
         val keyCaptor = argumentCaptor<String>()
-        val bytesCaptor = argumentCaptor<ByteArray>()
-        whenever(storage.put(keyCaptor.capture(), bytesCaptor.capture()))
-            .thenReturn(PutResult("k", 0, null))
+        var captured: ByteArray = ByteArray(0)
+        whenever(storage.putStream(keyCaptor.capture(), any<java.io.InputStream>()))
+            .thenAnswer { invocation ->
+                val key: String = invocation.getArgument(0)
+                val input: java.io.InputStream = invocation.getArgument(1)
+                // SnapshotFailedRecordWriter streams through putStream; for
+                // the urgent single-record writer, decompress to verify gzip
+                // contents. Use raw readBytes for simplicity.
+                captured = input.readBytes()
+                PutResult(key, captured.size.toLong(), null)
+            }
 
         val writer = UrgentChunkArtifactWriter(
             objectMapper = objectMapper,
@@ -56,7 +65,7 @@ class UrgentChunkArtifactWriterTest {
 
         assertThat(key).matches("^runs/abc/ranking-overall/chunks/part-[0-9a-f-]{36}\\.jsonl\\.gz$")
         assertThat(keyCaptor.firstValue).isEqualTo(key)
-        assertThat(bytesCaptor.firstValue).isNotEmpty
-        verify(storage).put(any<String>(), any<ByteArray>())
+        assertThat(captured).isNotEmpty
+        verify(storage).putStream(any<String>(), any<java.io.InputStream>())
     }
 }

--- a/module-external-api/src/test/kotlin/maple/externalapi/dataflow/DataflowContractTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/dataflow/DataflowContractTest.kt
@@ -166,7 +166,7 @@ class DataflowContractTest {
         val executor = Executors.newSingleThreadExecutor { runnable ->
             Thread.ofPlatform().name("ranking-worker").unstarted(runnable)
         }
-        val runKey: String = rankingPhase.execute(executor).get(30, TimeUnit.SECONDS)
+        val runKey: String = rankingPhase.execute(executor, "20260610-xyz").get(30, TimeUnit.SECONDS)
         assertThat(runKey).startsWith("runs/")
 
         // act: run OCID lookup — it's suspend, so wrap in runBlocking

--- a/module-external-api/src/test/kotlin/maple/externalapi/scheduler/ExternalApiSchedulerTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/scheduler/ExternalApiSchedulerTest.kt
@@ -1,5 +1,6 @@
 package maple.externalapi.scheduler
 
+import java.time.Clock
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutorService
 import kotlinx.coroutines.runBlocking
@@ -9,10 +10,12 @@ import maple.externalapi.runstatus.RunStatusTracker
 import maple.externalapi.scheduler.phase.CharacterBasicFetchPhase
 import maple.externalapi.scheduler.phase.OcidLookupPhase
 import maple.externalapi.scheduler.phase.RankingFetchPhase
+import maple.externalapi.scheduler.phase.RunIdGenerator
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doNothing
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.timeout
@@ -21,10 +24,11 @@ import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.ObjectProvider
 
 /**
- * Migration Task 10: [ExternalApiScheduler] must treat the result of
- * [RankingFetchPhase.execute] as a runKey String (e.g. "runs/20260610-xyz"),
- * strip the "runs/" prefix to obtain the runId, and pass the full runKey
- * (not the runId) downstream to [OcidLookupPhase.execute].
+ * Migration Task 10: [ExternalApiScheduler] must pre-generate the runId
+ * (via [RunIdGenerator]) and pass it to [RankingFetchPhase.execute] so the
+ * run-status tracker transitions to RANKING_FETCH for the new run BEFORE
+ * any async phase begins. The returned runKey is then forwarded unchanged
+ * (with the `runs/` prefix) downstream to [OcidLookupPhase.execute].
  *
  * Run-status wiring: when char-basic ends, ExternalApiScheduler must transition
  * to [PipelinePhase.CHARACTER_BASIC_DONE] — NOT [PipelinePhase.COMPLETED] — because
@@ -34,11 +38,16 @@ import org.springframework.beans.factory.ObjectProvider
 class ExternalApiSchedulerTest {
 
     @Test
-    fun `triggerDailyRefresh extracts runId from runKey and forwards runKey to OCID lookup phase`() {
+    fun `triggerDailyRefresh generates runId up front and passes it to ranking execute then forwards runKey to OCID lookup`() {
         val rankingPhase = mock<RankingFetchPhase>()
-        val runKey = "runs/20260610-xyz"
-        whenever(rankingPhase.execute(any<ExecutorService>()))
-            .thenReturn(CompletableFuture.completedFuture(runKey))
+        // Ranking echoes the runId it was given back as the runKey.
+        // This matches the production contract: RankingFetchPhase.execute
+        // uses the runId to build `runs/$runId`.
+        whenever(rankingPhase.execute(any<ExecutorService>(), any<String>()))
+            .thenAnswer { invocation ->
+                val runId: String = invocation.getArgument(1)
+                CompletableFuture.completedFuture("runs/$runId")
+            }
 
         val ocidLookupPhase = mock<OcidLookupPhase>()
 
@@ -53,6 +62,10 @@ class ExternalApiSchedulerTest {
 
         val itemEquipmentLoop = mock<ItemEquipmentContinuousLoop>()
 
+        val runIdCaptor = argumentCaptor<String>()
+        // startRun is a void method so we use doNothing for the mock.
+        doNothing().whenever(runStatusTracker).startRun(runIdCaptor.capture())
+
         val scheduler = ExternalApiScheduler(
             ocidLookupPhase = ocidLookupPhase,
             ocidCacheProvider = ocidCache,
@@ -60,6 +73,7 @@ class ExternalApiSchedulerTest {
             characterBasicPhaseProvider = charBasicProvider,
             itemEquipmentContinuousLoop = itemEquipmentLoop,
             runStatusTracker = runStatusTracker,
+            runIdGenerator = RunIdGenerator(Clock.systemUTC()),
             runOnStartup = false,
             skipCharacterBasic = false,
         )
@@ -72,10 +86,16 @@ class ExternalApiSchedulerTest {
         runBlocking {
             verify(ocidLookupPhase, timeout(5_000)).execute(any<ExecutorService>(), runKeyCaptor.capture())
         }
-        assertThat(runKeyCaptor.firstValue).isEqualTo("runs/20260610-xyz")
 
-        // The runId passed to startRun is the segment after "runs/".
-        verify(runStatusTracker, timeout(5_000)).startRun("20260610-xyz")
+        // The runId passed to startRun is the SAME one passed to ranking.execute.
+        // Before the fix, startRun was called inside the .handle callback with
+        // the runId derived from the runKey — so a ranking failure would leave
+        // the previous run's FAILED status visible on /api/internal/run-status.
+        val runIdPassedToRanking = argumentCaptor<String>()
+        verify(rankingPhase, timeout(5_000)).execute(any<ExecutorService>(), runIdPassedToRanking.capture())
+        assertThat(runIdCaptor.firstValue).isEqualTo(runIdPassedToRanking.firstValue)
+        // The runKey forwarded to OcidLookupPhase matches `runs/<runId>`.
+        assertThat(runKeyCaptor.firstValue).isEqualTo("runs/${runIdCaptor.firstValue}")
     }
 
     @Test
@@ -87,7 +107,7 @@ class ExternalApiSchedulerTest {
         // full completion via completeRun.
 
         val rankingPhase = mock<RankingFetchPhase>()
-        whenever(rankingPhase.execute(any<ExecutorService>()))
+        whenever(rankingPhase.execute(any<ExecutorService>(), any<String>()))
             .thenReturn(CompletableFuture.completedFuture("runs/run-cb-done"))
 
         val ocidLookupPhase = mock<OcidLookupPhase>()
@@ -118,6 +138,7 @@ class ExternalApiSchedulerTest {
             characterBasicPhaseProvider = charBasicProvider,
             itemEquipmentContinuousLoop = itemEquipmentLoop,
             runStatusTracker = runStatusTracker,
+            runIdGenerator = RunIdGenerator(Clock.systemUTC()),
             runOnStartup = false,
             skipCharacterBasic = false,
         )
@@ -133,5 +154,59 @@ class ExternalApiSchedulerTest {
             org.mockito.kotlin.any<Int>(),
             org.mockito.kotlin.any<Long>(),
         )
+    }
+
+    /**
+     * Regression for the bug where a fresh pipeline cycle left the previous
+     * run's FAILED status visible on /api/internal/run-status because
+     * `startRun` was buried in the `.handle` callback of ranking.execute().
+     * If ranking throws, the handle fires with `ex != null` and startRun is
+     * skipped — but the daily refresh continues to failRun with the stale
+     * runId. The fix pre-generates the runId and calls startRun BEFORE
+     * ranking starts, so a ranking failure cannot leave a stale status.
+     *
+     * Note: the current chain uses .handle() to swallow the ranking exception
+     * (returning null), so a ranking failure does not reach failRun — the
+     * status stays as RANKING_FETCH for the new runId. What we assert here
+     * is the core property of the fix: startRun fires *for the new runId*
+     * before ranking, so the API shows the new run even if ranking fails.
+     */
+    @Test
+    fun `triggerDailyRefresh calls startRun before ranking execute, even if ranking fails`() {
+        val rankingPhase = mock<RankingFetchPhase>()
+        whenever(rankingPhase.execute(any<ExecutorService>(), any<String>()))
+            .thenReturn(CompletableFuture.failedFuture(RuntimeException("rank api down")))
+
+        val ocidLookupPhase = mock<OcidLookupPhase>()
+        val ocidCache = mock<OcidCacheProvider>()
+        val runStatusTracker = mock<RunStatusTracker>()
+
+        val rankingProvider = mock<ObjectProvider<RankingFetchPhase>>()
+        whenever(rankingProvider.ifAvailable).thenReturn(rankingPhase)
+
+        val charBasicProvider = mock<ObjectProvider<CharacterBasicFetchPhase>>()
+        whenever(charBasicProvider.ifAvailable).thenReturn(null)
+
+        val itemEquipmentLoop = mock<ItemEquipmentContinuousLoop>()
+
+        val scheduler = ExternalApiScheduler(
+            ocidLookupPhase = ocidLookupPhase,
+            ocidCacheProvider = ocidCache,
+            rankingFetchPhaseProvider = rankingProvider,
+            characterBasicPhaseProvider = charBasicProvider,
+            itemEquipmentContinuousLoop = itemEquipmentLoop,
+            runStatusTracker = runStatusTracker,
+            runIdGenerator = RunIdGenerator(Clock.systemUTC()),
+            runOnStartup = false,
+            skipCharacterBasic = false,
+        )
+
+        scheduler.triggerDailyRefresh(null)
+
+        // startRun must fire for the new runId before ranking.execute() even
+        // returns. The previous bug deferred it into .handle, so a ranking
+        // failure meant the tracker never transitioned — the previous run's
+        // FAILED status would remain visible on /api/internal/run-status.
+        verify(runStatusTracker, timeout(2_000)).startRun(any<String>())
     }
 }

--- a/module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/ItemEquipmentFetchPhaseTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/ItemEquipmentFetchPhaseTest.kt
@@ -50,7 +50,6 @@ class ItemEquipmentFetchPhaseTest {
             permitsPerSecond = 1000,
             batchSize = 10,
             clock = Clock.systemUTC(),
-            runIdGenerator = RunIdGenerator(Clock.systemUTC()),
             runMarkerWriter = runMarkerWriter,
             schedulerProgressLogger = mock<SchedulerProgressLogger>(),
         )
@@ -61,7 +60,9 @@ class ItemEquipmentFetchPhaseTest {
             // We don't need the full batch to run — the marker is written
             // before the batch loop. Allow the rest to fail at the mocked
             // sinkFactory; the marker write is what we assert.
-            runCatching { phase.execute(executor, entries).get(5, TimeUnit.SECONDS) }
+            runCatching {
+                phase.execute(executor, entries, "20260612-test-000000000").get(5, TimeUnit.SECONDS)
+            }
         } finally {
             executor.shutdownNow()
         }

--- a/module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/RankingFetchPhaseTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/RankingFetchPhaseTest.kt
@@ -89,7 +89,7 @@ class RankingFetchPhaseTest {
             objectStorage = storage,
         )
 
-        val result: CompletableFuture<String> = phase.execute(Executors.newSingleThreadExecutor())
+        val result: CompletableFuture<String> = phase.execute(Executors.newSingleThreadExecutor(), "20260610-xyz")
         val runKey = result.get(15, TimeUnit.SECONDS)
 
         assertTrue(

--- a/module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/RankingFetchPhaseTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/RankingFetchPhaseTest.kt
@@ -16,11 +16,13 @@ import maple.externalapi.snapshot.SinkEventPublisher
 import maple.externalapi.snapshot.SnapshotChunkingProperties
 import maple.externalapi.snapshot.SnapshotSinkEventPublisher
 import maple.externalapi.snapshot.event.SnapshotChunkEventPublisher
+import maple.expectation.common.storage.PutResult
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import java.io.InputStream
 import java.time.Clock
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executors
@@ -35,6 +37,22 @@ class RankingFetchPhaseTest {
     @Test
     fun `execute returns runKey as String starting with runs slash`() {
         val storage = mock<ObjectStorage>()
+        // RankingFetchPhase writes a single empty chunk (empty ranking array) at
+        // close via the new GzipJsonlChunkWriter → putStream path. Mock it so
+        // close() returns a non-null PutResult.
+        whenever(storage.putStream(any<String>(), any<InputStream>()))
+            .thenAnswer { invocation ->
+                val key: String = invocation.getArgument(0)
+                val input: InputStream = invocation.getArgument(1)
+                PutResult(key, input.readBytes().size.toLong(), null)
+            }
+        whenever(storage.put(any<String>(), any<ByteArray>()))
+            .thenAnswer { invocation ->
+                val key: String = invocation.getArgument(0)
+                val bytes: ByteArray = invocation.getArgument(1)
+                PutResult(key, bytes.size.toLong(), null)
+            }
+
         val objectMapper = ObjectMapper()
             .registerModule(kotlinModule())
             .registerModule(JavaTimeModule())

--- a/module-external-api/src/test/kotlin/maple/externalapi/snapshot/ChunkFileManagerTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/snapshot/ChunkFileManagerTest.kt
@@ -14,6 +14,7 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.io.InputStream
 import java.time.Clock
 import java.time.Instant
 
@@ -71,10 +72,12 @@ class ChunkFileManagerTest {
     fun `appendSuccess accumulates records and rotates when limit hit`() {
         val storage = mock<ObjectStorage>()
         val keyCaptor = argumentCaptor<String>()
-        whenever(storage.put(keyCaptor.capture(), any<ByteArray>()))
+        whenever(storage.putStream(keyCaptor.capture(), any<InputStream>()))
             .thenAnswer { invocation ->
                 val key: String = invocation.getArgument(0)
-                PutResult(key, 0L, null)
+                val input: InputStream = invocation.getArgument(1)
+                val bytes = input.readBytes()
+                PutResult(key, bytes.size.toLong(), null)
             }
 
         val manager = ChunkFileManager(
@@ -108,6 +111,6 @@ class ChunkFileManagerTest {
         assertThat(capturedKeys).hasSize(2)
         assertThat(capturedKeys[0]).isEqualTo("runs/testrun/ranking-overall/chunks/part-000001.jsonl.gz")
         assertThat(capturedKeys[1]).isEqualTo("runs/testrun/ranking-overall/chunks/part-000002.jsonl.gz")
-        verify(storage, org.mockito.kotlin.times(2)).put(any<String>(), any<ByteArray>())
+        verify(storage, org.mockito.kotlin.times(2)).putStream(any<String>(), any<InputStream>())
     }
 }

--- a/module-external-api/src/test/kotlin/maple/externalapi/snapshot/EndpointSinkFactoryTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/snapshot/EndpointSinkFactoryTest.kt
@@ -34,10 +34,11 @@ class EndpointSinkFactoryTest {
     fun `createForCharacterBasic produces a sink whose chunk keys live under the supplied runKey`() {
         val storage = mock<ObjectStorage>()
         val keyCaptor = argumentCaptor<String>()
-        whenever(storage.put(keyCaptor.capture(), any<ByteArray>()))
+        whenever(storage.putStream(keyCaptor.capture(), any<java.io.InputStream>()))
             .thenAnswer { invocation ->
                 val key: String = invocation.getArgument(0)
-                PutResult(key, 0L, null)
+                val input: java.io.InputStream = invocation.getArgument(1)
+                PutResult(key, input.readBytes().size.toLong(), null)
             }
 
         val characterBasicPublisher = mock<SnapshotChunkEventPublisher>()

--- a/module-external-api/src/test/kotlin/maple/externalapi/snapshot/GzipJsonlChunkWriterTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/snapshot/GzipJsonlChunkWriterTest.kt
@@ -13,6 +13,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.io.ByteArrayInputStream
+import java.io.InputStream
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneOffset
@@ -26,15 +27,19 @@ class GzipJsonlChunkWriterTest {
     private val fixedClock = Clock.fixed(Instant.parse("2026-06-10T00:00:00Z"), ZoneOffset.UTC)
 
     @Test
-    fun `close puts gzipped JSONL to ObjectStorage and returns stats`() {
+    fun `close streams gzipped JSONL to ObjectStorage via putStream and returns stats`() {
         val storage = mock<ObjectStorage>()
         val keyCaptor = argumentCaptor<String>()
-        val bytesCaptor = argumentCaptor<ByteArray>()
-        whenever(storage.put(keyCaptor.capture(), bytesCaptor.capture()))
+        // Buffer what the writer streams so the test can re-read it after
+        // putStream returns. The writer's close() drains the input it
+        // passes in, so the captured stream itself is exhausted by then.
+        var captured: ByteArray = ByteArray(0)
+        whenever(storage.putStream(keyCaptor.capture(), any<InputStream>()))
             .thenAnswer { invocation ->
                 val key: String = invocation.getArgument(0)
-                val bytes: ByteArray = invocation.getArgument(1)
-                PutResult(key, bytes.size.toLong(), null)
+                val input: InputStream = invocation.getArgument(1)
+                captured = input.readBytes()
+                PutResult(key, captured.size.toLong(), null)
             }
 
         val writer = GzipJsonlChunkWriter(
@@ -62,7 +67,7 @@ class GzipJsonlChunkWriterTest {
 
         val stats = writer.close()
 
-        verify(storage).put(any<String>(), any<ByteArray>())
+        verify(storage).putStream(any<String>(), any<InputStream>())
         assertThat(keyCaptor.firstValue).isEqualTo("runs/abc/ranking-overall/part-000001.jsonl.gz")
         assertThat(stats.partIndex).isEqualTo(1)
         assertThat(stats.path).isEqualTo("part-000001.jsonl.gz")
@@ -72,7 +77,9 @@ class GzipJsonlChunkWriterTest {
         assertThat(stats.startedAt).isEqualTo(Instant.parse("2026-06-10T00:00:00Z"))
         assertThat(stats.finishedAt).isEqualTo(Instant.parse("2026-06-10T00:00:00Z"))
 
-        val raw = GZIPInputStream(ByteArrayInputStream(bytesCaptor.firstValue)).bufferedReader().readText()
+        val raw = GZIPInputStream(ByteArrayInputStream(captured))
+            .bufferedReader()
+            .readText()
         val lines = raw.lines().filter { it.isNotBlank() }
         assertThat(lines).hasSize(3)
         lines.forEach { line ->
@@ -84,5 +91,82 @@ class GzipJsonlChunkWriterTest {
             val decoded = String(java.util.Base64.getDecoder().decode(node.get("bodyBytes").asText()))
             assertThat(decoded).contains("\"character_name\"")
         }
+    }
+
+    /**
+     * Regression for the OOM that crashed pipeline runs at
+     * `max-uncompressed-bytes: 128MB` (commit 4fa308f19+ era).
+     *
+     * The previous heap-buffered implementation allocated a
+     * `ByteArrayOutputStream` large enough to hold the entire chunk and a
+     * second copy via `toByteArray()` (~256MB peak), exceeding the 1GB
+     * writer-thread heap when deflater state was added.
+     *
+     * With the temp-file + putStream refactor, the writer thread's heap
+     * footprint is bounded by the deflater window (~32KB) regardless of
+     * chunk size, so a 32MB chunk must close cleanly. We assert:
+     *  1. close() returns without OOM,
+     *  2. putStream is called exactly once (no fallback to put),
+     *  3. the bytes streamed to storage decompress to a valid JSONL
+     *     line count equal to the record count.
+     */
+    @Test
+    fun `close streams 32MB chunk without loading it all into heap`() {
+        val storage = mock<ObjectStorage>()
+        var captured: ByteArray = ByteArray(0)
+        whenever(storage.putStream(any<String>(), any<InputStream>()))
+            .thenAnswer { invocation ->
+                val input: InputStream = invocation.getArgument(1)
+                captured = input.readBytes()
+                PutResult(invocation.getArgument(0), captured.size.toLong(), null)
+            }
+
+        val writer = GzipJsonlChunkWriter(
+            chunkKey = "runs/big/item-equipment/part-000001.jsonl.gz",
+            partIndex = 1,
+            maxRecords = Int.MAX_VALUE,
+            // Production knob is 128MB; 32MB here keeps the test fast and
+            // still well above the heap budget the old code blew through.
+            maxUncompressedBytes = 32L * 1024 * 1024,
+            objectMapper = objectMapper,
+            objectStorage = storage,
+            clock = fixedClock,
+        )
+
+        // Each record's JSON envelope is ~250 bytes after Jackson serialization.
+        // 160_000 records × ~250B ≈ 40MB uncompressed, comfortably over the cap.
+        val recordCount = 160_000
+        repeat(recordCount) { i ->
+            writer.append(
+                SnapshotChunkRecord.Success(
+                    bodyBytes = objectMapper.writeValueAsBytes(
+                        mapOf(
+                            "character_name" to "char_$i",
+                            "ocid" to "ocid_$i",
+                            "guild" to "guild_$i",
+                            "level" to 250 + (i % 10),
+                        ),
+                    ),
+                    key = "char_$i",
+                    endpoint = "item-equipment",
+                    keyType = "OCID",
+                    httpStatus = 200,
+                    fetchedAt = Instant.parse("2026-06-10T00:00:00Z"),
+                ),
+            )
+        }
+
+        val stats = writer.close()
+
+        assertThat(stats.recordCount).isEqualTo(recordCount)
+        assertThat(stats.uncompressedBytes).isGreaterThan(32L * 1024 * 1024)
+        assertThat(stats.compressedBytes).isGreaterThan(0)
+        verify(storage).putStream(any<String>(), any<InputStream>())
+
+        val raw = GZIPInputStream(ByteArrayInputStream(captured))
+            .bufferedReader()
+            .readText()
+        val lines = raw.lines().filter { it.isNotBlank() }
+        assertThat(lines).hasSize(recordCount)
     }
 }


### PR DESCRIPTION
## Summary
Cherry-pick of the two fix commits from PR #1278 onto the release branch.

- **810b3ca41** — `fix(ext-api): stream gzipped chunks to ObjectStorage to bound writer heap`
  Replaces `ByteArrayOutputStream` (256MB peak per 128MB chunk) with temp file + `putStream`. Writer-thread heap now bounded by deflater window (~32KB). Fixes the OOMs that killed pipeline runs at 10:27 / 12:10 / 12:44 KST on 2026-06-12.

- **fe8a60c18** — `fix(ext-api): call RunStatusTracker.startRun up front so /run-status reflects the active cycle`
  Pre-generates the runId at the top of every entry point and calls `startRun` BEFORE any async work begins. Previously `startRun` was buried in the `.handle` callback of `RankingFetchPhase.execute()`, so a ranking failure left the previous run's FAILED status visible on `/api/internal/run-status`. `ItemEquipmentContinuousLoop` also never called `startRun`, so brand-new item-equipment cycles under fresh runIds were invisible to the API.

## Test plan
- [x] Full `module-external-api` test suite — 61 tests pass
- [x] 32MB regression test (`GzipJsonlChunkWriterTest.close streams 32MB chunk without loading it all into heap`) — 160K records, 0 OOM
- [x] `ExternalApiSchedulerTest.triggerDailyRefresh calls startRun before ranking execute, even if ranking fails` — locks in the run-status fix
- [ ] End-to-end pipeline run (deferred — full run takes ~2h; unit tests cover both code paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)