### PR TITLE
fix(storage): add putFile to skip double-spool in writer hot path

### DIFF
--- a/module-common/src/main/kotlin/maple/expectation/common/storage/ObjectStorage.kt
+++ b/module-common/src/main/kotlin/maple/expectation/common/storage/ObjectStorage.kt
@@ -1,6 +1,7 @@
 package maple.expectation.common.storage
 
 import java.io.InputStream
+import java.nio.file.Path
 import java.time.Instant
 
 /**
@@ -18,6 +19,18 @@ interface ObjectStorage {
 
     /** Put data from a stream. Caller is responsible for closing `input`. */
     fun putStream(key: String, input: InputStream): PutResult
+
+    /**
+     * Put a pre-existing file at [path] under [key]. Avoids the double-spool
+     * of [putStream] for callers that already have the bytes on disk (e.g.
+     * [maple.externalapi.snapshot.GzipJsonlChunkWriter] which writes each
+     * chunk to a temp file before upload). The caller relinquishes the file —
+     * implementations move or upload it, and the caller MUST NOT delete the
+     * file or write to it again after this call returns.
+     *
+     * Throws if [path] does not exist.
+     */
+    fun putFile(key: String, path: Path): PutResult
 
     /** Get object as bytes. Throws if key not found. */
     fun get(key: String): ByteArray

