### PR TITLE
feat(coolify): self-healing design + Phase 1 (infra under Coolify + autoheal)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -420,7 +420,9 @@ jobs:
       # `docker compose up`, otherwise compose fails with
       # "network maple-network declared as external, but could not be found".
       - name: Create external maple-network
-        run: docker network create --subnet=172.20.0.0/16 maple-network || docker network inspect maple-network >/dev/null
+        run: |
+          docker network inspect maple-network >/dev/null 2>&1 \
+            || docker network create --subnet=172.20.0.0/16 maple-network >/dev/null
 
       - name: Bring up full stack
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -415,6 +415,13 @@ jobs:
           SA_CLEANUP_SECRET_KEY=${SA_CLEANUP_SECRET_KEY}
           EOF
 
+      # maple-network is declared external in docker-compose.yml (shared
+      # with the future maple-apps Coolify resource). Create it before
+      # `docker compose up`, otherwise compose fails with
+      # "network maple-network declared as external, but could not be found".
+      - name: Create external maple-network
+        run: docker network create --subnet=172.20.0.0/16 maple-network || docker network inspect maple-network >/dev/null
+
       - name: Bring up full stack
         run: |
           docker compose -f docker-compose.yml -f docker-compose.services.yml up -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
   # Prometheus for metrics collection
   prometheus:
     image: prom/prometheus:latest
+    labels:
+      autoheal: "true"
     container_name: maple-prometheus
     restart: always
     # network_mode: host — prometheus reaches Spring Boot modules on the
@@ -32,6 +34,8 @@ services:
   # Replaced: MySQL, MongoDB, Redis Queue
   postgres:
     image: jumski/postgres-17-pgmq:latest
+    labels:
+      autoheal: "true"
     container_name: maple-postgres
     restart: always
     ports:
@@ -56,6 +60,8 @@ services:
   # Grafana for visualization
   grafana:
     image: grafana/grafana:latest
+    labels:
+      autoheal: "true"
     container_name: maple-grafana
     restart: always
     ports:
@@ -82,6 +88,8 @@ services:
   # Kafka (Message Queue)
   kafka:
     image: confluentinc/cp-kafka:latest
+    labels:
+      autoheal: "true"
     container_name: maple-kafka
     restart: always
     ports:
@@ -119,6 +127,8 @@ services:
   # Redis (Cache)
   redis:
     image: redis:7-alpine
+    labels:
+      autoheal: "true"
     container_name: maple-redis
     restart: always
     ports:
@@ -138,6 +148,8 @@ services:
   # Loki — log storage (single-binary, filesystem backend)
   loki:
     image: grafana/loki:2.9.0
+    labels:
+      autoheal: "true"
     container_name: maple-loki
     restart: always
     ports:
@@ -158,6 +170,8 @@ services:
   # Promtail — log shipper, tail module logs → push to Loki
   promtail:
     image: grafana/promtail:2.9.0
+    labels:
+      autoheal: "true"
     container_name: maple-promtail
     restart: always
     command: -config.file=/etc/promtail/config.yml
@@ -180,6 +194,8 @@ services:
   # MinIO object storage (V1 / issue #1216)
   minio:
     image: minio/minio:latest
+    labels:
+      autoheal: "true"
     command: server /data --console-address ":9001"
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER}
@@ -197,6 +213,23 @@ services:
       timeout: 5s
       retries: 5
       start_period: 30s
+
+  # autoheal — watches Docker health_status events and restarts any
+  # container carrying the `autoheal=true` label that goes unhealthy.
+  # Closes the soft-failure gap (process alive, /health DOWN) that the
+  # restart: always policy and Coolify Sentinel cannot cover. See ADR-731.
+  autoheal:
+    image: willfarrell/autoheal:latest
+    container_name: maple-autoheal
+    restart: always
+    environment:
+      AUTOHEAL_CONTAINER_LABEL: autoheal
+      AUTOHEAL_INTERVAL: 5
+      AUTOHEAL_DEFAULT_STOP_TIMEOUT: 30
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    networks:
+      - maple-network
 
   minio-bootstrap:
     image: minio/mc:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,12 @@ services:
     volumes:
       - ./docker/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus_data:/prometheus
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:9090/-/healthy || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
 
   # PostgreSQL + PGMQ (Primary Database - Issue #589, #590, #591)
   # Replaced: MySQL, MongoDB, Redis Queue
@@ -45,6 +51,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+      start_period: 30s
 
   # Grafana for visualization
   grafana:
@@ -65,6 +72,12 @@ services:
     depends_on:
       - prometheus
       - loki
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:3000/api/health || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
 
   # Kafka (Message Queue)
   kafka:
@@ -96,6 +109,12 @@ services:
       - maple-network
     depends_on:
       - postgres
+    healthcheck:
+      test: ["CMD-SHELL", "kafka-broker-api-versions --bootstrap-server localhost:9092 >/dev/null 2>&1 || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
 
   # Redis (Cache)
   redis:
@@ -109,6 +128,12 @@ services:
       - redis_data:/data
     networks:
       - maple-network
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 10s
 
   # Loki — log storage (single-binary, filesystem backend)
   loki:
@@ -128,6 +153,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
+      start_period: 30s
 
   # Promtail — log shipper, tail module logs → push to Loki
   promtail:
@@ -144,6 +170,12 @@ services:
     depends_on:
       loki:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:9080/ready || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
 
   # MinIO object storage (V1 / issue #1216)
   minio:
@@ -164,6 +196,7 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+      start_period: 30s
 
   minio-bootstrap:
     image: minio/mc:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,7 +122,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 40s
+      start_period: 60s
 
   # Redis (Cache)
   redis:
@@ -185,7 +185,10 @@ services:
       loki:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "wget -q --spider http://localhost:9080/ready || exit 1"]
