### PR TITLE
fix(ext-api): ITEM_EQUIPMENT uses OCID_LOOKUP runId, not CHARACTER_BASIC

### DIFF
--- a/module-external-api/src/main/kotlin/maple/externalapi/scheduler/ExternalApiScheduler.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/scheduler/ExternalApiScheduler.kt
@@ -113,7 +113,12 @@ class ExternalApiScheduler(
                 }
             }
             .thenCompose {
-                triggerPhase(PipelinePhase.ITEM_EQUIPMENT, ieRunId, cbRunId)
+                // ITEM_EQUIPMENT needs the OCID_LOOKUP runId, not CHARACTER_BASIC.
+                // loadFromRun(upstreamRunId) reads `ocid-mapping-{upstreamRunId}.jsonl.gz`,
+                // which OCID_LOOKUP writes — CHARACTER_BASIC only writes character-basic
+                // chunks and does not produce an ocid-mapping file. Passing cbRunId here
+                // makes loadFromRun 404 and the phase exits with 0 records.
+                triggerPhase(PipelinePhase.ITEM_EQUIPMENT, ieRunId, oRunId)
             }
             .whenComplete { _, ex ->
                 if (ex != null) {


### PR DESCRIPTION
## Summary
- `ExternalApiScheduler` chained `ITEM_EQUIPMENT` after `CHARACTER_BASIC` but passed `cbRunId` as upstream runId. `OcidCacheProvider.loadFromRun(runId)` reads `ocid-mapping-{runId}.jsonl.gz`, which only `OCID_LOOKUP` writes — `CHARACTER_BASIC` produces character-basic chunks, not the OCID mapping file. `loadFromRun` 404'd and the phase exited with 0 records.
- Fix: pass `oRunId` (OCID_LOOKUP runId) to the `ITEM_EQUIPMENT` trigger so the OCID cache is loaded from the correct mapping file.

## Root cause
```kotlin
// Before
triggerPhase(PipelinePhase.ITEM_EQUIPMENT, ieRunId, cbRunId)
//  loadFromRun(cbRunId) → 404 on ocid-mapping-cbRunId.jsonl.gz
//  → 0 records processed → 0 items fetched → all-failure symptom
```

## Test plan
- [x] Compile + test on `perf/ext-api-loop-throughput-adr-729`
- [ ] Server runtime check: ITEM_EQUIPMENT phase exits with `success > 0` after pipeline completes
- [ ] Log shows `loaded key=ocid-mapping-{oRunId}.jsonl.gz` in OcidCacheProvider

🤖 Generated with [Claude Code](https://claude.com/claude-code)