### PR TITLE
feat(ext-api): phase stop endpoint (#1290)

### DIFF
--- a/docs/superpowers/plans/2026-06-18-issue-1290-phase-stop-endpoint.md
+++ b/docs/superpowers/plans/2026-06-18-issue-1290-phase-stop-endpoint.md
@@ -1,0 +1,1536 @@
+# Phase Stop Endpoint Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `POST /api/internal/stop/phase/{phaseName}` to gracefully halt an in-flight ext-api phase at its chunk/page boundary, transitioning the slot to `STOPPED`.
+
+**Architecture:** Shared `PhaseStopSignal` component (ConcurrentHashMap<PipelinePhase, AtomicBoolean>) is consulted by each phase bean's chunk loop. Tripped flag → throw `PhaseStoppedException` → scheduler catches in `whenComplete` → `RunStatusTracker.stopRun()` (terminal-but-retainable, slot persists, next acquire overwrites). Stop endpoint is fire-and-forget (202); not-running case returns 200 NOT_RUNNING.
+
+**Tech Stack:** Kotlin, Spring Boot, ConcurrentHashMap, AtomicBoolean, CompletableFuture whenComplete, JUnit 5 + AssertJ + mockito-kotlin.
+
+**Spec:** `docs/superpowers/specs/2026-06-18-issue-1290-phase-stop-endpoint-design.md`
+
+---
+
+## File Structure
+
+**New files:**
+- `module-external-api/src/main/kotlin/maple/externalapi/scheduler/PhaseStopSignal.kt`
+- `module-external-api/src/main/kotlin/maple/externalapi/scheduler/PhaseStoppedException.kt`
+- `module-external-api/src/test/kotlin/maple/externalapi/scheduler/PhaseStopSignalTest.kt`
+- `module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/BatchFetchSupportStopTest.kt`
+
+**Modified files:**
+- `module-external-api/src/main/kotlin/maple/externalapi/runstatus/PipelinePhase.kt`
+- `module-external-api/src/main/kotlin/maple/externalapi/runstatus/RunStatus.kt`
+- `module-external-api/src/main/kotlin/maple/externalapi/runstatus/RunStatusTracker.kt`
+- `module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/BatchFetchSupport.kt`
+- `module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/RankingFetchPhase.kt`
+- `module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/OcidLookupPhase.kt`
+- `module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/CharacterBasicFetchPhase.kt`
+- `module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/ItemEquipmentFetchPhase.kt`
+- `module-external-api/src/main/kotlin/maple/externalapi/scheduler/ExternalApiScheduler.kt`
+- `module-external-api/src/main/kotlin/maple/externalapi/runstatus/InternalApiController.kt`
+- `module-external-api/src/test/kotlin/maple/externalapi/runstatus/RunStatusTrackerTest.kt`
+- `module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/RankingFetchPhaseTest.kt`
+- `module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/OcidLookupPhaseTest.kt`
+- `module-external-api/src/test/kotlin/maple/externalapi/scheduler/ExternalApiSchedulerTest.kt`
+- `module-external-api/src/test/kotlin/maple/externalapi/runstatus/InternalApiControllerTest.kt`
+
+---
+
+### Task 1: Add `STOPPED` to PipelinePhase enum + extend RunStatus.isTerminal
+
+**Files:**
+- Modify: `module-external-api/src/main/kotlin/maple/externalapi/runstatus/PipelinePhase.kt`
+- Modify: `module-external-api/src/main/kotlin/maple/externalapi/runstatus/RunStatus.kt`
+- Test: `module-external-api/src/test/kotlin/maple/externalapi/runstatus/RunStatusTest.kt` (create if missing)
+
+- [ ] **Step 1: Locate or create RunStatusTest**
+
+Check if `module-external-api/src/test/kotlin/maple/externalapi/runstatus/RunStatusTest.kt` exists. If not, create it:
+
+```kotlin
+package maple.externalapi.runstatus
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.assertFalse
+import java.time.Instant
+
+class RunStatusTest {
+
+    private fun statusOf(phase: PipelinePhase): RunStatus = RunStatus(
+        runId = "r",
+        phase = phase,
+        triggeredPhase = phase,
+        startedAt = Instant.EPOCH,
+    )
+
+    @Test
+    fun `COMPLETED is terminal`() {
+        assertTrue(statusOf(PipelinePhase.COMPLETED).isTerminal)
+    }
+
+    @Test
+    fun `FAILED is terminal`() {
+        assertTrue(statusOf(PipelinePhase.FAILED).isTerminal)
+    }
+
+    @Test
+    fun `STOPPED is terminal`() {
+        assertTrue(statusOf(PipelinePhase.STOPPED).isTerminal)
+    }
+
+    @Test
+    fun `RANKING_FETCH is not terminal`() {
+        assertFalse(statusOf(PipelinePhase.RANKING_FETCH).isTerminal)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :module-external-api:test --tests "maple.externalapi.runstatus.RunStatusTest"`
+
+Expected: Compile error — `STOPPED` is not a member of `PipelinePhase`.
+
+- [ ] **Step 3: Add STOPPED to PipelinePhase**
+
+Edit `module-external-api/src/main/kotlin/maple/externalapi/runstatus/PipelinePhase.kt`:
+
+```kotlin
+package maple.externalapi.runstatus
+
+enum class PipelinePhase {
+    IDLE,
+    RANKING_FETCH,
+    OCID_LOOKUP,
+    OCID_CACHE_REFRESH,
+    CHARACTER_BASIC,
+    CHARACTER_BASIC_DONE,
+    ITEM_EQUIPMENT,
+    COMPLETED,
+    FAILED,
+    STOPPED,
+}
+```
+
+- [ ] **Step 4: Extend RunStatus.isTerminal predicate**
+
+Edit `module-external-api/src/main/kotlin/maple/externalapi/runstatus/RunStatus.kt`:
+
+```kotlin
+package maple.externalapi.runstatus
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import java.time.Instant
+
+data class RunStatus(
+    val runId: String,
+    val phase: PipelinePhase,
+    val triggeredPhase: PipelinePhase,
+    val startedAt: Instant,
+    val updatedAt: Instant? = null,
+    val completedAt: Instant? = null,
+    val chunksProcessed: Int = 0,
+    val recordsProcessed: Long = 0,
+    val errorMessage: String? = null,
+) {
+    @get:JsonProperty("terminal")
+    val isTerminal: Boolean
+        get() = phase == PipelinePhase.COMPLETED
+            || phase == PipelinePhase.FAILED
+            || phase == PipelinePhase.STOPPED
+}
+```
+
+- [ ] **Step 5: Run tests, verify pass**
+
+Run: `./gradlew :module-external-api:test --tests "maple.externalapi.runstatus.RunStatusTest"`
+
+Expected: PASS (4/4).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add module-external-api/src/main/kotlin/maple/externalapi/runstatus/PipelinePhase.kt \
+        module-external-api/src/main/kotlin/maple/externalapi/runstatus/RunStatus.kt \
+        module-external-api/src/test/kotlin/maple/externalapi/runstatus/RunStatusTest.kt
+git commit -m "feat(ext-api): add STOPPED to PipelinePhase + extend isTerminal
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: PhaseStoppedException
+
+**Files:**
+- Create: `module-external-api/src/main/kotlin/maple/externalapi/scheduler/PhaseStoppedException.kt`
+
+- [ ] **Step 1: Create the exception class**
+
+Create `module-external-api/src/main/kotlin/maple/externalapi/scheduler/PhaseStoppedException.kt`:
+
+```kotlin
+package maple.externalapi.scheduler
+
+import maple.externalapi.runstatus.PipelinePhase
+
+/**
+ * Thrown by phase beans when they detect a stop request at a chunk/page/batch
+ * boundary. Caught specifically in `ExternalApiScheduler.runXxxPhase` `whenComplete`
+ * handlers to drive a STOPPED terminal transition (vs. FAILED for other exceptions).
+ */
+class PhaseStoppedException(
+    val phase: PipelinePhase,
+) : RuntimeException("phase ${phase.name} stopped at chunk boundary")
+```
+
+- [ ] **Step 2: Compile**
+
+Run: `./gradlew :module-external-api:compileKotlin :module-external-api:compileJava --continue`
+
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add module-external-api/src/main/kotlin/maple/externalapi/scheduler/PhaseStoppedException.kt
+git commit -m "feat(ext-api): add PhaseStoppedException
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: PhaseStopSignal component + tests
+
+**Files:**
+- Create: `module-external-api/src/main/kotlin/maple/externalapi/scheduler/PhaseStopSignal.kt`
+- Create: `module-external-api/src/test/kotlin/maple/externalapi/scheduler/PhaseStopSignalTest.kt`
+
+- [ ] **Step 1: Write failing test**
+
+Create `module-external-api/src/test/kotlin/maple/externalapi/scheduler/PhaseStopSignalTest.kt`:
+
+```kotlin
+package maple.externalapi.scheduler
+
+import maple.externalapi.runstatus.PipelinePhase
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+
+class PhaseStopSignalTest {
+
+    @Test
+    fun `requestStop on idle phase returns true and trips flag`() {
+        val signal = PhaseStopSignal()
+        assertTrue(signal.requestStop(PipelinePhase.ITEM_EQUIPMENT))
+        assertTrue(signal.isStopRequested(PipelinePhase.ITEM_EQUIPMENT))
+    }
+
+    @Test
+    fun `requestStop is idempotent — second call returns false (no state change)`() {
+        val signal = PhaseStopSignal()
+        assertTrue(signal.requestStop(PipelinePhase.ITEM_EQUIPMENT))
+        assertFalse(signal.requestStop(PipelinePhase.ITEM_EQUIPMENT))
+        assertTrue(signal.isStopRequested(PipelinePhase.ITEM_EQUIPMENT))
+    }
+
+    @Test
+    fun `isStopRequested on never-requested phase is false`() {
+        val signal = PhaseStopSignal()
+        assertFalse(signal.isStopRequested(PipelinePhase.OCID_LOOKUP))
+    }
+
+    @Test
+    fun `clear resets flag to false`() {
+        val signal = PhaseStopSignal()
+        signal.requestStop(PipelinePhase.RANKING_FETCH)
+        signal.clear(PipelinePhase.RANKING_FETCH)
+        assertFalse(signal.isStopRequested(PipelinePhase.RANKING_FETCH))
+    }
+
+    @Test
+    fun `clear on never-requested phase is no-op`() {
+        val signal = PhaseStopSignal()
+        signal.clear(PipelinePhase.CHARACTER_BASIC)
+        assertFalse(signal.isStopRequested(PipelinePhase.CHARACTER_BASIC))
+    }
+
+    @Test
+    fun `flags are per-phase — one phase's stop does not affect another`() {
+        val signal = PhaseStopSignal()
+        signal.requestStop(PipelinePhase.ITEM_EQUIPMENT)
+        assertFalse(signal.isStopRequested(PipelinePhase.OCID_LOOKUP))
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :module-external-api:test --tests "maple.externalapi.scheduler.PhaseStopSignalTest"`
+
+Expected: Compile error — `PhaseStopSignal` unresolved.
+
+- [ ] **Step 3: Implement PhaseStopSignal**
+
+Create `module-external-api/src/main/kotlin/maple/externalapi/scheduler/PhaseStopSignal.kt`:
+
+```kotlin
+package maple.externalapi.scheduler
+
+import maple.externalapi.runstatus.PipelinePhase
+import org.springframework.stereotype.Component
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Per-phase stop flag map. `requestStop` returns the previous state (true on first
+ * call, false on idempotent repeat) so callers can tell whether their request was
+ * the one that tripped the flag. `clear` is unconditional reset.
+ */
+@Component
+class PhaseStopSignal {
+
+    private val flags = ConcurrentHashMap<PipelinePhase, AtomicBoolean>()
+
+    fun requestStop(phase: PipelinePhase): Boolean {
+        val flag = flags.computeIfAbsent(phase) { AtomicBoolean(false) }
+        return flag.compareAndSet(false, true)
+    }
+
+    fun isStopRequested(phase: PipelinePhase): Boolean =
+        flags[phase]?.get() == true
+
+    fun clear(phase: PipelinePhase) {
+        flags[phase]?.set(false)
+    }
+}
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `./gradlew :module-external-api:test --tests "maple.externalapi.scheduler.PhaseStopSignalTest"`
+
+Expected: PASS (6/6).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add module-external-api/src/main/kotlin/maple/externalapi/scheduler/PhaseStopSignal.kt \
+        module-external-api/src/test/kotlin/maple/externalapi/scheduler/PhaseStopSignalTest.kt
+git commit -m "feat(ext-api): add PhaseStopSignal component
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: RunStatusTracker.stopRun + tests
+
+**Files:**
+- Modify: `module-external-api/src/main/kotlin/maple/externalapi/runstatus/RunStatusTracker.kt`
+- Modify: `module-external-api/src/test/kotlin/maple/externalapi/runstatus/RunStatusTrackerTest.kt` (create if missing)
+
+- [ ] **Step 1: Locate or create RunStatusTrackerTest**
+
+Check if `module-external-api/src/test/kotlin/maple/externalapi/runstatus/RunStatusTrackerTest.kt` exists. If not, create it with the contents below. If it exists, add the new test methods to the existing file.
+
+```kotlin
+package maple.externalapi.runstatus
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+
+class RunStatusTrackerTest {
+
+    private val fixedInstant = Instant.parse("2026-06-18T05:00:00Z")
+    private val clock = Clock.fixed(fixedInstant, ZoneOffset.UTC)
+    private val tracker = RunStatusTracker(clock)
+
+    @Test
+    fun `stopRun sets phase to STOPPED with terminal=true and persists slot record`() {
+        val acquired = tracker.acquirePhaseSlot(PipelinePhase.ITEM_EQUIPMENT, "run-1")
+        assertNotNull(acquired)
+
+        tracker.stopRun(PipelinePhase.ITEM_EQUIPMENT, "run-1", chunksProcessed = 42, recordsProcessed = 1000L)
+
+        val status = tracker.getPhaseStatus(PipelinePhase.ITEM_EQUIPMENT)
+        assertNotNull(status, "stopped record must persist in slot")
+        assertEquals(PipelinePhase.STOPPED, status!!.phase)
+        assertTrue(status.isTerminal)
+        assertEquals(42, status.chunksProcessed)
+        assertEquals(1000L, status.recordsProcessed)
+        assertEquals(fixedInstant, status.completedAt)
+    }
+
+    @Test
+    fun `stopRun with mismatched runId is a no-op`() {
+        tracker.acquirePhaseSlot(PipelinePhase.ITEM_EQUIPMENT, "run-1")
+        tracker.stopRun(PipelinePhase.ITEM_EQUIPMENT, "different-run", 0, 0L)
+
+        val status = tracker.getPhaseStatus(PipelinePhase.ITEM_EQUIPMENT)
+        assertEquals(PipelinePhase.ITEM_EQUIPMENT, status!!.phase)
+        assertFalse(status.isTerminal)
+    }
+
+    @Test
+    fun `acquirePhaseSlot after stopRun succeeds (terminal-overwrite)`() {
+        tracker.acquirePhaseSlot(PipelinePhase.ITEM_EQUIPMENT, "run-1")
+        tracker.stopRun(PipelinePhase.ITEM_EQUIPMENT, "run-1", 0, 0L)
+        assertTrue(tracker.getPhaseStatus(PipelinePhase.ITEM_EQUIPMENT)!!.isTerminal)
+
+        val newAcquire = tracker.acquirePhaseSlot(PipelinePhase.ITEM_EQUIPMENT, "run-2")
+        assertNotNull(newAcquire, "slot must be acquirable after STOPPED")
+        assertEquals("run-2", newAcquire!!.runId)
+        assertEquals(PipelinePhase.ITEM_EQUIPMENT, newAcquire.phase)
+    }
+
+    @Test
+    fun `hasNonTerminalRun returns null after stopRun (allows next trigger)`() {
+        tracker.acquirePhaseSlot(PipelinePhase.OCID_LOOKUP, "run-1")
+        tracker.stopRun(PipelinePhase.OCID_LOOKUP, "run-1", 0, 0L)
+
+        assertNull(tracker.hasNonTerminalRun(PipelinePhase.OCID_LOOKUP))
+    }
+
+    @Test
+    fun `stopRun on empty slot is no-op`() {
+        tracker.stopRun(PipelinePhase.RANKING_FETCH, "phantom", 0, 0L)
+        assertNull(tracker.getPhaseStatus(PipelinePhase.RANKING_FETCH))
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `./gradlew :module-external-api:test --tests "maple.externalapi.runstatus.RunStatusTrackerTest"`
+
+Expected: Compile error — `stopRun` unresolved.
+
+- [ ] **Step 3: Add stopRun method**
+
+In `module-external-api/src/main/kotlin/maple/externalapi/runstatus/RunStatusTracker.kt`, add the following method after `failRun` (before `releasePhaseSlot`):
+
+```kotlin
+    /**
+     * Mark phase slot's run as STOPPED with chunks/records counts. Slot record
+     * persists (NOT cleared). Next acquire on the same phase will overwrite the
+     * STOPPED terminal record (terminal-overwrite CAS). Use this when a phase run
+     * ended because a stop request was detected at a chunk/page boundary.
+     */
+    fun stopRun(phase: PipelinePhase, runId: String, chunksProcessed: Int, recordsProcessed: Long) {
+        val now = Instant.now(clock)
+        slots[phase]?.updateAndGet { current ->
+            if (current == null || current.runId != runId) return@updateAndGet current
+            current.copy(
+                phase = PipelinePhase.STOPPED,
+                updatedAt = now,
+                completedAt = now,
+                chunksProcessed = chunksProcessed,
+                recordsProcessed = recordsProcessed,
+            )
+        }
+        log.info("[RunStatus] phase-slot stopped phase={} runId={} chunks={} records={}",
+            phase, runId, chunksProcessed, recordsProcessed)
+    }
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `./gradlew :module-external-api:test --tests "maple.externalapi.runstatus.RunStatusTrackerTest"`
+
+Expected: PASS (5/5).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add module-external-api/src/main/kotlin/maple/externalapi/runstatus/RunStatusTracker.kt \
+        module-external-api/src/test/kotlin/maple/externalapi/runstatus/RunStatusTrackerTest.kt
+git commit -m "feat(ext-api): add RunStatusTracker.stopRun
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: BatchFetchSupport — phase on ctx + signal check
+
+**Files:**
+- Modify: `module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/BatchFetchSupport.kt`
+- Modify (existing tests in same package to add `phase` to BatchFetchContext construction)
+- Create: `module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/BatchFetchSupportStopTest.kt`
+
+- [ ] **Step 1: Write failing test**
+
+Create `module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/BatchFetchSupportStopTest.kt`:
+
+```kotlin
+package maple.externalapi.scheduler.phase
+
+import io.github.bucket4j.Bucket
+import maple.externalapi.domain.ExternalApiEndpoint
+import maple.externalapi.metrics.SnapshotFetchMetrics
+import maple.externalapi.port.out.ExternalApiClientPort
+import maple.externalapi.scheduler.PhaseStopSignal
+import maple.externalapi.runstatus.PipelinePhase
+import maple.externalapi.snapshot.ChunkedSnapshotSink
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.time.Instant
+import java.util.concurrent.CompletableFuture
+
+class BatchFetchSupportStopTest {
+
+    @Test
+    fun `processBatch throws PhaseStoppedException when stop requested before first batch`() {
+        val clientPort = mock<ExternalApiClientPort>()
+        whenever(clientPort.fetch(any(), any(), any())).thenAnswer {
+            CompletableFuture.completedFuture(ByteArray(0))
+        }
+        val signal = PhaseStopSignal()
+        signal.requestStop(PipelinePhase.ITEM_EQUIPMENT)
+
+        val support = BatchFetchSupport(
+            clientPort = clientPort,
+            fetchMetrics = mock<SnapshotFetchMetrics>(),
+            maxInFlight = 10,
+            schedulerRateLimiter = mock(),
+            schedulerProgressLogger = mock(),
+            httpStatusExtractor = mock(),
+            stopSignal = signal,
+        )
+
+        val ctx = BatchFetchContext(
+            endpoint = "item-equipment",
+            phase = PipelinePhase.ITEM_EQUIPMENT,
+            apiEndpoint = ExternalApiEndpoint.ITEM_EQUIPMENT,
+            onFetched = {},
+            onFailed = {},
+        )
+        val sink = mock<ChunkedSnapshotSink>()
+
+        val ex = assertThrows(PhaseStoppedException::class.java) {
+            kotlinx.coroutines.runBlocking {
+                support.processBatch(
+                    rateLimiter = Bucket.builder().addLimit(limit = io.github.bucket4j.Bandwidth.simple(java.time.Duration.ofSeconds(1), 100)).build(),
+                    entries = listOf(
+                        AbstractMap.SimpleEntry("ign1", "ocid1"),
+                        AbstractMap.SimpleEntry("ign2", "ocid2"),
+                    ),
+                    batchSize = 10,
+                    ctx = ctx,
+                    sink = sink,
+                    runId = "test-run",
+                    start = Instant.now(),
+                )
+            }
+        }
+        assertEquals(PipelinePhase.ITEM_EQUIPMENT, ex.phase)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :module-external-api:test --tests "maple.externalapi.scheduler.phase.BatchFetchSupportStopTest"`
+
+Expected: Compile error — `BatchFetchContext` lacks `phase`, `BatchFetchSupport` lacks `stopSignal` ctor param, `PhaseStoppedException` unresolved from this package.
+
+- [ ] **Step 3: Add `phase` field to BatchFetchContext**
+
+In `module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/BatchFetchSupport.kt`, replace the data class:
+
+```kotlin
+data class BatchFetchContext(
+    val endpoint: String,
+    val phase: PipelinePhase,
+    val apiEndpoint: ExternalApiEndpoint,
+    val onFetched: () -> Unit,
+    val onFailed: () -> Unit,
+)
+```
+
+Add the import at the top (next to existing imports):
+
+```kotlin
+import maple.externalapi.runstatus.PipelinePhase
+import maple.externalapi.scheduler.PhaseStopSignal
+```
+
+- [ ] **Step 4: Inject stopSignal into BatchFetchSupport constructor**
+
+In the same file, replace the `BatchFetchSupport` constructor signature:
+
+```kotlin
+@Component
+class BatchFetchSupport(
+    private val clientPort: ExternalApiClientPort,
+    private val fetchMetrics: SnapshotFetchMetrics,
+    @Value("\${external-api.concurrency.max-in-flight:100}")
+    maxInFlight: Int,
+    private val schedulerRateLimiter: SchedulerRateLimiter,
+    private val schedulerProgressLogger: SchedulerProgressLogger,
+    private val httpStatusExtractor: HttpStatusExtractor,
+    private val stopSignal: PhaseStopSignal,
+) {
+```
+
+- [ ] **Step 5: Add stop check at top of processBatch while loop**
+
+In `processBatch`, replace the `while (processed < entries.size) {` opening:
+
+```kotlin
+        while (processed < entries.size) {
+            if (stopSignal.isStopRequested(ctx.phase)) {
+                throw PhaseStoppedException(ctx.phase)
+            }
+            val permits = schedulerRateLimiter.acquirePermitsSuspend(rateLimiter, batchSize, entries.size - processed)
+            if (permits == 0) continue
+```
+
+Add the import:
+
+```kotlin
+import maple.externalapi.scheduler.PhaseStoppedException
+```
+
+- [ ] **Step 6: Fix existing callers (CharBasic / ItemEquipment phases will fail to compile next task)**
+
+CharBasic and ItemEquipment phases construct `BatchFetchContext` without `phase`. Compile will fail in those tasks. The two following tasks (8, 9) add `phase = PipelinePhase.XXX` to those constructions.
+
+If any existing test in the module constructs `BatchFetchContext` directly, add `phase = PipelinePhase.ITEM_EQUIPMENT` (or the matching phase) — search with:
+
+```bash
+grep -rn "BatchFetchContext(" module-external-api/src/test --include="*.kt"
+```
+
+and update each call site.
+
+- [ ] **Step 7: Run stop test, verify pass**
+
+Run: `./gradlew :module-external-api:test --tests "maple.externalapi.scheduler.phase.BatchFetchSupportStopTest"`
+
+Expected: PASS (1/1).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/BatchFetchSupport.kt \
+        module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/BatchFetchSupportStopTest.kt
+git commit -m "feat(ext-api): BatchFetchSupport phase-aware stop check
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: RankingFetchPhase — inject signal + check in processPages
+
+**Files:**
+- Modify: `module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/RankingFetchPhase.kt`
+- Modify: `module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/RankingFetchPhaseTest.kt` (create if missing)
+
+- [ ] **Step 1: Locate or create RankingFetchPhaseTest**
+
+Check if `module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/RankingFetchPhaseTest.kt` exists. If yes, read it to understand construction. If no, skip ahead to step 2.
+
+If creating new, write:
+
+```kotlin
+package maple.externalapi.scheduler.phase
+
+import maple.externalapi.scheduler.PhaseStopSignal
+import maple.externalapi.runstatus.PipelinePhase
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.mockito.kotlin.mock
+import java.util.concurrent.Executors
+
+class RankingFetchPhaseStopTest {
+
+    @Test
+    fun `execute throws PhaseStoppedException when stop requested before first page`() {
+        val signal = PhaseStopSignal()
+        signal.requestStop(PipelinePhase.RANKING_FETCH)
+
+        val phase = RankingFetchPhase(
+            clientPort = mock(),
+            objectMapper = com.fasterxml.jackson.databind.ObjectMapper(),
+            chunkingProperties = mock(),
+            volumeMetrics = mock(),
+            metrics = mock(),
+            rankingPublisher = mock(),
+            maxPages = 5,
+            permitsPerSecond = 100,
+            runMarkerWriter = mock(),
+            objectStorage = mock(),
+            stopSignal = signal,
+        )
+
+        val ex = assertThrows(PhaseStoppedException::class.java) {
+            phase.execute(Executors.newSingleThreadExecutor(), "test-run").join()
+        }
+        assertEquals(PipelinePhase.RANKING_FETCH, ex.phase)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :module-external-api:test --tests "maple.externalapi.scheduler.phase.RankingFetchPhaseStopTest"`
+
+Expected: Compile error — `stopSignal` ctor param unresolved.
+
+- [ ] **Step 3: Add stopSignal ctor param + check in processPages**
+
+In `module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/RankingFetchPhase.kt`:
+
+Add imports (next to existing imports):
+
+```kotlin
+import maple.externalapi.scheduler.PhaseStopSignal
+import maple.externalapi.scheduler.PhaseStoppedException
+```
+
+Replace constructor:
+
+```kotlin
+class RankingFetchPhase(
+    private val clientPort: ExternalApiClientPort,
+    private val objectMapper: ObjectMapper,
+    private val chunkingProperties: SnapshotChunkingProperties,
+    private val volumeMetrics: SnapshotVolumeMetrics,
+    private val metrics: ExternalApiMetrics,
+    @Qualifier("rankingSnapshotPublisher")
+    private val rankingPublisher: SnapshotChunkEventPublisher,
+    @Value("\${external-api.ranking.max-pages:300}")
+    private val maxPages: Int,
+    @Value("\${external-api.ranking.permits-per-second:50}")
+    private val permitsPerSecond: Int,
+    private val runMarkerWriter: RunMarkerWriter,
+    private val objectStorage: ObjectStorage,
+    private val stopSignal: PhaseStopSignal,
+) {
+```
+
+Replace `processPages` opening:
+
+```kotlin
+    private fun processPages(
+        workerExecutor: ExecutorService,
+        sink: ChunkedSnapshotSink,
+        rateLimiter: io.github.bucket4j.Bucket,
+        date: String,
+        currentPage: Int,
+        fetched: AtomicInteger,
+        failed: AtomicInteger,
+    ): CompletableFuture<Void> {
+        if (currentPage > maxPages) {
+            return CompletableFuture.completedFuture(null)
+        }
+        if (stopSignal.isStopRequested(PipelinePhase.RANKING_FETCH)) {
+            throw PhaseStoppedException(PipelinePhase.RANKING_FETCH)
+        }
+
+        SchedulerPhaseUtils.acquirePermits(rateLimiter, 1, 1)
+```
+
+- [ ] **Step 4: Update existing RankingFetchPhaseTest construction (if it exists)**
+
+If existing `RankingFetchPhaseTest.kt` constructs `RankingFetchPhase`, add the new ctor arg:
+
+```kotlin
+            stopSignal = maple.externalapi.scheduler.PhaseStopSignal(),
+```
+
+- [ ] **Step 5: Run all tests in this phase package, verify pass**
+
+Run: `./gradlew :module-external-api:test --tests "maple.externalapi.scheduler.phase.*"`
+
+Expected: All tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/RankingFetchPhase.kt \
+        module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/RankingFetchPhaseStopTest.kt \
+        module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/RankingFetchPhaseTest.kt
+git commit -m "feat(ext-api): RankingFetchPhase stop boundary check
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: OcidLookupPhase — inject signal + check in processBatch
+
+**Files:**
+- Modify: `module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/OcidLookupPhase.kt`
+- Modify: `module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/OcidLookupPhaseTest.kt`
+
+- [ ] **Step 1: Add a stop-check test**
+
+Append to `module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/OcidLookupPhaseTest.kt`:
+
+```kotlin
+    @Test
+    fun `execute throws PhaseStoppedException when stop requested before processBatch`() {
+        val storage = mock<ObjectStorage>()
+        val nexonClient = mock<NexonAuthClient>()
+        val objectMapper = ObjectMapper().registerModule(kotlinModule())
+        val stopSignal = PhaseStopSignal()
+        stopSignal.requestStop(PipelinePhase.OCID_LOOKUP)
+
+        val now = Instant.now()
+        whenever(storage.listByPrefix("runs/abc/ranking-overall/chunks")).thenReturn(listOf(
+            ObjectInfo("runs/abc/ranking-overall/chunks/part-000001.jsonl.gz", 100, now)
+        ))
+        val chunkBytes = run {
+            val out = java.io.ByteArrayOutputStream()
+            java.util.zip.GZIPOutputStream(out).use { gz ->
+                gz.write("{\"key\":\"user1\"}\n".toByteArray())
+            }
+            out.toByteArray()
+        }
+        whenever(storage.getStream("runs/abc/ranking-overall/chunks/part-000001.jsonl.gz"))
+            .thenReturn(chunkBytes.inputStream())
+        whenever(storage.listByPrefix("ocid-mapping/")).thenReturn(emptyList())
+
+        val clientPort = mock<maple.externalapi.port.out.ExternalApiClientPort>()
+        whenever(clientPort.fetch(any(), any(), any())).thenReturn(CompletableFuture.completedFuture(ByteArray(0)))
+
+        val phase = OcidLookupPhase(
+            clientPort = clientPort,
+            objectMapper = objectMapper,
+            ocidLookupPermitsPerSecond = 100,
+            batchSize = 100,
+            eventPublisher = mock<maple.externalapi.snapshot.event.SnapshotChunkEventPublisher>(),
+            objectStorage = storage,
+            nexonAuthClient = nexonClient,
+            stopSignal = stopSignal,
+        )
+
+        assertThrows(PhaseStoppedException::class.java) {
+            kotlinx.coroutines.runBlocking {
+                phase.execute(Executors.newSingleThreadExecutor(), "runs/abc", "abc")
+            }
+        }
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :module-external-api:test --tests "maple.externalapi.scheduler.phase.OcidLookupPhaseTest.execute throws PhaseStoppedException when stop requested before processBatch"`
+
+Expected: Compile error — `stopSignal` ctor param unresolved.
+
+- [ ] **Step 3: Add stopSignal ctor + check at processBatch loop top**
+
+In `module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/OcidLookupPhase.kt`:
+
+Add imports:
+
+```kotlin
+import maple.externalapi.scheduler.PhaseStopSignal
+import maple.externalapi.scheduler.PhaseStoppedException
+```
+
+Replace constructor:
+
+```kotlin
+class OcidLookupPhase(
+    private val clientPort: ExternalApiClientPort,
+    private val objectMapper: ObjectMapper,
+    @Value("\${external-api.rate-limit.ocid-lookup-permits-per-second:400}")
+    private val ocidLookupPermitsPerSecond: Int,
+    @Value("\${external-api.batch-size:1000}")
+    private val batchSize: Int,
+    @Qualifier("ocidLookupSnapshotPublisher")
+    private val eventPublisher: SnapshotChunkEventPublisher,
+    private val objectStorage: ObjectStorage,
+    private val nexonAuthClient: NexonAuthClient,
+    private val stopSignal: PhaseStopSignal,
+) {
+```
+
+In `processBatch` (private suspend function), replace the `while (current < igns.size) {` opening:
+
+```kotlin
+        var current = processed
+        while (current < igns.size) {
+            if (stopSignal.isStopRequested(PipelinePhase.OCID_LOOKUP)) {
+                throw PhaseStoppedException(PipelinePhase.OCID_LOOKUP)
+            }
+            val permits = SchedulerPhaseUtils.acquirePermits(rateLimiter, batchSize, igns.size - current)
+```
+
+- [ ] **Step 4: Update existing OcidLookupPhaseTest construction**
+
+In `OcidLookupPhaseTest.kt`, update the `OcidLookupPhase(...)` construction in the two existing tests to add:
+
+```kotlin
+            stopSignal = PhaseStopSignal(),
+```
+
+- [ ] **Step 5: Run all tests, verify pass**
+
+Run: `./gradlew :module-external-api:test --tests "maple.externalapi.scheduler.phase.OcidLookupPhaseTest"`
+
+Expected: PASS (3/3 including new stop test).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/OcidLookupPhase.kt \
+        module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/OcidLookupPhaseTest.kt
+git commit -m "feat(ext-api): OcidLookupPhase stop boundary check
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: CharacterBasicFetchPhase — set ctx.phase = CHARACTER_BASIC
+
+**Files:**
+- Modify: `module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/CharacterBasicFetchPhase.kt`
+- Modify: `module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/CharacterBasicFetchPhaseTest.kt` (if exists)
+
+- [ ] **Step 1: Update ctx construction in CharacterBasicFetchPhase**
+
+In `module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/CharacterBasicFetchPhase.kt`, replace the `ctx = BatchFetchContext(` block in `execute()`:
+
+```kotlin
+        val ctx = BatchFetchContext(
+            endpoint = "character-basic",
+            phase = PipelinePhase.CHARACTER_BASIC,
+            apiEndpoint = ExternalApiEndpoint.CHARACTER_BASIC,
+            onFetched = { metrics.recordCharacterBasicFetched() },
+            onFailed = { metrics.recordCharacterBasicFailed() },
+        )
+```
+
+Add import:
+
+```kotlin
+import maple.externalapi.runstatus.PipelinePhase
+```
+
+- [ ] **Step 2: Update existing test construction**
+
+If `CharacterBasicFetchPhaseTest.kt` constructs `BatchFetchContext` directly, add `phase = PipelinePhase.CHARACTER_BASIC`. Search:
+
+```bash
+grep -n "BatchFetchContext(" module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/CharacterBasicFetchPhaseTest.kt
+```
+
+- [ ] **Step 3: Run tests, verify pass**
+
+Run: `./gradlew :module-external-api:test --tests "maple.externalapi.scheduler.phase.CharacterBasicFetchPhase*"`
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/CharacterBasicFetchPhase.kt \
+        module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/CharacterBasicFetchPhaseTest.kt
+git commit -m "feat(ext-api): CharacterBasicFetchPhase wires ctx.phase
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: ItemEquipmentFetchPhase — set ctx.phase = ITEM_EQUIPMENT
+
+**Files:**
+- Modify: `module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/ItemEquipmentFetchPhase.kt`
+- Modify: `module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/ItemEquipmentFetchPhaseTest.kt` (if exists)
+
+- [ ] **Step 1: Update ctx construction in ItemEquipmentFetchPhase**
+
+In `module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/ItemEquipmentFetchPhase.kt`, replace the `ctx = BatchFetchContext(` block in `execute()`:
+
+```kotlin
+        val ctx = BatchFetchContext(
+            endpoint = "item-equipment",
+            phase = PipelinePhase.ITEM_EQUIPMENT,
+            apiEndpoint = ExternalApiEndpoint.ITEM_EQUIPMENT,
+            onFetched = { metrics.recordItemEquipmentFetched() },
+            onFailed = { metrics.recordItemEquipmentFailed() },
+        )
+```
+
+Add import:
+
+```kotlin
+import maple.externalapi.runstatus.PipelinePhase
+```
+
+- [ ] **Step 2: Update existing test construction**
+
+If `ItemEquipmentFetchPhaseTest.kt` constructs `BatchFetchContext` directly, add `phase = PipelinePhase.ITEM_EQUIPMENT`. Search:
+
+```bash
+grep -n "BatchFetchContext(" module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/ItemEquipmentFetchPhaseTest.kt
+```
+
+- [ ] **Step 3: Run tests, verify pass**
+
+Run: `./gradlew :module-external-api:test --tests "maple.externalapi.scheduler.phase.ItemEquipmentFetchPhase*"`
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/ItemEquipmentFetchPhase.kt \
+        module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/ItemEquipmentFetchPhaseTest.kt
+git commit -m "feat(ext-api): ItemEquipmentFetchPhase wires ctx.phase
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 10: ExternalApiScheduler — requestPhaseStop + whenComplete stop branch
+
+**Files:**
+- Modify: `module-external-api/src/main/kotlin/maple/externalapi/scheduler/ExternalApiScheduler.kt`
+- Modify: `module-external-api/src/test/kotlin/maple/externalapi/scheduler/ExternalApiSchedulerTest.kt` (extend)
+
+- [ ] **Step 1: Wire PhaseStopSignal into ExternalApiSchedulerTest setup (if test constructs scheduler manually)**
+
+If `ExternalApiSchedulerTest.kt` constructs `ExternalApiScheduler(...)` directly (not via Spring autowiring), construct a `PhaseStopSignal` in the `@BeforeEach` (or shared setup) and pass it as the new constructor arg. Example patch:
+
+```kotlin
+private val stopSignal = PhaseStopSignal()
+
+@BeforeEach
+fun setup() {
+    // ... existing setup ...
+    scheduler = ExternalApiScheduler(
+        // ... existing args ...
+        stopSignal = stopSignal,
+    )
+}
+```
+
+If the test uses `@SpringBootTest` or `@WebMvcTest` and the scheduler is autowired, no change to the setup is needed — `PhaseStopSignal` is auto-injected.
+
+- [ ] **Step 2: Extend ExternalApiSchedulerTest with stop-related cases**
+
+Append the following tests to the test class:
+
+```kotlin
+    @Test
+    fun `requestPhaseStop returns true when phase slot has non-terminal run`() {
+        // pre-populate slot with non-terminal run
+        runStatusTracker.acquirePhaseSlot(PipelinePhase.ITEM_EQUIPMENT, "run-1")
+        assertTrue(scheduler.requestPhaseStop(PipelinePhase.ITEM_EQUIPMENT))
+    }
+
+    @Test
+    fun `requestPhaseStop returns false when phase slot empty`() {
+        assertFalse(scheduler.requestPhaseStop(PipelinePhase.ITEM_EQUIPMENT))
+    }
+
+    @Test
+    fun `requestPhaseStop returns false when phase slot already terminal`() {
+        runStatusTracker.acquirePhaseSlot(PipelinePhase.ITEM_EQUIPMENT, "run-1")
+        runStatusTracker.completeRun(PipelinePhase.ITEM_EQUIPMENT, "run-1", 0, 0L)
+        assertFalse(scheduler.requestPhaseStop(PipelinePhase.ITEM_EQUIPMENT))
+    }
+
+    @Test
+    fun `runXxxPhase whenComplete catches PhaseStoppedException → stopRun + signal cleared`() {
+        runStatusTracker.acquirePhaseSlot(PipelinePhase.ITEM_EQUIPMENT, "run-1")
+        scheduler.requestPhaseStop(PipelinePhase.ITEM_EQUIPMENT)
+        assertTrue(stopSignal.isStopRequested(PipelinePhase.ITEM_EQUIPMENT))
+
+        // Force the run to throw PhaseStoppedException by stubbing itemEquipmentPhase
+        whenever(itemEquipmentPhase.execute(any(), any(), any())).thenReturn(
+            CompletableFuture.failedFuture(PhaseStoppedException(PipelinePhase.ITEM_EQUIPMENT))
+        )
+
+        val future = scheduler.runItemEquipmentPhase("run-1", "upstream-run")
+        future.join() // wait — exception absorbed by whenComplete, future completed normally
+
+        val status = runStatusTracker.getPhaseStatus(PipelinePhase.ITEM_EQUIPMENT)
+        assertEquals(PipelinePhase.STOPPED, status!!.phase)
+        assertTrue(status.isTerminal)
+        assertFalse(stopSignal.isStopRequested(PipelinePhase.ITEM_EQUIPMENT), "signal must be cleared")
+    }
+
+    @Test
+    fun `runXxxPhase success path clears signal`() {
+        runStatusTracker.acquirePhaseSlot(PipelinePhase.ITEM_EQUIPMENT, "run-1")
+        stopSignal.requestStop(PipelinePhase.ITEM_EQUIPMENT)
+
+        whenever(itemEquipmentPhase.execute(any(), any(), any())).thenReturn(
+            CompletableFuture.completedFuture(Unit)
+        )
+
+        scheduler.runItemEquipmentPhase("run-1", "upstream-run").join()
+
+        assertFalse(stopSignal.isStopRequested(PipelinePhase.ITEM_EQUIPMENT))
+        assertEquals(PipelinePhase.COMPLETED, runStatusTracker.getPhaseStatus(PipelinePhase.ITEM_EQUIPMENT)!!.phase)
+    }
+
+    @Test
+    fun `runXxxPhase generic failure path clears signal`() {
+        runStatusTracker.acquirePhaseSlot(PipelinePhase.ITEM_EQUIPMENT, "run-1")
+        stopSignal.requestStop(PipelinePhase.ITEM_EQUIPMENT)
+
+        whenever(itemEquipmentPhase.execute(any(), any(), any())).thenReturn(
+            CompletableFuture.failedFuture(RuntimeException("nexon down"))
+        )
+
+        scheduler.runItemEquipmentPhase("run-1", "upstream-run").join()
+
+        assertFalse(stopSignal.isStopRequested(PipelinePhase.ITEM_EQUIPMENT))
+        assertEquals(PipelinePhase.FAILED, runStatusTracker.getPhaseStatus(PipelinePhase.ITEM_EQUIPMENT)!!.phase)
+    }
+```
+
+Add to the imports at the top of `ExternalApiSchedulerTest.kt`:
+
+```kotlin
+import maple.externalapi.scheduler.PhaseStopSignal
+import maple.externalapi.scheduler.PhaseStoppedException
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `./gradlew :module-external-api:test --tests "maple.externalapi.scheduler.ExternalApiSchedulerTest"`
+
+Expected: Compile error — `requestPhaseStop` unresolved on scheduler, plus signal clearing tests fail.
+
+- [ ] **Step 4: Add stopSignal ctor + requestPhaseStop method**
+
+In `module-external-api/src/main/kotlin/maple/externalapi/scheduler/ExternalApiScheduler.kt`:
+
+Add imports:
+
+```kotlin
+import maple.externalapi.scheduler.PhaseStopSignal
+```
+
+Replace constructor (add `private val stopSignal: PhaseStopSignal,` at the end of the param list):
+
+```kotlin
+class ExternalApiScheduler(
+    private val ocidLookupPhase: OcidLookupPhase,
+    private val ocidCacheProvider: OcidCacheProvider,
+    private val rankingFetchPhaseProvider: ObjectProvider<RankingFetchPhase>,
+    private val characterBasicPhaseProvider: ObjectProvider<CharacterBasicFetchPhase>,
+    private val itemEquipmentFetchPhaseProvider: ObjectProvider<ItemEquipmentFetchPhase>,
+    private val schedulerMetrics: SchedulerMetrics,
+    private val runStatusTracker: RunStatusTracker,
+    private val runIdGenerator: RunIdGenerator,
+    @Value("\${external-api.schedule.run-on-startup:false}")
+    private val runOnStartup: Boolean,
+    @Value("\${external-api.schedule.skip-character-basic:false}")
+    private val skipCharacterBasic: Boolean,
+    private val stopSignal: PhaseStopSignal,
+) : ManagedLifecycle {
+```
+
+Add the new method (anywhere before `triggerPhase`):
+
+```kotlin
+    /**
+     * Set the stop flag for [phase] if and only if its slot currently holds a
+     * non-terminal run. Returns true if the request was applied (or already
+     * applied — flag is idempotent); false if there is nothing to stop.
+     *
+     * Cross-phase safe: only the named phase's flag is set. Other phases
+     * continue uninterrupted.
+     */
+    fun requestPhaseStop(phase: PipelinePhase): Boolean {
+        val hadNonTerminal = runStatusTracker.hasNonTerminalRun(phase) != null
+        if (hadNonTerminal) {
+            stopSignal.requestStop(phase)
+            log.info("[Scheduler] stop requested phase={} runId={}",
+                phase, runStatusTracker.getPhaseStatus(phase)?.runId)
+        }
+        return hadNonTerminal || stopSignal.isStopRequested(phase)
+    }
+```
+
+- [ ] **Step 5: Update whenComplete in runRankingPhase**
+
+In `runRankingPhase`, replace the existing `.whenComplete { _, ex -> ... }.thenRun { }` block:
+
+```kotlin
+        return future
+            .whenComplete { _, ex ->
+                when {
+                    ex is PhaseStoppedException -> {
+                        log.info("[Scheduler] runRankingPhase stopped runId={} phase={}", runId, ex.phase)
+                        runStatusTracker.stopRun(PipelinePhase.RANKING_FETCH, runId, 0, 0)
+                        stopSignal.clear(PipelinePhase.RANKING_FETCH)
+                    }
+                    ex != null -> {
+                        log.error("[Scheduler] runRankingPhase failed runId={}", runId, ex)
+                        runStatusTracker.failRun(PipelinePhase.RANKING_FETCH, runId, ex.message ?: "unknown")
+                        runStatusTracker.releasePhaseSlot(PipelinePhase.RANKING_FETCH, runId)
+                        stopSignal.clear(PipelinePhase.RANKING_FETCH)
+                    }
+                    else -> {
+                        runStatusTracker.completeRun(PipelinePhase.RANKING_FETCH, runId, 0, 0)
+                        stopSignal.clear(PipelinePhase.RANKING_FETCH)
+                    }
+                }
+            }
+            .thenRun { }
+```
+
+- [ ] **Step 6: Update whenComplete in runOcidPhase**
+
+Same pattern, in `runOcidPhase`:
+
+```kotlin
+        return future
+            .whenComplete { _, ex ->
+                when {
+                    ex is PhaseStoppedException -> {
+                        log.info("[Scheduler] runOcidPhase stopped runId={} phase={}", runId, ex.phase)
+                        runStatusTracker.stopRun(PipelinePhase.OCID_LOOKUP, runId, 0, 0)
+                        stopSignal.clear(PipelinePhase.OCID_LOOKUP)
+                    }
+                    ex != null -> {
+                        log.error("[Scheduler] runOcidPhase failed runId={} upstreamRunId={}", runId, upstreamRunId, ex)
+                        runStatusTracker.failRun(PipelinePhase.OCID_LOOKUP, runId, ex.message ?: "unknown")
+                        runStatusTracker.releasePhaseSlot(PipelinePhase.OCID_LOOKUP, runId)
+                        stopSignal.clear(PipelinePhase.OCID_LOOKUP)
+                    }
+                    else -> {
+                        runStatusTracker.completeRun(PipelinePhase.OCID_LOOKUP, runId, 0, 0)
+                        stopSignal.clear(PipelinePhase.OCID_LOOKUP)
+                    }
+                }
+            }
+            .thenRun { }
+```
+
+- [ ] **Step 7: Update whenComplete in runCharBasicPhase**
+
+Same pattern, replace the `.whenComplete { _, ex -> ... }.thenRun { }` block:
+
+```kotlin
+        return future
+            .whenComplete { _, ex ->
+                when {
+                    ex is PhaseStoppedException -> {
+                        log.info("[Scheduler] runCharBasicPhase stopped runId={} phase={}", runId, ex.phase)
+                        runStatusTracker.stopRun(PipelinePhase.CHARACTER_BASIC, runId, 0, 0)
+                        stopSignal.clear(PipelinePhase.CHARACTER_BASIC)
+                    }
+                    ex != null -> {
+                        log.error("[Scheduler] runCharBasicPhase failed runId={}", runId, ex)
+                        runStatusTracker.failRun(PipelinePhase.CHARACTER_BASIC, runId, ex.message ?: "unknown")
+                        runStatusTracker.releasePhaseSlot(PipelinePhase.CHARACTER_BASIC, runId)
+                        stopSignal.clear(PipelinePhase.CHARACTER_BASIC)
+                    }
+                    else -> {
+                        runStatusTracker.completeRun(PipelinePhase.CHARACTER_BASIC, runId, 0, 0)
+                        stopSignal.clear(PipelinePhase.CHARACTER_BASIC)
+                    }
+                }
+            }
+            .thenRun { }
+```
+
+- [ ] **Step 8: Update whenComplete in runItemEquipmentPhase**
+
+Same pattern, replace the `.whenComplete { _, ex -> ... }.thenRun { }` block. Preserve the existing chunks/records drain logic inside the `else` branch:
+
+```kotlin
+        return future
+            .whenComplete { _, ex ->
+                when {
+                    ex is PhaseStoppedException -> {
+                        log.info("[Scheduler] runItemEquipmentPhase stopped runId={} phase={}", runId, ex.phase)
+                        runStatusTracker.stopRun(PipelinePhase.ITEM_EQUIPMENT, runId, 0, 0)
+                        stopSignal.clear(PipelinePhase.ITEM_EQUIPMENT)
+                    }
+                    ex != null -> {
+                        log.error("[Scheduler] runItemEquipmentPhase failed runId={}", runId, ex)
+                        runStatusTracker.failRun(PipelinePhase.ITEM_EQUIPMENT, runId, ex.message ?: "unknown")
+                        runStatusTracker.releasePhaseSlot(PipelinePhase.ITEM_EQUIPMENT, runId)
+                        stopSignal.clear(PipelinePhase.ITEM_EQUIPMENT)
+                    }
+                    else -> {
+                        val chunks = schedulerMetrics.drainRunChunks().toInt()
+                        val records = schedulerMetrics.drainRunRecords()
+                        runStatusTracker.completeRun(PipelinePhase.ITEM_EQUIPMENT, runId, chunks, records)
+                        stopSignal.clear(PipelinePhase.ITEM_EQUIPMENT)
+                    }
+                }
+            }
+            .thenRun { }
+```
+
+- [ ] **Step 9: Run scheduler tests, verify pass**
+
+Run: `./gradlew :module-external-api:test --tests "maple.externalapi.scheduler.ExternalApiSchedulerTest"`
+
+Expected: PASS (existing + new tests).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add module-external-api/src/main/kotlin/maple/externalapi/scheduler/ExternalApiScheduler.kt \
+        module-external-api/src/test/kotlin/maple/externalapi/scheduler/ExternalApiSchedulerTest.kt
+git commit -m "feat(ext-api): scheduler requestPhaseStop + PhaseStoppedException handling
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 11: InternalApiController — stopPhase endpoint + tests
+
+**Files:**
+- Modify: `module-external-api/src/main/kotlin/maple/externalapi/runstatus/InternalApiController.kt`
+- Modify: `module-external-api/src/test/kotlin/maple/externalapi/runstatus/InternalApiControllerTest.kt`
+
+- [ ] **Step 1: Wire PhaseStopSignal into InternalApiControllerTest setup (if test constructs controller manually)**
+
+If `InternalApiControllerTest.kt` constructs `InternalApiController(...)` directly (not via Spring autowiring), construct a `PhaseStopSignal` in the `@BeforeEach` (or shared setup) and inject it via the `scheduler` arg. Example patch:
+
+```kotlin
+private val stopSignal = PhaseStopSignal()
+
+@BeforeEach
+fun setup() {
+    // ... existing setup ...
+    val scheduler = ExternalApiScheduler(
+        // ... existing args ...
+        stopSignal = stopSignal,
+    )
+    controller = InternalApiController(
+        // ... existing args ...
+        scheduler = scheduler,
+    )
+}
+```
+
+If the test uses `@WebMvcTest` / `@SpringBootTest` and the controller is autowired, no change to setup is needed.
+
+- [ ] **Step 2: Extend InternalApiControllerTest**
+
+Append the following tests:
+
+```kotlin
+    @Test
+    fun `POST stop phase returns 202 STOP_REQUESTED when phase is running`() {
+        runStatusTracker.acquirePhaseSlot(PipelinePhase.ITEM_EQUIPMENT, "run-1")
+
+        val response = controller.stopPhase(
+            phaseName = "ITEM_EQUIPMENT",
+            airflowRunId = "airflow-corr-1",
+        )
+
+        assertEquals(HttpStatus.ACCEPTED, response.statusCode)
+        val body = response.body!!
+        assertEquals("STOP_REQUESTED", body["status"])
+        assertEquals("ITEM_EQUIPMENT", body["phase"])
+        assertEquals("run-1", body["runId"])
+        assertTrue(stopSignal.isStopRequested(PipelinePhase.ITEM_EQUIPMENT))
+    }
+
+    @Test
+    fun `POST stop phase returns 200 NOT_RUNNING when slot empty`() {
+        val response = controller.stopPhase(
+            phaseName = "ITEM_EQUIPMENT",
+            airflowRunId = null,
+        )
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        val body = response.body!!
+        assertEquals("NOT_RUNNING", body["status"])
+        assertEquals("ITEM_EQUIPMENT", body["phase"])
+    }
+
+    @Test
+    fun `POST stop phase returns 200 NOT_RUNNING when slot is terminal`() {
+        runStatusTracker.acquirePhaseSlot(PipelinePhase.ITEM_EQUIPMENT, "run-old")
+        runStatusTracker.completeRun(PipelinePhase.ITEM_EQUIPMENT, "run-old", 0, 0L)
+
+        val response = controller.stopPhase(
+            phaseName = "ITEM_EQUIPMENT",
+            airflowRunId = null,
+        )
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertEquals("NOT_RUNNING", response.body!!["status"])
+    }
+
+    @Test
+    fun `POST stop phase returns 400 INVALID_PHASE for unknown name`() {
+        val response = controller.stopPhase(
+            phaseName = "BOGUS",
+            airflowRunId = null,
+        )
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+        assertEquals("INVALID_PHASE", response.body!!["error"])
+    }
+
+    @Test
+    fun `POST stop phase returns 400 INVALID_PHASE for non-triggerable phase`() {
+        val response = controller.stopPhase(
+            phaseName = "COMPLETED",
+            airflowRunId = null,
+        )
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+        assertEquals("INVALID_PHASE", response.body!!["error"])
+    }
+
+    @Test
+    fun `POST stop phase on phase A does not affect phase B running`() {
+        runStatusTracker.acquirePhaseSlot(PipelinePhase.ITEM_EQUIPMENT, "run-1")
+
+        controller.stopPhase(phaseName = "OCID_LOOKUP", airflowRunId = null)
+
+        // OCID_LOOKUP is not running → NOT_RUNNING, and ITEM_EQUIPMENT flag not set
+        assertFalse(stopSignal.isStopRequested(PipelinePhase.ITEM_EQUIPMENT))
+        assertFalse(stopSignal.isStopRequested(PipelinePhase.OCID_LOOKUP))
+    }
+```
+
+Add imports to the test file as needed (the test setup likely uses `controller` and `runStatusTracker` already; if `stopSignal` is not yet wired into the test setup, add it).
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `./gradlew :module-external-api:test --tests "maple.externalapi.runstatus.InternalApiControllerTest"`
+
+Expected: Compile error — `stopPhase` unresolved on controller.
+
+- [ ] **Step 4: Add stopPhase endpoint to controller**
+
+In `module-external-api/src/main/kotlin/maple/externalapi/runstatus/InternalApiController.kt`, add the new method below `triggerPhase`:
+
+```kotlin
+    @PostMapping("/stop/phase/{phaseName}")
+    fun stopPhase(
+        @PathVariable phaseName: String,
+        @RequestHeader("X-Airflow-Run-Id", required = false) airflowRunId: String?,
+    ): ResponseEntity<Map<String, String>> {
+        val phase = runCatching { PipelinePhase.valueOf(phaseName) }.getOrNull()
+        if (phase == null || phase !in triggerablePhases) {
+            return badRequestInvalidPhase()
+        }
+        val wasRunning = scheduler.requestPhaseStop(phase)
+        if (wasRunning) {
+            val runId = runStatusTracker.getPhaseStatus(phase)?.runId ?: ""
+            log.info(
+                "[InternalApi] stop requested phase={} runId={} airflowRunId={}",
+                phase, runId, airflowRunId,
+            )
+            return ResponseEntity.accepted().body(mapOf(
+                "status" to "STOP_REQUESTED",
+                "phase" to phase.name,
+                "runId" to runId,
+            ))
+        }
+        val lastRunId = runStatusTracker.getLastCompletedForPhase(phase)?.runId ?: ""
+        return ResponseEntity.ok().body(mapOf(
+            "status" to "NOT_RUNNING",
+            "phase" to phase.name,
+            "runId" to lastRunId,
+        ))
+    }
+```
+
+Add the logger field to the controller (alongside other private fields, or as a top-level `private val log`):
+
+```kotlin
+private val log = LoggerFactory.getLogger(InternalApiController::class.java)
+```
+
+Add imports at top:
+
+```kotlin
+import org.slf4j.LoggerFactory
+```
+
+- [ ] **Step 5: Run all controller tests, verify pass**
+
+Run: `./gradlew :module-external-api:test --tests "maple.externalapi.runstatus.InternalApiControllerTest"`
+
+Expected: PASS (existing + 6 new tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add module-external-api/src/main/kotlin/maple/externalapi/runstatus/InternalApiController.kt \
+        module-external-api/src/test/kotlin/maple/externalapi/runstatus/InternalApiControllerTest.kt
+git commit -m "feat(ext-api): POST /api/internal/stop/phase/{phaseName} endpoint
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 12: Final compile + full module test pass
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Compile everything**
+
+Run:
+```bash
+./gradlew :module-external-api:compileKotlin :module-external-api:compileJava --continue
+```
+
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 2: Run full module test suite**
+
+Run: `./gradlew :module-external-api:test`
+
+Expected: BUILD SUCCESSFUL with all tests passing (existing + new).
+
+- [ ] **Step 3: Verify no leftover `XXX` placeholders in production code**
+
+```bash
+grep -rn "XXX" module-external-api/src/main --include="*.kt"
+```
+
+Expected: No matches (or only matches in unrelated test fixtures).
+
+- [ ] **Step 4: Push branch and prepare for review**
+
+```bash
+git push -u origin feature/issue-1290-stop-endpoint
+```
+
+Final report to user:
+- Branch: `feature/issue-1290-stop-endpoint`
+- Commit count
+- File diff summary
+- Test counts (existing + new)

--- a/docs/superpowers/plans/2026-06-18-issue-1290-phase-stop-endpoint.md
+++ b/docs/superpowers/plans/2026-06-18-issue-1290-phase-stop-endpoint.md
@@ -1272,7 +1272,9 @@ Same pattern, replace the `.whenComplete { _, ex -> ... }.thenRun { }` block. Pr
                 when {
                     ex is PhaseStoppedException -> {
                         log.info("[Scheduler] runItemEquipmentPhase stopped runId={} phase={}", runId, ex.phase)
-                        runStatusTracker.stopRun(PipelinePhase.ITEM_EQUIPMENT, runId, 0, 0)
+                        val chunks = schedulerMetrics.drainRunChunks().toInt()
+                        val records = schedulerMetrics.drainRunRecords()
+                        runStatusTracker.stopRun(PipelinePhase.ITEM_EQUIPMENT, runId, chunks, records)
                         stopSignal.clear(PipelinePhase.ITEM_EQUIPMENT)
                     }
                     ex != null -> {
@@ -1358,6 +1360,7 @@ Append the following tests:
         assertEquals("STOP_REQUESTED", body["status"])
         assertEquals("ITEM_EQUIPMENT", body["phase"])
         assertEquals("run-1", body["runId"])
+        assertEquals("airflow-corr-1", body["airflowRunId"])
         assertTrue(stopSignal.isStopRequested(PipelinePhase.ITEM_EQUIPMENT))
     }
 
@@ -1455,6 +1458,7 @@ In `module-external-api/src/main/kotlin/maple/externalapi/runstatus/InternalApiC
                 "status" to "STOP_REQUESTED",
                 "phase" to phase.name,
                 "runId" to runId,
+                "airflowRunId" to (airflowRunId ?: ""),
             ))
         }
         val lastRunId = runStatusTracker.getLastCompletedForPhase(phase)?.runId ?: ""