--- a/module-external-api/src/main/kotlin/maple/externalapi/snapshot/GzipJsonlChunkWriter.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/snapshot/GzipJsonlChunkWriter.kt
@@ -32,12 +32,17 @@ data class ChunkStats(
  * intermediate buffer plus `ByteArrayOutputStream.toByteArray()` reached
  * ~256MB before `objectStorage.put` was called.
  *
- * On close(), the temp file is streamed to storage via
- * [ObjectStorage.putStream] and deleted. The two backends
- * ([maple.expectation.infrastructure.storage.LocalFsObjectStorage],
- * [maple.expectation.infrastructure.storage.MinioObjectStorage]) both
- * spool to a temp file internally, so net disk usage during a chunk
- * rotation is at most two copies of the chunk briefly.
+ * On close(), the temp file is uploaded to storage via
+ * [ObjectStorage.putFile] — the AWS SDK (MinIO) streams from the Path in
+ * 8MB chunks; the LocalFs backend atomically renames the file in place.
+ * Both backends avoid the double-spool of the original [ObjectStorage.putStream]
+ * impl, which copied the input into a SECOND temp file before uploading —
+ * a 128MB disk write + read + delete per chunk, making the writer the
+ * bottleneck at ~50 files/s instead of the expected ~150.
+ *
+ * File ownership: the writer deletes the temp file only on the failure
+ * path. On success, [ObjectStorage.putFile] takes ownership and the file
+ * is moved/atomically-renamed to the destination.
  */
 class GzipJsonlChunkWriter(
     private val chunkKey: String,
@@ -61,6 +66,7 @@ class GzipJsonlChunkWriter(
     private var recordCount: Int = 0
     private var uncompressedBytes: Long = 0
     private val startedAt: Instant = Instant.now(clock)
+    private var closed: Boolean = false
 
     fun append(record: SnapshotChunkRecord.Success) {
         require(record.bodyBytes.isNotEmpty()) { "bodyBytes must not be empty for key=${record.key}" }
@@ -75,23 +81,27 @@ class GzipJsonlChunkWriter(
         recordCount >= maxRecords || uncompressedBytes >= maxUncompressedBytes
 
     fun close(): ChunkStats {
-        var putSize: Long = 0L
-        try {
-            gzipped.close()
-            fileOut.close()
-            Files.newInputStream(tempFile).use { input ->
-                val result = objectStorage.putStream(chunkKey, input)
-                putSize = result.size
-            }
-        } finally {
+        require(!closed) { "close() already called" }
+        closed = true
+        gzipped.close()
+        fileOut.close()
+        val result = try {
+            objectStorage.putFile(chunkKey, tempFile)
+        } catch (t: Throwable) {
+            // Storage failed — temp file is still ours to clean up.
             Files.deleteIfExists(tempFile)
+            throw t
         }
+        // Success path: storage took ownership via atomic move (Local) or
+        // upload (MinIO). Either way, the temp file at the original path
+        // no longer exists — try delete (no-op if so).
+        Files.deleteIfExists(tempFile)
         return ChunkStats(
             partIndex = partIndex,
             path = chunkKey.substringAfterLast('/'),
             recordCount = recordCount,
             uncompressedBytes = uncompressedBytes,
-            compressedBytes = putSize,
+            compressedBytes = result.size,
             startedAt = startedAt,
             finishedAt = Instant.now(clock),
         )

--- a/module-external-api/src/test/kotlin/maple/externalapi/artifact/UrgentChunkArtifactWriterTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/artifact/UrgentChunkArtifactWriterTest.kt
@@ -14,7 +14,8 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import java.io.ByteArrayInputStream
+import java.nio.file.Files
+import java.nio.file.Path
 import java.time.Instant
 
 /**
@@ -35,14 +36,11 @@ class UrgentChunkArtifactWriterTest {
         val storage = mock<ObjectStorage>()
         val keyCaptor = argumentCaptor<String>()
         var captured: ByteArray = ByteArray(0)
-        whenever(storage.putStream(keyCaptor.capture(), any<java.io.InputStream>()))
+        whenever(storage.putFile(keyCaptor.capture(), any<Path>()))
             .thenAnswer { invocation ->
                 val key: String = invocation.getArgument(0)
-                val input: java.io.InputStream = invocation.getArgument(1)
-                // SnapshotFailedRecordWriter streams through putStream; for
-                // the urgent single-record writer, decompress to verify gzip
-                // contents. Use raw readBytes for simplicity.
-                captured = input.readBytes()
+                val path: Path = invocation.getArgument(1)
+                captured = Files.readAllBytes(path)
                 PutResult(key, captured.size.toLong(), null)
             }
 
@@ -66,6 +64,6 @@ class UrgentChunkArtifactWriterTest {
         assertThat(key).matches("^runs/abc/ranking-overall/chunks/part-[0-9a-f-]{36}\\.jsonl\\.gz$")
         assertThat(keyCaptor.firstValue).isEqualTo(key)
         assertThat(captured).isNotEmpty
-        verify(storage).putStream(any<String>(), any<java.io.InputStream>())
+        verify(storage).putFile(any<String>(), any<Path>())
     }
 }

--- a/module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/RankingFetchPhaseTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/RankingFetchPhaseTest.kt
@@ -22,14 +22,15 @@ import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
-import java.io.InputStream
+import java.nio.file.Files
+import java.nio.file.Path
 import java.time.Clock
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
 /**
- * Migration Task 8: `execute(workerExecutor)` must return `CompletableFuture<String>`
+ * Migration Task 8: `execute(workerExecutor, runId)` must return `CompletableFuture<String>`
  * whose value is the runKey (e.g. `runs/20260610-...`) — not a Path.
  */
 class RankingFetchPhaseTest {
@@ -38,13 +39,13 @@ class RankingFetchPhaseTest {
     fun `execute returns runKey as String starting with runs slash`() {
         val storage = mock<ObjectStorage>()
         // RankingFetchPhase writes a single empty chunk (empty ranking array) at
-        // close via the new GzipJsonlChunkWriter → putStream path. Mock it so
-        // close() returns a non-null PutResult.
-        whenever(storage.putStream(any<String>(), any<InputStream>()))
+        // close via GzipJsonlChunkWriter → putFile. Mock it so close() returns
+        // a non-null PutResult.
+        whenever(storage.putFile(any<String>(), any<Path>()))
             .thenAnswer { invocation ->
                 val key: String = invocation.getArgument(0)
-                val input: InputStream = invocation.getArgument(1)
-                PutResult(key, input.readBytes().size.toLong(), null)
+                val path: Path = invocation.getArgument(1)
+                PutResult(key, Files.size(path), null)
             }
         whenever(storage.put(any<String>(), any<ByteArray>()))
             .thenAnswer { invocation ->

--- a/module-external-api/src/test/kotlin/maple/externalapi/snapshot/ChunkFileManagerTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/snapshot/ChunkFileManagerTest.kt
@@ -14,7 +14,8 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import java.io.InputStream
+import java.nio.file.Files
+import java.nio.file.Path
 import java.time.Clock
 import java.time.Instant
 
@@ -72,11 +73,11 @@ class ChunkFileManagerTest {
     fun `appendSuccess accumulates records and rotates when limit hit`() {
         val storage = mock<ObjectStorage>()
         val keyCaptor = argumentCaptor<String>()
-        whenever(storage.putStream(keyCaptor.capture(), any<InputStream>()))
+        whenever(storage.putFile(keyCaptor.capture(), any<Path>()))
             .thenAnswer { invocation ->
                 val key: String = invocation.getArgument(0)
-                val input: InputStream = invocation.getArgument(1)
-                val bytes = input.readBytes()
+                val path: Path = invocation.getArgument(1)
+                val bytes = Files.readAllBytes(path)
                 PutResult(key, bytes.size.toLong(), null)
             }
 
@@ -111,6 +112,6 @@ class ChunkFileManagerTest {
         assertThat(capturedKeys).hasSize(2)
         assertThat(capturedKeys[0]).isEqualTo("runs/testrun/ranking-overall/chunks/part-000001.jsonl.gz")
         assertThat(capturedKeys[1]).isEqualTo("runs/testrun/ranking-overall/chunks/part-000002.jsonl.gz")
-        verify(storage, org.mockito.kotlin.times(2)).putStream(any<String>(), any<InputStream>())
+        verify(storage, org.mockito.kotlin.times(2)).putFile(any<String>(), any<Path>())
     }
 }

--- a/module-external-api/src/test/kotlin/maple/externalapi/snapshot/EndpointSinkFactoryTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/snapshot/EndpointSinkFactoryTest.kt
@@ -15,6 +15,8 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import java.nio.file.Files
+import java.nio.file.Path
 import java.time.Clock
 import java.time.Instant
 import java.util.concurrent.TimeUnit
@@ -34,11 +36,11 @@ class EndpointSinkFactoryTest {
     fun `createForCharacterBasic produces a sink whose chunk keys live under the supplied runKey`() {
         val storage = mock<ObjectStorage>()
         val keyCaptor = argumentCaptor<String>()
-        whenever(storage.putStream(keyCaptor.capture(), any<java.io.InputStream>()))
+        whenever(storage.putFile(keyCaptor.capture(), any<Path>()))
             .thenAnswer { invocation ->
                 val key: String = invocation.getArgument(0)
-                val input: java.io.InputStream = invocation.getArgument(1)
-                PutResult(key, input.readBytes().size.toLong(), null)
+                val path: Path = invocation.getArgument(1)
+                PutResult(key, Files.size(path), null)
             }
 
         val characterBasicPublisher = mock<SnapshotChunkEventPublisher>()

--- a/module-external-api/src/test/kotlin/maple/externalapi/snapshot/GzipJsonlChunkWriterTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/snapshot/GzipJsonlChunkWriterTest.kt
@@ -13,7 +13,8 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.io.ByteArrayInputStream
-import java.io.InputStream
+import java.nio.file.Files
+import java.nio.file.Path
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneOffset
@@ -27,18 +28,16 @@ class GzipJsonlChunkWriterTest {
     private val fixedClock = Clock.fixed(Instant.parse("2026-06-10T00:00:00Z"), ZoneOffset.UTC)
 
     @Test
-    fun `close streams gzipped JSONL to ObjectStorage via putStream and returns stats`() {
+    fun `close uploads gzipped JSONL via putFile and returns stats`() {
         val storage = mock<ObjectStorage>()
         val keyCaptor = argumentCaptor<String>()
-        // Buffer what the writer streams so the test can re-read it after
-        // putStream returns. The writer's close() drains the input it
-        // passes in, so the captured stream itself is exhausted by then.
+        val pathCaptor = argumentCaptor<Path>()
         var captured: ByteArray = ByteArray(0)
-        whenever(storage.putStream(keyCaptor.capture(), any<InputStream>()))
+        whenever(storage.putFile(keyCaptor.capture(), pathCaptor.capture()))
             .thenAnswer { invocation ->
                 val key: String = invocation.getArgument(0)
-                val input: InputStream = invocation.getArgument(1)
-                captured = input.readBytes()
+                val path: Path = invocation.getArgument(1)
+                captured = Files.readAllBytes(path)
                 PutResult(key, captured.size.toLong(), null)
             }
 
@@ -67,8 +66,12 @@ class GzipJsonlChunkWriterTest {
 
         val stats = writer.close()
 
-        verify(storage).putStream(any<String>(), any<InputStream>())
+        verify(storage).putFile(any<String>(), any<Path>())
         assertThat(keyCaptor.firstValue).isEqualTo("runs/abc/ranking-overall/part-000001.jsonl.gz")
+        // The Path argument is captured; its underlying file is deleted by
+        // the writer after putFile returns, so we cannot assert existence
+        // here. The path is verified by the captured bytes being
+        // successfully decompressed (below).
         assertThat(stats.partIndex).isEqualTo(1)
         assertThat(stats.path).isEqualTo("part-000001.jsonl.gz")
         assertThat(stats.recordCount).isEqualTo(3)
@@ -95,29 +98,29 @@ class GzipJsonlChunkWriterTest {
 
     /**
      * Regression for the OOM that crashed pipeline runs at
-     * `max-uncompressed-bytes: 128MB` (commit 4fa308f19+ era).
+     * `max-uncompressed-bytes: 128MB`.
      *
      * The previous heap-buffered implementation allocated a
      * `ByteArrayOutputStream` large enough to hold the entire chunk and a
      * second copy via `toByteArray()` (~256MB peak), exceeding the 1GB
      * writer-thread heap when deflater state was added.
      *
-     * With the temp-file + putStream refactor, the writer thread's heap
+     * With the temp-file + putFile refactor, the writer thread's heap
      * footprint is bounded by the deflater window (~32KB) regardless of
      * chunk size, so a 32MB chunk must close cleanly. We assert:
      *  1. close() returns without OOM,
-     *  2. putStream is called exactly once (no fallback to put),
-     *  3. the bytes streamed to storage decompress to a valid JSONL
+     *  2. putFile is called exactly once (no fallback to put/putStream),
+     *  3. the bytes uploaded to storage decompress to a valid JSONL
      *     line count equal to the record count.
      */
     @Test
-    fun `close streams 32MB chunk without loading it all into heap`() {
+    fun `close uploads 32MB chunk via putFile without loading it all into heap`() {
         val storage = mock<ObjectStorage>()
         var captured: ByteArray = ByteArray(0)
-        whenever(storage.putStream(any<String>(), any<InputStream>()))
+        whenever(storage.putFile(any<String>(), any<Path>()))
             .thenAnswer { invocation ->
-                val input: InputStream = invocation.getArgument(1)
-                captured = input.readBytes()
+                val path: Path = invocation.getArgument(1)
+                captured = Files.readAllBytes(path)
                 PutResult(invocation.getArgument(0), captured.size.toLong(), null)
             }
 
@@ -161,7 +164,7 @@ class GzipJsonlChunkWriterTest {
         assertThat(stats.recordCount).isEqualTo(recordCount)
         assertThat(stats.uncompressedBytes).isGreaterThan(32L * 1024 * 1024)
         assertThat(stats.compressedBytes).isGreaterThan(0)
-        verify(storage).putStream(any<String>(), any<InputStream>())
+        verify(storage).putFile(any<String>(), any<Path>())
 
         val raw = GZIPInputStream(ByteArrayInputStream(captured))
             .bufferedReader()

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/storage/LocalFsObjectStorage.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/storage/LocalFsObjectStorage.kt
@@ -49,6 +49,18 @@ class LocalFsObjectStorage(
         return PutResult(key, bytes, hash)
     }
 
+    override fun putFile(key: String, path: java.nio.file.Path): PutResult {
+        // The caller's file becomes the destination — atomic rename, no copy.
+        // Saves 128MB of disk I/O per chunk versus putStream's
+        // Files.copy(input, temp) + move(temp, dest) on hot paths.
+        val dest = resolve(key)
+        dest.parent.toFile().mkdirs()
+        require(Files.exists(path)) { "putFile source does not exist: $path" }
+        Files.move(path, dest, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
+        val hash = sha256Hex(Files.readAllBytes(dest))
+        return PutResult(key, Files.size(dest), hash)
+    }
+
     override fun get(key: String): ByteArray = Files.readAllBytes(resolve(key))
 
     override fun getStream(key: String): java.io.InputStream = Files.newInputStream(resolve(key))

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/storage/MinioObjectStorage.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/storage/MinioObjectStorage.kt
@@ -85,6 +85,26 @@ class MinioObjectStorage(
         }
     }
 
+    override fun putFile(key: String, path: java.nio.file.Path): PutResult {
+        // Stream the caller's file directly via the AWS SDK — the SDK reads
+        // from the Path in 8MB chunks and (for objects >= 5MB) uses multipart
+        // upload automatically. No intermediate spool, no extra disk write.
+        // Saves ~128MB of disk I/O per chunk versus putStream on a 128MB
+        // uncompressed chunk that the writer already has on disk.
+        require(Files.exists(path)) { "putFile source does not exist: $path" }
+        val size = Files.size(path)
+        val resp = s3.putObject(
+            PutObjectRequest.builder()
+                .bucket(props.bucket)
+                .key(key)
+                .contentLength(size)
+                .contentType("application/octet-stream")
+                .build(),
+            path,
+        )
+        return PutResult(key, size, resp.eTag())
+    }
+
     override fun get(key: String): ByteArray =
         s3.getObjectAsBytes(GetObjectRequest.builder().bucket(props.bucket).key(key).build())
             .asByteArray()


### PR DESCRIPTION
## Summary
The OOM fix in #1278 moved chunk upload from `ObjectStorage.put(byte[])` to `ObjectStorage.putStream(InputStream)`. The two backend impls both spool the input into a SECOND temp file before uploading — 128MB disk write + read + delete per chunk. This dropped item-equipment throughput from 143 files/s to 50 files/s.

Add `ObjectStorage.putFile(key, path)` that takes a pre-existing file the caller already has on disk. Backends:
- **LocalFs**: `Files.move(path, dest, ATOMIC_MOVE)` — zero copy, the writer's temp file IS the destination.
- **Minio**: `s3.putObject(req, path)` — AWS SDK streams from the Path in 8MB chunks, uses multipart upload for objects ≥ 5MB. No intermediate spool.

`GzipJsonlChunkWriter.close()` now calls `putFile` directly with the temp file. File ownership transfers on success (storage has moved/uploaded); on the failure path the writer's catch block still deletes the temp file.

Expected throughput recovery: ~3× (50 → ~150 files/s for item-equipment, matching the pre-OOM baseline).

## Test plan
- [x] Full `module-external-api` + `module-infra` test suite — all pass
- [x] `GzipJsonlChunkWriterTest.close uploads 32MB chunk via putFile` — 160K records, 0 OOM
- [ ] End-to-end pipeline run to confirm item-equipment rate recovers (deferred — full run takes ~2h; will run before merging to release-0.6.12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)