### PR TITLE
fix(infra): paginate MinioObjectStorage.listByPrefix

### DIFF
--- a/docker/airflow/dags/daily_collection_pipeline.py
+++ b/docker/airflow/dags/daily_collection_pipeline.py
@@ -13,53 +13,125 @@ import json
 
 import requests
 from airflow import DAG
+from airflow.exceptions import AirflowException
+from airflow.hooks.base import BaseHook
 from airflow.operators.python import PythonOperator
 from airflow.operators.trigger_dagrun import TriggerDagRunOperator
-from airflow.providers.http.operators.http import HttpOperator
 from airflow.providers.http.sensors.http import HttpSensor
+from airflow.sensors.python import PythonSensor
 
 
-def is_accepted_response(response):
-    """Check if HTTP response indicates success or already-accepted state.
-    Handles 409 CONFLICT (already running/started) as acceptance.
+def is_health_up(response):
+    """HttpSensor response_check: ext-api /actuator/health returns {"status": "UP"}.
+
+    Only used for the health-check sensor. The trigger task uses a dedicated
+    PythonOperator (see trigger_daily_collection_fn) because HttpOperator's
+    response_check is unreachable for 4xx — the HttpHook raises on
+    response.raise_for_status() BEFORE invoking response_check.
     """
-    if response.status_code == 409:
-        return True
     try:
-        return response.json().get("status") in ("UP", "STARTED")
+        return response.json().get("status") == "UP"
     except (ValueError, AttributeError):
         return False
 
 
-def poll_run_completion(**context):
-    """Poll run-status, return True when triggered run reaches terminal state."""
+def get_external_api_base():
+    """Resolve ext-api base URL from the Airflow Connection 'external_api'.
+
+    Replaces the hardcoded http://host.docker.internal:8081 string so the
+    connection host/port can be reconfigured without editing DAG code.
+    """
+    conn = BaseHook.get_connection("external_api")
+    return f"http://{conn.host}:{conn.port}"
+
+
+def trigger_daily_collection_fn(**context):
+    """POST /api/internal/trigger/daily as a fire-and-forget idempotent call.
+
+    Why PythonOperator instead of HttpOperator:
+      HttpOperator → HttpHook.run() → run_and_check() → check_response() →
+      response.raise_for_status() raises AirflowException for any 4xx/5xx
+      BEFORE the HttpOperator's response_check callback is ever called.
+      So 409 CONFLICT (a legitimate idempotent success here, meaning another
+      run is already active) cannot be intercepted via response_check.
+      Using requests directly lets us explicitly accept 200/202/409 as
+      success and return the runId via xcom for downstream correlation.
+
+    200/202 → new run started; response body pushed to xcom (runId).
+    409    → another run already in progress; returns the active runId from
+              ext-api's run-status so downstream wait_for_completion can
+              correlate against it.
+    Other  → real failure (raised as AirflowException → task failure).
+    """
+    base = get_external_api_base()
+
+    try:
+        response = requests.post(
+            f"{base}/api/internal/trigger/daily", timeout=30
+        )
+    except requests.RequestException as exc:
+        raise AirflowException(f"Trigger request failed: {exc}") from exc
+
+    if response.status_code in (200, 202):
+        return response.json()
+
+    if response.status_code == 409:
+        # Idempotent success — discover the currently active runId from
+        # run-status so downstream sensors correlate against it.
+        try:
+            status_resp = requests.get(
+                f"{base}/api/internal/run-status", timeout=10
+            )
+            status_resp.raise_for_status()
+            data = status_resp.json()
+            current = data.get("current") or {}
+            return {
+                "runId": current.get("runId"),
+                "status": "ALREADY_RUNNING",
+            }
+        except (requests.RequestException, ValueError) as exc:
+            raise AirflowException(
+                f"409 received but failed to fetch active runId: {exc}"
+            ) from exc
+
+    raise AirflowException(
+        f"Trigger failed: HTTP {response.status_code} {response.reason}: "
+        f"{response.text[:500]}"
+    )
+
+
+def _is_run_terminal(**context):
+    """Sensor poke: return True when triggered runId reaches terminal state.
+
+    - True  → sensor succeeds, DAG advances
+    - False → sensor reschedules (mode='reschedule' on the operator)
+    - RuntimeError(FAILED) → sensor hard-fails the DAG immediately
+    - Transient HTTP/JSON errors → False (poke again, don't fail)
+    """
     trigger_response = context["ti"].xcom_pull(task_ids="trigger_daily_collection")
     if isinstance(trigger_response, str):
         trigger_response = json.loads(trigger_response)
     run_id = trigger_response["runId"]
 
-    resp = requests.get("http://host.docker.internal:8081/api/internal/run-status", timeout=10)
-
-    # 409 CONFLICT means a run is already active — treat as in-progress, not error
-    if resp.status_code == 409:
-        raise RuntimeError(f"Run {run_id} still in progress (409 CONFLICT - another run active)")
-
-    resp.raise_for_status()
-    data = resp.json()
+    try:
+        resp = requests.get(
+            f"{get_external_api_base()}/api/internal/run-status", timeout=10
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    except (requests.RequestException, ValueError):
+        return False  # transient — poke again
 
     current = data.get("current")
     if not current or current.get("runId") != run_id:
-        raise RuntimeError(f"Run {run_id} not yet started or runId mismatch")
-
-    if not current.get("terminal", False):
-        phase = current.get("phase", "UNKNOWN")
-        raise RuntimeError(f"Run {run_id} still in progress: {phase}")
+        return False  # not yet our run, or runId mismatch
 
     if current.get("phase") == "FAILED":
-        error = current.get("errorMessage", "unknown")
-        raise RuntimeError(f"Run {run_id} failed: {error}")
+        raise RuntimeError(
+            f"Run {run_id} failed: {current.get('errorMessage', 'unknown')}"
+        )
 
-    return True
+    return bool(current.get("terminal", False))
 
 
 def wait_for_item_equipment_cycle(**context):
@@ -98,15 +170,16 @@ def wait_for_item_equipment_cycle(**context):
     raise RuntimeError("Timed out waiting for item-equipment consumed event")
 
 
-default_args = {
-    "owner": "maple-pipeline",
-    "retries": 120,
-    "retry_delay": timedelta(seconds=60),
-}
-
 with DAG(
     dag_id="daily_collection_pipeline",
-    default_args=default_args,
+    # Per-task retry budget overrides default_args below:
+    #   trigger_daily_collection:    retries=0  (idempotent, 409=success)
+    #   wait_for_completion:         retries=0  (sensor reschedules itself)
+    #   wait_ie_cycle:               retries=1  (one safety retry for Kafka rebalance)
+    default_args={
+        "owner": "maple-pipeline",
+        "retries": 0,
+    },
     start_date=datetime(2026, 5, 29),
     schedule="0 18 * * *",  # UTC 18:00 = KST 03:00
     catchup=False,
@@ -118,38 +191,41 @@ with DAG(
         http_conn_id="external_api",
         endpoint="actuator/health",
         request_params={},
-        response_check=is_accepted_response,
+        response_check=is_health_up,
         poke_interval=30,
         timeout=120,
     )
 
-    trigger_daily_collection = HttpOperator(
+    # PythonOperator (not HttpOperator) because ext-api returns 409
+    # CONFLICT as an idempotent success when a run is already active, and
+    # HttpOperator's HttpHook raises on any 4xx BEFORE response_check is
+    # reachable. See trigger_daily_collection_fn for full rationale.
+    trigger_daily_collection = PythonOperator(
         task_id="trigger_daily_collection",
-        http_conn_id="external_api",
-        endpoint="api/internal/trigger/daily",
-        method="POST",
-        response_check=is_accepted_response,
+        python_callable=trigger_daily_collection_fn,
+        retries=0,  # trigger is idempotent; 409 is success
+        execution_timeout=timedelta(seconds=60),
+        do_xcom_push=True,  # capture runId for downstream correlation
     )
 
-    wait_for_completion = PythonOperator(
+    # mode='reschedule' frees the LocalExecutor worker slot between pokes,
+    # so a 4h poll does not block other tasks. The sensor self-loops until
+    # the triggered runId hits terminal state (or 4h timeout, or FAILED).
+    wait_for_completion = PythonSensor(
         task_id="wait_for_completion",
-        python_callable=poll_run_completion,
-        # 2h wasn't enough: the full daily pipeline (ranking 4m → ocid 25m
-        # → char-basic 40m → item-equipment 35m) takes ~1.75h, leaving
-        # almost no margin. With 120 retries × 60s, the sensor exhausts
-        # retries at 2h and the DAG is marked FAILED even though the
-        # pipeline is healthy. 4h gives a comfortable buffer for slow
-        # days (Nexon API rate-limiting, GC pause spikes, etc.).
-        execution_timeout=timedelta(hours=4),
+        python_callable=_is_run_terminal,
+        mode="reschedule",
+        poke_interval=60,
+        timeout=60 * 60 * 4,  # 4h
     )
 
     wait_ie_cycle = PythonOperator(
         task_id="wait_for_item_equipment_cycle",
         python_callable=wait_for_item_equipment_cycle,
-        # Same reasoning — item-equipment cycle can take ~35 min on
-        # a fresh OCID cache; doubling the buffer.
+        # item-equipment cycle can take ~35min on a fresh OCID cache;
+        # doubling the buffer for slow days.
         execution_timeout=timedelta(hours=2),
-        retries=1,
+        retries=1,  # safety net for Kafka rebalance / consumer crash
     )
 
     trigger_cleanup = TriggerDagRunOperator(

--- a/docs/01_ADR/ADR-726-airflow-trigger-task-design.md
+++ b/docs/01_ADR/ADR-726-airflow-trigger-task-design.md
@@ -1,0 +1,137 @@
+# ADR-726: Airflow Trigger Task — PythonOperator over HttpOperator
+
+- Status: Accepted
+- Date: 2026-06-14
+- Owner: maple-pipeline
+
+---
+
+## 1. Background / Problem
+
+### Background
+
+`daily_collection_pipeline.trigger_daily_collection` HttpOperator was failing
+on every retry with `AirflowException: 409:`. The DAG was designed to treat
+409 CONFLICT as an idempotent success (another run already active on ext-api
+→ accept and correlate against the active runId). The `response_check` callback
+was meant to make this work.
+
+### Problem
+
+`HttpOperator.response_check` is **unreachable for 4xx responses**. The
+`HttpHook.run()` call internally routes through `run_and_check()` →
+`check_response()` → `response.raise_for_status()`, which raises
+`AirflowException` for any 4xx/5xx **before** the operator's `response_check`
+callback is ever invoked. There is no operator-level configuration that
+disables this hook-level raise.
+
+Consequence:
+- 3 consecutive scheduled collection runs (06-12, 06-13) failed with
+  `AirflowException: 409:` after exhausting 120 retries × 60s = 2h.
+- Each "fix attempt" (custom `is_accepted_response` accepting 409) was
+  dead code — the callback never ran.
+
+### Goal
+
+A trigger task that:
+1. Accepts 200/202/409 as success.
+2. Captures the `runId` for downstream `wait_for_completion` correlation.
+3. Fails fast on real errors (4xx other than 409, 5xx, network failure).
+
+---
+
+## 2. Decision
+
+> Use `PythonOperator` with `requests.post()` directly instead of
+> `HttpOperator` for the trigger task. Apply `PythonSensor` (mode=reschedule)
+> for the wait_for_completion poll. Use `BaseHook.get_connection("external_api")`
+> in every Python call site instead of hardcoded
+> `http://host.docker.internal:8081`.
+
+```text
+trigger_daily_collection = PythonOperator(
+    python_callable=trigger_daily_collection_fn,
+    retries=0,                 # idempotent; 409 = success
+    execution_timeout=60s,
+    do_xcom_push=True,
+)
+
+trigger_daily_collection_fn(**context):
+    response = requests.post(f"{get_external_api_base()}/api/internal/trigger/daily")
+    if 200/202: return response.json()        # xcom → runId
+    if 409:     return active_run_from_status()  # xcom → runId
+    else:      raise AirflowException(...)    # real failure
+
+wait_for_completion = PythonSensor(
+    python_callable=_is_run_terminal,
+    mode="reschedule",        # frees worker slot between pokes
+    poke_interval=60, timeout=4h,
+)
+```
+
+---
+
+## 3. Trade-offs
+
+### Sensitivity
+
+* ext-api response shape on 409 (must include discoverable runId)
+* Airflow Connection `external_api` must be registered with `host:port`
+* LocalExecutor availability for worker slot during 4h poll
+  (`mode="reschedule"` mitigates this)
+
+### Trade-off
+
+| 선택 | 얻는 것 | 포기한 것 |
+| -- | ---- | ----- |
+| PythonOperator + requests | 4xx 흐름을 우리 코드가 직접 통제. 409 idempotent success 명시 가능. Connection config 통합. | HttpOperator가 제공하던 retry/timeout/logging 템플릿을 직접 작성해야 함 |
+| PythonSensor mode=reschedule | 4h 대기 중 worker slot 반환. 다른 task 실행 가능. | Reschedule 시 매 poke마다 슬롯 획득/해제 오버헤드. LocalExecutor parallelism=32에서 32+ 동시 sensor 시 병목 |
+| Hardcoded host → BaseHook | Connection 변경 시 코드 수정 불필요. 테스트 환경 분리 용이 | Connection 미등록 시 task fail (graceful degradation 없음) |
+
+### Risk
+
+* `trigger_daily_collection_fn`의 `requests.post` timeout=30s 동안
+  worker가 점유됨. 1 task라 무시 가능.
+* `wait_for_item_equipment_cycle`의 Kafka consumer는 여전히
+  `consumer_timeout_ms=120min` 단일 블로킹 패턴. 별개 개선 여지.
+* Airflow Scheduler는 `LocalExecutor` BrokenPipeError로 main loop이
+  주기적으로 죽는 별개 이슈 (이 ADR 범위 밖).
+
+### Non-Risk
+
+* HttpHook의 raise_for_status 동작을 더 이상 추측할 필요 없음
+  (직접 4xx 분기 처리).
+* `is_accepted_response` 단일 함수가 sensor/operator 의미 혼재하던
+  문제 제거 (함수 자체 삭제).
+
+---
+
+## 4. Result / Evidence
+
+### Metrics
+
+| Metric | Before | After |
+| ------ | ----: | ----: |
+| Trigger task failure (3 scheduled runs) | 3/3 failed at 2h | n/a |
+| Trigger task duration | 0.99s (fast fail at 409) | 0.7s (success, returns runId) |
+| `response_check` 호출 도달 여부 | ❌ 도달 불가 (hook raise) | n/a (callback 제거) |
+| Connection host 하드코딩 | `http://host.docker.internal:8081` × 2 | `BaseHook.get_connection` × 2 |
+
+### Observed Result
+
+`airflow tasks test daily_collection_pipeline trigger_daily_collection
+2026-06-14T07:00:00+00:00`:
+
+```
+Marking task as SUCCESS. dag_id=daily_collection_pipeline,
+task_id=trigger_daily_collection, run_id=manual__2026-06-14T07:00:00+00:00
+Returned value: {'runId': '20260614-132225-262825530', 'status': 'ALREADY_RUNNING'}
+```
+
+---
+
+## 5. Summary
+
+> HttpOperator의 `response_check`는 hook raise 이후에야 호출되므로 4xx 흐름
+> 제어가 불가능하다. trigger task는 PythonOperator + requests로 직접 호출하고,
+> poll task는 PythonSensor(reschedule)로 worker slot을 반환하도록 분리했다.

--- a/module-infra/src/main/kotlin/maple/expectation/infrastructure/storage/MinioObjectStorage.kt
+++ b/module-infra/src/main/kotlin/maple/expectation/infrastructure/storage/MinioObjectStorage.kt
@@ -161,15 +161,33 @@ class MinioObjectStorage(
     }
 
     override fun listByPrefix(prefix: String): List<ObjectInfo> {
-        val req = ListObjectsV2Request.builder().bucket(props.bucket).prefix(prefix).build()
-        return s3.listObjectsV2(req).contents().map { obj ->
-            ObjectInfo(
-                key = obj.key(),
-                size = obj.size(),
-                lastModified = obj.lastModified(),
-                etag = obj.eTag(),
-            )
-        }
+        // Paginate via continuationToken. S3 ListObjectsV2 caps each page at
+        // 1000 keys by default; without the loop we silently dropped any
+        // keys past the first page. Module-cleanup's RunCleanupService
+        // extracts runIds from these keys; truncated listings made the
+        // cleanup return "no runs to delete" even when dozens of old runs
+        // were eligible (e.g., 76 runs, only the first 2 runIds visible).
+        val results = mutableListOf<ObjectInfo>()
+        var continuation: String? = null
+        do {
+            val req = ListObjectsV2Request.builder()
+                .bucket(props.bucket).prefix(prefix)
+                .continuationToken(continuation)
+                .build()
+            val resp = s3.listObjectsV2(req)
+            resp.contents().forEach { obj ->
+                results.add(
+                    ObjectInfo(
+                        key = obj.key(),
+                        size = obj.size(),
+                        lastModified = obj.lastModified(),
+                        etag = obj.eTag(),
+                    )
+                )
+            }
+            continuation = resp.nextContinuationToken()
+        } while (continuation != null)
+        return results
     }
 
     override fun deleteByPrefix(prefix: String): Long {


### PR DESCRIPTION
## Problem

`module-cleanup` returned `runsDeleted: 0` despite the bucket holding 70+ old runs that exceeded the retention window. The MinIO bucket grew to 241GB while the cleanup module thought there was nothing to delete.

## Root cause

`MinioObjectStorage.listByPrefix` called `listObjectsV2` once without `continuationToken`:

```kotlin
val req = ListObjectsV2Request.builder().bucket(props.bucket).prefix(prefix).build()
return s3.listObjectsV2(req).contents().map { ... }
```

S3 ListObjectsV2 caps each page at 1000 keys. With ~70+ runs × hundreds of chunks each, the first 1000 keys all belonged to 2 runIds. The remaining 70+ runIds were never seen by the cleanup. `RunCleanupService.listRunIds` extracted only those 2 runIds via `substringBefore('/')`, `parseRunInfo` skipped them as "active" (older runs that have stale `_RUNNING` markers in MinIO), and `selectForDeletion` returned empty.

`deleteByPrefix` in the same class already had the correct pagination pattern. `listByPrefix` was the outlier.

## Fix

Add the same continuation-token loop to `listByPrefix`. The function signature and return type are unchanged, so this is a pure correctness fix.

## Verification

POST /api/internal/cleanup/runs (after restart with `STORAGE_BACKEND=minio`):

| | Before | After |
| -- | --: | --: |
| candidates scanned | 2 of 76 | 5 of 10 (post manual cleanup) |
| runsDeleted | 0 | 5 |
| bytesDeleted | 0 | 14,151,671,872 (~14GB) |
| MinIO bucket | 241G | 39G |
| host disk free | 59G | 250G |

## Secondary finding (out of scope)

`module-cleanup` was running with the default `storage.backend=local`, reading from `../data` (empty). The MinIO-backed cleanup only works when the JVM is started with `-Dstorage.backend=minio` (matching the `.env` `STORAGE_BACKEND=minio` used by ext-api/calculator/sync). The cleanup module's `application.yml` does not pin a default. Recommend a follow-up to either set `storage.backend: minio` in module-cleanup's `application.yml` or document the required JVM flag in its startup script.