+      # promtail image (Debian) ships no wget/curl/nc; bash /dev/tcp probes
+      # the readiness port directly. CMD-SHELL uses dash (no /dev/tcp), so
+      # invoke bash explicitly.
+      test: ["CMD-SHELL", "bash -c 'echo > /dev/tcp/localhost/9080' || exit 1"]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -228,6 +231,15 @@ services:
       AUTOHEAL_DEFAULT_STOP_TIMEOUT: 30
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+    healthcheck:
+      # autoheal can't restart itself (excluded from its own label), but a
+      # socket-presence probe surfaces its liveness in the Coolify UI. Crash
+      # recovery is restart: always.
+      test: ["CMD-SHELL", "ls /var/run/docker.sock >/dev/null 2>&1 || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
     networks:
       - maple-network
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -188,10 +188,11 @@ services:
 
 networks:
   maple-network:
-    driver: bridge
-    ipam:
-      config:
-        - subnet: 172.20.0.0/16
+    # External so both the maple-infra and the future maple-apps Coolify
+    # resources share it. Created once before first deploy:
+    #   docker network create --subnet=172.20.0.0/16 maple-network
+    external: true
+    name: maple-network
 
 volumes:
   prometheus_data:

--- a/docs/01_ADR/ADR-731_coolify-self-healing-infra.md
+++ b/docs/01_ADR/ADR-731_coolify-self-healing-infra.md
@@ -44,7 +44,7 @@ L3 autoheal sidecar             → health_status=unhealthy → docker restart
 ### Sensitivity
 
 * autoheal mounts `/var/run/docker.sock` rw — host-Docker root-equivalent (same trust level Coolify already has).
-* `start_period` tuning per service (redis 10s … kafka 40s, apps 90s in Phase 2) — too short → boot-time restart loops.
+* `start_period` tuning per service (redis 10s … kafka 60s, apps 90s in Phase 2) — too short → boot-time restart loops.
 
 ### Trade-off
 
@@ -55,7 +55,9 @@ L3 autoheal sidecar             → health_status=unhealthy → docker restart
 
 ### Risk
 
-* autoheal itself dies → no L3. Mitigated by `restart: always` + Coolify UI visibility.
+* autoheal itself dies → no L3. Mitigated by `restart: always` + Coolify UI visibility (a socket-presence healthcheck surfaces autoheal's state).
+* prometheus runs `network_mode: host` (to reach host Spring Boot ports via localhost); its healthcheck probes the host's `:9090/-/healthy` (a prometheus-specific path). It is intentionally NOT a member of `maple-network`, so it does not conflict with the future `maple-apps` resource. L3 coverage for prometheus is weaker (host-namespace probe) — accepted trade-off vs re-networking prometheus out of Phase 1 scope.
+* external `maple-network` survives resource deletion — manual lifecycle (create on first deploy, `docker network rm` on full teardown). Documented in the Phase 3 ops guide.
 
 ### Non-Risk
 

--- a/docs/01_ADR/ADR-731_coolify-self-healing-infra.md
+++ b/docs/01_ADR/ADR-731_coolify-self-healing-infra.md
@@ -1,0 +1,85 @@
+# ADR-731: Coolify-managed infra with 3-layer self-healing
+
+- Status: Accepted
+- Date: 2026-06-22
+- Owner: zbnerd
+
+---
+
+## 1. Background / Problem
+
+### Background
+
+- PR #1324 dockerized the 4 services + 8 infra containers. ADR-720 names Coolify + Docker Compose as the deployment layer.
+- Investigation 2026-06-22: the `maple-*` containers run as plain `docker compose up`, NOT under Coolify (no Coolify labels). So Sentinel, the Coolify UI, and git auto-deploy ignore them.
+
+### Problem
+
+- Hard crashes (OOM, JVM panic) recover via Docker `restart: always` — handled.
+- **Soft failures (process alive, `/health` DOWN) do not recover** — Docker restart fires only on exit, and Coolify v4.x has no K8s-style liveness probe. This is the gap.
+- 5 infra containers (kafka, redis, grafana, prometheus, promtail) have no healthcheck.
+
+### Goal
+
+- Every infra container self-heals on both hard crash and soft failure, under Coolify management.
+
+---
+
+## 2. Decision
+
+> Move infra under Coolify as a Docker Compose resource; add healthchecks everywhere; add an `autoheal` sidecar that restarts unhealthy containers.
+
+```text
+L1 Docker restart: always       → process exit → instant restart
+L2 Coolify Sentinel             → stopped container → restart (server setting)
+L3 autoheal sidecar             → health_status=unhealthy → docker restart
+```
+
+`maple-network` becomes `external` so the future `maple-apps` resource shares it.
+
+---
+
+## 3. Trade-offs
+
+### Sensitivity
+
+* autoheal mounts `/var/run/docker.sock` rw — host-Docker root-equivalent (same trust level Coolify already has).
+* `start_period` tuning per service (redis 10s … kafka 40s, apps 90s in Phase 2) — too short → boot-time restart loops.
+
+### Trade-off
+
+| 선택 | 얻는 것 | 포기한 것 |
+| -- | ---- | ----- |
+| autoheal sidecar over pure Coolify-native | guaranteed unhealthy→restart (soft-failure coverage) | extra container + socket mount |
+| external network over owned | shared with future apps resource; survives single-resource down | manual one-time `docker network create` |
+
+### Risk
+
+* autoheal itself dies → no L3. Mitigated by `restart: always` + Coolify UI visibility.
+
+### Non-Risk
+
+* Data loss on Coolify takeover — named volumes reused, data preserved.
+* minio-bootstrap re-run — idempotent (SA created only if missing or `--rotate`), key files rewritten with same values.
+
+---
+
+## 4. Result / Evidence
+
+### Metrics
+
+| Metric | Value | Notes |
+| ------ | ----: | ----- |
+| containers without healthcheck (before) | 5 | kafka, redis, grafana, prometheus, promtail |
+| soft-failure auto-recovery (before) | 0 | Docker restart ignores unhealthy |
+| soft-failure auto-recovery (target) | all persistent containers | via autoheal |
+
+### Observed Result
+
+Code changes merged (Phase 1). Operator live-migration + force-kill/force-unhealthy recovery verification pending on the Coolify host (runbook R-5/R-6 in the Phase 1 plan).
+
+---
+
+## 5. Summary
+
+> Run infra under Coolify with healthchecks on every container and an autoheal sidecar, so both hard crashes and soft failures self-heal.

--- a/docs/superpowers/plans/2026-06-22-coolify-self-healing-phase1.md
+++ b/docs/superpowers/plans/2026-06-22-coolify-self-healing-phase1.md
@@ -442,19 +442,9 @@ Expected output includes a line like `AUTOHEAL_CONTAINER_LABEL=autoheal` and (af
 
 - [ ] **Step 5: Verify autoheal restarts an unhealthy container (the core guarantee)**
 
-Run a throwaway test container that always fails its healthcheck and carries the autoheal label:
+Run a throwaway test container that always fails its healthcheck and carries the autoheal label (autoheal watches host-wide via the socket, so no network membership is needed):
 ```bash
 docker run -d --name autoheal-test \
-  --network maple-network \
-  --label autoheal=true \
-  --restart=no \
-  -e AUTOHEAL_CONTAINER_LABEL=autoheal \
-  alpine:latest sh -c 'apk add --no-cache wget >/dev/null 2>&1; sleep 3600'
-# Attach a failing healthcheck to the running test container is not possible
-# post-create, so instead recreate it with the failing check baked in:
-docker rm -f autoheal-test
-docker run -d --name autoheal-test \
-  --network maple-network \
   --label autoheal=true \
   --restart=no \
   --health-cmd 'exit 1' \
@@ -545,6 +535,8 @@ These steps are NOT code; they run in the Coolify UI / on the host. They are the
 ### R-3: Take down the manual stack (preserve volumes)
 
 The existing `maple-*` containers were started by manual `docker compose up`. Coolify must take over the same container names / volumes.
+
+**Maintenance window (grill-me fix A):** taking infra down briefly disconnects the 4 apps (still running on `nohup`) from postgres/minio/kafka/redis for ~30–60s. Apps will log connection errors and retry; expect a short spike of failed requests. Perform this during a low-traffic window. The external-network conversion forces a full infra recreate, so a brief outage here is unavoidable.
 
 1. On the host, from the repo root:
    ```bash

--- a/docs/superpowers/plans/2026-06-22-coolify-self-healing-phase1.md
+++ b/docs/superpowers/plans/2026-06-22-coolify-self-healing-phase1.md
@@ -1,0 +1,637 @@
+# Coolify Self-Healing — Phase 1 (Infra) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ` `]`) syntax for tracking.
+
+**Goal:** Bring the infra stack under Coolify as a self-healing Docker Compose resource — external shared network, healthchecks on every container, and an autoheal sidecar that restarts unhealthy containers (closing the soft-failure gap Docker restart policies and Coolify Sentinel cannot cover).
+
+**Architecture:** `docker-compose.yml` becomes a Coolify-managed resource (`maple-infra`). The `maple-network` flips to `external` (shared with the future `maple-apps` resource). Every persistent container gets a Docker `healthcheck` + an `autoheal: "true"` label. A new `autoheal` container watches Docker `health_status` events over the socket and `docker restart`s any labeled container that goes unhealthy. Hard crashes still recover via the existing `restart: always` policy; Coolify Sentinel adds crash-restart on top; autoheal adds the missing unhealthy→restart path.
+
+**Tech Stack:** Docker Compose v3.8, `willfarrell/autoheal`, Alpine busybox `wget` health probes, Coolify v4.1.2, GitHub Actions CI smoke job.
+
+**Scope:** Phase 1 ONLY. The 4 app services (`docker-compose.services.yml`) are NOT touched — they stay on their current startup path. Phase 2 (apps under Coolify + CI→GHCR image pipeline) and Phase 3 (auto-deploy, cAdvisor/promtail observability, ops guide) are separate follow-up plans. See `docs/superpowers/specs/2026-06-22-coolify-self-healing-design.md`.
+
+**Branch:** `feat/coolify-self-healing` (already created, tracks `origin/develop`).
+
+**Working directory:** `/home/maple/probabilistic-valuation-engine`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `docs/01_ADR/ADR-731_coolify-self-healing-infra.md` | Create | ADR documenting the 3-layer self-healing + external-network + autoheal decision |
+| `docker-compose.yml` | Modify | (1) `maple-network` → external; (2) add healthchecks to kafka/redis/grafana/prometheus/promtail; (3) add `start_period` to postgres/minio/loki healthchecks; (4) add `autoheal` service; (5) add `autoheal: "true"` labels to persistent services |
+| `.github/workflows/ci.yml` | Modify | Add `docker network create maple-network` step to the `docker-smoke` job (the external-network change otherwise breaks smoke, which relies on compose owning the network) |
+
+No Kotlin/Java code changes in Phase 1. No `docker-compose.services.yml` changes.
+
+---
+
+## Task 1: ADR-731 — self-healing infra under Coolify
+
+**Files:**
+- Create: `docs/01_ADR/ADR-731_coolify-self-healing-infra.md`
+
+ADR is required by the repo RPI workflow before implementation. Condense the spec's Phase-1 decisions into the repo's 5-section ADR format (see `.claude/rules/adr-conventions.md`). Keep it short — the spec already holds the detail.
+
+- [ ] **Step 1: Write the ADR**
+
+Create `docs/01_ADR/ADR-731_coolify-self-healing-infra.md` with exactly this content (adapt the date if implementing on a different day):
+
+```markdown
+# ADR-731: Coolify-managed infra with 3-layer self-healing
+
+- Status: Accepted
+- Date: 2026-06-22
+- Owner: zbnerd
+
+---
+
+## 1. Background / Problem
+
+### Background
+
+- PR #1324 dockerized the 4 services + 8 infra containers. ADR-720 names Coolify + Docker Compose as the deployment layer.
+- Investigation 2026-06-22: the `maple-*` containers run as plain `docker compose up`, NOT under Coolify (no Coolify labels). So Sentinel, the Coolify UI, and git auto-deploy ignore them.
+
+### Problem
+
+- Hard crashes (OOM, JVM panic) recover via Docker `restart: always` — handled.
+- **Soft failures (process alive, `/health` DOWN) do not recover** — Docker restart fires only on exit, and Coolify v4.x has no K8s-style liveness probe. This is the gap.
+- 5 infra containers (kafka, redis, grafana, prometheus, promtail) have no healthcheck.
+
+### Goal
+
+- Every infra container self-heals on both hard crash and soft failure, under Coolify management.
+
+---
+
+## 2. Decision
+
+> Move infra under Coolify as a Docker Compose resource; add healthchecks everywhere; add an `autoheal` sidecar that restarts unhealthy containers.
+
+```text
+L1 Docker restart: always       → process exit → instant restart
+L2 Coolify Sentinel             → stopped container → restart (server setting)
+L3 autoheal sidecar             → health_status=unhealthy → docker restart
+```
+
+`maple-network` becomes `external` so the future `maple-apps` resource shares it.
+
+---
+
+## 3. Trade-offs
+
+### Sensitivity
+
+* autoheal mounts `/var/run/docker.sock` rw — host-Docker root-equivalent (same trust level Coolify already has).
+* `start_period` tuning per service (redis 10s … kafka 40s, apps 90s in Phase 2) — too short → boot-time restart loops.
+
+### Trade-off
+
+| 선택 | 얻는 것 | 포기한 것 |
+| -- | ---- | ----- |
+| autoheal sidecar over pure Coolify-native | guaranteed unhealthy→restart (soft-failure coverage) | extra container + socket mount |
+| external network over owned | shared with future apps resource; survives single-resource down | manual one-time `docker network create` |
+
+### Risk
+
+* autoheal itself dies → no L3. Mitigated by `restart: always` + Coolify UI visibility.
+
+### Non-Risk
+
+* Data loss on Coolify takeover — named volumes reused, data preserved.
+* minio-bootstrap re-run — idempotent (SA created only if missing or `--rotate`), key files rewritten with same values.
+
+---
+
+## 4. Result / Evidence
+
+### Metrics
+
+| Metric | Value | Notes |
+| ------ | ----: | ----- |
+| containers without healthcheck (before) | 5 | kafka, redis, grafana, prometheus, promtail |
+| soft-failure auto-recovery (before) | 0 | Docker restart ignores unhealthy |
+| soft-failure auto-recovery (target) | all persistent containers | via autoheal |
+
+### Observed Result
+
+To be filled after Phase 1 operator verification (force-kill + force-unhealthy recovery tests in the runbook).
+
+---
+
+## 5. Summary
+
+> Run infra under Coolify with healthchecks on every container and an autoheal sidecar, so both hard crashes and soft failures self-heal.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/01_ADR/ADR-731_coolify-self-healing-infra.md
+git commit -m "$(cat <<'EOF'
+docs(adr): ADR-731 Coolify-managed infra with 3-layer self-healing
+
+Condenses the Phase-1 decisions from the design spec into the repo ADR
+format: external network, healthchecks everywhere, autoheal sidecar
+closing the unhealthy->restart gap that Docker restart policy and
+Coolify Sentinel cannot cover.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Convert `maple-network` to external + CI smoke fix
+
+**Files:**
+- Modify: `docker-compose.yml` (networks block, lines ~189-194)
+- Modify: `.github/workflows/ci.yml` (docker-smoke job, before the "Bring up full stack" step at line ~418)
+
+**Why these ship together:** the `docker-smoke` CI job runs `docker compose up` relying on compose owning `maple-network`. The moment the network becomes `external`, that job fails unless the runner creates the network first. They must land in one commit to keep CI green.
+
+- [ ] **Step 1: Edit the networks block in `docker-compose.yml`**
+
+Replace this block (currently at the bottom of `docker-compose.yml`):
+
+```yaml
+networks:
+  maple-network:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.20.0.0/16
+```
+
+with:
+
+```yaml
+networks:
+  maple-network:
+    # External so both the maple-infra and the future maple-apps Coolify
+    # resources share it. Created once before first deploy:
+    #   docker network create --subnet=172.20.0.0/16 maple-network
+    external: true
+    name: maple-network
+```
+
+(The subnet is preserved on the create command so existing container IPs / any hardcoded assumptions are unaffected. DNS-based service discovery works regardless of subnet.)
+
+- [ ] **Step 2: Add a network-create step to the ci.yml docker-smoke job**
+
+In `.github/workflows/ci.yml`, immediately BEFORE the `- name: Bring up full stack` step (line ~418), insert this new step:
+
+```yaml
+      # maple-network is declared external in docker-compose.yml (shared
+      # with the future maple-apps Coolify resource). Create it before
+      # `docker compose up`, otherwise compose fails with
+      # "network maple-network declared as external, but could not be found".
+      - name: Create external maple-network
+        run: docker network create --subnet=172.20.0.0/16 maple-network || docker network inspect maple-network >/dev/null
+```
+
+- [ ] **Step 3: Validate the compose file parses**
+
+Run:
+```bash
+docker compose -f docker-compose.yml config >/dev/null
+```
+Expected: exit 0, no "network declared as external but not found" error (config does not require the network to exist, only `up` does). If it errors on syntax, fix indentation.
+
+- [ ] **Step 4: Verify locally that external network + bring-up works**
+
+Run:
+```bash
+docker network create --subnet=172.20.0.0/16 maple-network || docker network inspect maple-network >/dev/null
+# Bring up infra only (no services overlay) to confirm infra parses + starts
+docker compose -f docker-compose.yml up -d postgres minio kafka redis
+```
+Expected: 4 containers reach running. Then tear down:
+```bash
+docker compose -f docker-compose.yml down
+```
+Leave the network in place (do NOT delete it — infra expects it external now).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docker-compose.yml .github/workflows/ci.yml
+git commit -m "$(cat <<'EOF'
+feat(infra): maple-network external + CI smoke network-create step
+
+Flip maple-network to external so the future maple-apps Coolify resource
+shares it. Add a docker network create step to the docker-smoke CI job,
+which previously relied on compose owning the network.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Healthchecks on all infra containers
+
+**Files:**
+- Modify: `docker-compose.yml`
+
+Add healthchecks to the 5 services that lack them (kafka, redis, grafana, prometheus, promtail) and add `start_period` to the 3 that already have one (postgres, minio, loki). Alpine-based images ship busybox `wget` (no `curl`).
+
+- [ ] **Step 1: Add healthcheck to `kafka`**
+
+In `docker-compose.yml`, under the `kafka:` service (currently no `healthcheck:`), add (same 4-space indentation as the sibling `environment:`/`volumes:` keys):
+
+```yaml
+    healthcheck:
+      test: ["CMD-SHELL", "kafka-broker-api-versions --bootstrap-server localhost:9092 >/dev/null 2>&1 || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+```
+
+- [ ] **Step 2: Add healthcheck to `redis`**
+
+Under the `redis:` service, add:
+
+```yaml
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 10s
+```
+
+- [ ] **Step 3: Add healthcheck to `grafana`**
+
+Under the `grafana:` service, add (grafana listens on 3000 inside the container; the host port 3001→3000 mapping is irrelevant for the in-container probe):
+
+```yaml
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:3000/api/health || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+```
+
+- [ ] **Step 4: Add healthcheck to `prometheus`**
+
+Under the `prometheus:` service (uses `network_mode: host`, so localhost:9090 is the host), add after the `volumes:` block:
+
+```yaml
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:9090/-/healthy || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+```
+
+- [ ] **Step 5: Add healthcheck to `promtail`**
+
+Under the `promtail:` service, add:
+
+```yaml
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:9080/ready || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+```
+
+- [ ] **Step 6: Add `start_period` to the existing `postgres` healthcheck**
+
+Under the `postgres:` service, the existing `healthcheck:` block currently has `test`/`interval`/`timeout`/`retries`. Add one line after `retries: 5`:
+
+```yaml
+      start_period: 30s
+```
+
+(Full postgres healthcheck becomes `test: ["CMD-SHELL", "pg_isready -U maple -d maple_expectation"]`, `interval: 10s`, `timeout: 5s`, `retries: 5`, `start_period: 30s`.)
+
+- [ ] **Step 7: Add `start_period` to the existing `minio` healthcheck**
+
+Under `minio:`, after `retries: 5`, add:
+
+```yaml
+      start_period: 30s
+```
+
+- [ ] **Step 8: Add `start_period` to the existing `loki` healthcheck**
+
+Under `loki:`, after `retries: 3`, add:
+
+```yaml
+      start_period: 30s
+```
+
+- [ ] **Step 9: Validate the compose file parses**
+
+Run:
+```bash
+docker compose -f docker-compose.yml config >/dev/null && echo OK
+```
+Expected: prints `OK`, exit 0.
+
+- [ ] **Step 10: Verify each healthcheck reports healthy**
+
+Bring up infra and poll each container's health status (run from the repo root; `maple-network` already exists from Task 2 Step 4):
+```bash
+docker compose -f docker-compose.yml up -d
+# wait ~60s for start_periods to elapse, then:
+for c in maple-postgres maple-minio maple-kafka maple-redis maple-grafana maple-prometheus maple-loki maple-promtail; do
+  printf '%-22s %s\n' "$c" "$(docker inspect --format '{{.State.Health.Status}}' "$c" 2>/dev/null || echo 'no-healthcheck')"
+done
+```
+Expected: every line shows `healthy` (not `starting`, not `no-healthcheck`, not `unhealthy`). If any shows `starting`, wait longer and re-run. If any shows `unhealthy`, run `docker inspect --format '{{json .State.Health}}' <name>` and read the failing probe's stderr in the `.Log` array.
+
+- [ ] **Step 11: Tear down**
+
+```bash
+docker compose -f docker-compose.yml down
+```
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add docker-compose.yml
+git commit -m "$(cat <<'EOF'
+feat(infra): healthchecks on all infra containers
+
+Add healthchecks to kafka/redis/grafana/prometheus/promtail (Alpine
+wget-based; redis-cli ping) and start_period to the existing
+postgres/minio/loki healthchecks. Every persistent infra container now
+reports a health state for depends_on chains and the autoheal sidecar.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: autoheal sidecar + labels
+
+**Files:**
+- Modify: `docker-compose.yml`
+
+Add the `autoheal` service and an `autoheal: "true"` label to every persistent container. Labels are EXCLUDED on `minio-bootstrap` (one-shot job) and `autoheal` itself (cannot restart itself).
+
+- [ ] **Step 1: Add the `autoheal` service**
+
+In `docker-compose.yml`, add this as a new top-level service (place it right before `minio-bootstrap:` so the one-shot job stays last):
+
+```yaml
+  # autoheal — watches Docker health_status events and restarts any
+  # container carrying the `autoheal=true` label that goes unhealthy.
+  # Closes the soft-failure gap (process alive, /health DOWN) that the
+  # restart: always policy and Coolify Sentinel cannot cover.
+  # See ADR-731.
+  autoheal:
+    image: willfarrell/autoheal:latest
+    container_name: maple-autoheal
+    restart: always
+    environment:
+      AUTOHEAL_CONTAINER_LABEL: autoheal
+      AUTOHEAL_INTERVAL: 5
+      AUTOHEAL_DEFAULT_STOP_TIMEOUT: 30
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    networks:
+      - maple-network
+```
+
+Note: socket is mounted read-write. autoheal needs the `restart` API. If a later autoheal version supports read-only socket operation, switch to `:ro`; until verified, rw is required (Coolify itself uses socket rw — same trust level).
+
+- [ ] **Step 2: Add the `autoheal: "true"` label to the 8 persistent services**
+
+For EACH of: `postgres`, `minio`, `kafka`, `redis`, `loki`, `grafana`, `prometheus`, `promtail` — add this block under the service (4-space indent, alongside `restart:`/`environment:`):
+
+```yaml
+    labels:
+      autoheal: "true"
+```
+
+Do NOT add the label to `minio-bootstrap` or `autoheal`.
+
+- [ ] **Step 3: Validate the compose file parses**
+
+Run:
+```bash
+docker compose -f docker-compose.yml config >/dev/null && echo OK
+```
+Expected: prints `OK`, exit 0.
+
+- [ ] **Step 4: Bring up infra including autoheal**
+
+```bash
+docker compose -f docker-compose.yml up -d
+```
+Expected: `maple-autoheal` reaches running; on first start its logs show it registered the Docker event stream. Confirm:
+```bash
+docker logs maple-autoheal 2>&1 | tail -20
+```
+Expected output includes a line like `AUTOHEAL_CONTAINER_LABEL=autoheal` and (after a few seconds) references to monitoring, with no errors.
+
+- [ ] **Step 5: Verify autoheal restarts an unhealthy container (the core guarantee)**
+
+Run a throwaway test container that always fails its healthcheck and carries the autoheal label:
+```bash
+docker run -d --name autoheal-test \
+  --network maple-network \
+  --label autoheal=true \
+  --restart=no \
+  -e AUTOHEAL_CONTAINER_LABEL=autoheal \
+  alpine:latest sh -c 'apk add --no-cache wget >/dev/null 2>&1; sleep 3600'
+# Attach a failing healthcheck to the running test container is not possible
+# post-create, so instead recreate it with the failing check baked in:
+docker rm -f autoheal-test
+docker run -d --name autoheal-test \
+  --network maple-network \
+  --label autoheal=true \
+  --restart=no \
+  --health-cmd 'exit 1' \
+  --health-interval=5s \
+  --health-retries=2 \
+  --health-timeout=2s \
+  alpine:latest sleep 3600
+```
+Now poll the test container's restart count — autoheal should restart it once it goes unhealthy (within ~`AUTOHEAL_INTERVAL` + probe retries ≈ 15–25s):
+```bash
+for i in $(seq 1 12); do
+  rc=$(docker inspect --format '{{.RestartCount}}' autoheal-test)
+  hs=$(docker inspect --format '{{.State.Health.Status}}' autoheal-test)
+  echo "attempt=$i health=$hs restarts=$rc"
+  [ "$rc" -ge 1 ] && { echo "AUTOHEAL RESTARTED THE UNHEALTHY CONTAINER"; break; }
+  sleep 3
+done
+```
+Expected: the loop prints `AUTOHEAL RESTARTED THE UNHEALTHY CONTAINER` with `restarts >= 1`. If it never restarts, check `docker logs maple-autoheal` — it must show a restart event for `autoheal-test`. If autoheal never saw the label, confirm `AUTOHEAL_CONTAINER_LABEL=autoheal` is set on the autoheal container and the test container's label key matches.
+
+- [ ] **Step 6: Clean up the test container**
+
+```bash
+docker rm -f autoheal-test
+```
+
+- [ ] **Step 7: Verify a real infra container's label is visible to autoheal**
+
+Confirm autoheal sees a real labeled container (postgres) so we know the labels from Step 2 are effective:
+```bash
+docker inspect maple-postgres --format '{{index .Config.Labels "autoheal"}}'
+```
+Expected: prints `true`. (autoheal only acts on unhealthy state; this just confirms the label is set.)
+
+- [ ] **Step 8: Tear down**
+
+```bash
+docker compose -f docker-compose.yml down
+```
+(The `maple-network` external network is NOT removed by `down` — leave it.)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add docker-compose.yml
+git commit -m "$(cat <<'EOF'
+feat(infra): autoheal sidecar + autoheal labels
+
+Add the autoheal container (watches Docker health_status events over the
+socket, restarts unhealthy labeled containers) and the autoheal=true label
+on every persistent infra service. Closes the soft-failure self-healing
+gap. Verified: autoheal restarts a force-unhealthy test container.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Operator Runbook — Phase 1 Coolify migration
+
+These steps are NOT code; they run in the Coolify UI / on the host. They are the gate between "code merged" and "infra self-healing in production." Perform after the Phase 1 PR merges to `develop`.
+
+### R-1: Enable Coolify Sentinel auto-restart (L2)
+
+1. Coolify UI → **Server settings** (the server running the maple stack).
+2. Enable **"Auto-restart stopped/unsual containers"** (or the equivalently named setting in 4.1.2). If already enabled, skip.
+3. This is L2 in the 3-layer model — covers stopped-container cases L1 might miss.
+
+### R-2: Create the `maple-infra` Coolify resource
+
+1. Coolify UI → **+ New Resource** → **Docker Compose** (not "Application").
+2. Point it at the repo (`probabilistic-valuation-engine`) and the compose file `docker-compose.yml`.
+3. Name the resource `maple-infra`.
+4. In the resource's **Environment variables / Secrets**, set the values that the compose file currently interpolates from the operator `.env` (these become tier-A Coolify Secrets — see spec Section 6):
+   - `DB_ROOT_PASSWORD` (secret)
+   - `MINIO_ROOT_USER` (secret)
+   - `MINIO_ROOT_PASSWORD` (secret)
+   - `GRAFANA_ADMIN_USER` (secret)
+   - `GRAFANA_ADMIN_PASSWORD` (secret)
+   - `TZ` (plain)
+   - Plus the `.env.bootstrap` values `minio-bootstrap` consumes:
+     - `SA_EXT_API_SECRET_KEY`, `SA_CALCULATOR_SECRET_KEY`, `SA_SYNCHRONIZER_SECRET_KEY`, `SA_CLEANUP_SECRET_KEY` (secrets)
+     - `MINIO_ENDPOINT` = `http://minio:9000` (plain)
+5. Do NOT deploy yet.
+
+### R-3: Take down the manual stack (preserve volumes)
+
+The existing `maple-*` containers were started by manual `docker compose up`. Coolify must take over the same container names / volumes.
+
+1. On the host, from the repo root:
+   ```bash
+   docker compose -f docker-compose.yml down
+   ```
+   This stops the manual infra containers. **Named volumes** (`postgres_data`, `minio_data`, `kafka_data`, `redis_data`, `loki_data`, `grafana_data`, `prometheus_data`) are NOT removed by `down` (only `down -v` removes them) — data is preserved.
+2. Confirm the network still exists (Coolify needs it):
+   ```bash
+   docker network inspect maple-network >/dev/null && echo "network present" || docker network create --subnet=172.20.0.0/16 maple-network
+   ```
+
+### R-4: First Coolify deploy + verify data preserved
+
+1. Coolify UI → `maple-infra` resource → **Deploy**.
+2. Wait for all containers to report healthy in the Coolify UI (healthchecks now drive status).
+3. Verify data survived the takeover:
+   ```bash
+   # Postgres row count sanity (replace with a known table if preferred)
+   docker exec maple-postgres psql -U maple -d maple_expectation -c "SELECT count(*) FROM pg_stat_user_tables;"
+   # MinIO bucket + object presence
+   docker exec maple-minio mc alias set local http://localhost:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"
+   docker exec maple-minio mc ls local/maple-expectation | head
+   ```
+   Expected: pg_stat_user_tables shows the expected table count (non-zero if data existed); MinIO lists the `maple-expectation` bucket with objects. If empty, STOP — the volume mapping diverged; investigate before proceeding.
+
+### R-5: Verify hard-crash recovery (L1/L2)
+
+1. Force-kill a container:
+   ```bash
+   docker kill maple-redis
+   ```
+2. Within seconds, the container should restart (Docker `restart: always`). Confirm:
+   ```bash
+   docker ps --filter name=maple-redis --format '{{.Status}}'
+   ```
+   Expected: `Up X seconds (health: starting)` or `(healthy)` — i.e., it came back.
+
+### R-6: Verify soft-failure recovery (L3 autoheal) on a real container
+
+1. Make a real container unhealthy by breaking its probe target. For `grafana`, stop the internal API health route is hard; use `redis` instead — pause the redis process inside the container so `redis-cli ping` fails:
+   ```bash
+   docker exec maple-redis sh -c 'kill -STOP 1' 2>/dev/null || true
+   ```
+   (If SIGSTOP on PID 1 is blocked by the image, fall back to the throwaway `autoheal-test` container method from Task 4 Step 5 — the guarantee is identical.)
+2. Wait for the healthcheck to flip unhealthy (~`interval`×`retries`, ≤90s) and watch autoheal:
+   ```bash
+   docker logs -f maple-autoheal
+   ```
+   Expected: autoheal logs a `health_status=unhealthy` event for `maple-redis` and issues a restart.
+3. Confirm recovery:
+   ```bash
+   docker inspect maple-redis --format '{{.RestartCount}}'
+   ```
+   Expected: `>= 1` and the container returns to `healthy`.
+
+### R-7: Backfill ADR-731 Result/Evidence
+
+After R-5 and R-6 succeed, edit `docs/01_ADR/ADR-731_coolify-self-healing-infra.md` Section 4 "Observed Result" with the actual outcomes (force-kill recovered in Ns; autoheal restarted the unhealthy container in Ns; all 8 infra containers healthy in Coolify UI). Commit on a follow-up.
+
+---
+
+## Self-Review (completed during authoring)
+
+**Spec coverage (Phase 1 slice):**
+- Network external conversion → Task 2 ✓
+- Healthchecks (5 new + 3 start_period) → Task 3 ✓
+- autoheal sidecar + labels → Task 4 ✓
+- ADR → Task 1 ✓
+- CI smoke parity (network-create) → Task 2 ✓
+- Coolify resource creation + Secrets → Runbook R-2 ✓
+- Sentinel L2 enablement → Runbook R-1 ✓
+- Data preservation → Runbook R-3/R-4 ✓
+- Hard-crash + soft-failure verification → Runbook R-5/R-6 ✓
+- Phase 2 (apps, image pipeline) and Phase 3 (cAdvisor/promtail/auto-deploy/ops guide) → explicitly out of scope, follow-up plans ✓
+
+**Placeholder scan:** none. Every step has exact YAML or exact commands with expected output.
+
+**Type/label consistency:** the label key is `autoheal` with value `"true"` everywhere (autoheal env `AUTOHEAL_CONTAINER_LABEL: autoheal`, compose `labels: autoheal: "true"`, test container `--label autoheal=true`). Container names use the `maple-` prefix consistently.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-06-22-coolify-self-healing-phase1.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — dispatch a fresh subagent per task, review between tasks, fast iteration.
+
+**2. Inline Execution** — execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+Which approach?

--- a/docs/superpowers/plans/2026-06-22-coolify-self-healing-phase2.md
+++ b/docs/superpowers/plans/2026-06-22-coolify-self-healing-phase2.md
@@ -1,0 +1,650 @@
+# Coolify Self-Healing — Phase 2 (Apps + Image Pipeline) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring the 4 Spring Boot services under Coolify as a self-healing `maple-apps` Docker Compose resource — images built and pushed by CI to GHCR, SA keys on a stable absolute host path shared with the infra resource, and `/actuator/health` healthchecks + autoheal labels on every app.
+
+**Architecture:** GitHub Actions builds the 4 jars → `build.sh` produces local `maple/<svc>:sha-<7>` images → a new CI job (on `develop` push) re-tags and pushes to `ghcr.io/zbnerd/maple-<svc>:{sha,latest}`. `docker-compose.services.yml` references each app image via a per-service `${IMAGE_<SVC>}` env var (default stays `maple/<svc>:dev` so local dev + the docker-smoke CI job are unchanged). MinIO SA keys move from repo-relative `./docker/services/secrets/` to a `SECRETS_DIR`-driven absolute host path (`/opt/maple/secrets` under Coolify) so both resources read the same files. Each app gets the L3 healthcheck + `autoheal: "true"` label from the Phase-1 pattern.
+
+**Tech Stack:** Docker Compose v3.8, GitHub Actions, GHCR (`ghcr.io/zbnerd/...`), Coolify v4.1.2, Alpine busybox `wget`, Spring Boot Actuator `/actuator/health`.
+
+**Prerequisites:** Phase 1 merged + deployed (the `maple-infra` resource, external `maple-network`, autoheal sidecar, and Coolify Secrets for infra must all be live). See `docs/superpowers/plans/2026-06-22-coolify-self-healing-phase1.md`.
+
+**Scope:** Phase 2 ONLY. `docker-compose.yml` gets two small edits (minio-bootstrap `SECRETS_DIR` env + bind mount). `docker-compose.services.yml` gets the app image vars, SA path interpolation, healthchecks, and labels. `.github/workflows/ci.yml` gets the `build-and-push` job. Phase 3 (cAdvisor, promtail docker discovery, auto-deploy, ops guide) is a separate plan.
+
+**Branch:** `feat/coolify-self-healing` (continue on the Phase-1 branch, or a follow-up branch off it — engineer's choice; keep commits linear).
+
+**Working directory:** `/home/maple/probabilistic-valuation-engine`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `docs/01_ADR/ADR-732_coolify-apps-image-pipeline.md` | Create | ADR: apps under Coolify + CI→GHCR image pipeline + SA absolute-path migration |
+| `docker/minio/bootstrap.sh` | Modify | Honor `SECRETS_DIR` env (default repo-relative; Coolify sets absolute) |
+| `docker-compose.yml` | Modify | minio-bootstrap: add `SECRETS_DIR` env + bind-mount the secrets host dir |
+| `docker-compose.services.yml` | Modify | (1) per-service `${IMAGE_<SVC>}` image vars; (2) `secrets:` file paths via `${SECRETS_DIR_HOST}`; (3) app healthchecks; (4) `autoheal: "true"` labels |
+| `.github/workflows/ci.yml` | Modify | Add `build-and-push` job (build → tag → push to GHCR on `develop` push) |
+
+No Kotlin/Java code changes (apps already expose `/actuator/prometheus`, so `/actuator/health` is exposed by the actuator default — verified in a step).
+
+---
+
+## Task P2-1: ADR-732 — apps + image pipeline
+
+**Files:**
+- Create: `docs/01_ADR/ADR-732_coolify-apps-image-pipeline.md`
+
+- [ ] **Step 1: Write the ADR**
+
+Create `docs/01_ADR/ADR-732_coolify-apps-image-pipeline.md`:
+
+```markdown
+# ADR-732: Apps under Coolify with CI→GHCR image pipeline
+
+- Status: Accepted
+- Date: 2026-06-22
+- Owner: zbnerd
+
+---
+
+## 1. Background / Problem
+
+### Background
+
+- Phase 1 (ADR-731) put infra under Coolify with 3-layer self-healing. The 4 app services still run via `nohup java -jar` or manual `docker compose up`, not under Coolify.
+- `build.sh` produces local-only images (`maple/<svc>:dev` + `:sha-<7>`). There is no registry, no server-side image source.
+
+### Problem
+
+- Apps are not Coolify-managed → no Sentinel restart, no UI, no auto-deploy, no L3 self-healing.
+- MinIO SA keys live at repo-relative `./docker/services/secrets/`. Coolify copies compose to its own deploy dir, so this path resolves differently per resource and the apps cannot reliably read the keys the infra resource's `minio-bootstrap` wrote.
+
+### Goal
+
+- Apps deploy from a registry image via Coolify; SA keys sit on a stable absolute host path shared by both resources; every app has the L3 healthcheck + autoheal label.
+
+---
+
+## 2. Decision
+
+> Build images in CI, push to GHCR; reference them in compose via per-service image env vars; move SA keys to a `SECRETS_DIR`-driven absolute path.
+
+```text
+push to develop
+  → GitHub Actions: bootJar → build.sh (local maple/<svc>:sha-<7>)
+  → re-tag + push ghcr.io/zbnerd/maple-<svc>:{sha-<7>,latest}
+Coolify maple-apps resource (image env → ghcr path) → docker compose up
+SA keys: bootstrap writes $SECRETS_DIR; apps read $SECRETS_DIR_HOST via secrets: file:
+```
+
+---
+
+## 3. Trade-offs
+
+### Sensitivity
+
+* GHCR availability — Coolify deploy blocks if registry unreachable (imagePullBackOff). Mitigation: `:latest` + `:sha` both pushed; pin to sha for audit, latest for auto-deploy.
+* `/opt/maple/secrets` must exist + be backed up — losing it = no app SA access.
+
+### Trade-off
+
+| 선택 | 얻는 것 | 포기한 것 |
+| -- | ---- | ----- |
+| CI→GHCR over Coolify-internal build | thin server, sha audit, clean rollback | registry dependency + CI build minutes |
+| Per-service `${IMAGE_<SVC>}` env var | full image control, no path-separator bugs | 4 env vars instead of 1 prefix |
+| Absolute SA path over repo-relative | shared by both Coolify resources | local dev needs SECRETS_DIR unset (default preserves old behavior) |
+
+### Risk
+
+* GHCR package visibility defaults to inherited/private — Coolify must be authorized to pull. Mitigation: set package visibility + Coolify pull token in ops runbook.
+
+### Non-Risk
+
+* docker-smoke CI job — uses local `maple/<svc>:dev` (IMAGE_* unset); unaffected.
+* Local dev — SECRETS_DIR/SECRETS_DIR_HOST unset → defaults to repo-relative path; unchanged workflow.
+
+---
+
+## 4. Result / Evidence
+
+### Metrics
+
+| Metric | Value | Notes |
+| ------ | ----: | ----- |
+| apps under Coolify (before) | 0 | nohup/manual compose |
+| image source (before) | local only | no registry |
+
+### Observed Result
+
+To be filled after Phase 2 operator verification (GHCR push green, maple-apps deploy healthy, L3 soft-failure recovery on an app).
+
+---
+
+## 5. Summary
+
+> Deploy the 4 apps from GHCR images under Coolify, with SA keys on a shared absolute path and L3 healthchecks, so the app layer gains the same self-healing the infra layer has.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/01_ADR/ADR-732_coolify-apps-image-pipeline.md
+git commit -m "$(cat <<'EOF'
+docs(adr): ADR-732 apps under Coolify with CI->GHCR image pipeline
+
+Documents the Phase-2 decisions: per-service GHCR image refs, SA key
+migration to an absolute SECRETS_DIR shared by both Coolify resources,
+and app L3 healthchecks + autoheal labels.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task P2-2: bootstrap.sh honors `SECRETS_DIR`
+
+**Files:**
+- Modify: `docker/minio/bootstrap.sh`
+
+Add a `SECRETS_DIR` env (default keeps the existing repo-relative behavior so local dev is unchanged). Coolify sets it to `/opt/maple/secrets`.
+
+- [ ] **Step 1: Add the SECRETS_DIR definition**
+
+In `docker/minio/bootstrap.sh`, locate the block that currently ends with:
+
+```bash
+echo "[bootstrap] REPO_ROOT=${REPO_ROOT}"
+```
+
+Immediately AFTER that `echo` line, insert:
+
+```bash
+
+# SECRETS_DIR: where SA key files are written. Defaults to the repo's
+# docker/services/secrets for local dev (REPO_ROOT is /workspace in the
+# minio-bootstrap container, the host repo root otherwise). Coolify sets
+# this to an absolute host path (/opt/maple/secrets) so both the
+# maple-infra and maple-apps resources read the same files — repo-relative
+# paths break under Coolify's deploy dir. See ADR-732.
+SECRETS_DIR="${SECRETS_DIR:-${REPO_ROOT}/docker/services/secrets}"
+```
+
+- [ ] **Step 2: Replace the three repo-relative secret-path references**
+
+The current lines are:
+
+```bash
+mkdir -p "${REPO_ROOT}/docker/services/secrets"
+chmod 700 "${REPO_ROOT}/docker/services/secrets"
+```
+
+and inside the loop:
+
+```bash
+  printf '%s' "${secret}" > "${REPO_ROOT}/docker/services/secrets/sa-${module}.key"
+  chmod 0444 "${REPO_ROOT}/docker/services/secrets/sa-${module}.key"
+  echo "[bootstrap] wrote ${REPO_ROOT}/docker/services/secrets/sa-${module}.key"
+```
+
+Replace ALL of these `"${REPO_ROOT}/docker/services/secrets"` references with `"${SECRETS_DIR}"`. The resulting lines:
+
+```bash
+mkdir -p "${SECRETS_DIR}"
+chmod 700 "${SECRETS_DIR}"
+```
+
+```bash
+  printf '%s' "${secret}" > "${SECRETS_DIR}/sa-${module}.key"
+  chmod 0444 "${SECRETS_DIR}/sa-${module}.key"
+  echo "[bootstrap] wrote ${SECRETS_DIR}/sa-${module}.key"
+```
+
+- [ ] **Step 3: Verify the script parses**
+
+Run:
+```bash
+bash -n docker/minio/bootstrap.sh && echo OK
+```
+Expected: prints `OK`, exit 0 (syntax check; `-n` does not execute).
+
+- [ ] **Step 4: Verify default behavior is unchanged (local-dev parity)**
+
+Run a dry invocation with `SECRETS_DIR` unset against a throwaway dir to confirm it writes to the REPO_ROOT-derived path:
+```bash
+# Use a temp REPO_ROOT so we don't touch the real secrets dir.
+REPO_ROOT="$(mktemp -d)" bash -c '
+  set -e
+  # Source only the SECRETS_DIR derivation + a no-op to confirm default logic.
+  REPO_ROOT_OUT="${REPO_ROOT}"
+  SECRETS_DIR="${SECRETS_DIR:-${REPO_ROOT_OUT}/docker/services/secrets}"
+  echo "SECRETS_DIR defaults to: ${SECRETS_DIR}"
+'
+```
+Expected: prints `SECRETS_DIR defaults to: <tmpdir>/docker/services/secrets`. Then confirm an explicit override wins:
+```bash
+SECRETS_DIR=/opt/maple/secrets bash -c 'echo "${SECRETS_DIR:-/workspace/docker/services/secrets}"'
+```
+Expected: prints `/opt/maple/secrets`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docker/minio/bootstrap.sh
+git commit -m "$(cat <<'EOF'
+feat(bootstrap): honor SECRETS_DIR for SA key output path
+
+bootstrap.sh writes SA keys to SECRETS_DIR (default repo-relative for
+local dev). Coolify sets it to /opt/maple/secrets so the maple-infra
+and maple-apps resources share the same files. Local dev unchanged.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task P2-3: minio-bootstrap `SECRETS_DIR` env + bind mount in `docker-compose.yml`
+
+**Files:**
+- Modify: `docker-compose.yml` (the `minio-bootstrap:` service, lines ~168-187)
+
+Two vars drive the secret path: `SECRETS_DIR` (in-container path bootstrap writes to) and `SECRETS_DIR_HOST` (host-side path used by the bind mount and the services overlay's `secrets: file:`). Coolify sets both to `/opt/maple/secrets` (host=path identity). Local dev leaves both unset → defaults keep the current `./docker/services/secrets` workflow.
+
+- [ ] **Step 1: Add the `SECRETS_DIR` env to minio-bootstrap**
+
+In `docker-compose.yml`, the `minio-bootstrap:` service `environment:` block currently contains the `MINIO_ENDPOINT` override. Add one key after it:
+
+```yaml
+    environment:
+      # Override .env.bootstrap MINIO_ENDPOINT for in-container DNS.
+      # .env.bootstrap keeps localhost:9000 so host-side tooling works.
+      MINIO_ENDPOINT: http://minio:9000
+      # SA key output path (ADR-732). Coolify sets this to /opt/maple/secrets;
+      # local dev leaves it unset → bootstrap defaults to /workspace/docker/services/secrets.
+      SECRETS_DIR: ${SECRETS_DIR:-/workspace/docker/services/secrets}
+```
+
+- [ ] **Step 2: Add the bind mount for the secrets host dir**
+
+The current `volumes:` block is:
+
+```yaml
+    volumes:
+      - ./docker/minio:/scripts:ro
+      # /workspace = repo root, writable so bootstrap.sh can persist SA secrets
+      # to docker/services/secrets/ and .env.<module>. See plan task 8.
+      - ./:/workspace:rw
+```
+
+Add a third mount so that when `SECRETS_DIR_HOST` points outside `/workspace` (Coolify: `/opt/maple/secrets`), bootstrap can write there. Replace the whole `volumes:` block with:
+
+```yaml
+    volumes:
+      - ./docker/minio:/scripts:ro
+      # /workspace = repo root (local dev). bootstrap's REPO_ROOT fallback
+      # and host-side tooling read SA keys here when SECRETS_DIR is unset.
+      - ./:/workspace:rw
+      # SA secrets output dir (ADR-732). When SECRETS_DIR_HOST is set
+      # (Coolify: /opt/maple/secrets), mount that host path read-write so
+      # bootstrap writes keys there and the maple-apps resource reads them.
+      # Local dev: defaults to the repo dir under the /workspace mount above
+      # (redundant but harmless bind).
+      - ${SECRETS_DIR_HOST:-./docker/services/secrets}:${SECRETS_DIR:-/workspace/docker/services/secrets}:rw
+```
+
+- [ ] **Step 3: Validate the compose file parses**
+
+Run:
+```bash
+docker compose -f docker-compose.yml config >/dev/null && echo OK
+```
+Expected: prints `OK`, exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docker-compose.yml
+git commit -m "$(cat <<'EOF'
+feat(infra): minio-bootstrap SECRETS_DIR env + secrets bind mount
+
+Pass SECRETS_DIR to bootstrap and bind-mount the secrets host dir so
+SA keys can land on /opt/maple/secrets under Coolify (shared with the
+maple-apps resource). Local dev defaults preserve the repo-relative path.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task P2-4: `docker-compose.services.yml` — image vars, SA path, healthchecks, labels
+
+**Files:**
+- Modify: `docker-compose.services.yml` (entire file — all 4 services + the `secrets:` block)
+
+- [ ] **Step 1: Verify `/actuator/health` is exposed on all 4 apps**
+
+Confirm the actuator health endpoint is web-exposed (the healthcheck depends on it). Spring Boot exposes `health` by default; this step only checks nothing excludes it. Run:
+```bash
+grep -rn "management.endpoints.web.exposure" module-external-api/src/main/resources/ module-calculator/src/main/resources/ module-synchronizer/src/main/resources/ module-cleanup/src/main/resources/ 2>/dev/null || echo "no explicit exposure config — defaults apply (health exposed)"
+```
+Expected: prints `no explicit exposure config — defaults apply (health exposed)` OR, if a config exists, confirm it includes `health` in the include list. If `health` is excluded anywhere, add `health` to that `include` before proceeding (out of this plan's scope to define; surface to the user). Proceed only when confirmed exposed.
+
+- [ ] **Step 2: Switch each app `image:` to a per-service env var**
+
+For EACH of the 4 services, replace the hardcoded image line:
+
+| Service | Replace | With |
+|---------|---------|------|
+| external-api | `image: maple/external-api:dev` | `image: ${IMAGE_EXTERNAL_API:-maple/external-api:dev}` |
+| calculator | `image: maple/calculator:dev` | `image: ${IMAGE_CALCULATOR:-maple/calculator:dev}` |
+| synchronizer | `image: maple/synchronizer:dev` | `image: ${IMAGE_SYNCHRONIZER:-maple/synchronizer:dev}` |
+| cleanup | `image: maple/cleanup:dev` | `image: ${IMAGE_CLEANUP:-maple/cleanup:dev}` |
+
+Default `maple/<svc>:dev` keeps local dev + docker-smoke CI unchanged. Coolify sets each to `ghcr.io/zbnerd/maple-<svc>:latest` (or a pinned `:sha-<7>`).
+
+- [ ] **Step 3: Add healthcheck + autoheal label to each of the 4 services**
+
+For EACH service, add (under the service, 4-space indent alongside `image:`/`environment:`):
+
+```yaml
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:${SERVER_PORT}/actuator/health | grep -q '\"status\":\"UP\"' || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 90s
+    labels:
+      autoheal: "true"
+```
+
+`${SERVER_PORT}` is already set per service (8081/8082/8083/8084) in each `environment:` block, so the healthcheck probes the right port per service. Repeat the identical block under all 4 services.
+
+- [ ] **Step 4: Switch the `secrets:` block file paths to `SECRETS_DIR_HOST`**
+
+The bottom `secrets:` block currently is:
+
+```yaml
+secrets:
+  sa-ext-api:
+    file: docker/services/secrets/sa-ext-api.key
+  sa-calculator:
+    file: docker/services/secrets/sa-calculator.key
+  sa-synchronizer:
+    file: docker/services/secrets/sa-synchronizer.key
+  sa-cleanup:
+    file: docker/services/secrets/sa-cleanup.key
+```
+
+Replace with `${SECRETS_DIR_HOST}` interpolation (default keeps `docker/services/secrets` for local dev / docker-smoke):
+
+```yaml
+secrets:
+  sa-ext-api:
+    file: ${SECRETS_DIR_HOST:-docker/services/secrets}/sa-ext-api.key
+  sa-calculator:
+    file: ${SECRETS_DIR_HOST:-docker/services/secrets}/sa-calculator.key
+  sa-synchronizer:
+    file: ${SECRETS_DIR_HOST:-docker/services/secrets}/sa-synchronizer.key
+  sa-cleanup:
+    file: ${SECRETS_DIR_HOST:-docker/services/secrets}/sa-cleanup.key
+```
+
+- [ ] **Step 5: Validate the services overlay parses**
+
+Run:
+```bash
+docker compose -f docker-compose.yml -f docker-compose.services.yml config >/dev/null && echo OK
+```
+Expected: prints `OK`, exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docker-compose.services.yml
+git commit -m "$(cat <<'EOF'
+feat(apps): per-service image vars, SA path interp, healthchecks, labels
+
+docker-compose.services.yml: reference each app image via ${IMAGE_<SVC>}
+(default maple/<svc>:dev for local dev + smoke CI), route SA key file
+paths through ${SECRETS_DIR_HOST}, and add the L3 /actuator/health
+healthcheck + autoheal=true label to all 4 apps.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task P2-5: CI `build-and-push` job (GHCR)
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (add a new job; also add `packages: write` to top-level permissions)
+
+- [ ] **Step 1: Add `packages: write` to the top-level permissions**
+
+The top-level `permissions:` block (around line 22) currently is:
+
+```yaml
+permissions:
+  contents: read
+  checks: write           # Required for test report annotations
+  pull-requests: write    # Required for PR comments
+```
+
+Add one line:
+
+```yaml
+permissions:
+  contents: read
+  checks: write           # Required for test report annotations
+  pull-requests: write    # Required for PR comments
+  packages: write         # Required for GHCR image push (ADR-732)
+```
+
+- [ ] **Step 2: Add the `build-and-push` job**
+
+Add this as a new top-level job (place it after the `docker-smoke:` job, at the same indentation as the other job keys — 2 spaces):
+
+```yaml
+  # ============================================
+  # Build & Push Images to GHCR (ADR-732)
+  # Runs only on pushes to develop (merges). Builds the 4 service images
+  # via build.sh (local maple/<svc>:sha-<7>), re-tags and pushes them to
+  # ghcr.io/zbnerd/maple-<svc>:{sha-<7>,latest}. PR builds are validated
+  # by the docker-smoke job (which uses local :dev images), so this job
+  # does not gate PRs.
+  # ============================================
+  build-and-push:
+    name: Build & Push Images (GHCR)
+    runs-on: ubuntu-latest
+    needs: test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+    env:
+      GHCR_OWNER: zbnerd
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup JDK ${{ env.JAVA_VERSION }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: 'temurin'
+
+      - name: Grant Execute Permission for Gradlew
+        run: chmod +x gradlew
+
+      - name: Build service jars
+        run: ./gradlew :module-external-api:bootJar :module-calculator:bootJar :module-synchronizer:bootJar :module-cleanup:bootJar -x test --no-daemon
+
+      - name: Build service images (build.sh)
+        run: ./docker/services/build.sh
+
+      - name: Login to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Tag & push images (sha + latest)
+        run: |
+          set -euo pipefail
+          SHA7="$(git rev-parse --short=7 HEAD)"
+          echo "Publishing sha-${SHA7} + latest for GHCR_OWNER=${GHCR_OWNER}"
+          for mod in external-api calculator synchronizer cleanup; do
+            docker tag "maple/${mod}:sha-${SHA7}" "ghcr.io/${GHCR_OWNER}/maple-${mod}:sha-${SHA7}"
+            docker tag "maple/${mod}:sha-${SHA7}" "ghcr.io/${GHCR_OWNER}/maple-${mod}:latest"
+            docker push "ghcr.io/${GHCR_OWNER}/maple-${mod}:sha-${SHA7}"
+            docker push "ghcr.io/${GHCR_OWNER}/maple-${mod}:latest"
+          done
+```
+
+Notes for the engineer:
+- `secrets.GITHUB_TOKEN` is auto-provided by GitHub Actions; no extra secret config needed.
+- The job `if:` gate restricts pushes to `develop` only, so PR runs and other branches do not push.
+- The `docker-smoke` job is unchanged — it still builds local `maple/<svc>:dev` and does not depend on GHCR.
+
+- [ ] **Step 3: Validate the workflow YAML**
+
+Run:
+```bash
+python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/ci.yml')); print('YAML OK')"
+```
+Expected: prints `YAML OK`, exit 0. (PyYAML is commonly available; if not, use `yamllint .github/workflows/ci.yml` or `docker run --rm -v "$PWD":/w mikefarah/yq e -i '.' /w/.github/workflows/ci.yml >/dev/null && echo OK`.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "$(cat <<'EOF'
+ci: build-and-push job publishes 4 service images to GHCR
+
+On push to develop, build jars + images (build.sh), re-tag and push
+ghcr.io/zbnerd/maple-<svc>:{sha-<7>,latest}. Adds packages:write
+permission. PRs are still validated by docker-smoke (local :dev images);
+this job does not gate PRs.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 5: Verify the job runs after merge (post-PR)**
+
+This verification happens after the Phase-2 PR merges to `develop`:
+1. Open the Actions tab → confirm the `Build & Push Images (GHCR)` job ran green on the develop push.
+2. Confirm packages exist: `https://github.com/zbnerd?tab=packages` lists `maple-external-api`, `maple-calculator`, `maple-synchronizer`, `maple-cleanup`.
+3. Pull test (from the server): `docker pull ghcr.io/zbnerd/maple-external-api:latest` succeeds.
+Record any failures as runbook items.
+
+---
+
+## Operator Runbook — Phase 2 Coolify apps migration
+
+These steps run in the Coolify UI / on the host, after the Phase-2 PR merges to `develop` and the `build-and-push` job has published images.
+
+### R-1: Seed `/opt/maple/secrets` from the existing repo keys
+
+1. On the host, create the dir and copy the existing SA keys (generated by the current manual `minio-bootstrap`) so apps have valid keys from the first deploy:
+   ```bash
+   sudo mkdir -p /opt/maple/secrets
+   sudo chmod 700 /opt/maple/secrets
+   sudo cp docker/services/secrets/sa-*.key /opt/maple/secrets/
+   sudo chmod 0444 /opt/maple/secrets/sa-*.key
+   # Ensure the Docker daemon / container maple user (UID in the runtime image) can read them
+   ls -la /opt/maple/secrets/
+   ```
+2. Confirm 4 files present (`sa-ext-api.key`, `sa-calculator.key`, `sa-synchronizer.key`, `sa-cleanup.key`). These now match the SA users MinIO already has (bootstrap is idempotent — re-run won't rotate them without `--rotate`).
+
+### R-2: Set GHCR package visibility + Coolify pull access
+
+1. GitHub → profile → Packages → each `maple-<svc>` → Package settings. Set visibility to **Private** (or Internal) and link the Coolify server's pull credential.
+2. On the Coolify server, authenticate Docker to GHCR so `docker compose up` can pull:
+   ```bash
+   # Create a GitHub PAT with read:packages scope, then:
+   echo "<PAT>" | docker login ghcr.io -u zbnerd --password-stdin
+   ```
+   (Coolify may manage this via its own registry credential feature — prefer that if available.)
+
+### R-3: Create the `maple-apps` Coolify resource
+
+1. Coolify UI → **+ New Resource** → **Docker Compose**.
+2. Point at the repo and the file `docker-compose.services.yml`.
+3. Name the resource `maple-apps`.
+4. In the resource environment, set (plain):
+   - `IMAGE_EXTERNAL_API=ghcr.io/zbnerd/maple-external-api:latest`
+   - `IMAGE_CALCULATOR=ghcr.io/zbnerd/maple-calculator:latest`
+   - `IMAGE_SYNCHRONIZER=ghcr.io/zbnerd/maple-synchronizer:latest`
+   - `IMAGE_CLEANUP=ghcr.io/zbnerd/maple-cleanup:latest`
+   - `SECRETS_DIR=/opt/maple/secrets`
+   - `SECRETS_DIR_HOST=/opt/maple/secrets`
+   - `KAFKA_BOOTSTRAP_SERVERS=kafka:29092`
+   - `SPRING_PROFILES_ACTIVE=local`
+   - `MINIO_ENDPOINT=http://minio:9000`
+   - `MINIO_BUCKET=maple-expectation`
+   - `MINIO_REGION=us-east-1`
+   - `STORAGE_BACKEND=minio`
+   - `MINIO_ACCESS_KEY` per service (ext-api / calculator / synchronizer / cleanup)
+   - `DB_URL=jdbc:postgresql://postgres:5432/maple_expectation?user=maple&password=${DB_ROOT_PASSWORD}` (Coolify interpolates the Secret into this string)
+5. Set as Coolify **Secrets**:
+   - `DB_ROOT_PASSWORD` (= the infra resource's value)
+   - `NEXON_API_KEY` (external-api only; leave unset for the other 3 — they ignore it)
+6. Do NOT deploy yet.
+
+### R-4: First deploy + verify health + L3
+
+1. Deploy `maple-apps`. Coolify pulls the 4 GHCR images and starts the containers.
+2. Confirm all 4 report healthy in the Coolify UI (the `/actuator/health` healthchecks drive status). If any stays unhealthy, `docker logs maple-<svc>` and `docker inspect maple-<svc> --format '{{json .State.Health}}'`.
+3. Confirm autoheal sees the app labels:
+   ```bash
+   docker inspect maple-calculator --format '{{index .Config.Labels "autoheal"}}'
+   ```
+   Expected: `true`.
+4. L3 soft-failure check on one app (e.g., calculator): make `/actuator/health` return non-UP by stopping the Spring context is hard externally — instead simulate via a temporary failing healthcheck override is not possible on a running container, so verify L3 indirectly: confirm autoheal is wired (it restarted the Phase-1 test container already) and that the app's label is `true`; the same mechanism applies. If a direct test is required, redeploy one app with a deliberately failing healthcheck (e.g., port mismatch) and confirm autoheal restarts it, then redeploy correctly.
+
+### R-5: Rollback drill
+
+1. In the `maple-apps` resource env, set e.g. `IMAGE_CALCULATOR=ghcr.io/zbnerd/maple-calculator:sha-<prior-7>` (the previous good sha).
+2. Redeploy. Confirm it pulls the prior image and starts healthy.
+3. This validates the rollback path; restore `:latest` afterward.
+
+### R-6: Backfill ADR-732 Result/Evidence
+
+Edit `docs/01_ADR/ADR-732_coolify-apps-image-pipeline.md` Section 4 with: GHCR packages published, `maple-apps` all 4 healthy in Coolify UI, rollback drill result. Commit.
+
+---
+
+## Self-Review (completed during authoring)
+
+**Spec coverage (Phase-2 slice):**
+- Image pipeline CI→GHCR → P2-5 ✓ (spec Section 7 option B)
+- Per-service image vars → P2-4 Step 2 ✓
+- SA absolute path migration → P2-2 + P2-3 + P2-4 Step 4 ✓ (spec Section 6 tier-B)
+- App `/actuator/health` healthchecks + autoheal labels → P2-4 Step 3 ✓ (spec Section 5)
+- Coolify `maple-apps` resource + Secrets → Runbook R-3 ✓ (spec Section 6 tier-A/C)
+- Deploy/rollback semantics → Runbook R-4/R-5 ✓ (spec Section 7)
+- ADR → P2-1 ✓ (RPI rule)
+
+**Placeholder scan:** none. Every step has exact YAML, shell, or compose content with expected output.
+
+**Consistency:** variable names used consistently — `SECRETS_DIR` (in-container, bootstrap + minio-bootstrap env), `SECRETS_DIR_HOST` (host-side, volumes + secrets `file:`), `IMAGE_<SVC>` (per-service, 4 vars). GHCR path `ghcr.io/zbnerd/maple-<svc>` consistent across CI job + runbook. Healthcheck block identical across 4 apps.
+
+**Local-dev parity:** all new env vars default to values that reproduce current behavior (`maple/<svc>:dev`, repo-relative secrets path), so docker-smoke CI and local dev are unchanged.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-06-22-coolify-self-healing-phase2.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — dispatch a fresh subagent per task, review between tasks.
+
+**2. Inline Execution** — execute tasks in this session using executing-plans, batch with checkpoints.
+
+Which approach?

--- a/docs/superpowers/plans/2026-06-22-coolify-self-healing-phase3.md
+++ b/docs/superpowers/plans/2026-06-22-coolify-self-healing-phase3.md
@@ -1,0 +1,560 @@
+# Coolify Self-Healing — Phase 3 (Automation + Observability + Ops Guide) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close out the Coolify self-healing rollout — add a restart-rate alert backed by cAdvisor, collect container stdout logs (opt-in) via promtail Docker discovery, enable apps git auto-deploy in Coolify, and write the operator setup guide that ties Phases 1–3 together.
+
+**Architecture:** cAdvisor runs on the infra resource and exposes per-container metrics; prometheus (host-network) scrapes it via the host port and evaluates a `ContainerRestartThrashing` rule on `container_start_time_seconds`. promtail gains a `docker_sd_configs` job that tails stdout of containers labeled `logging=promtail` (opt-in, avoids duplicating the file-tailed module logs). The `maple-apps` Coolify resource gets auto-deploy ON (push to `develop` → CI image → redeploy). A single ops guide documents the whole 3-resource topology + recovery procedures.
+
+**Tech Stack:** cAdvisor (`gcr.io/cadvisor/cadvisor`), prometheus + alert_rules.yml, promtail `docker_sd_configs`, Coolify v4.1.2 auto-deploy.
+
+**Prerequisites:** Phase 1 (infra under Coolify + autoheal) AND Phase 2 (apps under Coolify + GHCR images) merged and deployed. See `docs/superpowers/plans/2026-06-22-coolify-self-healing-phase1.md` and `-phase2.md`.
+
+**Scope:** Phase 3 ONLY. Edits touch `docker-compose.yml` (cAdvisor + promtail socket mount), `docker/prometheus/prometheus.yml` (cAdvisor scrape), `docker/prometheus/rules/alert_rules.yml` (restart alert), `docker/promtail/config.yml` (docker_sd job), and a new ops guide. **Pre-existing gaps noted but NOT fixed here:** alertmanager is referenced by `prometheus.yml` but only defined in the legacy `docker-compose.observability.yml` overlay (not running); node-exporter likewise. Those are a separate cleanup.
+
+**Branch:** `feat/coolify-self-healing` (continue on the Phase-1/2 branch).
+
+**Working directory:** `/home/maple/probabilistic-valuation-engine`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `docs/01_ADR/ADR-733_coolify-observability-autodeploy.md` | Create | ADR: cAdvisor restart-rate alert, promtail docker discovery, auto-deploy, ops guide; records the alertmanager/node-exporter pre-existing gaps |
+| `docker-compose.yml` | Modify | (1) add `cadvisor` service; (2) add docker-socket mount to `promtail`; (3) add `logging: promtail` label to `autoheal` + `cadvisor` (opt-in stdout logging) |
+| `docker/prometheus/prometheus.yml` | Modify | Add `cadvisor` scrape job |
+| `docker/prometheus/rules/alert_rules.yml` | Modify | Add `ContainerRestartThrashing` rule |
+| `docker/promtail/config.yml` | Modify | Add `docker_containers` `docker_sd_configs` job (opt-in label) |
+| `docs/21_Operations/coolify-setup-guide.md` | Create | Operator guide for the full 3-resource Coolify topology + recovery |
+
+---
+
+## Task P3-1: ADR-733 — observability + auto-deploy
+
+**Files:**
+- Create: `docs/01_ADR/ADR-733_coolify-observability-autodeploy.md`
+
+- [ ] **Step 1: Write the ADR**
+
+Create `docs/01_ADR/ADR-733_coolify-observability-autodeploy.md`:
+
+```markdown
+# ADR-733: Observability (cAdvisor restart alert) + apps auto-deploy
+
+- Status: Accepted
+- Date: 2026-06-22
+- Owner: zbnerd
+
+---
+
+## 1. Background / Problem
+
+### Background
+
+- Phases 1–2 (ADR-731/732) gave infra + apps 3-layer self-healing under Coolify. Visibility into restarts was a noted gap (spec Section 8).
+
+### Problem
+
+- No metric tells us when containers are thrashing (restart loops). The autoheal/restart policies work silently.
+- Container stdout (e.g., autoheal restart events) is not collected — promtail only tails module log files.
+- App deploys are still manual; push-to-develop should redeploy.
+- No single ops document for the Coolify topology.
+
+### Goal
+
+- A restart-rate alert; opt-in container stdout logging; apps auto-deploy; a setup guide.
+
+---
+
+## 2. Decision
+
+> Add cAdvisor for per-container metrics + a `ContainerRestartThrashing` alert on `container_start_time_seconds`; add a promtail `docker_sd_configs` job opt-in via label; enable Coolify auto-deploy for `maple-apps`; write `docs/21_Operations/coolify-setup-guide.md`.
+
+```text
+cAdvisor (container_start_time_seconds) → prometheus → ContainerRestartThrashing rule
+container stdout (label logging=promtail) → promtail docker_sd → Loki
+push to develop → GHCR image → Coolify maple-apps auto-deploy
+```
+
+Restart detection: cAdvisor exposes `container_start_time_seconds` (a gauge that jumps on each restart). `changes(...[5m])` counts those jumps; >2 in 5m fires the alert.
+
+---
+
+## 3. Trade-offs
+
+### Sensitivity
+
+* cAdvisor mounts `/` (rootfs) read-only + docker socket paths — broad host read access (standard cAdvisor requirement; read-only).
+* promtail now reads the Docker socket (ro) for discovery — same trust class as autoheal.
+* `changes()` on a gauge can count non-restart value fluctuations in edge cases; `for: 1m` + threshold >2 dampens false positives.
+
+### Trade-off
+
+| 선택 | 얻는 것 | 포기한 것 |
+| -- | ---- | ----- |
+| cAdvisor `container_start_time_seconds` + `changes()` | per-container restart visibility, no extra exporter | gauge-based counting (not a true restart_counter) |
+| opt-in `logging=promtail` label | avoids duplicating file-tailed module logs | only labeled containers' stdout is collected |
+| auto-deploy ON for apps | push-to-deploy | bad commit auto-redeploys; mitigated by sha rollback |
+
+### Risk
+
+* alertmanager is referenced by prometheus but NOT running (only in the legacy `docker-compose.observability.yml` overlay). The restart alert will be evaluated and visible in the prometheus UI, but delivery (Slack/email) requires wiring alertmanager — deferred.
+
+### Non-Risk
+
+* cAdvisor itself — covered by `restart: always` + the autoheal label.
+
+---
+
+## 4. Result / Evidence
+
+### Metrics
+
+| Metric | Value | Notes |
+| ------ | ----: | ----- |
+| restart-rate metric (before) | none | silent thrashing |
+| container stdout collection (before) | none | file-tailed module logs only |
+
+### Observed Result
+
+To be filled after Phase 3 verification (cAdvisor scrape up, alert fires on a forced-restart test, promtail ships container stdout to Loki).
+
+---
+
+## 5. Summary
+
+> Add cAdvisor-based restart alerting, opt-in container stdout logging, apps auto-deploy, and a setup guide to complete Coolify self-healing observability.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/01_ADR/ADR-733_coolify-observability-autodeploy.md
+git commit -m "$(cat <<'EOF'
+docs(adr): ADR-733 observability (cAdvisor restart alert) + auto-deploy
+
+Records Phase-3 decisions: cAdvisor + ContainerRestartThrashing on
+container_start_time_seconds changes(), opt-in promtail docker_sd,
+maple-apps auto-deploy, and the ops guide. Notes the alertmanager /
+node-exporter pre-existing gaps (legacy overlay, not running).
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task P3-2: cAdvisor service + prometheus scrape + restart alert
+
+**Files:**
+- Modify: `docker-compose.yml` (add `cadvisor` service)
+- Modify: `docker/prometheus/prometheus.yml` (add scrape job)
+- Modify: `docker/prometheus/rules/alert_rules.yml` (add alert rule)
+
+- [ ] **Step 1: Add the `cadvisor` service to `docker-compose.yml`**
+
+Add this as a new top-level service (place it right after `prometheus:` so the observability exporters sit together, before `postgres:`):
+
+```yaml
+  # cAdvisor — per-container metrics for restart-rate alerting (ADR-733).
+  # Exposes container_start_time_seconds (a gauge that jumps on each restart);
+  # prometheus evaluates ContainerRestartThrashing via changes() on it.
+  # Host port 8086 (container internal 8080) to avoid app-port conflicts.
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:latest
+    container_name: maple-cadvisor
+    restart: always
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+      - /dev/disk/:/dev/disk:ro
+    devices:
+      - /dev/kmsg
+    ports:
+      - "8086:8080"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:8080/metrics || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+    labels:
+      autoheal: "true"
+      logging: "promtail"
+    networks:
+      - maple-network
+```
+
+(`logging: promtail` opts cAdvisor's stdout into the promtail docker job added in P3-3.)
+
+- [ ] **Step 2: Add the cAdvisor scrape job to prometheus.yml**
+
+In `docker/prometheus/prometheus.yml`, the `scrape_configs:` block ends after the `node-exporter` job (around the `# Node Exporter` section). Add a new job after it. prometheus runs with `network_mode: host`, so it reaches cAdvisor via the host port `localhost:8086` (same pattern as the module scrapes):
+
+```yaml
+  # ============================================
+  # cAdvisor - per-container metrics (restart-rate alerting, ADR-733)
+  # Reached via the host port (prometheus uses network_mode: host).
+  # ============================================
+  - job_name: 'cadvisor'
+    scrape_interval: 15s
+    scrape_timeout: 10s
+    metrics_path: '/metrics'
+    static_configs:
+      - targets: ['localhost:8086']
+        labels:
+          component: 'containers'
+```
+
+- [ ] **Step 3: Add the `ContainerRestartThrashing` alert rule**
+
+In `docker/prometheus/rules/alert_rules.yml`, the `rules:` list (under `groups: - name: maple-expectation-alerts`) contains entries like `HighCpuUsage`, `HighMemoryUsage`, etc. Append one more rule to that SAME `rules:` list (match the existing 4-space indent for the `- alert:` key, 6-space for fields):
+
+```yaml
+      # ============================================
+      # Container Restart Thrashing (ADR-733)
+      # cAdvisor's container_start_time_seconds jumps on each container
+      # restart; changes() counts those jumps over the window.
+      # ============================================
+      - alert: ContainerRestartThrashing
+        expr: changes(container_start_time_seconds{container!="",container!="POD"}[5m]) > 2
+        for: 1m
+        labels:
+          severity: warning
+          category: system
+        annotations:
+          summary: "Container {{ $labels.name }} is restarting repeatedly"
+          description: "{{ $labels.name }} restarted {{ $value }} times in the last 5m"
+```
+
+- [ ] **Step 4: Validate compose + YAML parse**
+
+Run:
+```bash
+docker compose -f docker-compose.yml config >/dev/null && echo "COMPOSE OK"
+python3 -c "import yaml; yaml.safe_load(open('docker/prometheus/prometheus.yml')); yaml.safe_load(open('docker/prometheus/rules/alert_rules.yml')); print('PROM YAML OK')"
+```
+Expected: prints `COMPOSE OK` then `PROM YAML OK`.
+
+- [ ] **Step 5: Verify cAdvisor is scraped + the alert rule loads**
+
+Bring up infra (Phase 1 already made `maple-network` external):
+```bash
+docker compose -f docker-compose.yml up -d cadvisor prometheus
+# wait ~30s, then:
+curl -s http://localhost:8086/metrics | grep -m1 container_start_time_seconds
+curl -s http://localhost:9090/api/v1/targets | grep -o '"cadvisor"[^}]*"health":"up"' | head -1
+curl -s "http://localhost:9090/api/v1/rules" | grep -o 'ContainerRestartThrashing'
+```
+Expected: the first curl prints a `container_start_time_seconds ...` line; the targets query shows cadvisor `health: up`; the rules query prints `ContainerRestartThrashing`. Tear down:
+```bash
+docker compose -f docker-compose.yml down
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docker-compose.yml docker/prometheus/prometheus.yml docker/prometheus/rules/alert_rules.yml
+git commit -m "$(cat <<'EOF'
+feat(observability): cAdvisor + ContainerRestartThrashing alert
+
+Add cAdvisor (host port 8086) exposing container_start_time_seconds,
+a prometheus scrape job, and a ContainerRestartThrashing rule
+(changes() > 2 in 5m) so restart loops are visible/alerted. cAdvisor
+carries the autoheal + logging=promtail labels.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task P3-3: promtail Docker discovery (opt-in container stdout)
+
+**Files:**
+- Modify: `docker/promtail/config.yml` (add `docker_containers` scrape job)
+- Modify: `docker-compose.yml` (promtail: add docker-socket mount + `logging: promtail` label to autoheal)
+
+- [ ] **Step 1: Add the `docker_containers` job to promtail config**
+
+In `docker/promtail/config.yml`, the `scrape_configs:` list currently has `module_logs` and `artifact_logs`. Append a new job at the end of `scrape_configs:` (same indent as the existing `- job_name:` entries):
+
+```yaml
+  # Container stdout collection (ADR-733). opt-in: only containers carrying
+  # the label logging=promtail are scraped, so the file-tailed module logs
+  # above are NOT duplicated. Targets the docker socket.
+  - job_name: docker_containers
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 30s
+        filters:
+          - name: label
+            values: ["logging=promtail"]
+    relabel_configs:
+      - source_labels: ["__meta_docker_container_name"]
+        regex: '/(.*)'
+        target_label: container
+      - source_labels: ["__meta_docker_container_label_com_docker_compose_service"]
+        target_label: service
+    pipeline_stages:
+      - json:
+          expressions:
+            level: level
+            message: message
+            timestamp: timestamp
+          on_error: continue
+      - labels:
+          level:
+      - timestamp:
+          source: timestamp
+          format: '2006-01-02T15:04:05.999999999Z07:00'
+          on_failure: continue
+```
+
+- [ ] **Step 2: Mount the Docker socket into promtail**
+
+In `docker-compose.yml`, the `promtail:` service `volumes:` block currently is:
+
+```yaml
+    volumes:
+      - ./docker/promtail/config.yml:/etc/promtail/config.yml:ro
+      - ./:/var/log/app:ro
+      - ./data:/var/log/data:ro
+```
+
+Add one mount (read-only socket):
+
+```yaml
+    volumes:
+      - ./docker/promtail/config.yml:/etc/promtail/config.yml:ro
+      - ./:/var/log/app:ro
+      - ./data:/var/log/data:ro
+      # Docker socket for docker_sd_configs container-stdout discovery (ADR-733).
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+```
+
+- [ ] **Step 3: Add the `logging: promtail` label to `autoheal`**
+
+In `docker-compose.yml`, the `autoheal:` service currently has `labels: autoheal: "true"` (added in Phase 1 Task 4). Extend that `labels:` block so autoheal's stdout is also collected:
+
+```yaml
+    labels:
+      autoheal: "true"
+      logging: "promtail"
+```
+
+(cAdvisor already got `logging: "promtail"` in P3-2 Step 1. The 4 apps stay UNLABELED — their logs are already file-tailed by `module_logs`.)
+
+- [ ] **Step 4: Validate parse**
+
+Run:
+```bash
+docker compose -f docker-compose.yml config >/dev/null && echo "COMPOSE OK"
+python3 -c "import yaml; yaml.safe_load(open('docker/promtail/config.yml')); print('PROMTAIL YAML OK')"
+```
+Expected: `COMPOSE OK` then `PROMTAIL YAML OK`.
+
+- [ ] **Step 5: Verify promtail discovers the labeled containers**
+
+Bring up the relevant containers + promtail:
+```bash
+docker compose -f docker-compose.yml up -d autoheal cadvisor loki promtail
+# wait ~30s for discovery refresh, then check promtail targets:
+curl -s http://localhost:9080/targets 2>/dev/null | grep -oE 'container=[a-z-]+' | sort -u
+# Or check Loki received a container-labeled stream:
+curl -s -G "http://localhost:3100/loki/api/v1/labels" 2>/dev/null | head
+```
+Expected: the targets output includes `container=maple-autoheal` and `container=maple-cadvisor`. (If `curl :9080/targets` returns no parseable output, check `docker logs maple-promtail` for `docker_containers` discovery lines.) Tear down:
+```bash
+docker compose -f docker-compose.yml down
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docker/promtail/config.yml docker-compose.yml
+git commit -m "$(cat <<'EOF'
+feat(observability): promtail docker_sd for opt-in container stdout
+
+Add a docker_containers docker_sd_configs job (label logging=promtail)
+and mount the Docker socket read-only into promtail. Opt-in: only
+autoheal + cadvisor stdout is collected; module logs stay file-tailed
+(unduplicated).
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task P3-4: Operator setup guide
+
+**Files:**
+- Create: `docs/21_Operations/coolify-setup-guide.md`
+
+- [ ] **Step 1: Write the guide**
+
+Create `docs/21_Operations/coolify-setup-guide.md`:
+
+````markdown
+# Coolify Setup Guide — Self-Healing Maple Stack
+
+How the maple stack runs under Coolify (3-layer self-healing) and how to operate it. Covers Phases 1–3 (ADRs 731, 732, 733).
+
+## Topology
+
+Two Coolify **Docker Compose** resources, one shared external network, one autoheal sidecar.
+
+| Resource | Compose file | Containers | Auto-deploy |
+|----------|--------------|------------|-------------|
+| `maple-infra` | `docker-compose.yml` | postgres, minio, kafka, redis, prometheus, grafana, loki, promtail, cadvisor, autoheal, minio-bootstrap | OFF (manual) |
+| `maple-apps` | `docker-compose.services.yml` | external-api, calculator, synchronizer, cleanup | ON (push to `develop`) |
+
+Network: `maple-network` is **external** — create once before first deploy:
+```bash
+docker network create --subnet=172.20.0.0/16 maple-network
+```
+
+## 3-Layer self-healing
+
+| Layer | Owner | Fires on | Action |
+|-------|-------|----------|--------|
+| L1 Docker restart policy | Docker daemon | container exit | instant restart |
+| L2 Coolify Sentinel | Coolify server setting | stopped/abnormal-exit container | restart |
+| L3 autoheal | autoheal sidecar | `health_status=unhealthy` (labeled containers) | `docker restart` |
+
+Every persistent container has a `healthcheck` + the `autoheal: "true"` label. Excluded: `minio-bootstrap` (one-shot), `autoheal` (cannot restart itself).
+
+## Secrets
+
+| Tier | Mechanism | Examples |
+|------|-----------|----------|
+| A. Coolify Secrets (encrypted) | Coolify UI → env | `DB_ROOT_PASSWORD`, `NEXON_API_KEY`, `MINIO_ROOT_USER/PASSWORD`, `GRAFANA_ADMIN_*`, `SA_*_SECRET_KEY` |
+| B. File secret (SA keys) | bind mount at `SECRETS_DIR_HOST` (`/opt/maple/secrets`) | `sa-<module>.key` (4 files) |
+| C. Plain config | Coolify env | `DB_URL`, `KAFKA_BOOTSTRAP_SERVERS`, image refs, `SECRETS_DIR` |
+
+`/opt/maple/secrets/` is written by `minio-bootstrap` (infra resource) and read by the apps (apps resource) via the compose `secrets:` directive. **Back it up** alongside the volumes.
+
+## Deploy order
+
+1. `docker network create --subnet=172.20.0.0/16 maple-network` (one-time)
+2. Deploy `maple-infra` → wait all healthy.
+3. Deploy `maple-apps` → wait all healthy. If infra not ready, apps crash→restart until it is.
+
+## Image pipeline (apps)
+
+```
+push to develop
+  → GitHub Actions: bootJar → build.sh → tag/push ghcr.io/zbnerd/maple-<svc>:{sha,latest}
+Coolify maple-apps (auto-deploy) → docker compose pull + up
+```
+
+Image refs in compose use `${IMAGE_<SVC>}` (default `maple/<svc>:dev` for local dev).
+
+## Rollback
+
+- **Apps:** set `IMAGE_<SVC>=ghcr.io/zbnerd/maple-<svc>:sha-<prior>` in the `maple-apps` resource env, redeploy. Or use Coolify's Rollback UI.
+- **Infra:** NOT a rollback target — postgres/kafka version downgrades risk data. Fix-forward or restore from volume backup.
+
+## Recovery verification
+
+- **Hard crash:** `docker kill maple-redis` → it restarts within seconds (L1/L2).
+- **Soft failure (unhealthy):** break a probe target or pause the service; within ~90–150s autoheal restarts it (L3). Watch `docker logs -f maple-autoheal`.
+- **Restart-rate alert:** `ContainerRestartThrashing` (cAdvisor `container_start_time_seconds`, `changes() > 2` in 5m) in the prometheus UI.
+
+## Observability gaps (pre-existing, separate cleanup)
+
+- **alertmanager:** referenced by `prometheus.yml` (`alertmanager:9093`) but only defined in the legacy `docker-compose.observability.yml` overlay; not running. Alerts evaluate in prometheus but are not delivered until alertmanager is wired into the active `docker-compose.yml`.
+- **node-exporter:** scraped by `prometheus.yml` but only defined in the legacy overlay; not running. System metrics alerts (`HighCpuUsage`, etc.) have no data until it is wired in.
+
+## Backup checklist
+
+- Named volumes: `postgres_data`, `minio_data`, `kafka_data`, `redis_data`, `loki_data`, `grafana_data`, `prometheus_data`.
+- `/opt/maple/secrets/` (SA keys).
+- Coolify resource configs (export from UI).
+````
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/21_Operations/coolify-setup-guide.md
+git commit -m "$(cat <<'EOF'
+docs(ops): Coolify setup guide for the self-healing maple stack
+
+Single operator reference for the 3-resource topology, 3-layer
+self-healing, secrets tiers, deploy order, image pipeline, rollback,
+and recovery verification. Records the pre-existing alertmanager /
+node-exporter gaps and the backup checklist.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Operator Runbook — Phase 3 activation
+
+After the Phase-3 PR merges to `develop` and the infra/apps resources redeploy with the new compose.
+
+### R-1: Enable apps auto-deploy
+
+1. Coolify UI → `maple-apps` resource → **Auto Deploy** → enable, branch `develop`.
+2. Trigger a test: push a trivial commit to `develop` → confirm GHCR image builds (CI) and `maple-apps` auto-redeploys to healthy.
+
+### R-2: Verify cAdvisor metrics + restart alert
+
+1. Confirm the cadvisor target is up: `curl -s http://localhost:9090/api/v1/targets | grep cadvisor`.
+2. Force a test restart loop (throwaway container labeled so it's scraped by cAdvisor):
+   ```bash
+   docker run -d --name thrash-test --restart=always alpine sh -c 'exit 1'
+   ```
+   cAdvisor tracks it; `container_start_time_seconds{name="thrash-test"}` changes each restart. Watch the alert:
+   ```bash
+   # In the prometheus UI (http://localhost:9090/alerts) watch ContainerRestartThrashing go pending → firing
+   ```
+3. Clean up: `docker rm -f thrash-test`.
+
+### R-3: Verify promtail ships container stdout
+
+1. In Grafana (Loki datasource), query `{container="maple-autoheal"}` — autoheal restart-event logs should appear.
+
+### R-4: Backfill ADR-733 Result/Evidence
+
+Edit `docs/01_ADR/ADR-733_coolify-observability-autodeploy.md` Section 4: cAdvisor target up, alert fired on the thrash test, promtail shipped container stdout. Commit.
+
+---
+
+## Self-Review (completed during authoring)
+
+**Spec coverage (Phase-3 slice):**
+- cAdvisor restart-rate → P3-2 ✓ (spec Section 8 option (a))
+- Restart alert rule → P3-2 ✓
+- promtail docker_sd container stdout → P3-3 ✓ (spec Section 8 gap #2)
+- Apps auto-deploy ON → Runbook R-1 ✓ (spec Section 7)
+- Ops guide → P3-4 ✓ (spec Section 9 Phase 3 exit)
+- ADR → P3-1 ✓ (RPI rule)
+- Pre-existing gaps (alertmanager, node-exporter) documented, not fixed ✓
+
+**Placeholder scan:** none. Every step has exact YAML or commands with expected output.
+
+**Consistency:** cAdvisor host port 8086 consistent across compose + prometheus scrape. Alert name `ContainerRestartThrashing` consistent across rule + runbook. `logging=promtail` label consistent across cadvisor/autoheal + promtail filter. prometheus reaches cAdvisor via `localhost:8086` (host-network pattern, matching module scrapes).
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-06-22-coolify-self-healing-phase3.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — dispatch a fresh subagent per task, review between tasks.
+
+**2. Inline Execution** — execute tasks in this session using executing-plans, batch with checkpoints.
+
+Which approach?

--- a/docs/superpowers/plans/2026-06-22-coolify-self-healing-phase3.md
+++ b/docs/superpowers/plans/2026-06-22-coolify-self-healing-phase3.md
@@ -104,7 +104,7 @@ Restart detection: cAdvisor exposes `container_start_time_seconds` (a gauge that
 
 ### Non-Risk
 
-* cAdvisor itself — covered by `restart: always` + the autoheal label.
+* cAdvisor itself — covered by `restart: always` (no healthcheck; avoids a false restart-loop on images lacking the probe binary).
 
 ---
 
@@ -177,14 +177,11 @@ Add this as a new top-level service (place it right after `prometheus:` so the o
       - /dev/kmsg
     ports:
       - "8086:8080"
-    healthcheck:
-      test: ["CMD-SHELL", "wget -q --spider http://localhost:8080/metrics || exit 1"]
-      interval: 30s
-      timeout: 5s
-      retries: 3
-      start_period: 30s
+    # No healthcheck (grill-me fix B): cAdvisor is observability infra, not
+    # business-critical — crash recovery is restart: always below. A healthcheck
+    # would risk a false restart-loop on images whose busybox lacks the probe
+    # binary, and autoheal only acts on unhealthy state anyway. See ADR-733.
     labels:
-      autoheal: "true"
       logging: "promtail"
     networks:
       - maple-network

--- a/docs/superpowers/specs/2026-06-22-coolify-self-healing-design.md
+++ b/docs/superpowers/specs/2026-06-22-coolify-self-healing-design.md
@@ -198,7 +198,8 @@ autoheal:
     AUTOHEAL_INTERVAL: 5              # unhealthy poll (seconds)
     AUTOHEAL_DEFAULT_STOP_TIMEOUT: 30
   volumes:
-    - /var/run/docker.sock:/var/run/docker.sock:ro
+    # rw required — autoheal calls the Docker restart API (:ro would break it)
+    - /var/run/docker.sock:/var/run/docker.sock
   networks: [maple-network]
 ```
 

--- a/docs/superpowers/specs/2026-06-22-coolify-self-healing-design.md
+++ b/docs/superpowers/specs/2026-06-22-coolify-self-healing-design.md
@@ -1,0 +1,357 @@
+# Coolify-aware Self-Healing & Service Management Design
+
+- Status: Proposed
+- Date: 2026-06-22
+- Owner: zbnerd
+- Related: ADR-720 (Airflow control plane adoption — names Coolify + Docker Compose as deployment layer), ADR-730 (calculator writer temp-file upload), PR #1324 (single-source MinIO SA secrets), `docs/superpowers/specs/2026-06-15-minio-operations-design.md` (Coolify per-application secret model roadmap)
+
+---
+
+## 1. Background / Problem
+
+### Background
+
+The 4 Spring Boot services (external-api, calculator, synchronizer, cleanup) and 8 infra containers (postgres, minio, kafka, redis, prometheus, grafana, loki, promtail) were dockerized in PR #1324. ADR-720 designates **Coolify + Docker Compose** as the deployment layer (K8s complexity avoidance). Coolify v4.1.2 is installed and running on the host.
+
+### Problem
+
+Investigation (2026-06-22) revealed the gap behind the original concern — *"if a container dies, restart/self-healing isn't implemented yet, right?"*:
+
+1. **The maple stack is NOT under Coolify management.** The `maple-*` containers carry no Coolify labels; they were started by manual `docker compose up`. Because Coolify does not own them, **Sentinel (Coolify's container monitor), the Coolify UI, healthcheck reporting, git auto-deploy, and crash-restart all ignore them.**
+2. **Crash recovery (process exit) IS handled** by Docker `restart` policies — `always` on infra, `unless-stopped` on apps. OOM kill, JVM panic, segfault → daemon auto-restarts.
+3. **Soft-failure recovery (process alive, `/health` DOWN) is NOT handled.** Docker `restart` policy fires only on container exit, not on `unhealthy`. Coolify v4.x lacks K8s-style liveness probes that restart unhealthy containers (ADR-720 Risk line acknowledges this: *"Coolify 미성숙 — Docker Compose fallback 유지"*).
+4. **4 app services are not currently running in Docker** (`docker ps` shows only infra). They run via `nohup java -jar` or are stopped.
+5. **4 infra containers have no healthcheck** (kafka, redis, grafana, prometheus, promtail), blocking `depends_on: service_healthy` chains and visibility.
+
+### Goal
+
+Bring the full maple stack (infra + 4 apps) under Coolify management as Docker Compose resources, and close the self-healing gap so that **both hard crashes and soft failures auto-recover**, with operational visibility.
+
+### Non-Goals
+
+- Migrating off Docker Compose to K8s/Swarm (ADR-720 explicitly defers this).
+- Redis reintroduction policy debate (ADR-022 settled — Redis allowed).
+- Readiness/liveness probe separation (deferred to a future K8s migration; current design uses a single healthcheck per service).
+- Changing StorageConfig's file-based MinIO SA secret model (PR #1324's deliberate decision is preserved).
+
+---
+
+## 2. Decision Summary
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | Migrate full stack to Coolify as **2 Docker Compose resources** (`maple-infra`, `maple-apps`) | Matches existing 2-file compose split; separates deploy cadence (infra rare, apps frequent); isolates blast radius |
+| 2 | repo compose = **single source of truth**; Coolify imports, does not fork | Keeps config version-controlled, reviewable, local-dev parity |
+| 3 | `maple-network` → **external network** (created once, shared by both resources) | Cross-resource container references; survives single-resource down |
+| 4 | **3-layer self-healing**: Docker restart policy (L1) + Coolify Sentinel crash-restart (L2) + autoheal sidecar for unhealthy→restart (L3) | L3 closes the soft-failure gap that L1/L2 cannot cover |
+| 5 | **autoheal sidecar** (`willfarrell/autoheal`) in `maple-infra`, watches all containers via Docker socket | Guaranteed unhealthy→restart, K8s-liveness-probe equivalent, works under Coolify |
+| 6 | Secrets model: **Coolify Secrets (encrypted)** for passwords + **absolute-path file bind mount** for MinIO SA keys + Coolify env for plain config | Tier-matched to secret nature; preserves PR #1324 file-based SA model; removes repo-relative bind-mount fragility under Coolify |
+| 7 | Image pipeline: **CI → GHCR → Coolify pull** (option B); infra auto-deploy OFF, apps auto-deploy ON | Server stays thin; sha-pinned rollback; infra changes deliberate |
+| 8 | **Phased rollout**: Phase 1 infra → Phase 2 apps → Phase 3 automation + ops guide | Risk reduction; validate health/autoheal/network before app migration |
+
+---
+
+## 3. Architecture / Topology
+
+### Two Coolify Docker Compose resources
+
+| Resource | Compose file | Containers | Deploy cadence |
+|----------|--------------|------------|----------------|
+| `maple-infra` | `docker-compose.yml` | postgres, minio, kafka, redis, prometheus, grafana, loki, promtail, minio-bootstrap, **autoheal** | Rare (infra stable) |
+| `maple-apps` | `docker-compose.services.yml` | external-api, calculator, synchronizer, cleanup | Frequent (git push) |
+
+### Network: external conversion
+
+```yaml
+# docker-compose.yml — remove owned network definition, reference external
+networks:
+  maple-network:
+    external: true
+    name: maple-network
+```
+One-time creation before first Coolify deploy:
+```bash
+docker network create maple-network
+```
+
+### Dependency flow (cross-resource)
+
+```
+[maple-infra resource]                    [maple-apps resource]
+  postgres (healthy) ─────────────────────► external-api
+  minio (healthy) ───────────────────────► calculator
+  kafka ──────────────────────────────────► synchronizer
+  redis ──────────────────────────────────► cleanup
+  autoheal (watches all containers via socket, both resources)
+```
+
+Cross-resource `depends_on` is not supported by Compose. Startup ordering is handled by:
+1. Infra resource deployed/healthy first.
+2. Apps crash→restart loop naturally waits for infra readiness (L1 restart policy + L3 autoheal). This is the standard pattern for split-resource Compose deployments.
+
+### autoheal placement
+
+Lives in `maple-infra`, starts first. Mounts Docker socket → monitors host-wide containers regardless of resource boundary.
+
+### Ownership transfer (data preservation)
+
+Manual `docker compose up` containers are taken down; Coolify brings up same-named containers. Named volumes (`postgres_data`, `minio_data`, `kafka_data`, `redis_data`, `loki_data`, `grafana_data`, `prometheus_data`) are reused → **data preserved** across the transfer.
+
+---
+
+## 4. Self-Healing Mechanism (3-layer)
+
+| Layer | Owner | Trigger | Latency | Covers |
+|-------|-------|---------|---------|--------|
+| **L1 Docker restart policy** | Docker daemon | container exit (non-zero) | instant (~seconds) | hard crash: OOM kill, JVM panic, segfault |
+| **L2 Coolify Sentinel** | Coolify 4.1.2 | stopped / unexpected-exit container (server setting "Auto-restart stopped/unsual containers") | tens of seconds–minutes | cases L1 misses (daemon restart gaps, exit-0 abnormal stops) |
+| **L3 autoheal sidecar** | autoheal container | `health_status=unhealthy` Docker event | ~`interval`×`retries` (typically 90–150s) | **soft failure: process alive, unresponsive** (connection-pool exhaustion, thread-pool hang, GC storm, liveness DOWN) |
+
+L3 alone covers soft failure. L1/L2 require process death. The user's original concern — *"alive but dead"* — is the L3 domain.
+
+### Soft-failure recovery flow (example)
+
+```
+calculator: connection pool exhausted → /actuator/health DOWN (process alive)
+  ↓ Docker healthcheck (wget /actuator/health, interval 30s × retries 3)
+  ↓ ~90s → health_status=unhealthy event
+  ↓ autoheal detects label autoheal=true
+  ↓ docker restart maple-calculator
+  ↓ container restart, start_period → health starting → healthy
+  ↓ recovered
+```
+
+### L2 verification item
+
+Coolify 4.1.2's "auto-restart stopped containers" server setting must be confirmed enabled (Coolify UI → Server settings). Design assumes enabled; the plan includes enabling it as an ops step if off.
+
+### autoheal safety
+
+- `start_period` generous (infra 10–40s per Section 5 table — redis fast-boot 10s, kafka slow-boot 40s, others 30s; apps 90s) to prevent boot-time false-unhealthy restart loops.
+- `autoheal` container itself: label excluded (cannot restart itself), `restart: always`.
+- `minio-bootstrap`: label excluded (one-shot, unhealthy meaningless).
+- Docker socket mount required read-write for `restart` API; Coolify already uses socket rw (same trust level on the node). Verify autoheal version's read-only socket support; fall back to rw if needed.
+
+### Thrash prevention
+
+autoheal has built-in backoff. Spring Boot liveness/readiness separation is deferred to a future K8s migration (see Non-Goals) — current design intentionally restarts on any `/health` DOWN via the single healthcheck. Readiness-only failures (drain traffic without restart) are a K8s-era concern.
+
+---
+
+## 5. Healthcheck Specs (per service)
+
+Runtime base: Alpine (prometheus, grafana, loki, promtail, eclipse-temurin runtime) → `wget` available, `curl` absent. All checks use `wget`.
+
+### New healthchecks (5 services currently without)
+
+| Service | test | interval | start_period | timeout | retries |
+|---------|------|----------|--------------|---------|---------|
+| kafka | `kafka-broker-api-versions --bootstrap-server localhost:9092 >/dev/null 2>&1` | 30s | 40s | 10s | 3 |
+| redis | `redis-cli ping` (expects `PONG`) | 10s | 10s | 3s | 3 |
+| grafana | `wget -q --spider http://localhost:3000/api/health` | 30s | 30s | 5s | 3 |
+| prometheus | `wget -q --spider http://localhost:9090/-/healthy` (host network) | 30s | 30s | 5s | 3 |
+| promtail | `wget -q --spider http://localhost:9080/ready` | 30s | 30s | 5s | 3 |
+
+### Existing healthchecks (3) — keep, add start_period
+
+| Service | test (unchanged) | added start_period |
+|---------|------------------|--------------------|
+| postgres | `pg_isready -U maple -d maple_expectation` | 30s |
+| minio | `mc ready local` | 30s |
+| loki | `wget -q --spider http://localhost:3100/ready` | 30s |
+
+### Apps (4) — common spec, port branches per service
+
+```yaml
+healthcheck:
+  test: ["CMD-SHELL", "wget -qO- http://localhost:${SERVER_PORT}/actuator/health | grep -q '\"status\":\"UP\"' || exit 1"]
+  interval: 30s
+  timeout: 5s
+  retries: 3
+  start_period: 90s   # JVM boot + Spring context
+labels:
+  autoheal: "true"
+```
+
+- `SERVER_PORT` env (8081–8084) drives dynamic port — independent of Dockerfile's generic `EXPOSE 8080`.
+- **Verification item:** `/actuator/health` web exposure confirmed. Spring Boot exposes `health` by default; plan confirms `management.endpoints.web.exposure.include` does not exclude it.
+
+### autoheal label mapping
+
+| Container | `autoheal: "true"` | Notes |
+|-----------|--------------------|-------|
+| postgres, minio, kafka, redis, loki, grafana | ✅ | persistent infra |
+| prometheus, promtail | ✅ | observability (restart on death) |
+| external-api, calculator, synchronizer, cleanup | ✅ | apps |
+| **minio-bootstrap** | ❌ | one-shot provisioning job |
+| **autoheal (self)** | ❌ | cannot self-restart; `restart: always` only |
+
+### autoheal container spec
+
+```yaml
+autoheal:
+  image: willfarrell/autoheal:latest
+  container_name: maple-autoheal
+  restart: always
+  environment:
+    AUTOHEAL_CONTAINER_LABEL: autoheal
+    AUTOHEAL_INTERVAL: 5              # unhealthy poll (seconds)
+    AUTOHEAL_DEFAULT_STOP_TIMEOUT: 30
+  volumes:
+    - /var/run/docker.sock:/var/run/docker.sock:ro
+  networks: [maple-network]
+```
+
+---
+
+## 6. Secrets & Env Model (Coolify)
+
+Current state (PR #1324): MinIO SA keys = file-based docker secrets (`/run/secrets/sa-<module>`, read via `Files.readString` in StorageConfig). Passwords (API key, DB root) = operator `.env` compose interpolation.
+
+**Problem:** Coolify copies the compose file to its own working dir (`/data/coolify/applications/<uuid>/`) before `docker compose up`. Repo-relative bind mounts (`./docker/services/secrets/sa-ext-api.key`) **break** — the path resolves differently per resource, and `minio-bootstrap` + the apps must see the same file.
+
+### 3-tier model
+
+| Tier | Kind | Mechanism | Examples |
+|------|------|-----------|----------|
+| **A. Coolify Secrets (encrypted)** | true secrets | Coolify UI "Secrets" (encrypted at rest, masked, resource-scoped) → env injection | `DB_ROOT_PASSWORD`, `NEXON_API_KEY`, `MINIO_ROOT_PASSWORD`, `MINIO_ROOT_USER`, `GRAFANA_ADMIN_PASSWORD` |
+| **B. File secret (SA keys)** | MinIO SA | **absolute host-path** bind mount (Coolify-persistent path), `MINIO_SECRET_KEY_FILE` retained | `sa-ext-api.key`, `sa-calculator.key`, `sa-synchronizer.key`, `sa-cleanup.key` |
+| **C. Plain config** | non-secret | Coolify per-resource env (plaintext) | `DB_URL`, `KAFKA_BOOTSTRAP_SERVERS`, `MINIO_ENDPOINT`, `SPRING_PROFILES_ACTIVE`, `SERVER_PORT` |
+
+### Tier-B core change: absolute host path
+
+```yaml
+# secrets path pinned to a stable absolute host location shared by both resources
+secrets:
+  sa-ext-api:
+    file: /opt/maple/secrets/sa-ext-api.key   # repo-relative → absolute
+```
+
+- `/opt/maple/secrets/` (or Coolify-recommended persistent path) = single source. `minio-bootstrap` writes; apps read.
+- Permissions: `chmod 700`; owner readable by the container's `maple` user.
+- Explicitly named as a backup target in the ops guide.
+
+### StorageConfig: no change
+
+`MINIO_SECRET_KEY_FILE` retained. PR #1324's decision (single-source SA, least-privilege per module) is preserved. The Coolify per-application secret model is the documented future (minio-operations spec) but SA keys are deliberately file-based; tier-mixing is justified because each secret's nature maps to its mechanism.
+
+### Tier-A migration (`.env` → Coolify Secrets)
+
+Operator `.env` secrets move to Coolify Secrets. `.env` remains for local dev / nohup fallback (critical-rules: `.env` is READ-ONLY, never modified). Coolify resources become self-contained — no `.env` dependency at deploy time.
+
+Dual-source compatibility: same variable names, local `docker compose` uses `.env` interpolation, Coolify uses its own env/secret injection.
+
+---
+
+## 7. Deploy / Rollback / Image Pipeline
+
+### Image build (decision B: CI → registry → Coolify pull)
+
+| Option | Flow | Pros | Cons |
+|--------|------|------|------|
+| A. Coolify pre-deploy hook build | Coolify clones repo → hook runs `build.sh` → up | single system, fewer deps | server needs JDK21+gradle, slow deploys (minutes), server build load |
+| **B. CI → GHCR → Coolify pull (chosen)** | GitHub Actions (merge to develop) builds → GHCR push `ghcr.io/.../maple-<svc>:sha-<7>` → Coolify pulls tag → up | thin server, build/deploy split, sha pinning + audit, easy rollback | registry dependency, CI build job added |
+| C. dev-machine build → server load | local build → `docker save \| ssh load` | no infra | manual, no auto-deploy |
+
+`build.sh` already produces dual tags `:dev` + `:sha-<7char>` (commit b27328824). CI pushes these to GHCR. Coolify app resources reference `ghcr.io/.../maple-<svc>:sha-<7>` (or track `:latest`).
+
+### Deploy triggers
+
+| Resource | git auto-deploy | Reason |
+|----------|-----------------|--------|
+| `maple-infra` | **OFF** (manual) | infra changes deliberate; bad version bump risks data loss; strict version pinning |
+| `maple-apps` | **ON** (push to develop → CI → image → Coolify webhook redeploy) | apps change frequently; automation value high |
+
+### Deploy order (initial transfer + ongoing)
+
+1. `docker network create maple-network` (one-time)
+2. Deploy `maple-infra` resource → postgres/minio/kafka/redis/autoheal up, wait healthy
+3. Deploy `maple-apps` resource → 4 apps up. If infra not ready, apps crash→restart loop naturally waits (Section 3 pattern)
+
+### Rollback
+
+- **Apps:** Coolify "Rollback" UI (prior deployment containers preserved) or change image tag to the previous sha and redeploy. Sha tags enable exact-version return.
+- **Infra:** rollback ≠ simple image swap. postgres/kafka version downgrade risks data migration. **Infra is not a rollback target** — on failure, fix-forward (new version) or restore from volume backup. Documented in the ops guide.
+
+---
+
+## 8. Observability (existing assets + self-heal delta)
+
+Already running: prometheus (metrics), grafana (dashboard), loki+promtail (logs). Self-healing does not rebuild the observability stack — only deltas.
+
+| Item | Method | Status |
+|------|--------|--------|
+| autoheal restart events | `docker logs maple-autoheal` + Coolify UI deployment history | built-in |
+| container unhealthy transition | Docker `health_status` event → `docker events --filter event=health_status` | manual query |
+| restart-rate metric | container restart counter in prometheus | **gap** |
+| autoheal logs → loki | promtail currently tails module logs (`./logs`, `./data`) only; container stdout not collected | **gap** |
+
+### 2 small additions (plan-included, lower priority — Phase 3)
+
+1. **autoheal log collection** — add Docker socket discovery to promtail config (container stdout collection). Filter to `logging=promtail`-labeled containers to avoid duplicate of file-tailed module logs. Or minimum: scrape autoheal only.
+2. **Restart-rate alerting** — option (a) `cAdvisor` container (per-container `restart_counter`) → grafana panel + alertmanager threshold (recommended, lightweight, infra-only); option (b) Spring Boot `app_started_time` gauge (requires distinguishing container restart vs app restart). Recommend (a).
+
+### Success criteria (operational verification)
+
+- Force-kill a container → L1/L2 auto-recovers (instant–minutes).
+- Force an app `/actuator/health` DOWN (e.g., simulate connection-pool exhaustion) → L3 autoheal restarts within ~90–150s → recovers.
+- Full recovery traceable via `docker events` + autoheal logs.
+- Both resources show healthy in Coolify UI.
+
+---
+
+## 9. Phased Rollout
+
+| Phase | Scope | Exit criteria |
+|-------|-------|---------------|
+| **1. Infra under Coolify** | `maple-infra` resource only (apps stay nohup/compose). network external conversion, healthchecks added, autoheal deployed, Sentinel setting verified | All infra containers managed by Coolify, healthy in UI, autoheal restarts a force-killed container |
+| **2. Apps under Coolify** | `maple-apps` resource. image pipeline B (CI→GHCR) built. SA key absolute-path migration. `/actuator/health` healthchecks | 4 apps managed by Coolify, L3 soft-failure recovery verified, data volumes preserved |
+| **3. Automation + ops guide** | apps git auto-deploy ON, promtail/cAdvisor observability deltas, `docs/21_Operations/coolify-setup-guide.md` written | Push to develop → auto redeploy; restart-rate alerting live |
+
+---
+
+## 10. Risks / Trade-offs
+
+### Sensitivity
+
+- Docker socket rw mount (autoheal) = host-Docker root-equivalent. Trust boundary = the Coolify node (Coolify itself uses socket rw).
+- `start_period` tuning — too short → boot-time restart loops; too long → slow soft-failure detection.
+- Infra version bumps (postgres/kafka) — irreversible data-migration risk; mitigated by infra auto-deploy OFF + manual version pinning.
+- Cross-resource startup ordering — apps must tolerate infra-not-ready via crash→restart (standard pattern, but adds startup latency on cold boot).
+
+### Trade-offs
+
+| Choice | Gain | Forego |
+|--------|------|--------|
+| autoheal sidecar over pure Coolify-native | guaranteed unhealthy→restart (soft-failure coverage) | extra container + socket mount |
+| 2 resources over 1 | deploy cadence split, blast-radius isolation | 2 resources to manage + external network |
+| CI→GHCR over Coolify-internal build | thin server, sha audit, clean rollback | registry dependency + CI job |
+| File-based SA keys (tier-B) preserved | PR #1324 consistency, least-privilege SA | two secret mechanisms (transitional, tier-justified) |
+
+### Risk (residual)
+
+- autoheal itself dies → no L3. Mitigated by `restart: always` + Coolify UI visibility. No autoheal-of-autoheal (acceptable; autoheal is trivially stateless).
+- Single-node Coolify — no multi-node HA (ADR-720 scope; multi-node is a later phase).
+
+### Non-Risk
+
+- Data loss on Coolify takeover — named volumes reused, data preserved.
+- `.env` regression — `.env` untouched (READ-ONLY rule), only superseded at Coolify deploy time by Coolify Secrets.
+
+---
+
+## 11. Verification Items (for the implementation plan)
+
+- [ ] Coolify 4.1.2 "Auto-restart stopped containers" server setting enabled.
+- [ ] `/actuator/health` exposed on all 4 apps (`management.endpoints.web.exposure.include`).
+- [ ] autoheal image version supports read-only Docker socket (else rw fallback).
+- [ ] prometheus/grafana/loki/promtail images include `wget` (busybox) — spot-check.
+- [ ] `/opt/maple/secrets/` path writable by minio-bootstrap, readable by app containers' `maple` user.
+- [ ] GHCR registry + GitHub Actions CI build job wired (Phase 2).
+- [ ] Named volumes intact after Coolify takeover (dry-run: `docker volume ls` before/after).
+
+---
+
+## 12. Summary
+
+> Bring the maple stack under Coolify as two Docker Compose resources (`maple-infra`, `maple-apps`) with an external shared network, and close the self-healing gap with a 3-layer model — Docker restart policy + Coolify Sentinel + autoheal sidecar — so both hard crashes and soft failures (process-alive-but-unhealthy) auto-recover, with SA keys on a stable absolute path and apps deployed via CI→GHCR image pipeline.


### PR DESCRIPTION
## Summary

Brings the infra stack under Coolify as a self-healing Docker Compose resource and closes the soft-failure self-healing gap. Investigation found the `maple-*` containers were running as plain `docker compose up` (NOT Coolify-managed), and soft failures (process alive, `/health` DOWN) were not covered — Docker `restart` fires only on exit, and Coolify v4.x has no K8s-style liveness probe.

**3-layer self-healing (ADR-731):**
- L1 Docker `restart: always` (existing) — hard crash
- L2 Coolify Sentinel crash-restart (server setting)
- L3 `autoheal` sidecar — `health_status=unhealthy` → `docker restart` (the new soft-failure coverage)

**This PR (Phase 1):**
- Design spec + Phase 1/2/3 implementation plans
- `maple-network` → external (shared with the future `maple-apps` resource)
- healthchecks on all 8 infra containers (5 new: kafka/redis/grafana/prometheus/promtail; `start_period` added to postgres/minio/loki)
- `autoheal` sidecar + `autoheal: "true"` labels on the 8 persistent services
- ci.yml `docker-smoke` job: create the external network before compose up

**Grill-me review applied:** promtail healthcheck uses `bash /dev/tcp` (image ships no wget/curl — verified in-container), autoheal gains a socket-presence healthcheck, kafka `start_period` 40s→60s, ci network-create inspect-first idiom, socket mount documented as rw, prometheus host-network L3 caveat + external-network teardown lifecycle noted in ADR-731.

**Phase 2 (apps + CI→GHCR) and Phase 3 (cAdvisor, promtail docker_sd, ops guide)** ship as separate follow-up PRs; their plans are included here for design completeness.

## Test plan
- [x] `docker compose -f docker-compose.yml config` parses (infra + full-stack overlay)
- [x] promtail healthcheck command verified in-container (`bash /dev/tcp/localhost/9080` PASS, server listens on 9080)
- [x] autoheal label count = 8 (postgres/minio/kafka/redis/loki/grafana/prometheus/promtail); minio-bootstrap + autoheal excluded
- [x] ci.yml YAML valid; network-create step placed before compose up
- [ ] CI: `docker-smoke` green (external network created, full stack healthchecks pass)
- [ ] Operator runbook (not in this PR's automation): create `maple-infra` Coolify resource, enable Sentinel auto-restart, force-kill + force-unhealthy recovery verification on the live host

🤖 Generated with [Claude Code](https://claude.com/claude-code)