@@ -1462,6 +1466,7 @@ In `module-external-api/src/main/kotlin/maple/externalapi/runstatus/InternalApiC
             "status" to "NOT_RUNNING",
             "phase" to phase.name,
             "runId" to lastRunId,
+            "airflowRunId" to (airflowRunId ?: ""),
         ))
     }
 ```

--- a/docs/superpowers/specs/2026-06-18-issue-1290-phase-stop-endpoint-design.md
+++ b/docs/superpowers/specs/2026-06-18-issue-1290-phase-stop-endpoint-design.md
@@ -1,0 +1,306 @@
+# Issue #1290: Graceful Phase Stop Endpoint — Design
+
+- Date: 2026-06-18
+- Branch: `feature/issue-1290-spec`
+- Status: Draft (pending user review)
+
+## 1. Goal
+
+Add `POST /api/internal/stop/phase/{phaseName}` to `module-external-api` for graceful stop of an in-flight phase. The phase finishes its current chunk / page / batch, then halts cleanly. No half-written chunks in MinIO. Stopped phase slot transitions to `STOPPED` (terminal, record persists in slot — next acquire overwrites).
+
+Blocked by #1289 (merged): per-phase runId tracking + slot CAS in `RunStatusTracker` are already in place.
+
+## 2. Components
+
+### 2.1 New: `PhaseStopSignal`
+
+`@Component` singleton. `ConcurrentHashMap<PipelinePhase, AtomicBoolean>`.
+
+```kotlin
+@Component
+class PhaseStopSignal {
+    private val flags = ConcurrentHashMap<PipelinePhase, AtomicBoolean>()
+
+    fun requestStop(phase: PipelinePhase): Boolean {
+        val flag = flags.computeIfAbsent(phase) { AtomicBoolean(false) }
+        return flag.compareAndSet(false, true)
+    }
+
+    fun isStopRequested(phase: PipelinePhase): Boolean =
+        flags[phase]?.get() == true
+
+    fun clear(phase: PipelinePhase) {
+        flags[phase]?.set(false)
+    }
+}
+```
+
+Notes:
+- `requestStop` returns the previous state (`false → true` = first request; `true → true` = already requested). Idempotent for the caller.
+- `clear` is unconditional reset; called by scheduler in `whenComplete` regardless of outcome.
+
+### 2.2 New: `PhaseStoppedException`
+
+```kotlin
+class PhaseStoppedException(val phase: PipelinePhase) : RuntimeException("phase ${phase.name} stopped at chunk boundary")
+```
+
+Throws from phase bean at chunk/page/batch boundary when `isStopRequested(phase)` returns true.
+
+### 2.3 PipelinePhase enum extension
+
+```kotlin
+enum class PipelinePhase {
+    IDLE, RANKING_FETCH, OCID_LOOKUP, OCID_CACHE_REFRESH,
+    CHARACTER_BASIC, CHARACTER_BASIC_DONE, ITEM_EQUIPMENT,
+    COMPLETED, FAILED,
+    STOPPED,  // ← new
+}
+```
+
+### 2.4 RunStatus.isTerminal extension
+
+```kotlin
+val isTerminal: Boolean
+    get() = phase == PipelinePhase.COMPLETED
+        || phase == PipelinePhase.FAILED
+        || phase == PipelinePhase.STOPPED
+```
+
+Existing `acquirePhaseSlot` CAS check (`current == null || current.isTerminal`) already covers STOPPED. No change to `acquirePhaseSlot` logic.
+
+### 2.5 RunStatusTracker — new `stopRun`
+
+```kotlin
+fun stopRun(phase: PipelinePhase, runId: String, chunksProcessed: Int, recordsProcessed: Long) {
+    val now = Instant.now(clock)
+    slots[phase]?.updateAndGet { current ->
+        if (current == null || current.runId != runId) return@updateAndGet current
+        current.copy(
+            phase = PipelinePhase.STOPPED,
+            updatedAt = now,
+            completedAt = now,
+            chunksProcessed = chunksProcessed,
+            recordsProcessed = recordsProcessed,
+        )
+    }
+    log.info("[RunStatus] phase-slot stopped phase={} runId={} chunks={} records={}",
+        phase, runId, chunksProcessed, recordsProcessed)
+}
+```
+
+Slot record persists. `releasePhaseSlot` NOT called.
+
+## 3. Stop Endpoint Contract
+
+`POST /api/internal/stop/phase/{phaseName}`
+
+| Header | Required | Purpose |
+|--------|----------|---------|
+| `X-Airflow-Run-Id` | optional | correlation only, best-effort, no validation against slot runId |
+
+### 3.1 Response shapes
+
+| Condition | HTTP | Body |
+|-----------|------|------|
+| Phase slot has non-terminal run | 202 | `{"status":"STOP_REQUESTED","phase":"ITEM_EQUIPMENT","runId":"<running-runId>"}` |
+| Phase slot empty or terminal | 200 | `{"status":"NOT_RUNNING","phase":"ITEM_EQUIPMENT","runId":null}` (or last-known runId from `getLastCompletedForPhase`) |
+| `phaseName` not in triggerable set | 400 | `{"error":"INVALID_PHASE","allowed":"RANKING_FETCH,OCID_LOOKUP,CHARACTER_BASIC,ITEM_EQUIPMENT"}` |
+
+### 3.2 triggerablePhases set
+
+Reuse the same set as `/trigger/phase/{phaseName}`:
+```kotlin
+private val triggerablePhases = setOf(
+    PipelinePhase.RANKING_FETCH,
+    PipelinePhase.OCID_LOOKUP,
+    PipelinePhase.CHARACTER_BASIC,
+    PipelinePhase.ITEM_EQUIPMENT,
+)
+```
+
+## 4. Phase Bean Boundary Check Pattern
+
+Each phase bean injects `PhaseStopSignal` and checks at the top of each iteration:
+
+```kotlin
+// RankingFetchPhase.processPages
+if (stopSignal.isStopRequested(PipelinePhase.RANKING_FETCH)) {
+    throw PhaseStoppedException(PipelinePhase.RANKING_FETCH)
+}
+
+// OcidLookupPhase.processBatch (top of while loop)
+if (stopSignal.isStopRequested(PipelinePhase.OCID_LOOKUP)) {
+    throw PhaseStoppedException(PipelinePhase.OCID_LOOKUP)
+}
+
+// BatchFetchSupport.processBatch — extended BatchFetchContext
+data class BatchFetchContext(
+    val endpoint: String,
+    val phase: PipelinePhase,  // ← new
+    val apiEndpoint: ExternalApiEndpoint,
+    val onFetched: () -> Unit,
+    val onFailed: () -> Unit,
+)
+// top of while loop:
+if (stopSignal.isStopRequested(ctx.phase)) {
+    throw PhaseStoppedException(ctx.phase)
+}
+```
+
+`BatchFetchSupport` constructor adds `PhaseStopSignal` injection. Callers (char-basic, item-equipment phases) populate `ctx.phase` when constructing `BatchFetchContext`.
+
+## 5. Scheduler Wiring
+
+### 5.1 New: `requestPhaseStop`
+
+```kotlin
+fun requestPhaseStop(phase: PipelinePhase): Boolean {
+    val hadNonTerminal = runStatusTracker.hasNonTerminalRun(phase) != null
+    if (hadNonTerminal) {
+        stopSignal.requestStop(phase)
+        log.info("[Scheduler] stop requested phase={} runId={}",
+            phase, runStatusTracker.getPhaseStatus(phase)?.runId)
+    }
+    return hadNonTerminal
+}
+```
+
+### 5.2 `runXxxPhase` whenComplete update (all 4)
+
+Template below uses `XXX` as a placeholder for the per-phase enum value (`RANKING_FETCH`, `OCID_LOOKUP`, `CHARACTER_BASIC`, `ITEM_EQUIPMENT`). The same shape is duplicated in each of the 4 phase methods.
+
+```kotlin
+return future
+    .whenComplete { _, ex ->
+        when {
+            ex is PhaseStoppedException -> {
+                log.info("[Scheduler] runXxxPhase stopped runId={} phase={}", runId, ex.phase)
+                runStatusTracker.stopRun(PipelinePhase.XXX, runId, 0, 0)
+                stopSignal.clear(PipelinePhase.XXX)
+            }
+            ex != null -> {
+                log.error("[Scheduler] runXxxPhase failed runId={}", runId, ex)
+                runStatusTracker.failRun(PipelinePhase.XXX, runId, ex.message ?: "unknown")
+                runStatusTracker.releasePhaseSlot(PipelinePhase.XXX, runId)
+                stopSignal.clear(PipelinePhase.XXX)
+            }
+            else -> {
+                runStatusTracker.completeRun(PipelinePhase.XXX, runId, 0, 0)
+                stopSignal.clear(PipelinePhase.XXX)
+            }
+        }
+    }
+    .thenRun { }
+```
+
+`clear` in all 3 branches prevents flag leakage to next run on the same phase.
+
+### 5.3 Completion cause unwrapping
+
+`CompletableFuture.whenComplete` receives the upstream exception directly. `ex is PhaseStoppedException` matches both synchronous throw and async rejection. No `CompletionException` unwrap needed for our specific type check.
+
+## 6. Controller Endpoint
+
+```kotlin
+@PostMapping("/stop/phase/{phaseName}")
+fun stopPhase(
+    @PathVariable phaseName: String,
+    @RequestHeader("X-Airflow-Run-Id", required = false) airflowRunId: String?,
+): ResponseEntity<Map<String, String>> {
+    val phase = runCatching { PipelinePhase.valueOf(phaseName) }.getOrNull()
+    if (phase == null || phase !in triggerablePhases) {
+        return badRequestInvalidPhase()
+    }
+    val wasRunning = scheduler.requestPhaseStop(phase)
+    if (wasRunning) {
+        val runId = runStatusTracker.getPhaseStatus(phase)?.runId
+        return ResponseEntity.accepted().body(mapOf(
+            "status" to "STOP_REQUESTED",
+            "phase" to phase.name,
+            "runId" to (runId ?: ""),
+        ))
+    }
+    val lastRunId = runStatusTracker.getLastCompletedForPhase(phase)?.runId
+    return ResponseEntity.ok().body(mapOf(
+        "status" to "NOT_RUNNING",
+        "phase" to phase.name,
+        "runId" to (lastRunId ?: ""),
+    ))
+}
+```
+
+## 7. Slot State Machine
+
+| Trigger | slot.phase before | slot.phase after | slot cleared? |
+|---------|------------------|-----------------|---------------|
+| Normal completion | phase | COMPLETED | No (terminal persists) |
+| Generic exception | phase | FAILED | Yes (`releasePhaseSlot`) |
+| `PhaseStoppedException` | phase | STOPPED | No (terminal persists, next acquire overwrites) |
+| New trigger on STOPPED | STOPPED | new phase | No (overwrite in-place) |
+| New trigger on COMPLETED | COMPLETED | new phase | No (overwrite in-place) |
+| New trigger on FAILED | null (released) | new phase | n/a |
+
+## 8. Files Touched
+
+| File | Change |
+|------|--------|
+| `module-external-api/.../runstatus/PipelinePhase.kt` | add `STOPPED` |
+| `module-external-api/.../runstatus/RunStatus.kt` | extend `isTerminal` predicate |
+| `module-external-api/.../runstatus/RunStatusTracker.kt` | add `stopRun` |
+| `module-external-api/.../runstatus/PhaseStopSignal.kt` | new component |
+| `module-external-api/.../scheduler/PhaseStoppedException.kt` | new exception |
+| `module-external-api/.../scheduler/ExternalApiScheduler.kt` | inject `PhaseStopSignal`, add `requestPhaseStop`, update `whenComplete` for all 4 phase methods |
+| `module-external-api/.../scheduler/phase/BatchFetchSupport.kt` | inject `PhaseStopSignal`, add `phase` to `BatchFetchContext`, check at loop top |
+| `module-external-api/.../scheduler/phase/RankingFetchPhase.kt` | inject `PhaseStopSignal`, check in `processPages` |
+| `module-external-api/.../scheduler/phase/OcidLookupPhase.kt` | inject `PhaseStopSignal`, check in `processBatch` while loop |
+| `module-external-api/.../scheduler/phase/CharacterBasicFetchPhase.kt` | set `ctx.phase = PipelinePhase.CHARACTER_BASIC` |
+| `module-external-api/.../scheduler/phase/ItemEquipmentFetchPhase.kt` | set `ctx.phase = PipelinePhase.ITEM_EQUIPMENT` |
+| `module-external-api/.../runstatus/InternalApiController.kt` | add `stopPhase` endpoint |
+
+## 9. Test Plan
+
+### 9.1 Unit tests
+
+- `PhaseStopSignalTest`: requestStop CAS, isStopRequested, clear
+- `RunStatusTrackerTest`: `stopRun` semantics; subsequent `acquirePhaseSlot` succeeds (terminal-overwrite)
+- `BatchFetchSupportTest`: stop flag trips at loop top with `ctx.phase`
+- `RankingFetchPhaseTest`: pre-set flag → no fetch, throws `PhaseStoppedException`
+- `OcidLookupPhaseTest`: pre-set flag → no batch, throws `PhaseStoppedException`
+- `CharacterBasicFetchPhaseTest`: pre-set flag → no batch, throws
+- `ItemEquipmentFetchPhaseTest`: pre-set flag → no batch, throws
+- `ExternalApiSchedulerTest`: `requestPhaseStop` true/false paths; whenComplete `stopRun`/`completeRun`/`failRun` branches; signal `clear` in all 3 branches
+- `InternalApiControllerTest`: 202 STOP_REQUESTED, 200 NOT_RUNNING, 400 INVALID_PHASE
+
+### 9.2 Edge cases
+
+- Stop on phase A while phase B running: no cross-phase interference (each phase has own flag)
+- Stop on already-STOPPED slot: `requestPhaseStop` returns false → 200 NOT_RUNNING
+- Double stop (idempotent): both requests return true; scheduler clears flag once at whenComplete
+- Stop request during trigger acquire race: scheduler clears in previous run's whenComplete (may not yet run when new run starts); new run's first boundary check sees flag → exits clean. Correct.
+
+### 9.3 Verification
+
+```
+./gradlew :module-external-api:test
+./gradlew :module-external-api:compileKotlin :module-external-api:compileJava --continue
+```
+
+## 10. Acceptance Criteria Mapping
+
+| AC | Implementation |
+|----|----------------|
+| `POST /api/internal/stop/phase/ITEM_EQUIPMENT` halts within one chunk boundary (≤30s) | Section 4 boundary check in `BatchFetchSupport.processBatch` (≤7s at 200/s, batchSize 1000) |
+| Same endpoint works for each phase | Section 4 per-phase boundary checks |
+| Stopped phase shows `phase=STOPPED` in /run-status, terminal | Section 2.3, 2.4, 2.5 + Section 7 state machine |
+| Not-running returns 200 NOT_RUNNING | Section 3.1 + Section 6 controller |
+| No half-written chunks in MinIO | `ChunkedSnapshotSink` atomic temp-file move; pipe in `OcidLookupPhase` close in `finally` |
+| New phase triggered immediately after stop | STOPPED is terminal-but-retainable; `acquirePhaseSlot` overwrites (Section 2.4) |
+| Existing daily unaffected by stop on different phase | Each phase has own flag; `requestPhaseStop` only sets the named phase's flag |
+
+## 11. Out of Scope
+
+- Manual smoke test against live Nexon API (deferred — same as #1289).
+- Stop endpoint for the daily chain as a whole (not requested).
+- Resumable stop (phase resumes from last successful chunk on next trigger — out of scope; new trigger starts fresh).
+- Per-`runId` stop (current design stops whatever non-terminal run is in the named phase slot).

--- a/docs/superpowers/specs/2026-06-18-issue-1290-phase-stop-endpoint-design.md
+++ b/docs/superpowers/specs/2026-06-18-issue-1290-phase-stop-endpoint-design.md
@@ -103,7 +103,7 @@ Slot record persists. `releasePhaseSlot` NOT called.
 
 | Condition | HTTP | Body |
 |-----------|------|------|
-| Phase slot has non-terminal run | 202 | `{"status":"STOP_REQUESTED","phase":"ITEM_EQUIPMENT","runId":"<running-runId>"}` |
+| Phase slot has non-terminal run | 202 | `{"status":"STOP_REQUESTED","phase":"ITEM_EQUIPMENT","runId":"<running-runId>","airflowRunId":"<echoed-from-header>"}` |
 | Phase slot empty or terminal | 200 | `{"status":"NOT_RUNNING","phase":"ITEM_EQUIPMENT","runId":null}` (or last-known runId from `getLastCompletedForPhase`) |
 | `phaseName` not in triggerable set | 400 | `{"error":"INVALID_PHASE","allowed":"RANKING_FETCH,OCID_LOOKUP,CHARACTER_BASIC,ITEM_EQUIPMENT"}` |
 

--- a/module-external-api/src/main/kotlin/maple/externalapi/runstatus/InternalApiController.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/runstatus/InternalApiController.kt
@@ -3,6 +3,7 @@ package maple.externalapi.runstatus
 import java.util.UUID
 import java.util.concurrent.ExecutorService
 import maple.externalapi.scheduler.ExternalApiScheduler
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -15,6 +16,7 @@ class InternalApiController(
     private val scheduler: ExternalApiScheduler,
     @Qualifier("internalApiExecutor") private val executor: ExecutorService,
 ) {
+    private val log = LoggerFactory.getLogger(InternalApiController::class.java)
     @GetMapping("/run-status")
     fun getRunStatus(): ResponseEntity<RunStatusResponse> {
         val phases = listOf(
@@ -81,6 +83,38 @@ class InternalApiController(
         val runId = airflowRunId ?: UUID.randomUUID().toString()
         executor.submit { scheduler.triggerPhase(phase, runId, upstreamRunId).join() }
         return ResponseEntity.accepted().body(mapOf("status" to "STARTED", "runId" to runId))
+    }
+
+    @PostMapping("/stop/phase/{phaseName}")
+    fun stopPhase(
+        @PathVariable phaseName: String,
+        @RequestHeader("X-Airflow-Run-Id", required = false) airflowRunId: String?,
+    ): ResponseEntity<Map<String, String>> {
+        val phase = runCatching { PipelinePhase.valueOf(phaseName) }.getOrNull()
+        if (phase == null || phase !in triggerablePhases) {
+            return badRequestInvalidPhase()
+        }
+        val wasRunning = scheduler.requestPhaseStop(phase)
+        if (wasRunning) {
+            val runId = runStatusTracker.getPhaseStatus(phase)?.runId ?: ""
+            log.info(
+                "[InternalApi] stop requested phase={} runId={} airflowRunId={}",
+                phase, runId, airflowRunId,
+            )
+            return ResponseEntity.accepted().body(mapOf(
+                "status" to "STOP_REQUESTED",
+                "phase" to phase.name,
+                "runId" to runId,
+                "airflowRunId" to (airflowRunId ?: ""),
+            ))
+        }
+        val lastRunId = runStatusTracker.getLastCompletedForPhase(phase)?.runId ?: ""
+        return ResponseEntity.ok().body(mapOf(
+            "status" to "NOT_RUNNING",
+            "phase" to phase.name,
+            "runId" to lastRunId,
+            "airflowRunId" to (airflowRunId ?: ""),
+        ))
     }
 
     private fun badRequestInvalidPhase(): ResponseEntity<Map<String, String>> =

--- a/module-external-api/src/main/kotlin/maple/externalapi/runstatus/PipelinePhase.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/runstatus/PipelinePhase.kt
@@ -10,4 +10,5 @@ enum class PipelinePhase {
     ITEM_EQUIPMENT,
     COMPLETED,
     FAILED,
+    STOPPED,
 }

--- a/module-external-api/src/main/kotlin/maple/externalapi/runstatus/RunStatus.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/runstatus/RunStatus.kt
@@ -15,5 +15,8 @@ data class RunStatus(
     val errorMessage: String? = null,
 ) {
     @get:JsonProperty("terminal")
-    val isTerminal: Boolean get() = phase == PipelinePhase.COMPLETED || phase == PipelinePhase.FAILED
+    val isTerminal: Boolean
+        get() = phase == PipelinePhase.COMPLETED
+            || phase == PipelinePhase.FAILED
+            || phase == PipelinePhase.STOPPED
 }

--- a/module-external-api/src/main/kotlin/maple/externalapi/runstatus/RunStatusTracker.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/runstatus/RunStatusTracker.kt
@@ -107,6 +107,28 @@ class RunStatusTracker(
     }
 
     /**
+     * Mark phase slot's run as STOPPED with chunks/records counts. Slot record
+     * persists (NOT cleared). Next acquire on the same phase will overwrite the
+     * STOPPED terminal record (terminal-overwrite CAS). Use this when a phase run
+     * ended because a stop request was detected at a chunk/page boundary.
+     */
+    fun stopRun(phase: PipelinePhase, runId: String, chunksProcessed: Int, recordsProcessed: Long) {
+        val now = Instant.now(clock)
+        slots[phase]?.updateAndGet { current ->
+            if (current == null || current.runId != runId) return@updateAndGet current
+            current.copy(
+                phase = PipelinePhase.STOPPED,
+                updatedAt = now,
+                completedAt = now,
+                chunksProcessed = chunksProcessed,
+                recordsProcessed = recordsProcessed,
+            )
+        }
+        log.info("[RunStatus] phase-slot stopped phase={} runId={} chunks={} records={}",
+            phase, runId, chunksProcessed, recordsProcessed)
+    }
+
+    /**
      * Clear slot if runId matches. Idempotent. Call only on FAILED (or operator override).
      * Successful runs keep their COMPLETED record in the slot until next acquire.
      */

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/ExternalApiScheduler.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/ExternalApiScheduler.kt
@@ -37,6 +37,7 @@ class ExternalApiScheduler(
     private val runOnStartup: Boolean,
     @Value("\${external-api.schedule.skip-character-basic:false}")
     private val skipCharacterBasic: Boolean,
+    private val stopSignal: PhaseStopSignal,
 	) : ManagedLifecycle {
     private val log = LoggerFactory.getLogger(ExternalApiScheduler::class.java)
     private val executor = Executors.newVirtualThreadPerTaskExecutor()
@@ -156,13 +157,23 @@ class ExternalApiScheduler(
         }
         return future
             .whenComplete { _, ex ->
-                if (ex != null) {
-                    log.error("[Scheduler] runRankingPhase failed runId={}", runId, ex)
-                    runStatusTracker.failRun(PipelinePhase.RANKING_FETCH, runId, ex.message ?: "unknown")
-                    runStatusTracker.releasePhaseSlot(PipelinePhase.RANKING_FETCH, runId)
-                } else {
-                    runStatusTracker.completeRun(PipelinePhase.RANKING_FETCH, runId, 0, 0)
-                    // do NOT release — terminal record persists for /run-status
+                when {
+                    ex is PhaseStoppedException -> {
+                        log.info("[Scheduler] runRankingPhase stopped runId={} phase={}", runId, ex.phase)
+                        runStatusTracker.stopRun(PipelinePhase.RANKING_FETCH, runId, 0, 0)
+                        stopSignal.clear(PipelinePhase.RANKING_FETCH)
+                    }
+                    ex != null -> {
+                        log.error("[Scheduler] runRankingPhase failed runId={}", runId, ex)
+                        runStatusTracker.failRun(PipelinePhase.RANKING_FETCH, runId, ex.message ?: "unknown")
+                        runStatusTracker.releasePhaseSlot(PipelinePhase.RANKING_FETCH, runId)
+                        stopSignal.clear(PipelinePhase.RANKING_FETCH)
+                    }
+                    else -> {
+                        runStatusTracker.completeRun(PipelinePhase.RANKING_FETCH, runId, 0, 0)
+                        // do NOT release — terminal record persists for /run-status
+                        stopSignal.clear(PipelinePhase.RANKING_FETCH)
+                    }
                 }
             }
             .thenRun { }
@@ -193,12 +204,22 @@ class ExternalApiScheduler(
         }
         return future
             .whenComplete { _, ex ->
-                if (ex != null) {
-                    log.error("[Scheduler] runOcidPhase failed runId={} upstreamRunId={}", runId, upstreamRunId, ex)
-                    runStatusTracker.failRun(PipelinePhase.OCID_LOOKUP, runId, ex.message ?: "unknown")
-                    runStatusTracker.releasePhaseSlot(PipelinePhase.OCID_LOOKUP, runId)
-                } else {
-                    runStatusTracker.completeRun(PipelinePhase.OCID_LOOKUP, runId, 0, 0)
+                when {
+                    ex is PhaseStoppedException -> {
+                        log.info("[Scheduler] runOcidPhase stopped runId={} phase={}", runId, ex.phase)
+                        runStatusTracker.stopRun(PipelinePhase.OCID_LOOKUP, runId, 0, 0)
+                        stopSignal.clear(PipelinePhase.OCID_LOOKUP)
+                    }
+                    ex != null -> {
+                        log.error("[Scheduler] runOcidPhase failed runId={} upstreamRunId={}", runId, upstreamRunId, ex)
+                        runStatusTracker.failRun(PipelinePhase.OCID_LOOKUP, runId, ex.message ?: "unknown")
+                        runStatusTracker.releasePhaseSlot(PipelinePhase.OCID_LOOKUP, runId)
+                        stopSignal.clear(PipelinePhase.OCID_LOOKUP)
+                    }
+                    else -> {
+                        runStatusTracker.completeRun(PipelinePhase.OCID_LOOKUP, runId, 0, 0)
+                        stopSignal.clear(PipelinePhase.OCID_LOOKUP)
+                    }
                 }
             }
             .thenRun { }
@@ -244,12 +265,22 @@ class ExternalApiScheduler(
         }
         return future
             .whenComplete { _, ex ->
-                if (ex != null) {
-                    log.error("[Scheduler] runCharBasicPhase failed runId={}", runId, ex)
-                    runStatusTracker.failRun(PipelinePhase.CHARACTER_BASIC, runId, ex.message ?: "unknown")
-                    runStatusTracker.releasePhaseSlot(PipelinePhase.CHARACTER_BASIC, runId)
-                } else {
-                    runStatusTracker.completeRun(PipelinePhase.CHARACTER_BASIC, runId, 0, 0)
+                when {
+                    ex is PhaseStoppedException -> {
+                        log.info("[Scheduler] runCharBasicPhase stopped runId={} phase={}", runId, ex.phase)
+                        runStatusTracker.stopRun(PipelinePhase.CHARACTER_BASIC, runId, 0, 0)
+                        stopSignal.clear(PipelinePhase.CHARACTER_BASIC)
+                    }
+                    ex != null -> {
+                        log.error("[Scheduler] runCharBasicPhase failed runId={}", runId, ex)
+                        runStatusTracker.failRun(PipelinePhase.CHARACTER_BASIC, runId, ex.message ?: "unknown")
+                        runStatusTracker.releasePhaseSlot(PipelinePhase.CHARACTER_BASIC, runId)
+                        stopSignal.clear(PipelinePhase.CHARACTER_BASIC)
+                    }
+                    else -> {
+                        runStatusTracker.completeRun(PipelinePhase.CHARACTER_BASIC, runId, 0, 0)
+                        stopSignal.clear(PipelinePhase.CHARACTER_BASIC)
+                    }
                 }
             }
             .thenRun { }
@@ -297,17 +328,47 @@ class ExternalApiScheduler(
         }
         return future
             .whenComplete { _, ex ->
-                if (ex != null) {
-                    log.error("[Scheduler] runItemEquipmentPhase failed runId={}", runId, ex)
-                    runStatusTracker.failRun(PipelinePhase.ITEM_EQUIPMENT, runId, ex.message ?: "unknown")
-                    runStatusTracker.releasePhaseSlot(PipelinePhase.ITEM_EQUIPMENT, runId)
-                } else {
-                    val chunks = schedulerMetrics.drainRunChunks().toInt()
-                    val records = schedulerMetrics.drainRunRecords()
-                    runStatusTracker.completeRun(PipelinePhase.ITEM_EQUIPMENT, runId, chunks, records)
+                when {
+                    ex is PhaseStoppedException -> {
+                        log.info("[Scheduler] runItemEquipmentPhase stopped runId={} phase={}", runId, ex.phase)
+                        val chunks = schedulerMetrics.drainRunChunks().toInt()
+                        val records = schedulerMetrics.drainRunRecords()
+                        runStatusTracker.stopRun(PipelinePhase.ITEM_EQUIPMENT, runId, chunks, records)
+                        stopSignal.clear(PipelinePhase.ITEM_EQUIPMENT)
+                    }
+                    ex != null -> {
+                        log.error("[Scheduler] runItemEquipmentPhase failed runId={}", runId, ex)
+                        runStatusTracker.failRun(PipelinePhase.ITEM_EQUIPMENT, runId, ex.message ?: "unknown")
+                        runStatusTracker.releasePhaseSlot(PipelinePhase.ITEM_EQUIPMENT, runId)
+                        stopSignal.clear(PipelinePhase.ITEM_EQUIPMENT)
+                    }
+                    else -> {
+                        val chunks = schedulerMetrics.drainRunChunks().toInt()
+                        val records = schedulerMetrics.drainRunRecords()
+                        runStatusTracker.completeRun(PipelinePhase.ITEM_EQUIPMENT, runId, chunks, records)
+                        stopSignal.clear(PipelinePhase.ITEM_EQUIPMENT)
+                    }
                 }
             }
             .thenRun { }
+    }
+
+    /**
+     * Set the stop flag for [phase] if and only if its slot currently holds a
+     * non-terminal run. Returns true if a stop was applied (either just now or
+     * already applied — flag is idempotent); false if there is nothing to stop.
+     *
+     * Cross-phase safe: only the named phase's flag is set. Other phases
+     * continue uninterrupted.
+     */
+    fun requestPhaseStop(phase: PipelinePhase): Boolean {
+        val hadNonTerminal = runStatusTracker.hasNonTerminalRun(phase) != null
+        if (hadNonTerminal) {
+            stopSignal.requestStop(phase)
+            log.info("[Scheduler] stop requested phase={} runId={}",
+                phase, runStatusTracker.getPhaseStatus(phase)?.runId)
+        }
+        return hadNonTerminal || stopSignal.isStopRequested(phase)
     }
 
     /**

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/ExternalApiScheduler.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/ExternalApiScheduler.kt
@@ -157,24 +157,12 @@ class ExternalApiScheduler(
         }
         return future
             .whenComplete { _, ex ->
-                when {
-                    ex is PhaseStoppedException -> {
-                        log.info("[Scheduler] runRankingPhase stopped runId={} phase={}", runId, ex.phase)
-                        runStatusTracker.stopRun(PipelinePhase.RANKING_FETCH, runId, 0, 0)
-                        stopSignal.clear(PipelinePhase.RANKING_FETCH)
-                    }
-                    ex != null -> {
-                        log.error("[Scheduler] runRankingPhase failed runId={}", runId, ex)
-                        runStatusTracker.failRun(PipelinePhase.RANKING_FETCH, runId, ex.message ?: "unknown")
-                        runStatusTracker.releasePhaseSlot(PipelinePhase.RANKING_FETCH, runId)
-                        stopSignal.clear(PipelinePhase.RANKING_FETCH)
-                    }
-                    else -> {
-                        runStatusTracker.completeRun(PipelinePhase.RANKING_FETCH, runId, 0, 0)
-                        // do NOT release — terminal record persists for /run-status
-                        stopSignal.clear(PipelinePhase.RANKING_FETCH)
-                    }
-                }
+                handlePhaseTerminal(
+                    phase = PipelinePhase.RANKING_FETCH,
+                    phaseLabel = "runRankingPhase",
+                    runId = runId,
+                    ex = ex,
+                )
             }
             .thenRun { }
     }
@@ -204,23 +192,13 @@ class ExternalApiScheduler(
         }
         return future
             .whenComplete { _, ex ->
-                when {
-                    ex is PhaseStoppedException -> {
-                        log.info("[Scheduler] runOcidPhase stopped runId={} phase={}", runId, ex.phase)
-                        runStatusTracker.stopRun(PipelinePhase.OCID_LOOKUP, runId, 0, 0)
-                        stopSignal.clear(PipelinePhase.OCID_LOOKUP)
-                    }
-                    ex != null -> {
-                        log.error("[Scheduler] runOcidPhase failed runId={} upstreamRunId={}", runId, upstreamRunId, ex)
-                        runStatusTracker.failRun(PipelinePhase.OCID_LOOKUP, runId, ex.message ?: "unknown")
-                        runStatusTracker.releasePhaseSlot(PipelinePhase.OCID_LOOKUP, runId)
-                        stopSignal.clear(PipelinePhase.OCID_LOOKUP)
-                    }
-                    else -> {
-                        runStatusTracker.completeRun(PipelinePhase.OCID_LOOKUP, runId, 0, 0)
-                        stopSignal.clear(PipelinePhase.OCID_LOOKUP)
-                    }
-                }
+                handlePhaseTerminal(
+                    phase = PipelinePhase.OCID_LOOKUP,
+                    phaseLabel = "runOcidPhase",
+                    runId = runId,
+                    ex = ex,
+                    failureLogContext = { "upstreamRunId={$upstreamRunId}" },
+                )
             }
             .thenRun { }
     }
@@ -265,23 +243,12 @@ class ExternalApiScheduler(
         }
         return future
             .whenComplete { _, ex ->
-                when {
-                    ex is PhaseStoppedException -> {
-                        log.info("[Scheduler] runCharBasicPhase stopped runId={} phase={}", runId, ex.phase)
-                        runStatusTracker.stopRun(PipelinePhase.CHARACTER_BASIC, runId, 0, 0)
-                        stopSignal.clear(PipelinePhase.CHARACTER_BASIC)
-                    }
-                    ex != null -> {
-                        log.error("[Scheduler] runCharBasicPhase failed runId={}", runId, ex)
-                        runStatusTracker.failRun(PipelinePhase.CHARACTER_BASIC, runId, ex.message ?: "unknown")
-                        runStatusTracker.releasePhaseSlot(PipelinePhase.CHARACTER_BASIC, runId)
-                        stopSignal.clear(PipelinePhase.CHARACTER_BASIC)
-                    }
-                    else -> {
-                        runStatusTracker.completeRun(PipelinePhase.CHARACTER_BASIC, runId, 0, 0)
-                        stopSignal.clear(PipelinePhase.CHARACTER_BASIC)
-                    }
-                }
+                handlePhaseTerminal(
+                    phase = PipelinePhase.CHARACTER_BASIC,
+                    phaseLabel = "runCharBasicPhase",
+                    runId = runId,
+                    ex = ex,
+                )
             }
             .thenRun { }
     }
@@ -328,27 +295,13 @@ class ExternalApiScheduler(
         }
         return future
             .whenComplete { _, ex ->
-                when {
-                    ex is PhaseStoppedException -> {
-                        log.info("[Scheduler] runItemEquipmentPhase stopped runId={} phase={}", runId, ex.phase)
-                        val chunks = schedulerMetrics.drainRunChunks().toInt()
-                        val records = schedulerMetrics.drainRunRecords()
-                        runStatusTracker.stopRun(PipelinePhase.ITEM_EQUIPMENT, runId, chunks, records)
-                        stopSignal.clear(PipelinePhase.ITEM_EQUIPMENT)
-                    }
-                    ex != null -> {
-                        log.error("[Scheduler] runItemEquipmentPhase failed runId={}", runId, ex)
-                        runStatusTracker.failRun(PipelinePhase.ITEM_EQUIPMENT, runId, ex.message ?: "unknown")
-                        runStatusTracker.releasePhaseSlot(PipelinePhase.ITEM_EQUIPMENT, runId)
-                        stopSignal.clear(PipelinePhase.ITEM_EQUIPMENT)
-                    }
-                    else -> {
-                        val chunks = schedulerMetrics.drainRunChunks().toInt()
-                        val records = schedulerMetrics.drainRunRecords()
-                        runStatusTracker.completeRun(PipelinePhase.ITEM_EQUIPMENT, runId, chunks, records)
-                        stopSignal.clear(PipelinePhase.ITEM_EQUIPMENT)
-                    }
-                }
+                handlePhaseTerminal(
+                    phase = PipelinePhase.ITEM_EQUIPMENT,
+                    phaseLabel = "runItemEquipmentPhase",
+                    runId = runId,
+                    ex = ex,
+                    drainMetrics = { schedulerMetrics.drainRunChunks().toInt() to schedulerMetrics.drainRunRecords() },
+                )
             }
             .thenRun { }
     }
@@ -390,6 +343,49 @@ class ExternalApiScheduler(
             else -> CompletableFuture.failedFuture(
                 IllegalArgumentException("Phase $phase is not a standalone-triggerable phase")
             )
+        }
+    }
+
+    /**
+     * Terminal-state handler shared by all per-phase `runXxxPhase` methods.
+     *
+     * Behavior is identical to the original inline `whenComplete` blocks:
+     * - [PhaseStoppedException]: INFO log, [RunStatusTracker.stopRun], clear stop signal
+     * - other [Throwable]: ERROR log, [RunStatusTracker.failRun], release slot, clear stop signal
+     * - success: [RunStatusTracker.completeRun], clear stop signal (terminal record persists)
+     *
+     * [drainMetrics] is only called on the stop and success branches (matching
+     * the original behavior — failure branch intentionally does not drain).
+     * [failureLogContext] is appended to the ERROR log line for phases that
+     * carry extra context (e.g. OCID_LOOKUP's upstreamRunId).
+     */
+    private fun handlePhaseTerminal(
+        phase: PipelinePhase,
+        phaseLabel: String,
+        runId: String,
+        ex: Throwable?,
+        drainMetrics: () -> Pair<Int, Long> = { 0 to 0L },
+        failureLogContext: () -> String? = { null },
+    ) {
+        when {
+            ex is PhaseStoppedException -> {
+                log.info("[Scheduler] {} stopped runId={} phase={}", phaseLabel, runId, ex.phase)
+                val (chunks, records) = drainMetrics()
+                runStatusTracker.stopRun(phase, runId, chunks, records)
+                stopSignal.clear(phase)
+            }
+            ex != null -> {
+                val extra = failureLogContext()?.let { " $it" } ?: ""
+                log.error("[Scheduler] {} failed runId={}$extra", phaseLabel, runId, ex)
+                runStatusTracker.failRun(phase, runId, ex.message ?: "unknown")
+                runStatusTracker.releasePhaseSlot(phase, runId)
+                stopSignal.clear(phase)
+            }
+            else -> {
+                val (chunks, records) = drainMetrics()
+                runStatusTracker.completeRun(phase, runId, chunks, records)
+                stopSignal.clear(phase)
+            }
         }
     }
 

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/ExternalApiScheduler.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/ExternalApiScheduler.kt
@@ -321,7 +321,7 @@ class ExternalApiScheduler(
             log.info("[Scheduler] stop requested phase={} runId={}",
                 phase, runStatusTracker.getPhaseStatus(phase)?.runId)
         }
-        return hadNonTerminal || stopSignal.isStopRequested(phase)
+        return hadNonTerminal
     }
 
     /**

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/PhaseStopSignal.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/PhaseStopSignal.kt
@@ -1,0 +1,29 @@
+package maple.externalapi.scheduler
+
+import maple.externalapi.runstatus.PipelinePhase
+import org.springframework.stereotype.Component
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Per-phase stop flag map. `requestStop` returns the previous state (true on first
+ * call, false on idempotent repeat) so callers can tell whether their request was
+ * the one that tripped the flag. `clear` is unconditional reset.
+ */
+@Component
+class PhaseStopSignal {
+
+    private val flags = ConcurrentHashMap<PipelinePhase, AtomicBoolean>()
+
+    fun requestStop(phase: PipelinePhase): Boolean {
+        val flag = flags.computeIfAbsent(phase) { AtomicBoolean(false) }
+        return flag.compareAndSet(false, true)
+    }
+
+    fun isStopRequested(phase: PipelinePhase): Boolean =
+        flags[phase]?.get() == true
+
+    fun clear(phase: PipelinePhase) {
+        flags[phase]?.set(false)
+    }
+}

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/PhaseStoppedException.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/PhaseStoppedException.kt
@@ -1,0 +1,12 @@
+package maple.externalapi.scheduler
+
+import maple.externalapi.runstatus.PipelinePhase
+
+/**
+ * Thrown by phase beans when they detect a stop request at a chunk/page/batch
+ * boundary. Caught specifically in `ExternalApiScheduler.runXxxPhase` `whenComplete`
+ * handlers to drive a STOPPED terminal transition (vs. FAILED for other exceptions).
+ */
+class PhaseStoppedException(
+    val phase: PipelinePhase,
+) : RuntimeException("phase ${phase.name} stopped at chunk boundary")

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/BatchFetchSupport.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/BatchFetchSupport.kt
@@ -41,7 +41,7 @@ private const val SLOW_BATCH_WAIT_MS: Long = 1_000L
 /** Endpoint-scoped fetch context shared by processBatch / fetchSingle / handleFailure. */
 data class BatchFetchContext(
     val endpoint: String,
-    val phase: PipelinePhase = PipelinePhase.IDLE,
+    val phase: PipelinePhase,
     val apiEndpoint: ExternalApiEndpoint,
     val onFetched: () -> Unit,
     val onFailed: () -> Unit,

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/BatchFetchSupport.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/BatchFetchSupport.kt
@@ -14,6 +14,9 @@ import maple.externalapi.domain.ExternalApiEndpoint
 import maple.externalapi.domain.ExternalApiProvider
 import maple.externalapi.metrics.SnapshotFetchMetrics
 import maple.externalapi.port.out.ExternalApiClientPort
+import maple.externalapi.runstatus.PipelinePhase
+import maple.externalapi.scheduler.PhaseStopSignal
+import maple.externalapi.scheduler.PhaseStoppedException
 import maple.externalapi.snapshot.ChunkedSnapshotSink
 import maple.externalapi.snapshot.SnapshotChunkRecord
 import org.slf4j.LoggerFactory
@@ -38,6 +41,7 @@ private const val SLOW_BATCH_WAIT_MS: Long = 1_000L
 /** Endpoint-scoped fetch context shared by processBatch / fetchSingle / handleFailure. */
 data class BatchFetchContext(
     val endpoint: String,
+    val phase: PipelinePhase = PipelinePhase.IDLE,
     val apiEndpoint: ExternalApiEndpoint,
     val onFetched: () -> Unit,
     val onFailed: () -> Unit,
@@ -58,6 +62,7 @@ class BatchFetchSupport(
     private val schedulerRateLimiter: SchedulerRateLimiter,
     private val schedulerProgressLogger: SchedulerProgressLogger,
     private val httpStatusExtractor: HttpStatusExtractor,
+    private val stopSignal: PhaseStopSignal,
 ) {
     private val log = LoggerFactory.getLogger(BatchFetchSupport::class.java)
     private val semaphore = Semaphore(maxInFlight)
@@ -82,6 +87,9 @@ class BatchFetchSupport(
         var progress = BatchProgress(start = start)
 
         while (processed < entries.size) {
+            if (stopSignal.isStopRequested(ctx.phase)) {
+                throw PhaseStoppedException(ctx.phase)
+            }
             val permits = schedulerRateLimiter.acquirePermitsSuspend(rateLimiter, batchSize, entries.size - processed)
             if (permits == 0) continue
 

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/CharacterBasicFetchPhase.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/CharacterBasicFetchPhase.kt
@@ -12,6 +12,7 @@ import maple.expectation.common.storage.ObjectStorage
 import maple.externalapi.domain.ExternalApiEndpoint
 import maple.externalapi.metrics.ExternalApiMetrics
 import maple.externalapi.metrics.SnapshotFetchMetrics
+import maple.externalapi.runstatus.PipelinePhase
 import maple.externalapi.snapshot.EndpointSinkFactory
 import maple.externalapi.snapshot.SnapshotChunkingProperties
 import org.slf4j.LoggerFactory
@@ -79,6 +80,7 @@ class CharacterBasicFetchPhase(
         val start = Instant.now(clock)
         val ctx = BatchFetchContext(
             endpoint = "character-basic",
+            phase = PipelinePhase.CHARACTER_BASIC,
             apiEndpoint = ExternalApiEndpoint.CHARACTER_BASIC,
             onFetched = { metrics.recordCharacterBasicFetched() },
             onFailed = { metrics.recordCharacterBasicFailed() },

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/ItemEquipmentFetchPhase.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/ItemEquipmentFetchPhase.kt
@@ -12,6 +12,7 @@ import maple.expectation.common.storage.ObjectStorage
 import maple.externalapi.domain.ExternalApiEndpoint
 import maple.externalapi.metrics.ExternalApiMetrics
 import maple.externalapi.metrics.SnapshotFetchMetrics
+import maple.externalapi.runstatus.PipelinePhase
 import maple.externalapi.snapshot.EndpointSinkFactory
 import maple.externalapi.snapshot.SnapshotChunkingProperties
 import org.slf4j.LoggerFactory
@@ -72,6 +73,7 @@ class ItemEquipmentFetchPhase(
         val start = Instant.now(clock)
         val ctx = BatchFetchContext(
             endpoint = "item-equipment",
+            phase = PipelinePhase.ITEM_EQUIPMENT,
             apiEndpoint = ExternalApiEndpoint.ITEM_EQUIPMENT,
             onFetched = { metrics.recordItemEquipmentFetched() },
             onFailed = { metrics.recordItemEquipmentFailed() },

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/OcidLookupPhase.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/OcidLookupPhase.kt
@@ -7,6 +7,9 @@ import maple.externalapi.snapshot.event.SnapshotChunkEventPublisher
 import maple.expectation.common.event.SnapshotRunCompletedEvent
 import maple.expectation.common.storage.ObjectStorage
 import maple.expectation.infrastructure.external.NexonAuthClient
+import maple.externalapi.runstatus.PipelinePhase
+import maple.externalapi.scheduler.PhaseStopSignal
+import maple.externalapi.scheduler.PhaseStoppedException
 import com.fasterxml.jackson.databind.ObjectMapper
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -67,6 +70,7 @@ class OcidLookupPhase(
     private val eventPublisher: SnapshotChunkEventPublisher,
     private val objectStorage: ObjectStorage,
     private val nexonAuthClient: NexonAuthClient,
+    private val stopSignal: PhaseStopSignal,
 ) {
     private val log = LoggerFactory.getLogger(OcidLookupPhase::class.java)
 
@@ -242,6 +246,9 @@ class OcidLookupPhase(
     ) {
         var current = processed
         while (current < igns.size) {
+            if (stopSignal.isStopRequested(PipelinePhase.OCID_LOOKUP)) {
+                throw PhaseStoppedException(PipelinePhase.OCID_LOOKUP)
+            }
             val permits = SchedulerPhaseUtils.acquirePermits(rateLimiter, batchSize, igns.size - current)
             if (permits == 0) {
                 yield()

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/RankingFetchPhase.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/RankingFetchPhase.kt
@@ -10,6 +10,9 @@ import maple.externalapi.domain.KeyType
 import maple.externalapi.metrics.ExternalApiMetrics
 import maple.externalapi.metrics.SnapshotVolumeMetrics
 import maple.externalapi.port.out.ExternalApiClientPort
+import maple.externalapi.runstatus.PipelinePhase
+import maple.externalapi.scheduler.PhaseStopSignal
+import maple.externalapi.scheduler.PhaseStoppedException
 import maple.externalapi.snapshot.ChunkFileManager
 import maple.externalapi.snapshot.ChunkedSnapshotSink
 import maple.externalapi.snapshot.SinkEventPublisher
@@ -45,6 +48,7 @@ class RankingFetchPhase(
     private val permitsPerSecond: Int,
     private val runMarkerWriter: RunMarkerWriter,
     private val objectStorage: ObjectStorage,
+    private val stopSignal: PhaseStopSignal,
 ) {
     private val log = LoggerFactory.getLogger(RankingFetchPhase::class.java)
 
@@ -104,6 +108,9 @@ class RankingFetchPhase(
     ): CompletableFuture<Void> {
         if (currentPage > maxPages) {
             return CompletableFuture.completedFuture(null)
+        }
+        if (stopSignal.isStopRequested(PipelinePhase.RANKING_FETCH)) {
+            throw PhaseStoppedException(PipelinePhase.RANKING_FETCH)
         }
 
         SchedulerPhaseUtils.acquirePermits(rateLimiter, 1, 1)

--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/RankingFetchPhase.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/RankingFetchPhase.kt
@@ -53,6 +53,9 @@ class RankingFetchPhase(
     private val log = LoggerFactory.getLogger(RankingFetchPhase::class.java)
 
     fun execute(workerExecutor: ExecutorService, runId: String): CompletableFuture<String> {
+        if (stopSignal.isStopRequested(PipelinePhase.RANKING_FETCH)) {
+            throw PhaseStoppedException(PipelinePhase.RANKING_FETCH)
+        }
         val date = LocalDate.now().minusDays(1).format(DateTimeFormatter.ISO_LOCAL_DATE)
         val runKey = "runs/$runId"
         val endpointConfig = chunkingProperties.configFor("ranking-overall")
@@ -108,9 +111,6 @@ class RankingFetchPhase(
     ): CompletableFuture<Void> {
         if (currentPage > maxPages) {
             return CompletableFuture.completedFuture(null)
-        }
-        if (stopSignal.isStopRequested(PipelinePhase.RANKING_FETCH)) {
-            throw PhaseStoppedException(PipelinePhase.RANKING_FETCH)
         }
 
         SchedulerPhaseUtils.acquirePermits(rateLimiter, 1, 1)

--- a/module-external-api/src/test/kotlin/maple/externalapi/dataflow/DataflowContractTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/dataflow/DataflowContractTest.kt
@@ -145,6 +145,7 @@ class DataflowContractTest {
             permitsPerSecond = 1000,
             runMarkerWriter = runMarkerWriter,
             objectStorage = objectStorage,
+            stopSignal = maple.externalapi.scheduler.PhaseStopSignal(),
         )
 
         val ocidPhase = OcidLookupPhase(

--- a/module-external-api/src/test/kotlin/maple/externalapi/dataflow/DataflowContractTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/dataflow/DataflowContractTest.kt
@@ -156,6 +156,7 @@ class DataflowContractTest {
             eventPublisher = ocidPublisher,
             objectStorage = objectStorage,
             nexonAuthClient = nexonAuthClient,
+            stopSignal = maple.externalapi.scheduler.PhaseStopSignal(),
         )
 
         // act: run ranking

--- a/module-external-api/src/test/kotlin/maple/externalapi/runstatus/InternalApiControllerTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/runstatus/InternalApiControllerTest.kt
@@ -5,9 +5,14 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import java.time.Instant
 import maple.externalapi.scheduler.ExternalApiScheduler
+import maple.externalapi.scheduler.PhaseStopSignal
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -24,13 +29,25 @@ class InternalApiControllerTest {
     private lateinit var mockMvc: MockMvc
     private lateinit var runStatusTracker: RunStatusTracker
     private lateinit var scheduler: ExternalApiScheduler
+    private lateinit var stopSignal: PhaseStopSignal
+    private lateinit var controller: InternalApiController
     private val objectMapper = ObjectMapper().registerKotlinModule().registerModule(JavaTimeModule())
 
     @BeforeEach
     fun setUp() {
-        runStatusTracker = org.mockito.kotlin.mock()
-        scheduler = org.mockito.kotlin.mock()
-        val controller = InternalApiController(runStatusTracker, scheduler, java.util.concurrent.Executors.newVirtualThreadPerTaskExecutor())
+        runStatusTracker = mock()
+        scheduler = mock()
+        stopSignal = PhaseStopSignal()
+        // Wire scheduler.requestPhaseStop so it actually trips the shared stopSignal.
+        whenever(scheduler.requestPhaseStop(any())).thenAnswer { invocation ->
+            val phase = invocation.getArgument<maple.externalapi.runstatus.PipelinePhase>(0)
+            val hadNonTerminal = runStatusTracker.hasNonTerminalRun(phase) != null
+            if (hadNonTerminal) {
+                stopSignal.requestStop(phase)
+            }
+            hadNonTerminal || stopSignal.isStopRequested(phase)
+        }
+        controller = InternalApiController(runStatusTracker, scheduler, java.util.concurrent.Executors.newVirtualThreadPerTaskExecutor())
         mockMvc = standaloneSetup(controller)
             .setMessageConverters(MappingJackson2HttpMessageConverter(objectMapper))
             .build()
@@ -232,5 +249,111 @@ class InternalApiControllerTest {
             .andExpect(status().isConflict)
             .andExpect(jsonPath("$.status").value("ALREADY_RUNNING"))
             .andExpect(jsonPath("$.runId").value("existing-run"))
+    }
+
+    @Test
+    fun `POST stop phase returns 202 STOP_REQUESTED when phase is running`() {
+        val slot = RunStatus(
+            runId = "run-1",
+            phase = PipelinePhase.ITEM_EQUIPMENT,
+            triggeredPhase = PipelinePhase.ITEM_EQUIPMENT,
+            startedAt = Instant.now(),
+        )
+        runStatusTracker.acquirePhaseSlot(PipelinePhase.ITEM_EQUIPMENT, "run-1")
+        whenever(runStatusTracker.hasNonTerminalRun(PipelinePhase.ITEM_EQUIPMENT)).thenReturn(slot)
+        whenever(runStatusTracker.getPhaseStatus(PipelinePhase.ITEM_EQUIPMENT)).thenReturn(slot)
+
+        val response = controller.stopPhase(
+            phaseName = "ITEM_EQUIPMENT",
+            airflowRunId = "airflow-corr-1",
+        )
+
+        assertEquals(HttpStatus.ACCEPTED, response.statusCode)
+        val body = response.body!!
+        assertEquals("STOP_REQUESTED", body["status"])
+        assertEquals("ITEM_EQUIPMENT", body["phase"])
+        assertEquals("run-1", body["runId"])
+        assertEquals("airflow-corr-1", body["airflowRunId"])
+        assertTrue(stopSignal.isStopRequested(PipelinePhase.ITEM_EQUIPMENT))
+    }
+
+    @Test
+    fun `POST stop phase returns 200 NOT_RUNNING when slot empty`() {
+        whenever(runStatusTracker.hasNonTerminalRun(PipelinePhase.ITEM_EQUIPMENT)).thenReturn(null)
+        whenever(runStatusTracker.getLastCompletedForPhase(PipelinePhase.ITEM_EQUIPMENT)).thenReturn(null)
+
+        val response = controller.stopPhase(
+            phaseName = "ITEM_EQUIPMENT",
+            airflowRunId = null,
+        )
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        val body = response.body!!
+        assertEquals("NOT_RUNNING", body["status"])
+        assertEquals("ITEM_EQUIPMENT", body["phase"])
+    }
+
+    @Test
+    fun `POST stop phase returns 200 NOT_RUNNING when slot is terminal`() {
+        val terminal = RunStatus(
+            runId = "run-old",
+            phase = PipelinePhase.COMPLETED,
+            triggeredPhase = PipelinePhase.ITEM_EQUIPMENT,
+            startedAt = Instant.now().minusSeconds(60),
+            completedAt = Instant.now(),
+        )
+        runStatusTracker.acquirePhaseSlot(PipelinePhase.ITEM_EQUIPMENT, "run-old")
+        runStatusTracker.completeRun(PipelinePhase.ITEM_EQUIPMENT, "run-old", 0, 0L)
+        whenever(runStatusTracker.hasNonTerminalRun(PipelinePhase.ITEM_EQUIPMENT)).thenReturn(null)
+        whenever(runStatusTracker.getLastCompletedForPhase(PipelinePhase.ITEM_EQUIPMENT)).thenReturn(terminal)
+
+        val response = controller.stopPhase(
+            phaseName = "ITEM_EQUIPMENT",
+            airflowRunId = null,
+        )
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertEquals("NOT_RUNNING", response.body!!["status"])
+    }
+
+    @Test
+    fun `POST stop phase returns 400 INVALID_PHASE for unknown name`() {
+        val response = controller.stopPhase(
+            phaseName = "BOGUS",
+            airflowRunId = null,
+        )
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+        assertEquals("INVALID_PHASE", response.body!!["error"])
+    }
+
+    @Test
+    fun `POST stop phase returns 400 INVALID_PHASE for non-triggerable phase`() {
+        val response = controller.stopPhase(
+            phaseName = "COMPLETED",
+            airflowRunId = null,
+        )
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+        assertEquals("INVALID_PHASE", response.body!!["error"])
+    }
+
+    @Test
+    fun `POST stop phase on phase A does not affect phase B running`() {
+        val slot = RunStatus(
+            runId = "run-1",
+            phase = PipelinePhase.ITEM_EQUIPMENT,
+            triggeredPhase = PipelinePhase.ITEM_EQUIPMENT,
+            startedAt = Instant.now(),
+        )
+        runStatusTracker.acquirePhaseSlot(PipelinePhase.ITEM_EQUIPMENT, "run-1")
+        whenever(runStatusTracker.hasNonTerminalRun(PipelinePhase.ITEM_EQUIPMENT)).thenReturn(slot)
+        whenever(runStatusTracker.hasNonTerminalRun(PipelinePhase.OCID_LOOKUP)).thenReturn(null)
+
+        controller.stopPhase(phaseName = "OCID_LOOKUP", airflowRunId = null)
+
+        // OCID_LOOKUP is not running → NOT_RUNNING, and ITEM_EQUIPMENT flag not set
+        assertFalse(stopSignal.isStopRequested(PipelinePhase.ITEM_EQUIPMENT))
+        assertFalse(stopSignal.isStopRequested(PipelinePhase.OCID_LOOKUP))
     }
 }

--- a/module-external-api/src/test/kotlin/maple/externalapi/runstatus/RunStatusTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/runstatus/RunStatusTest.kt
@@ -1,0 +1,36 @@
+package maple.externalapi.runstatus
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.assertFalse
+import java.time.Instant
+
+class RunStatusTest {
+
+    private fun statusOf(phase: PipelinePhase): RunStatus = RunStatus(
+        runId = "r",
+        phase = phase,
+        triggeredPhase = phase,
+        startedAt = Instant.EPOCH,
+    )
+
+    @Test
+    fun `COMPLETED is terminal`() {
+        assertTrue(statusOf(PipelinePhase.COMPLETED).isTerminal)
+    }
+
+    @Test
+    fun `FAILED is terminal`() {
+        assertTrue(statusOf(PipelinePhase.FAILED).isTerminal)
+    }
+
+    @Test
+    fun `STOPPED is terminal`() {
+        assertTrue(statusOf(PipelinePhase.STOPPED).isTerminal)
+    }
+
+    @Test
+    fun `RANKING_FETCH is not terminal`() {
+        assertFalse(statusOf(PipelinePhase.RANKING_FETCH).isTerminal)
+    }
+}

--- a/module-external-api/src/test/kotlin/maple/externalapi/runstatus/RunStatusTrackerTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/runstatus/RunStatusTrackerTest.kt
@@ -1,11 +1,16 @@
 package maple.externalapi.runstatus
 
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class RunStatusTrackerTest {
 
-    private val tracker = RunStatusTracker()
+    private val fixedInstant = Instant.parse("2026-06-18T05:00:00Z")
+    private val clock = Clock.fixed(fixedInstant, ZoneOffset.UTC)
+    private val tracker = RunStatusTracker(clock)
 
     @Test
     fun `all slots empty initially`() {
@@ -135,5 +140,57 @@ class RunStatusTrackerTest {
         tracker.completeRun(PipelinePhase.OCID_LOOKUP, "run-o", 20, 2_000L)
         val last = tracker.getLastCompletedRun()
         assertThat(last?.runId).isEqualTo("run-o")
+    }
+
+    @Test
+    fun `stopRun sets phase to STOPPED with terminal=true and persists slot record`() {
+        val acquired = tracker.acquirePhaseSlot(PipelinePhase.ITEM_EQUIPMENT, "run-1")
+        assertThat(acquired).isNotNull
+
+        tracker.stopRun(PipelinePhase.ITEM_EQUIPMENT, "run-1", chunksProcessed = 42, recordsProcessed = 1000L)
+
+        val status = tracker.getPhaseStatus(PipelinePhase.ITEM_EQUIPMENT)
+        assertThat(status).isNotNull
+        assertThat(status!!.phase).isEqualTo(PipelinePhase.STOPPED)
+        assertThat(status.isTerminal).isTrue()
+        assertThat(status.chunksProcessed).isEqualTo(42)
+        assertThat(status.recordsProcessed).isEqualTo(1000L)
+        assertThat(status.completedAt).isEqualTo(fixedInstant)
+    }
+
+    @Test
+    fun `stopRun with mismatched runId is a no-op`() {
+        tracker.acquirePhaseSlot(PipelinePhase.ITEM_EQUIPMENT, "run-1")
+        tracker.stopRun(PipelinePhase.ITEM_EQUIPMENT, "different-run", 0, 0L)
+
+        val status = tracker.getPhaseStatus(PipelinePhase.ITEM_EQUIPMENT)
+        assertThat(status!!.phase).isEqualTo(PipelinePhase.ITEM_EQUIPMENT)
+        assertThat(status.isTerminal).isFalse()
+    }
+
+    @Test
+    fun `acquirePhaseSlot after stopRun succeeds (terminal-overwrite)`() {
+        tracker.acquirePhaseSlot(PipelinePhase.ITEM_EQUIPMENT, "run-1")
+        tracker.stopRun(PipelinePhase.ITEM_EQUIPMENT, "run-1", 0, 0L)
+        assertThat(tracker.getPhaseStatus(PipelinePhase.ITEM_EQUIPMENT)!!.isTerminal).isTrue()
+
+        val newAcquire = tracker.acquirePhaseSlot(PipelinePhase.ITEM_EQUIPMENT, "run-2")
+        assertThat(newAcquire).isNotNull
+        assertThat(newAcquire!!.runId).isEqualTo("run-2")
+        assertThat(newAcquire.phase).isEqualTo(PipelinePhase.ITEM_EQUIPMENT)
+    }
+
+    @Test
+    fun `hasNonTerminalRun returns null after stopRun (allows next trigger)`() {
+        tracker.acquirePhaseSlot(PipelinePhase.OCID_LOOKUP, "run-1")
+        tracker.stopRun(PipelinePhase.OCID_LOOKUP, "run-1", 0, 0L)
+
+        assertThat(tracker.hasNonTerminalRun(PipelinePhase.OCID_LOOKUP)).isNull()
+    }
+
+    @Test
+    fun `stopRun on empty slot is no-op`() {
+        tracker.stopRun(PipelinePhase.RANKING_FETCH, "phantom", 0, 0L)
+        assertThat(tracker.getPhaseStatus(PipelinePhase.RANKING_FETCH)).isNull()
     }
 }

--- a/module-external-api/src/test/kotlin/maple/externalapi/runstatus/RunStatusTrackerTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/runstatus/RunStatusTrackerTest.kt
@@ -3,6 +3,7 @@ package maple.externalapi.runstatus
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneOffset
+import java.util.concurrent.atomic.AtomicLong
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -11,6 +12,16 @@ class RunStatusTrackerTest {
     private val fixedInstant = Instant.parse("2026-06-18T05:00:00Z")
     private val clock = Clock.fixed(fixedInstant, ZoneOffset.UTC)
     private val tracker = RunStatusTracker(clock)
+
+    private fun advancingTracker(): RunStatusTracker {
+        val nanos = AtomicLong(0L)
+        val advancingClock = object : Clock() {
+            override fun getZone(): ZoneOffset = ZoneOffset.UTC
+            override fun withZone(zone: java.time.ZoneId?): Clock = this
+            override fun instant(): Instant = Instant.ofEpochMilli(1_000_000L + nanos.incrementAndGet())
+        }
+        return RunStatusTracker(advancingClock)
+    }
 
     @Test
     fun `all slots empty initially`() {
@@ -124,8 +135,8 @@ class RunStatusTrackerTest {
 
     @Test
     fun `getCurrentStatus returns the most recently started non-terminal run across phases`() {
+        val tracker = advancingTracker()
         tracker.acquirePhaseSlot(PipelinePhase.RANKING_FETCH, "run-r")
-        Thread.sleep(5)
         tracker.acquirePhaseSlot(PipelinePhase.OCID_LOOKUP, "run-o")
         val current = tracker.getCurrentStatus()
         assertThat(current?.runId).isEqualTo("run-o")
@@ -133,9 +144,9 @@ class RunStatusTrackerTest {
 
     @Test
     fun `getLastCompletedRun returns the most recent terminal run across phases`() {
+        val tracker = advancingTracker()
         tracker.acquirePhaseSlot(PipelinePhase.RANKING_FETCH, "run-r")
         tracker.completeRun(PipelinePhase.RANKING_FETCH, "run-r", 10, 1_000L)
-        Thread.sleep(5)
         tracker.acquirePhaseSlot(PipelinePhase.OCID_LOOKUP, "run-o")
         tracker.completeRun(PipelinePhase.OCID_LOOKUP, "run-o", 20, 2_000L)
         val last = tracker.getLastCompletedRun()

--- a/module-external-api/src/test/kotlin/maple/externalapi/scheduler/ExternalApiSchedulerStopTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/scheduler/ExternalApiSchedulerStopTest.kt
@@ -3,6 +3,7 @@ package maple.externalapi.scheduler
 import java.time.Clock
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutorService
+import kotlinx.coroutines.runBlocking
 import maple.externalapi.cache.OcidCacheProvider
 import maple.externalapi.metrics.SchedulerMetrics
 import maple.externalapi.runstatus.PipelinePhase
@@ -17,8 +18,10 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import org.mockito.kotlin.wheneverBlocking
 import org.springframework.beans.factory.ObjectProvider
 
 /**
@@ -127,7 +130,139 @@ class ExternalApiSchedulerStopTest {
         // transitions are observable in sequence via the tracker mock.
     }
 
+    @Test
+    fun `runRankingPhase whenComplete catches PhaseStoppedException to stopRun + signal cleared`() {
+        val runStatusTracker = realRunStatusTracker()
+        val stopSignal = PhaseStopSignal()
+        val rankingPhase = mock<RankingFetchPhase>()
+        whenever(rankingPhase.execute(any<ExecutorService>(), any<String>()))
+            .thenReturn(CompletableFuture.failedFuture(PhaseStoppedException(PipelinePhase.RANKING_FETCH)))
+
+        val scheduler = allPhasesScheduler(runStatusTracker, stopSignal, rankingPhase = rankingPhase)
+
+        runStatusTracker.acquirePhaseSlot(PipelinePhase.RANKING_FETCH, "run-r")
+        scheduler.requestPhaseStop(PipelinePhase.RANKING_FETCH)
+        assertTrue(stopSignal.isStopRequested(PipelinePhase.RANKING_FETCH))
+
+        try {
+            scheduler.runRankingPhase("run-r", null).join()
+        } catch (ex: Exception) {
+            // Expected: whenComplete observes PhaseStoppedException; .join() surfaces it.
+        }
+
+        val status = runStatusTracker.getPhaseStatus(PipelinePhase.RANKING_FETCH)
+        assertEquals(PipelinePhase.STOPPED, status!!.phase)
+        assertTrue(status.isTerminal)
+        assertFalse(stopSignal.isStopRequested(PipelinePhase.RANKING_FETCH), "signal must be cleared")
+    }
+
+    @Test
+    fun `runOcidPhase whenComplete catches PhaseStoppedException to stopRun + signal cleared`() {
+        val runStatusTracker = realRunStatusTracker()
+        val stopSignal = PhaseStopSignal()
+        val ocidLookupPhase = mock<OcidLookupPhase>()
+        // runOcidPhase calls runBlocking { ocidLookupPhase.execute(...) }. Stub the
+        // suspend function to throw PhaseStoppedException; runBlocking propagates it
+        // synchronously and the outer runCatching converts it to a failed CF.
+        runBlocking {
+            wheneverBlocking { ocidLookupPhase.execute(any<ExecutorService>(), any<String>(), any<String>()) }
+                .doThrow(PhaseStoppedException(PipelinePhase.OCID_LOOKUP))
+        }
+
+        val scheduler = allPhasesScheduler(runStatusTracker, stopSignal, ocidLookupPhase = ocidLookupPhase)
+
+        runStatusTracker.acquirePhaseSlot(PipelinePhase.OCID_LOOKUP, "run-o")
+        scheduler.requestPhaseStop(PipelinePhase.OCID_LOOKUP)
+        assertTrue(stopSignal.isStopRequested(PipelinePhase.OCID_LOOKUP))
+
+        try {
+            scheduler.runOcidPhase("run-o", "upstream-run").join()
+        } catch (ex: Exception) {
+            // Expected: whenComplete observes PhaseStoppedException; .join() surfaces it.
+        }
+
+        val status = runStatusTracker.getPhaseStatus(PipelinePhase.OCID_LOOKUP)
+        assertEquals(PipelinePhase.STOPPED, status!!.phase)
+        assertTrue(status.isTerminal)
+        assertFalse(stopSignal.isStopRequested(PipelinePhase.OCID_LOOKUP), "signal must be cleared")
+    }
+
+    @Test
+    fun `runCharBasicPhase whenComplete catches PhaseStoppedException to stopRun + signal cleared`() {
+        val runStatusTracker = realRunStatusTracker()
+        val stopSignal = PhaseStopSignal()
+        val characterBasicPhase = mock<CharacterBasicFetchPhase>()
+        whenever(characterBasicPhase.execute(any<ExecutorService>(), any<Map<String, String>>(), any()))
+            .thenReturn(CompletableFuture.failedFuture(PhaseStoppedException(PipelinePhase.CHARACTER_BASIC)))
+
+        val scheduler = allPhasesScheduler(runStatusTracker, stopSignal, characterBasicPhase = characterBasicPhase)
+
+        runStatusTracker.acquirePhaseSlot(PipelinePhase.CHARACTER_BASIC, "run-cb")
+        scheduler.requestPhaseStop(PipelinePhase.CHARACTER_BASIC)
+        assertTrue(stopSignal.isStopRequested(PipelinePhase.CHARACTER_BASIC))
+
+        try {
+            scheduler.runCharBasicPhase("run-cb", "upstream-run").join()
+        } catch (ex: Exception) {
+            // Expected: whenComplete observes PhaseStoppedException; .join() surfaces it.
+        }
+
+        val status = runStatusTracker.getPhaseStatus(PipelinePhase.CHARACTER_BASIC)
+        assertEquals(PipelinePhase.STOPPED, status!!.phase)
+        assertTrue(status.isTerminal)
+        assertFalse(stopSignal.isStopRequested(PipelinePhase.CHARACTER_BASIC), "signal must be cleared")
+    }
+
     private fun realRunStatusTracker(): RunStatusTracker = RunStatusTracker()
+
+    /**
+     * Scheduler factory with all 4 phase beans wired (mocked). Unlike [itemEquipmentScheduler]
+     * which defaults the other providers to null, this lets each per-phase stop test stub the
+     * bean it cares about while leaving the others on inert defaults.
+     */
+    private fun allPhasesScheduler(
+        runStatusTracker: RunStatusTracker,
+        stopSignal: PhaseStopSignal = PhaseStopSignal(),
+        ocidLookupPhase: OcidLookupPhase = mock<OcidLookupPhase>(),
+        rankingPhase: RankingFetchPhase = mock<RankingFetchPhase>().also {
+            whenever(it.execute(any<ExecutorService>(), any<String>()))
+                .thenReturn(CompletableFuture.completedFuture("runs/run-r"))
+        },
+        characterBasicPhase: CharacterBasicFetchPhase = mock<CharacterBasicFetchPhase>().also {
+            whenever(it.execute(any<ExecutorService>(), any<Map<String, String>>(), any()))
+                .thenReturn(CompletableFuture.completedFuture(Unit))
+        },
+        itemEquipmentPhase: ItemEquipmentFetchPhase = mock<ItemEquipmentFetchPhase>().also {
+            whenever(it.execute(any<ExecutorService>(), any<List<Map.Entry<String, String>>>(), any<String>()))
+                .thenReturn(CompletableFuture.completedFuture(Unit))
+        },
+        ocidEntries: Map<String, String> = mapOf("ign1" to "ocid1"),
+    ): ExternalApiScheduler {
+        val ocidCache = mock<OcidCacheProvider>()
+        whenever(ocidCache.loadFromRun(any<String>())).thenReturn(ocidEntries)
+        val schedulerMetrics = mock<SchedulerMetrics>()
+        whenever(schedulerMetrics.drainRunChunks()).thenReturn(0L)
+        whenever(schedulerMetrics.drainRunRecords()).thenReturn(0L)
+        val rankingProvider = mock<ObjectProvider<RankingFetchPhase>>()
+        whenever(rankingProvider.ifAvailable).thenReturn(rankingPhase)
+        val charBasicProvider = mock<ObjectProvider<CharacterBasicFetchPhase>>()
+        whenever(charBasicProvider.ifAvailable).thenReturn(characterBasicPhase)
+        val itemEquipmentProvider = mock<ObjectProvider<ItemEquipmentFetchPhase>>()
+        whenever(itemEquipmentProvider.ifAvailable).thenReturn(itemEquipmentPhase)
+        return ExternalApiScheduler(
+            ocidLookupPhase = ocidLookupPhase,
+            ocidCacheProvider = ocidCache,
+            rankingFetchPhaseProvider = rankingProvider,
+            characterBasicPhaseProvider = charBasicProvider,
+            itemEquipmentFetchPhaseProvider = itemEquipmentProvider,
+            schedulerMetrics = schedulerMetrics,
+            runStatusTracker = runStatusTracker,
+            runIdGenerator = RunIdGenerator(Clock.systemUTC()),
+            runOnStartup = false,
+            skipCharacterBasic = false,
+            stopSignal = stopSignal,
+        )
+    }
 
     private fun itemEquipmentScheduler(
         runStatusTracker: RunStatusTracker,

--- a/module-external-api/src/test/kotlin/maple/externalapi/scheduler/ExternalApiSchedulerStopTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/scheduler/ExternalApiSchedulerStopTest.kt
@@ -1,0 +1,162 @@
+package maple.externalapi.scheduler
+
+import java.time.Clock
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ExecutorService
+import maple.externalapi.cache.OcidCacheProvider
+import maple.externalapi.metrics.SchedulerMetrics
+import maple.externalapi.runstatus.PipelinePhase
+import maple.externalapi.runstatus.RunStatusTracker
+import maple.externalapi.scheduler.phase.CharacterBasicFetchPhase
+import maple.externalapi.scheduler.phase.ItemEquipmentFetchPhase
+import maple.externalapi.scheduler.phase.OcidLookupPhase
+import maple.externalapi.scheduler.phase.RankingFetchPhase
+import maple.externalapi.scheduler.phase.RunIdGenerator
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.ObjectProvider
+
+/**
+ * Tests for the phase-stop branch in [ExternalApiScheduler]:
+ *   - `requestPhaseStop` returns true only when a non-terminal run is in the slot
+ *   - `runItemEquipmentPhase` `whenComplete` handles `PhaseStoppedException` →
+ *     `stopRun` + signal clear, and clears the signal on every terminal path
+ *     (success, generic failure, stop).
+ */
+class ExternalApiSchedulerStopTest {
+
+    @Test
+    fun `requestPhaseStop returns true when phase slot has non-terminal run`() {
+        val runStatusTracker = realRunStatusTracker()
+        val scheduler = itemEquipmentScheduler(runStatusTracker)
+
+        runStatusTracker.acquirePhaseSlot(PipelinePhase.ITEM_EQUIPMENT, "run-1")
+        assertTrue(scheduler.requestPhaseStop(PipelinePhase.ITEM_EQUIPMENT))
+    }
+
+    @Test
+    fun `requestPhaseStop returns false when phase slot empty`() {
+        val runStatusTracker = realRunStatusTracker()
+        val scheduler = itemEquipmentScheduler(runStatusTracker)
+
+        assertFalse(scheduler.requestPhaseStop(PipelinePhase.ITEM_EQUIPMENT))
+    }
+
+    @Test
+    fun `requestPhaseStop returns false when phase slot already terminal`() {
+        val runStatusTracker = realRunStatusTracker()
+        val scheduler = itemEquipmentScheduler(runStatusTracker)
+
+        runStatusTracker.acquirePhaseSlot(PipelinePhase.ITEM_EQUIPMENT, "run-1")
+        runStatusTracker.completeRun(PipelinePhase.ITEM_EQUIPMENT, "run-1", 0, 0L)
+        assertFalse(scheduler.requestPhaseStop(PipelinePhase.ITEM_EQUIPMENT))
+    }
+
+    @Test
+    fun `runItemEquipmentPhase whenComplete catches PhaseStoppedException to stopRun + signal cleared`() {
+        val runStatusTracker = realRunStatusTracker()
+        val stopSignal = PhaseStopSignal()
+        val itemEquipmentPhase = mock<ItemEquipmentFetchPhase>()
+        whenever(itemEquipmentPhase.execute(any<ExecutorService>(), any<List<Map.Entry<String, String>>>(), any<String>()))
+            .thenReturn(CompletableFuture.failedFuture(PhaseStoppedException(PipelinePhase.ITEM_EQUIPMENT)))
+
+        val scheduler = itemEquipmentScheduler(runStatusTracker, stopSignal, itemEquipmentPhase, ocidEntries = mapOf("ign1" to "ocid1"))
+
+        runStatusTracker.acquirePhaseSlot(PipelinePhase.ITEM_EQUIPMENT, "run-1")
+        scheduler.requestPhaseStop(PipelinePhase.ITEM_EQUIPMENT)
+        assertTrue(stopSignal.isStopRequested(PipelinePhase.ITEM_EQUIPMENT))
+
+        try {
+            scheduler.runItemEquipmentPhase("run-1", "upstream-run").get()
+        } catch (ex: Exception) {
+            // Expected: whenComplete observes PhaseStoppedException; .get() surfaces it.
+        }
+
+        val status = runStatusTracker.getPhaseStatus(PipelinePhase.ITEM_EQUIPMENT)
+        assertEquals(PipelinePhase.STOPPED, status!!.phase)
+        assertTrue(status.isTerminal)
+        assertFalse(stopSignal.isStopRequested(PipelinePhase.ITEM_EQUIPMENT), "signal must be cleared")
+    }
+
+    @Test
+    fun `runItemEquipmentPhase success path clears signal`() {
+        val runStatusTracker = realRunStatusTracker()
+        val stopSignal = PhaseStopSignal()
+        val itemEquipmentPhase = mock<ItemEquipmentFetchPhase>()
+        whenever(itemEquipmentPhase.execute(any<ExecutorService>(), any<List<Map.Entry<String, String>>>(), any<String>()))
+            .thenReturn(CompletableFuture.completedFuture(Unit))
+
+        val scheduler = itemEquipmentScheduler(runStatusTracker, stopSignal, itemEquipmentPhase, ocidEntries = mapOf("ign1" to "ocid1"))
+
+        runStatusTracker.acquirePhaseSlot(PipelinePhase.ITEM_EQUIPMENT, "run-1")
+        stopSignal.requestStop(PipelinePhase.ITEM_EQUIPMENT)
+
+        scheduler.runItemEquipmentPhase("run-1", "upstream-run").get()
+
+        assertFalse(stopSignal.isStopRequested(PipelinePhase.ITEM_EQUIPMENT))
+        assertEquals(PipelinePhase.COMPLETED, runStatusTracker.getPhaseStatus(PipelinePhase.ITEM_EQUIPMENT)!!.phase)
+    }
+
+    @Test
+    fun `runItemEquipmentPhase generic failure path clears signal`() {
+        val runStatusTracker = realRunStatusTracker()
+        val stopSignal = PhaseStopSignal()
+        val itemEquipmentPhase = mock<ItemEquipmentFetchPhase>()
+        whenever(itemEquipmentPhase.execute(any<ExecutorService>(), any<List<Map.Entry<String, String>>>(), any<String>()))
+            .thenReturn(CompletableFuture.failedFuture(RuntimeException("nexon down")))
+
+        val scheduler = itemEquipmentScheduler(runStatusTracker, stopSignal, itemEquipmentPhase, ocidEntries = mapOf("ign1" to "ocid1"))
+
+        runStatusTracker.acquirePhaseSlot(PipelinePhase.ITEM_EQUIPMENT, "run-1")
+        stopSignal.requestStop(PipelinePhase.ITEM_EQUIPMENT)
+
+        try {
+            scheduler.runItemEquipmentPhase("run-1", "upstream-run").get()
+        } catch (ex: Exception) {
+            // Expected: generic failure path surfaces the cause.
+        }
+
+        assertFalse(stopSignal.isStopRequested(PipelinePhase.ITEM_EQUIPMENT))
+        // Generic failure path calls failRun (slot becomes FAILED) then
+        // releasePhaseSlot (slot cleared for re-acquire). The two state
+        // transitions are observable in sequence via the tracker mock.
+    }
+
+    private fun realRunStatusTracker(): RunStatusTracker = RunStatusTracker()
+
+    private fun itemEquipmentScheduler(
+        runStatusTracker: RunStatusTracker,
+        stopSignal: PhaseStopSignal = PhaseStopSignal(),
+        itemEquipmentPhase: ItemEquipmentFetchPhase = mock<ItemEquipmentFetchPhase>().also {
+            whenever(it.execute(any<ExecutorService>(), any<List<Map.Entry<String, String>>>(), any<String>()))
+                .thenReturn(CompletableFuture.completedFuture(Unit))
+        },
+        ocidEntries: Map<String, String> = mapOf("ign1" to "ocid1"),
+    ): ExternalApiScheduler {
+        val ocidCache = mock<OcidCacheProvider>()
+        whenever(ocidCache.loadFromRun(any<String>())).thenReturn(ocidEntries)
+        val schedulerMetrics = mock<SchedulerMetrics>()
+        whenever(schedulerMetrics.drainRunChunks()).thenReturn(0L)
+        whenever(schedulerMetrics.drainRunRecords()).thenReturn(0L)
+        val itemEquipmentProvider = mock<ObjectProvider<ItemEquipmentFetchPhase>>()
+        whenever(itemEquipmentProvider.ifAvailable).thenReturn(itemEquipmentPhase)
+        return ExternalApiScheduler(
+            ocidLookupPhase = mock<OcidLookupPhase>(),
+            ocidCacheProvider = ocidCache,
+            rankingFetchPhaseProvider = mock<ObjectProvider<RankingFetchPhase>>().also { whenever(it.ifAvailable).thenReturn(null) },
+            characterBasicPhaseProvider = mock<ObjectProvider<CharacterBasicFetchPhase>>().also { whenever(it.ifAvailable).thenReturn(null) },
+            itemEquipmentFetchPhaseProvider = itemEquipmentProvider,
+            schedulerMetrics = schedulerMetrics,
+            runStatusTracker = runStatusTracker,
+            runIdGenerator = RunIdGenerator(Clock.systemUTC()),
+            runOnStartup = false,
+            skipCharacterBasic = false,
+            stopSignal = stopSignal,
+        )
+    }
+}

--- a/module-external-api/src/test/kotlin/maple/externalapi/scheduler/ExternalApiSchedulerTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/scheduler/ExternalApiSchedulerTest.kt
@@ -8,6 +8,7 @@ import maple.externalapi.cache.OcidCacheProvider
 import maple.externalapi.metrics.SchedulerMetrics
 import maple.externalapi.runstatus.PipelinePhase
 import maple.externalapi.runstatus.RunStatusTracker
+import maple.externalapi.scheduler.PhaseStopSignal
 import maple.externalapi.scheduler.phase.CharacterBasicFetchPhase
 import maple.externalapi.scheduler.phase.ItemEquipmentFetchPhase
 import maple.externalapi.scheduler.phase.OcidLookupPhase
@@ -102,6 +103,7 @@ class ExternalApiSchedulerTest {
             runIdGenerator = RunIdGenerator(Clock.systemUTC()),
             runOnStartup = false,
             skipCharacterBasic = false,
+            stopSignal = PhaseStopSignal(),
         )
 
         scheduler.triggerDailyRefresh(null).get()
@@ -180,6 +182,7 @@ class ExternalApiSchedulerTest {
             runIdGenerator = RunIdGenerator(Clock.systemUTC()),
             runOnStartup = false,
             skipCharacterBasic = false,
+            stopSignal = PhaseStopSignal(),
         )
 
         scheduler.triggerDailyRefresh(null).get()
@@ -242,6 +245,7 @@ class ExternalApiSchedulerTest {
             runIdGenerator = RunIdGenerator(Clock.systemUTC()),
             runOnStartup = false,
             skipCharacterBasic = false,
+            stopSignal = PhaseStopSignal(),
         )
 
         try {
@@ -296,6 +300,7 @@ class ExternalApiSchedulerTest {
             runIdGenerator = RunIdGenerator(Clock.systemUTC()),
             runOnStartup = false,
             skipCharacterBasic = false,
+            stopSignal = PhaseStopSignal(),
         )
 
         scheduler.runRankingPhase("run-r-1", null).get()
@@ -346,6 +351,7 @@ class ExternalApiSchedulerTest {
             runIdGenerator = RunIdGenerator(Clock.systemUTC()),
             runOnStartup = false,
             skipCharacterBasic = false,
+            stopSignal = PhaseStopSignal(),
         )
 
         scheduler.runOcidPhase("run-o-1", "run-r-1").get()
@@ -391,6 +397,7 @@ class ExternalApiSchedulerTest {
             runIdGenerator = RunIdGenerator(Clock.systemUTC()),
             runOnStartup = false,
             skipCharacterBasic = false,
+            stopSignal = PhaseStopSignal(),
         )
 
         try {
@@ -438,6 +445,7 @@ class ExternalApiSchedulerTest {
             runIdGenerator = RunIdGenerator(Clock.systemUTC()),
             runOnStartup = false,
             skipCharacterBasic = false,
+            stopSignal = PhaseStopSignal(),
         )
 
         try {
@@ -490,6 +498,7 @@ class ExternalApiSchedulerTest {
             runIdGenerator = RunIdGenerator(Clock.systemUTC()),
             runOnStartup = false,
             skipCharacterBasic = false,
+            stopSignal = PhaseStopSignal(),
         )
 
         scheduler.runCharBasicPhase("run-cb-1", "run-o-1").get()
@@ -536,6 +545,7 @@ class ExternalApiSchedulerTest {
             runIdGenerator = RunIdGenerator(Clock.systemUTC()),
             runOnStartup = false,
             skipCharacterBasic = false,
+            stopSignal = PhaseStopSignal(),
         )
 
         scheduler.runCharBasicPhase("run-cb-2", "run-o-empty").get()
@@ -586,6 +596,7 @@ class ExternalApiSchedulerTest {
             runIdGenerator = RunIdGenerator(Clock.systemUTC()),
             runOnStartup = false,
             skipCharacterBasic = false,
+            stopSignal = PhaseStopSignal(),
         )
 
         scheduler.runItemEquipmentPhase("run-ie-1", "run-cb-1").get()
@@ -636,6 +647,7 @@ class ExternalApiSchedulerTest {
             runIdGenerator = RunIdGenerator(Clock.systemUTC()),
             runOnStartup = false,
             skipCharacterBasic = false,
+            stopSignal = PhaseStopSignal(),
         )
 
         scheduler.runItemEquipmentPhase("run-ie-1", "run-cb-1").get()
@@ -680,6 +692,7 @@ class ExternalApiSchedulerTest {
             runIdGenerator = RunIdGenerator(Clock.systemUTC()),
             runOnStartup = false,
             skipCharacterBasic = false,
+            stopSignal = PhaseStopSignal(),
         )
 
         scheduler.triggerPhase(PipelinePhase.RANKING_FETCH, "run-r-1", null).get()
@@ -708,6 +721,7 @@ class ExternalApiSchedulerTest {
             runIdGenerator = RunIdGenerator(Clock.systemUTC()),
             runOnStartup = false,
             skipCharacterBasic = false,
+            stopSignal = PhaseStopSignal(),
         )
 
         val result = scheduler.triggerPhase(PipelinePhase.IDLE, "run-x", null)
@@ -768,6 +782,7 @@ class ExternalApiSchedulerTest {
             runIdGenerator = RunIdGenerator(Clock.systemUTC()),
             runOnStartup = false,
             skipCharacterBasic = false,
+            stopSignal = PhaseStopSignal(),
         )
 
         scheduler.triggerDailyRefresh("daily-run-1").get()
@@ -802,6 +817,7 @@ class ExternalApiSchedulerTest {
             runIdGenerator = RunIdGenerator(Clock.systemUTC()),
             runOnStartup = false,
             skipCharacterBasic = false,
+            stopSignal = PhaseStopSignal(),
         )
 
         val ex = try {

--- a/module-external-api/src/test/kotlin/maple/externalapi/scheduler/PhaseStopSignalTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/scheduler/PhaseStopSignalTest.kt
@@ -1,0 +1,52 @@
+package maple.externalapi.scheduler
+
+import maple.externalapi.runstatus.PipelinePhase
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+
+class PhaseStopSignalTest {
+
+    @Test
+    fun `requestStop on idle phase returns true and trips flag`() {
+        val signal = PhaseStopSignal()
+        assertTrue(signal.requestStop(PipelinePhase.ITEM_EQUIPMENT))
+        assertTrue(signal.isStopRequested(PipelinePhase.ITEM_EQUIPMENT))
+    }
+
+    @Test
+    fun `requestStop is idempotent — second call returns false (no state change)`() {
+        val signal = PhaseStopSignal()
+        assertTrue(signal.requestStop(PipelinePhase.ITEM_EQUIPMENT))
+        assertFalse(signal.requestStop(PipelinePhase.ITEM_EQUIPMENT))
+        assertTrue(signal.isStopRequested(PipelinePhase.ITEM_EQUIPMENT))
+    }
+
+    @Test
+    fun `isStopRequested on never-requested phase is false`() {
+        val signal = PhaseStopSignal()
+        assertFalse(signal.isStopRequested(PipelinePhase.OCID_LOOKUP))
+    }
+
+    @Test
+    fun `clear resets flag to false`() {
+        val signal = PhaseStopSignal()
+        signal.requestStop(PipelinePhase.RANKING_FETCH)
+        signal.clear(PipelinePhase.RANKING_FETCH)
+        assertFalse(signal.isStopRequested(PipelinePhase.RANKING_FETCH))
+    }
+
+    @Test
+    fun `clear on never-requested phase is no-op`() {
+        val signal = PhaseStopSignal()
+        signal.clear(PipelinePhase.CHARACTER_BASIC)
+        assertFalse(signal.isStopRequested(PipelinePhase.CHARACTER_BASIC))
+    }
+
+    @Test
+    fun `flags are per-phase — one phase's stop does not affect another`() {
+        val signal = PhaseStopSignal()
+        signal.requestStop(PipelinePhase.ITEM_EQUIPMENT)
+        assertFalse(signal.isStopRequested(PipelinePhase.OCID_LOOKUP))
+    }
+}

--- a/module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/BatchFetchSupportStopTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/BatchFetchSupportStopTest.kt
@@ -1,0 +1,73 @@
+package maple.externalapi.scheduler.phase
+
+import io.github.bucket4j.Bandwidth
+import io.github.bucket4j.Bucket
+import java.time.Duration
+import java.time.Instant
+import java.util.AbstractMap
+import java.util.concurrent.CompletableFuture
+import maple.externalapi.domain.ExternalApiEndpoint
+import maple.externalapi.metrics.SnapshotFetchMetrics
+import maple.externalapi.port.out.ExternalApiClientPort
+import maple.externalapi.runstatus.PipelinePhase
+import maple.externalapi.scheduler.PhaseStopSignal
+import maple.externalapi.scheduler.PhaseStoppedException
+import maple.externalapi.snapshot.ChunkedSnapshotSink
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class BatchFetchSupportStopTest {
+
+    @Test
+    fun `processBatch throws PhaseStoppedException when stop requested before first batch`() {
+        val clientPort = mock<ExternalApiClientPort>()
+        whenever(clientPort.fetch(any(), any(), any())).thenAnswer {
+            CompletableFuture.completedFuture(ByteArray(0))
+        }
+        val signal = PhaseStopSignal()
+        signal.requestStop(PipelinePhase.ITEM_EQUIPMENT)
+
+        val support = BatchFetchSupport(
+            clientPort = clientPort,
+            fetchMetrics = mock<SnapshotFetchMetrics>(),
+            maxInFlight = 10,
+            schedulerRateLimiter = mock(),
+            schedulerProgressLogger = mock(),
+            httpStatusExtractor = mock(),
+            stopSignal = signal,
+        )
+
+        val ctx = BatchFetchContext(
+            endpoint = "item-equipment",
+            phase = PipelinePhase.ITEM_EQUIPMENT,
+            apiEndpoint = ExternalApiEndpoint.ITEM_EQUIPMENT,
+            onFetched = {},
+            onFailed = {},
+        )
+        val sink = mock<ChunkedSnapshotSink>()
+
+        val ex = assertThrows(PhaseStoppedException::class.java) {
+            kotlinx.coroutines.runBlocking {
+                support.processBatch(
+                    rateLimiter = Bucket.builder()
+                        .addLimit(Bandwidth.simple(100L, Duration.ofSeconds(1)))
+                        .build(),
+                    entries = listOf(
+                        AbstractMap.SimpleEntry("ign1", "ocid1"),
+                        AbstractMap.SimpleEntry("ign2", "ocid2"),
+                    ),
+                    batchSize = 10,
+                    ctx = ctx,
+                    sink = sink,
+                    runId = "test-run",
+                    start = Instant.now(),
+                )
+            }
+        }
+        assertEquals(PipelinePhase.ITEM_EQUIPMENT, ex.phase)
+    }
+}

--- a/module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/OcidLookupPhaseTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/OcidLookupPhaseTest.kt
@@ -13,7 +13,11 @@ import maple.expectation.common.storage.ObjectInfo
 import maple.expectation.common.storage.ObjectStorage
 import maple.expectation.common.storage.PutResult
 import maple.expectation.infrastructure.external.NexonAuthClient
+import maple.externalapi.runstatus.PipelinePhase
+import maple.externalapi.scheduler.PhaseStopSignal
+import maple.externalapi.scheduler.PhaseStoppedException
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import java.io.InputStream
 import java.time.Instant
@@ -68,6 +72,7 @@ class OcidLookupPhaseTest {
             eventPublisher = mock<maple.externalapi.snapshot.event.SnapshotChunkEventPublisher>(),
             objectStorage = storage,
             nexonAuthClient = nexonClient,
+            stopSignal = PhaseStopSignal(),
         )
 
         kotlinx.coroutines.runBlocking {
@@ -154,6 +159,7 @@ class OcidLookupPhaseTest {
             eventPublisher = mock<maple.externalapi.snapshot.event.SnapshotChunkEventPublisher>(),
             objectStorage = storage,
             nexonAuthClient = nexonClient,
+            stopSignal = PhaseStopSignal(),
         )
 
         kotlinx.coroutines.runBlocking {
@@ -168,5 +174,49 @@ class OcidLookupPhaseTest {
         verify(storage).delete("ocid-mapping/ocid-mapping-old1.jsonl.gz")
         verify(storage).delete("ocid-mapping/ocid-mapping-old2.jsonl.gz")
         verify(storage, never()).delete("ocid-mapping/ocid-mapping-abc.jsonl.gz")
+    }
+
+    @Test
+    fun `execute throws PhaseStoppedException when stop requested before processBatch`() {
+        val storage = mock<ObjectStorage>()
+        val nexonClient = mock<NexonAuthClient>()
+        val objectMapper = ObjectMapper().registerModule(kotlinModule())
+        val stopSignal = PhaseStopSignal()
+        stopSignal.requestStop(PipelinePhase.OCID_LOOKUP)
+
+        val now = Instant.now()
+        whenever(storage.listByPrefix("runs/abc/ranking-overall/chunks")).thenReturn(listOf(
+            ObjectInfo("runs/abc/ranking-overall/chunks/part-000001.jsonl.gz", 100, now)
+        ))
+        val chunkBytes = run {
+            val out = java.io.ByteArrayOutputStream()
+            java.util.zip.GZIPOutputStream(out).use { gz ->
+                gz.write("{\"key\":\"user1\"}\n".toByteArray())
+            }
+            out.toByteArray()
+        }
+        whenever(storage.getStream("runs/abc/ranking-overall/chunks/part-000001.jsonl.gz"))
+            .thenReturn(chunkBytes.inputStream())
+        whenever(storage.listByPrefix("ocid-mapping/")).thenReturn(emptyList())
+
+        val clientPort = mock<maple.externalapi.port.out.ExternalApiClientPort>()
+        whenever(clientPort.fetch(any(), any(), any())).thenReturn(CompletableFuture.completedFuture(ByteArray(0)))
+
+        val phase = OcidLookupPhase(
+            clientPort = clientPort,
+            objectMapper = objectMapper,
+            ocidLookupPermitsPerSecond = 100,
+            batchSize = 100,
+            eventPublisher = mock<maple.externalapi.snapshot.event.SnapshotChunkEventPublisher>(),
+            objectStorage = storage,
+            nexonAuthClient = nexonClient,
+            stopSignal = stopSignal,
+        )
+
+        assertThrows(PhaseStoppedException::class.java) {
+            kotlinx.coroutines.runBlocking {
+                phase.execute(Executors.newSingleThreadExecutor(), "runs/abc", "abc")
+            }
+        }
     }
 }

--- a/module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/RankingFetchPhaseStopTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/RankingFetchPhaseStopTest.kt
@@ -1,0 +1,38 @@
+package maple.externalapi.scheduler.phase
+
+import maple.externalapi.scheduler.PhaseStopSignal
+import maple.externalapi.scheduler.PhaseStoppedException
+import maple.externalapi.runstatus.PipelinePhase
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.mockito.kotlin.mock
+import java.util.concurrent.Executors
+
+class RankingFetchPhaseStopTest {
+
+    @Test
+    fun `execute throws PhaseStoppedException when stop requested before first page`() {
+        val signal = PhaseStopSignal()
+        signal.requestStop(PipelinePhase.RANKING_FETCH)
+
+        val phase = RankingFetchPhase(
+            clientPort = mock(),
+            objectMapper = com.fasterxml.jackson.databind.ObjectMapper(),
+            chunkingProperties = mock(),
+            volumeMetrics = mock(),
+            metrics = mock(),
+            rankingPublisher = mock(),
+            maxPages = 5,
+            permitsPerSecond = 100,
+            runMarkerWriter = mock(),
+            objectStorage = mock(),
+            stopSignal = signal,
+        )
+
+        val ex = assertThrows(PhaseStoppedException::class.java) {
+            phase.execute(Executors.newSingleThreadExecutor(), "test-run").join()
+        }
+        assertEquals(PipelinePhase.RANKING_FETCH, ex.phase)
+    }
+}

--- a/module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/RankingFetchPhaseTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/RankingFetchPhaseTest.kt
@@ -90,6 +90,7 @@ class RankingFetchPhaseTest {
             permitsPerSecond = 1000,
             runMarkerWriter = RunMarkerWriter(Clock.systemUTC(), storage),
             objectStorage = storage,
+            stopSignal = maple.externalapi.scheduler.PhaseStopSignal(),
         )
 
         val result: CompletableFuture<String> = phase.execute(Executors.newSingleThreadExecutor(), "20260610-xyz")


### PR DESCRIPTION
## Summary
- Adds `POST /api/internal/stop/phase/{phaseName}` to gracefully halt an in-flight ext-api phase at its chunk/page boundary
- Phase transitions to `STOPPED` (new terminal value) on stop; slot record persists, next acquire overwrites
- Cross-phase safe: stop on phase A does not affect phase B
- Per-phase AtomicBoolean map (`PhaseStopSignal`) checked at every batch/page boundary
- `PhaseStoppedException` thrown by phase beans, caught specifically in scheduler `whenComplete` handlers

## Spec
- `docs/superpowers/specs/2026-06-18-issue-1290-phase-stop-endpoint-design.md`
- `docs/superpowers/plans/2026-06-18-issue-1290-phase-stop-endpoint.md`

## Components
- `PhaseStopSignal` — ConcurrentHashMap<PipelinePhase, AtomicBoolean> with CAS requestStop
- `PhaseStoppedException` — control-flow signal (not BaseException; not an error)
- `PipelinePhase.STOPPED` — new terminal enum value
- `RunStatus.isTerminal` — extended to include STOPPED
- `RunStatusTracker.stopRun` — terminal-but-retainable (slot persists, next acquire overwrites)
- Each of 4 phase beans — injects signal, checks at chunk/page boundary, throws PhaseStoppedException
- `ExternalApiScheduler.requestPhaseStop` — sets the flag if slot has non-terminal run
- `ExternalApiScheduler.runXxxPhase` whenComplete — 3 branches: STOPPED → stopRun + clear, exception → failRun + release + clear, success → completeRun + clear
- `InternalApiController.stopPhase` — POST endpoint (202 STOP_REQUESTED, 200 NOT_RUNNING, 400 INVALID_PHASE)

## Acceptance criteria
- [x] POST /api/internal/stop/phase/ITEM_EQUIPMENT halts within one chunk boundary (≤30s) — BatchFetchSupport loop-top check
- [x] Same endpoint works for each phase
- [x] Stopped phase shows phase=STOPPED in /run-status, terminal
- [x] Not-running returns 200 NOT_RUNNING (not 404/409)
- [x] No half-written chunks in MinIO (ChunkedSnapshotSink atomic temp-file move)
- [x] A new phase can be triggered immediately after a stop (terminal-overwrite CAS)
- [x] Existing daily unaffected by stop on different phase (per-phase flag)

## Test plan
- [x] `./gradlew :module-external-api:compileKotlin :module-external-api:compileJava --continue` BUILD SUCCESSFUL
- [x] `./gradlew :module-external-api:test` BUILD SUCCESSFUL — all tests pass
- [ ] Manual smoke test deferred (Nexon API in maintenance, per #1289 precedent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)