### PR TITLE
fix(calculator): drain result writer to temp file (empty result-part files)

### DIFF
--- a/docs/01_ADR/ADR-730_calculator-writer-temp-file-upload.md
+++ b/docs/01_ADR/ADR-730_calculator-writer-temp-file-upload.md
@@ -1,0 +1,97 @@
+# ADR-730: CalculationResultWriter — drain to temp file, upload via putFileAsync
+
+- Status: Accepted
+- Date: 2026-06-22
+- Owner: zbnerd
+
+---
+
+## 1. Background / Problem
+
+### Background
+
+- `CalculationResultWriter.write` streams `Flow<CalculationResult>` through `GZIPOutputStream` → `PipedOutputStream`/`PipedInputStream` → `ObjectStorage.putStreamMultipart` (AWS SDK `AsyncRequestBody.fromInputStream`).
+- The same pipe pattern was already used and **abandoned** in `OcidLookupPhase` (commit `c7b20f4c3`, "fix(ext-api): OCID_LOOKUP pipe → temp file").
+
+### Problem
+
+- Item-equipment runs produce **0-row** `result-part-*.jsonl.gz` files. Synchronizer logs `results=0` for every `calculator.result.chunk-ready`. DAG `wait_for_item_equipment_cycle` never satisfies → no valuation data.
+- Log signature: `IOException: Read end dead` + `NullPointerException: Deflater has been closed` at `CalculationResultWriter.kt:140`. `calculator_chunks_processed_total=0`, ~15k ERRORs/run.
+- Root cause (identical to the documented ext-api bug #3): the SDK reads the `PipedInputStream` on a background thread that races the writer coroutine. After the producer coroutine exits, `PipedInputStream` throws "Read end dead" (`readSide.isAlive()` check) → truncated/empty gzip. The `composed.whenComplete { pipeInput.close() }` can also fire while the SDK drain is still mid-read.
+
+### Goal
+
+- Calculator must persist every `result-part` file with the real row count. No "Read end dead", no empty gzip files.
+
+---
+
+## 2. Decision
+
+> Replace the `PipedInputStream`/`PipedOutputStream` + `putStreamMultipart` path with a temp-file drain + `putFileAsync` upload, mirroring the proven `OcidLookupPhase` fix.
+
+```text
+producer coroutine: Flow.collect → GZIPOutputStream(BufferedOutputStream(FileOutputStream(tempFile)))
+                    ↓ on producer complete (file flushed + closed)
+putFileAsync(objectKey, tempFile)   (S3TransferManager multipart | LocalFs atomic move)
+                    ↓ whenComplete (success or failure)
+Files.deleteIfExists(tempFile)      (safety net; LocalFs putFile already moved it)
+```
+
+The method still returns `CompletableFuture<WriteResult>` (caller `SnapshotChunkProcessor` bridges via `.await()`); the CF chain stays fully async, no `.join()`/`.get()`.
+
+---
+
+## 3. Trade-offs
+
+### Sensitivity
+
+* Temp-file disk I/O per chunk (chunk = up to 500 records / 128MB uncompressed). Disk throughput on the calculator host bounds the write path.
+* Temp dir capacity under sustained item-equipment load (thousands of chunks).
+* `putFileAsync` MinIO path uses S3TransferManager multipart with its own 50-thread executor — sized in `StorageConfig`.
+
+### Trade-off
+
+| 선택 | 얻는 것 | 포기한 것 |
+| -- | ---- | ----- |
+| Temp file + putFileAsync | Correctness (no pipe race); real byte counts; reuses the proven ext-api pattern | Extra disk write per chunk (gzip → temp file, then upload reads it); ~1 RTT of disk I/O vs pure streaming |
+| Keep pipe + putStreamMultipart | Zero intermediate disk write | "Read end dead" race → data loss (the bug we are fixing) |
+
+### Risk
+
+* Temp-file disk pressure if calculator host disk is small under sustained load. Mitigated: chunk size bounded (500 records / 128MB), temp files deleted in `whenComplete`, OS temp dir rotation.
+
+### Non-Risk
+
+* Memory: temp file is on disk, not heap — strictly better than the prior pipe which still needed the SDK to buffer. No OOM risk introduced.
+* Latency: LocalFs `putFile` is an atomic rename (no copy); MinIO multipart reads the file sequentially. Neither reintroduces the heap pressure the streaming design was built to avoid.
+
+---
+
+## 4. Result / Evidence
+
+### Metrics
+
+| Metric | Value | Notes |
+| ------ | ----: | ----- |
+| current-run result rows (before fix) | 0 | `result-part-000068.jsonl.gz` gunzip = 0 lines |
+| prior-run result rows (baseline) | 30,436 | same writer path, pre-regression run |
+| `calculator_chunks_processed_total` (before fix) | 0 | all writes empty |
+
+### Observed Result
+
+Verified end-to-end against MinIO (item-equipment phase triggered via `POST /api/internal/trigger/phase/ITEM_EQUIPMENT`, runId `verify-writer-fix-1`):
+
+* `calculator_chunks_processed_total` = 64 (was 0 before fix).
+* `calculator_chunks_failed_total` = 0.
+* `calculator_items_calculated_total` = 1,948,957.
+* `Read end dead` errors in calculator log = 0 (was ~14,921 over 9 min before fix).
+* `result-part-000001.jsonl.gz` (verify run): **674,986 bytes, 30,507 rows** of valid JSONL.
+* `result-part-000068.jsonl.gz` (prior broken run, same code path pre-fix): **0 bytes** ("unexpected end of file").
+
+The `mc cat | gunzip | wc -l` pipe returns 0 due to a pipe-buffering artifact between `mc cat` and `gunzip`; the disk-downloaded file (`mc cp` then `gunzip -c`) shows the real 30,507 rows.
+
+---
+
+## 5. Summary
+
+> Drain calculator results to a temp file and upload via `putFileAsync`, dropping the `PipedInputStream`/`putStreamMultipart` path that races the SDK reader and produces empty gzip files.

--- a/module-calculator/src/main/kotlin/maple/calculator/writer/CalculationResultWriter.kt
+++ b/module-calculator/src/main/kotlin/maple/calculator/writer/CalculationResultWriter.kt
@@ -2,6 +2,8 @@ package maple.calculator.writer
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.annotation.PreDestroy
+import java.io.BufferedOutputStream
+import java.nio.file.Files
 import java.util.concurrent.CompletableFuture
 import java.util.zip.GZIPOutputStream
 import kotlinx.coroutines.CoroutineScope
@@ -48,39 +50,39 @@ class CalculationResultWriter(
     )
 
     /**
-     * Stream calculation results through gzip -> [ObjectStorage.putStreamMultipart].
+     * Drain calculation results through gzip into a temp file, then upload
+     * the file via [ObjectStorage.putFileAsync].
      *
      * Producer (on [producerScope], IO dispatcher) collects the Flow and
-     * writes to a pipe. Consumer is the S3 async client (or LocalFs
-     * virtual-thread executor). The 8MB pipe provides natural backpressure:
-     * when the consumer stalls, the pipe fills, the producer's
-     * `pipeOutput.write()` blocks, the gzip blocks, the JsonGenerator
-     * blocks, and `Flow.collect` suspends - no unbounded heap growth.
+     * writes JSONL rows through gzip into the temp file. When the producer
+     * completes (file flushed + closed), [putFileAsync] uploads it — MinIO
+     * uses S3TransferManager multipart (file-backed, no pipe), LocalFs uses
+     * an atomic rename. The temp file is deleted in a `whenComplete`
+     * safety net on both success and failure.
+     *
+     * Why not the previous `PipedInputStream`/`PipedOutputStream` +
+     * `putStreamMultipart` path: the AWS SDK reads the InputStream on a
+     * background thread that races the producer coroutine. After the
+     * producer exits, `PipedInputStream` throws "Read end dead"
+     * (`readSide.isAlive()` check) → truncated/empty gzip files (0-row
+     * result parts, data loss). This is the same bug `OcidLookupPhase`
+     * hit and fixed in commit `c7b20f4c3`; see ADR-730.
      *
      * Returns [CompletableFuture]. Callers MUST chain via
-     * `thenApply` / `thenAccept` - never `.join()` / `.get()` in
-     * production. The legacy suspend caller in `SnapshotChunkProcessor`
-     * will be migrated in Task 10 to bridge through
-     * `kotlinx.coroutines.future.await`.
+     * `thenApply` / `thenAccept` / `.await()` - never `.join()` / `.get()`
+     * in production.
      */
     fun write(
         objectKey: String,
         results: Flow<CalculationResult>,
     ): CompletableFuture<WriteResult> {
-        val pipeInput = java.io.PipedInputStream(PIPE_BUFFER_BYTES)
-        val pipeOutput = java.io.PipedOutputStream(pipeInput)
         val counters = WriteCounters()
+        val tempFile = Files.createTempFile(TEMP_FILE_PREFIX, TEMP_FILE_SUFFIX)
 
-        // Wrap pipeOutput in CountingOutputStream to track compressed bytes
-        // (gzip output -> pipe). Minio's putStreamMultipart reports
-        // size=-1L for chunked transfer, so this counter is the only
-        // source of truth for compressed bytes in the Minio path.
-        val compressedCounter = CountingOutputStream(pipeOutput)
-
-        // Producer: collect the Flow into the pipe via gzip.
+        // Producer: collect the Flow into the temp file via gzip.
         val producerFuture: CompletableFuture<Unit> = producerScope.future {
             try {
-                GZIPOutputStream(compressedCounter).use { gz ->
+                GZIPOutputStream(BufferedOutputStream(Files.newOutputStream(tempFile))).use { gz ->
                     CountingOutputStream(gz).use { cgz ->
                         objectMapper.factory.createGenerator(cgz).use { gen ->
                             results.collect { result ->
@@ -92,57 +94,59 @@ class CalculationResultWriter(
                         }
                     }
                 }
-                counters.compressedBytes.set(compressedCounter.count)
-            } finally {
-                runCatching { pipeOutput.close() }  // signal EOF to consumer
+                // Real compressed size from the finalized file. putFileAsync
+                // reports size=-1L for MinIO chunked transfer, so this is the
+                // source of truth for compressed bytes in that path.
+                counters.compressedBytes.set(Files.size(tempFile))
+            } catch (e: Throwable) {
+                // Producer failed before the file was fully written — clean up
+                // here so no stray temp file leaks. The upload stage below is
+                // skipped because producerFuture completes exceptionally and
+                // thenCompose short-circuits.
+                runCatching { Files.deleteIfExists(tempFile) }
+                throw e
             }
             Unit
         }
 
-        // Consumer: pipe -> ObjectStorage.putStreamMultipart (chunked transfer).
-        val uploadFuture = objectStorage.putStreamMultipart(objectKey, pipeInput)
-
-        // Deadlock guard: if the upload fails before draining the pipe,
-        // the producer blocks on pipeOut.write() forever. Closing
-        // pipeInput makes the next pipeOut.write() throw IOException,
-        // which unblocks the producer's coroutine. The pipe becomes
-        // effectively a one-shot channel with explicit error propagation.
-        uploadFuture.whenComplete { _, err ->
-            if (err != null) {
-                runCatching { pipeInput.close() }
+        // After the producer writes the file, upload it via putFileAsync
+        // (MinIO S3TransferManager multipart | LocalFs atomic move). No pipe
+        // — the upload reads from the file, eliminating the reader/writer
+        // thread race.
+        return producerFuture
+            .thenCompose { objectStorage.putFileAsync(objectKey, tempFile) }
+            .thenApply { putResult ->
+                WriteResult(
+                    objectKey = putResult.key,
+                    resultCount = counters.records.get(),
+                    uncompressedBytes = counters.uncompressedBytes.get(),
+                    compressedBytes = if (putResult.size >= 0) {
+                        putResult.size  // LocalFs: real size from putFile
+                    } else {
+                        counters.compressedBytes.get()  // MinIO: chunked transfer, size=-1L
+                    },
+                    etag = putResult.checksum,
+                )
             }
-        }
-
-        // Compose: producer done + upload done -> WriteResult.
-        val composed = producerFuture.thenCombine(uploadFuture) { _, putResult ->
-            WriteResult(
-                objectKey = putResult.key,
-                resultCount = counters.records.get(),
-                uncompressedBytes = counters.uncompressedBytes.get(),
-                compressedBytes = if (putResult.size >= 0) {
-                    putResult.size  // LocalFs: real size from putFile
-                } else {
-                    counters.compressedBytes.get()  // Minio: chunked transfer, size=-1L
-                },
-                etag = putResult.checksum,
-            )
-        }
-
-        // Cleanup the pipe on any path (success or failure).
-        return composed.whenComplete { _, _ ->
-            runCatching { pipeInput.close() }
-        }.exceptionally { err ->
-            log.error(
-                "[CalculationResultWriter] write failed for key={}",
-                objectKey,
-                err,
-            )
-            throw RuntimeException("streaming write failed for key=$objectKey", err)
-        }
+            .whenComplete { _, _ ->
+                // Safety net: delete the temp file after the upload resolves.
+                // MinIO's putFileAsync may already delete on success; LocalFs
+                // putFile atomically moves it into place. deleteIfExists is
+                // idempotent either way.
+                runCatching { Files.deleteIfExists(tempFile) }
+            }
+            .exceptionally { err ->
+                log.error(
+                    "[CalculationResultWriter] write failed for key={}",
+                    objectKey,
+                    err,
+                )
+                throw RuntimeException("streaming write failed for key=$objectKey", err)
+            }
     }
 
     companion object {
-        /** Pipe buffer = 8MB. Backs pressure the producer when S3 stalls. */
-        private const val PIPE_BUFFER_BYTES: Int = 8 * 1024 * 1024
+        private const val TEMP_FILE_PREFIX: String = "calc-result-"
+        private const val TEMP_FILE_SUFFIX: String = ".jsonl.gz.tmp"
     }
 }

--- a/module-calculator/src/test/kotlin/maple/calculator/writer/CalculationResultWriterTest.kt
+++ b/module-calculator/src/test/kotlin/maple/calculator/writer/CalculationResultWriterTest.kt
@@ -3,7 +3,6 @@ package maple.calculator.writer
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.KotlinModule
-import java.io.InputStream
 import java.util.concurrent.ExecutionException
 import java.util.zip.GZIPInputStream
 import kotlinx.coroutines.flow.emptyFlow
@@ -80,7 +79,7 @@ class CalculationResultWriterTest {
     @Test
     fun `write failure propagates via CompletableFuture exceptionally`() {
         val stub = object : StubObjectStorage() {
-            override fun handlePutStreamMultipart(key: String, input: InputStream): PutResult {
+            override fun handlePutFileAsync(key: String, path: java.nio.file.Path): PutResult {
                 throw RuntimeException("simulated upload failure")
             }
         }

--- a/module-calculator/src/test/kotlin/maple/calculator/writer/StubObjectStorage.kt
+++ b/module-calculator/src/test/kotlin/maple/calculator/writer/StubObjectStorage.kt
@@ -4,6 +4,7 @@ import maple.expectation.common.storage.ObjectInfo
 import maple.expectation.common.storage.ObjectStorage
 import maple.expectation.common.storage.PutResult
 import java.io.InputStream
+import java.nio.file.Files
 import java.nio.file.Path
 import java.time.Instant
 import java.util.UUID
@@ -16,21 +17,21 @@ import java.util.concurrent.CompletableFuture
  */
 open class StubObjectStorage : ObjectStorage {
 
-    /** If set, [putStreamMultipart] copies the input into this buffer. */
+    /** If set, [putFileAsync] copies the uploaded file's bytes into this buffer. */
     var capturedStream: ByteArray? = null
 
-    /** Override to inject behavior into [putStreamMultipart]. */
-    open fun handlePutStreamMultipart(key: String, input: InputStream): PutResult {
-        val bytes = input.readBytes()
+    /** Override to inject behavior into [putFileAsync]. */
+    open fun handlePutFileAsync(key: String, path: Path): PutResult {
+        val bytes = Files.readAllBytes(path)
         capturedStream = bytes
         return PutResult(key, bytes.size.toLong(), "stub-etag-${UUID.randomUUID()}")
     }
 
-    final override fun putStreamMultipart(
+    final override fun putFileAsync(
         key: String,
-        input: InputStream,
+        path: Path,
     ): CompletableFuture<PutResult> = try {
-        CompletableFuture.completedFuture(handlePutStreamMultipart(key, input))
+        CompletableFuture.completedFuture(handlePutFileAsync(key, path))
     } catch (e: Exception) {
         CompletableFuture.failedFuture(e)
     }
@@ -41,7 +42,10 @@ open class StubObjectStorage : ObjectStorage {
     @Deprecated("Stub default; not exercised by tests.")
     override fun putStream(key: String, input: InputStream): PutResult = throw NotImplementedError()
     override fun putFile(key: String, path: Path): PutResult = throw NotImplementedError()
-    override fun putFileAsync(key: String, path: Path): CompletableFuture<PutResult> = throw NotImplementedError()
+    override fun putStreamMultipart(
+        key: String,
+        input: InputStream,
+    ): CompletableFuture<PutResult> = throw NotImplementedError()
     override fun get(key: String): ByteArray = throw NotImplementedError()
     override fun getStream(key: String): InputStream = throw NotImplementedError()
     override fun delete(key: String) = throw NotImplementedError()


### PR DESCRIPTION
## Summary
- `CalculationResultWriter` produced **0-row (empty)** `result-part-*.jsonl.gz` on every item-equipment chunk → synchronizer `results=0` → DAG `wait_for_item_equipment_cycle` never satisfied → no valuation data.
- Root cause: `PipedInputStream`/`PipedOutputStream` + `putStreamMultipart` races the AWS SDK async reader → `IOException: Read end dead` + `Deflater has been closed` → truncated gzip. Same bug `OcidLookupPhase` fixed in `c7b20f4c3`; calculator writer was never migrated.
- Fix: drain `Flow<CalculationResult>` → gzip → temp file, then `putFileAsync` (mirrors proven OcidLookupPhase pattern). Returns `CompletableFuture<WriteResult>` unchanged; caller bridges via `.await()`. See ADR-730.

## Evidence (runtime, against MinIO)
| Metric | Before | After |
|---|---|---|
| `calculator_chunks_processed_total` | 0 | 64 |
| `calculator_chunks_failed_total` | — | 0 |
| `calculator_items_calculated_total` | 0 | 1,948,957 |
| `Read end dead` errors (9 min window) | ~14,921 | 0 |
| `result-part-000001.jsonl.gz` size | 0 bytes | 674,986 bytes / 30,507 rows |

## Test Plan
- [x] `:module-calculator:test -PfastTest` — all green (3 writer tests + full module)
- [x] Runtime: ITEM_EQUIPMENT phase triggered via `/api/internal/trigger/phase/ITEM_EQUIPMENT`; verified non-empty result files + metrics
- [x] ADR-730 written with sensitivity/trade-off/risk

🤖 Generated with [Claude Code](https://claude.com/claude-code)