### PR TITLE
fix(ext-api): set ITEM_EQUIPMENT phase + don't overwrite daily runId

### DIFF
--- a/module-external-api/src/main/kotlin/maple/externalapi/runstatus/RunStatusTracker.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/runstatus/RunStatusTracker.kt
@@ -26,6 +26,28 @@ class RunStatusTracker(
         log.info("[RunStatus] started run={}", runId)
     }
 
+    /**
+     * Mark the start of a standalone item-equipment cycle within the
+     * continuous loop. Sets the initial phase to [PipelinePhase.ITEM_EQUIPMENT]
+     * (not RANKING_FETCH) so /api/internal/run-status reflects what the
+     * loop is actually doing.
+     *
+     * The continuous loop calls this at the top of each cycle because the
+     * full ExternalApiScheduler pipeline (ranking → ocid → character-basic
+     * → item-equipment) has already finished its earlier phases; the loop
+     * is running item-equipment independently on the latest OCID mapping.
+     */
+    fun startItemEquipmentCycle(runId: String) {
+        val status = RunStatus(
+            runId = runId,
+            phase = PipelinePhase.ITEM_EQUIPMENT,
+            startedAt = Instant.now(clock),
+            updatedAt = Instant.now(clock),
+        )
+        currentRun.set(status)
+        log.info("[RunStatus] item-equipment cycle started run={}", runId)
+    }
+
     fun transitionPhase(phase: PipelinePhase) {
         currentRun.updateAndGet { current ->
             current?.copy(phase = phase, updatedAt = Instant.now(clock))

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/ItemEquipmentContinuousLoop.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/ItemEquipmentContinuousLoop.kt
@@ -92,7 +92,12 @@ class ItemEquipmentContinuousLoop(
         // would stay on /api/internal/run-status even though a brand-new
         // cycle is in flight under a new runId.
         val cycleRunId = runIdGenerator.newRunId()
-        runStatusTracker.startRun(cycleRunId)
+        // Use startItemEquipmentCycle (not startRun) so the initial phase
+        // is ITEM_EQUIPMENT. startRun would set RANKING_FETCH, which is
+        // misleading — the full ranking→ocid→char-basic chain has already
+        // finished in ExternalApiScheduler; the loop is only running
+        // item-equipment.
+        runStatusTracker.startItemEquipmentCycle(cycleRunId)
 
         CompletableFuture.completedFuture(null)
             .thenCompose { itemEquipmentFetchPhase.execute(executor, entries, cycleRunId) }

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/ItemEquipmentContinuousLoop.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/ItemEquipmentContinuousLoop.kt
@@ -85,19 +85,30 @@ class ItemEquipmentContinuousLoop(
         }
         schedulerMetrics.incrementLockAcquired("item_equipment")
 
-        // Generate a per-cycle runId and tell the run-status tracker. The
-        // item-equipment loop runs indefinitely across multiple "runs" of
-        // ranking→ocid→character-basic (each of which writes a fresh OCID
-        // mapping file). Without this, the previous run's FAILED status
-        // would stay on /api/internal/run-status even though a brand-new
-        // cycle is in flight under a new runId.
+        // Generate a per-cycle runId. The run-status tracker is updated
+        // ONLY if no daily pipeline is currently in flight — otherwise we
+        // would overwrite the daily run's runId and break the Airflow
+        // sensor (which expects the daily runId throughout the poll).
+        // The previous bug: PR #1278 unconditionally called
+        // startItemEquipmentCycle on every cycle, which clobbered the
+        // daily trigger's runId mid-pipeline and caused the Airflow
+        // sensor to mark the DAG FAILED after 2h of "mismatch" retries.
         val cycleRunId = runIdGenerator.newRunId()
-        // Use startItemEquipmentCycle (not startRun) so the initial phase
-        // is ITEM_EQUIPMENT. startRun would set RANKING_FETCH, which is
-        // misleading — the full ranking→ocid→char-basic chain has already
-        // finished in ExternalApiScheduler; the loop is only running
-        // item-equipment.
-        runStatusTracker.startItemEquipmentCycle(cycleRunId)
+        val current = runStatusTracker.getCurrentStatus()
+        if (current == null || current.isTerminal) {
+            // Either no run is tracked yet, or the last tracked run
+            // (daily or earlier cycle) has reached a terminal state.
+            // Safe to register this cycle's runId in /run-status.
+            // Initial phase is ITEM_EQUIPMENT, not RANKING_FETCH — the
+            // full ranking→ocid→char-basic chain (if any) is long over.
+            runStatusTracker.startItemEquipmentCycle(cycleRunId)
+        }
+        // else: a daily pipeline is in flight (RANKING_FETCH →
+        // CHARACTER_BASIC_DONE). The loop's per-cycle runId stays a
+        // log-correlation handle only; /run-status continues to show the
+        // daily runId. When the daily completes via the completeRun
+        // guard below, the next loop cycle will start a fresh
+        // ITEM_EQUIPMENT-status run.
 
         CompletableFuture.completedFuture(null)
             .thenCompose { itemEquipmentFetchPhase.execute(executor, entries, cycleRunId) }

--- a/module-external-api/src/test/kotlin/maple/externalapi/runstatus/RunStatusTrackerTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/runstatus/RunStatusTrackerTest.kt
@@ -85,4 +85,39 @@ class RunStatusTrackerTest {
         assertThat(last.runId).isEqualTo("run-1")
         assertThat(last.phase).isEqualTo(PipelinePhase.COMPLETED)
     }
+
+    @Test
+    fun `startItemEquipmentCycle sets initial phase to ITEM_EQUIPMENT not RANKING_FETCH`() {
+        // Regression for the bug where ItemEquipmentContinuousLoop called
+        // startRun(), which hardcoded phase=RANKING_FETCH, leaving the
+        // run-status API displaying a misleading "ranking" label for the
+        // entire item-equipment cycle.
+        val runId = "item-equip-cycle-1"
+        tracker.startItemEquipmentCycle(runId)
+
+        val status = tracker.getCurrentStatus()!!
+        assertThat(status.runId).isEqualTo(runId)
+        assertThat(status.phase).isEqualTo(PipelinePhase.ITEM_EQUIPMENT)
+        assertThat(status.isTerminal).isFalse()
+    }
+
+    @Test
+    fun `startItemEquipmentCycle replaces a previous run-status cleanly`() {
+        // Multiple item-equipment cycles run sequentially; each new cycle
+        // must overwrite the previous run-status so /run-status reflects
+        // the in-flight cycle, not the previous one's terminal state.
+        tracker.startItemEquipmentCycle("cycle-1")
+        tracker.transitionPhase(PipelinePhase.ITEM_EQUIPMENT)
+        tracker.completeRun("cycle-1", 50, 100000L)
+
+        val last = tracker.getLastCompletedRun()!!
+        assertThat(last.runId).isEqualTo("cycle-1")
+        assertThat(last.phase).isEqualTo(PipelinePhase.COMPLETED)
+
+        tracker.startItemEquipmentCycle("cycle-2")
+        val current = tracker.getCurrentStatus()!!
+        assertThat(current.runId).isEqualTo("cycle-2")
+        assertThat(current.phase).isEqualTo(PipelinePhase.ITEM_EQUIPMENT)
+        assertThat(current.isTerminal).isFalse()
+    }
 }


### PR DESCRIPTION
## Summary
Two related fixes on the same branch — both stem from PR #1278, which added `startRun` to the item-equipment continuous loop and accidentally introduced two bugs.

### Fix 1: Phase display
- `RunStatusTracker.startRun` hardcoded initial phase to `RANKING_FETCH`. Correct for `ExternalApiScheduler`, wrong for `ItemEquipmentContinuousLoop` (which only runs the item-equipment phase in a continuous cycle).
- New `RunStatusTracker.startItemEquipmentCycle(runId)` method sets the initial phase to `ITEM_EQUIPMENT`. Loop uses it.

### Fix 2: Airflow DAG FAILED
- The daily_collection_pipeline Airflow DAG polls `/api/internal/run-status` expecting the daily trigger's runId throughout. `execution_timeout=2h` × 120 retries × 60s — task FAILED if never terminal.
- `startItemEquipmentCycle` (from #1278) unconditionally overwrote `currentRun` on every loop cycle, clobbering the daily runId mid-pipeline. The Airflow sensor saw "mismatch" every poll, exhausted retries after 2h, marked DAG FAILED — even though the daily was healthy (the actual writer OOM happened 33 min *after* the DAG FAILED).
- Fix: only call `startItemEquipmentCycle` if `currentRun` is null or terminal. If a daily pipeline is in flight, the loop's per-cycle runId stays a log-correlation handle only; `/run-status` continues to show the daily runId. When the daily completes via the `completeRun` guard, the next loop cycle will register a fresh ITEM_EQUIPMENT-status run.

## Test plan
- [x] `RunStatusTrackerTest.startItemEquipmentCycle sets initial phase to ITEM_EQUIPMENT not RANKING_FETCH` — locks in fix 1
- [x] `RunStatusTrackerTest.startItemEquipmentCycle replaces a previous run-status cleanly` — sequential cycles overwrite correctly
- [x] Full `module-external-api` test suite — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)