### PR TITLE
refactor(ext-api): OcidLookupPhase putStream -> putStreamMultipart (issue #1319)

### DIFF
--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/OcidLookupPhase.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/phase/OcidLookupPhase.kt
@@ -53,11 +53,16 @@ import java.util.zip.GZIPOutputStream
  *
  * <p>Streaming write: each successful mapping is pushed to a [Channel] and consumed by a
  * single writer coroutine that pipes bytes into a GZIPOutputStream wrapping
- * [ObjectStorage.putStream]. The previous implementation accumulated all 600K+ entries in a
- * `MutableList<String>` until the end of the phase — that held ~120MB of JSON strings in heap
- * for the entire OCID run and pushed the JVM over its 1GB ceiling when combined with other
- * in-flight state. Streaming keeps the heap footprint bounded to the pipe buffer (64KB) plus
- * the GZIPOutputStream internal buffer.
+ * [ObjectStorage.putStreamMultipart]. The previous implementation accumulated all 600K+
+ * entries in a `MutableList<String>` until the end of the phase — that held ~120MB of JSON
+ * strings in heap for the entire OCID run and pushed the JVM over its 1GB ceiling when
+ * combined with other in-flight state. Streaming keeps the heap footprint bounded to the
+ * pipe buffer (64KB) plus the GZIPOutputStream internal buffer.
+ *
+ * <p>Issue #1319: migrated from deprecated `putStream` (heap-draining `readBytes()` inside
+ * the impl) to `putStreamMultipart` (S3AsyncClient chunked transfer on Minio, temp-file +
+ * `putFile` on LocalFs virtual-thread). Heap peak: bounded to pipe (64KB) instead of the
+ * full OCID mapping chunk (~120MB).
  */
 @Component
 @ConditionalOnProperty(name = ["external-api.schedule.enabled"], havingValue = "true")
@@ -113,15 +118,24 @@ class OcidLookupPhase(
         val resultsChannel = Channel<String>(Channel.BUFFERED)
 
         // Pipe: producer writes to pipeOut (GZIPOutputStream), consumer reads
-        // from pipeIn (ObjectStorage.putStream). Buffer of 64KB caps JVM heap
-        // use from the pipe itself.
+        // from pipeIn (ObjectStorage.putStreamMultipart). Buffer of 64KB caps
+        // JVM heap use from the pipe itself.
         val pipeOut = PipedOutputStream()
         val pipeIn = PipedInputStream(pipeOut, 65_536)
 
         coroutineScope {
-            val putJob = async(Dispatchers.IO) { objectStorage.putStream(key, pipeIn) }
+            // putStreamMultipart returns CompletableFuture<PutResult> — no async
+            // wrapper needed; the S3AsyncClient / LocalFs-virtual-thread
+            // implementation handles concurrency. The CF chain runs in the
+            // background while the writer coroutine pumps bytes into the pipe.
+            val uploadFuture = objectStorage.putStreamMultipart(key, pipeIn)
 
-            val writerJob = launch(Dispatchers.IO) {
+            // Writer: CPU-bound (GZIPOutputStream.compress) on
+            // Dispatchers.Default per architecture-guardrails.md rule 9.
+            // pipeOut.write is blocking but bounded by the 64KB pipe
+            // buffer, so the natural backpressure makes the CPU work the
+            // bottleneck — Default pool is the right home.
+            val writerJob = launch(Dispatchers.Default) {
                 val gz = GZIPOutputStream(BufferedOutputStream(pipeOut))
                 try {
                     for (entry in resultsChannel) {
@@ -149,7 +163,10 @@ class OcidLookupPhase(
 
             resultsChannel.close()
             writerJob.join()
-            putJob.await()
+            // Single .await() at the coroutine→CF boundary. Equivalent to the
+            // previous putJob.await() but avoids the async wrapper (the
+            // uploadFuture is already running on the S3/LocalFs executor).
+            uploadFuture.await()
         }
         log.info(
             "[Scheduler] streamed {} OCID mappings to {} (heap-bounded via pipe)",

--- a/module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/OcidLookupPhaseTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/scheduler/phase/OcidLookupPhaseTest.kt
@@ -57,14 +57,17 @@ class OcidLookupPhaseTest {
         }
 
         // Collect streamed bytes (replaces the previous put() call). This
-        // is exactly the path MinioObjectStorage.putStream takes: it drains
-        // the input to a temp file, then puts that file to S3.
+        // is exactly the path MinioObjectStorage.putStreamMultipart takes: it
+        // streams the input through the S3AsyncClient chunked transfer. The
+        // mock drains it to bytes for assertion.
         val collectedBytes = java.util.concurrent.atomic.AtomicReference<ByteArray>()
-        whenever(storage.putStream(any(), any())).thenAnswer { invocation ->
+        whenever(storage.putStreamMultipart(any(), any())).thenAnswer { invocation ->
             val input = invocation.getArgument<InputStream>(1)
             val bytes = input.readBytes()
             collectedBytes.set(bytes)
-            PutResult(invocation.getArgument<String>(0), bytes.size.toLong(), null)
+            CompletableFuture.completedFuture(
+                PutResult(invocation.getArgument<String>(0), bytes.size.toLong(), null),
+            )
         }
 
         val phase = OcidLookupPhase(
@@ -88,9 +91,9 @@ class OcidLookupPhaseTest {
             )
         }
 
-        // Verify the streaming putStream was called with the right key.
+        // Verify the streaming putStreamMultipart was called with the right key.
         val mappingKeyCaptor = argumentCaptor<String>()
-        verify(storage).putStream(mappingKeyCaptor.capture(), any())
+        verify(storage).putStreamMultipart(mappingKeyCaptor.capture(), any())
         val mappingKey = mappingKeyCaptor.firstValue
         assertNotNull(mappingKey)
         assertTrue(
@@ -105,7 +108,7 @@ class OcidLookupPhaseTest {
         // The streamed bytes should be a non-empty valid gzip containing the
         // expected userIgn/ocid pairs.
         val bytes = collectedBytes.get()
-        assertNotNull(bytes, "putStream should have been called")
+        assertNotNull(bytes, "putStreamMultipart should have been called")
         assertTrue(bytes!!.isNotEmpty(), "streamed bytes should not be empty")
         val decompressed = GZIPInputStream(bytes.inputStream())
             .bufferedReader().readText()
@@ -151,9 +154,12 @@ class OcidLookupPhaseTest {
             val ign = invocation.getArgument<String>(2)
             CompletableFuture.completedFuture("{\"ocid\":\"ocid-for-$ign\"}".toByteArray())
         }
-        whenever(storage.putStream(any(), any())).thenAnswer { invocation ->
+        whenever(storage.putStreamMultipart(any(), any())).thenAnswer { invocation ->
             val input = invocation.getArgument<InputStream>(1)
-            PutResult(invocation.getArgument<String>(0), input.readBytes().size.toLong(), null)
+            val bytes = input.readBytes()
+            CompletableFuture.completedFuture(
+                PutResult(invocation.getArgument<String>(0), bytes.size.toLong(), null),
+            )
         }
 
         val phase = OcidLookupPhase(


### PR DESCRIPTION
## Summary

Migrate OcidLookupPhase to the CF-based putStreamMultipart API. Eliminates the heap-draining readBytes() path inside putStream. Heap peak bounded to the 64KB pipe buffer instead of the full OCID mapping chunk.

## Changes

- **OcidLookupPhase**: swap putStream (sync, returns PutResult) to putStreamMultipart (async, returns CompletableFuture<PutResult>). The async() wrapper around the upload is removed; the CF runs in the background while the writer coroutine pumps bytes into the pipe.
- **Dispatcher fix**: writer coroutine Dispatchers.IO -> Dispatchers.Default (GZIPOutputStream is CPU-bound per architecture-guardrails.md rule 9).
- **Test stubs**: updated from putStream to putStreamMultipart returning CF via thenAnswer.

## Verification

- [x] ./gradlew :module-external-api:compileKotlin (BUILD SUCCESSFUL)
- [ ] tests (skipped per user)
- [ ] runtime + smoke (skipped per user)

## Related

- Parent: #1312 (calculator streaming writer, merged in #1318)
- Same pattern as PR #1318 putStreamMultipart impl