### PR TITLE
feat(coolify): Phase 2 — apps under Coolify + CI->GHCR image pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ permissions:
   contents: read
   checks: write           # Required for test report annotations
   pull-requests: write    # Required for PR comments
+  packages: write         # Required for GHCR image push (ADR-732)
 
 # Concurrency: Cancel in-progress runs for same PR (save resources)
 concurrency:
@@ -466,3 +467,52 @@ jobs:
           rm -f docker/services/secrets/sa-synchronizer.key
           rm -f docker/services/secrets/sa-cleanup.key
           rmdir docker/services/secrets 2>/dev/null || true
+
+  # ============================================
+  # Build & Push Images to GHCR (ADR-732)
+  # Runs only on pushes to develop (merges). Builds the 4 service images
+  # via build.sh (local maple/<svc>:sha-<7>), re-tags and pushes them to
+  # ghcr.io/zbnerd/maple-<svc>:{sha-<7>,latest}. PR builds are validated
+  # by the docker-smoke job (which uses local :dev images), so this job
+  # does not gate PRs.
+  # ============================================
+  build-and-push:
+    name: Build & Push Images (GHCR)
+    runs-on: ubuntu-latest
+    needs: test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+    env:
+      GHCR_OWNER: zbnerd
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup JDK ${{ env.JAVA_VERSION }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: 'temurin'
+
+      - name: Grant Execute Permission for Gradlew
+        run: chmod +x gradlew
+
+      - name: Build service jars
+        run: ./gradlew :module-external-api:bootJar :module-calculator:bootJar :module-synchronizer:bootJar :module-cleanup:bootJar -x test --no-daemon
+
+      - name: Build service images (build.sh)
+        run: ./docker/services/build.sh
+
+      - name: Login to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Tag & push images (sha + latest)
+        run: |
+          set -euo pipefail
+          SHA7="$(git rev-parse --short=7 HEAD)"
+          echo "Publishing sha-${SHA7} + latest for GHCR_OWNER=${GHCR_OWNER}"
+          for mod in external-api calculator synchronizer cleanup; do
+            docker tag "maple/${mod}:sha-${SHA7}" "ghcr.io/${GHCR_OWNER}/maple-${mod}:sha-${SHA7}"
+            docker tag "maple/${mod}:sha-${SHA7}" "ghcr.io/${GHCR_OWNER}/maple-${mod}:latest"
+            docker push "ghcr.io/${GHCR_OWNER}/maple-${mod}:sha-${SHA7}"
+            docker push "ghcr.io/${GHCR_OWNER}/maple-${mod}:latest"
+          done

--- a/docker-compose.services.yml
+++ b/docker-compose.services.yml
@@ -14,7 +14,15 @@
 
 services:
   external-api:
-    image: maple/external-api:dev
+    image: ${IMAGE_EXTERNAL_API:-maple/external-api:dev}
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O - http://localhost:$${SERVER_PORT}/actuator/health | grep -q '\"status\":\"UP\"' || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 90s
+    labels:
+      autoheal: "true"
     container_name: maple-external-api
     restart: unless-stopped
     ports:
@@ -41,7 +49,15 @@ services:
       kafka:    {condition: service_started}
 
   calculator:
-    image: maple/calculator:dev
+    image: ${IMAGE_CALCULATOR:-maple/calculator:dev}
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O - http://localhost:$${SERVER_PORT}/actuator/health | grep -q '\"status\":\"UP\"' || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 90s
+    labels:
+      autoheal: "true"
     container_name: maple-calculator
     restart: unless-stopped
     ports:
@@ -67,7 +83,15 @@ services:
       minio:    {condition: service_healthy}
 
   synchronizer:
-    image: maple/synchronizer:dev
+    image: ${IMAGE_SYNCHRONIZER:-maple/synchronizer:dev}
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O - http://localhost:$${SERVER_PORT}/actuator/health | grep -q '\"status\":\"UP\"' || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 90s
+    labels:
+      autoheal: "true"
     container_name: maple-synchronizer
     restart: unless-stopped
     ports:
@@ -96,7 +120,15 @@ services:
       redis:    {condition: service_started}
 
   cleanup:
-    image: maple/cleanup:dev
+    image: ${IMAGE_CLEANUP:-maple/cleanup:dev}
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O - http://localhost:$${SERVER_PORT}/actuator/health | grep -q '\"status\":\"UP\"' || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 90s
+    labels:
+      autoheal: "true"
     container_name: maple-cleanup
     restart: unless-stopped
     ports:
@@ -124,10 +156,10 @@ services:
 
 secrets:
   sa-ext-api:
-    file: docker/services/secrets/sa-ext-api.key
+    file: ${SECRETS_DIR_HOST:-docker/services/secrets}/sa-ext-api.key
   sa-calculator:
-    file: docker/services/secrets/sa-calculator.key
+    file: ${SECRETS_DIR_HOST:-docker/services/secrets}/sa-calculator.key
   sa-synchronizer:
-    file: docker/services/secrets/sa-synchronizer.key
+    file: ${SECRETS_DIR_HOST:-docker/services/secrets}/sa-synchronizer.key
   sa-cleanup:
-    file: docker/services/secrets/sa-cleanup.key
+    file: ${SECRETS_DIR_HOST:-docker/services/secrets}/sa-cleanup.key

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -256,11 +256,20 @@ services:
       # Override .env.bootstrap MINIO_ENDPOINT for in-container DNS.
       # .env.bootstrap keeps localhost:9000 so host-side tooling works.
       MINIO_ENDPOINT: http://minio:9000
+      # SA key output path (ADR-732). Coolify sets this to /opt/maple/secrets;
+      # local dev leaves it unset → bootstrap defaults to /workspace/docker/services/secrets.
+      SECRETS_DIR: ${SECRETS_DIR:-/workspace/docker/services/secrets}
     volumes:
       - ./docker/minio:/scripts:ro
-      # /workspace = repo root, writable so bootstrap.sh can persist SA secrets
-      # to docker/services/secrets/ and .env.<module>. See plan task 8.
+      # /workspace = repo root (local dev). bootstrap's REPO_ROOT fallback
+      # and host-side tooling read SA keys here when SECRETS_DIR is unset.
       - ./:/workspace:rw
+      # SA secrets output dir (ADR-732). When SECRETS_DIR_HOST is set
+      # (Coolify: /opt/maple/secrets), mount that host path read-write so
+      # bootstrap writes keys there and the maple-apps resource reads them.
+      # Local dev: defaults to the repo dir under the /workspace mount above
+      # (redundant but harmless bind).
+      - ${SECRETS_DIR_HOST:-./docker/services/secrets}:${SECRETS_DIR:-/workspace/docker/services/secrets}:rw
     entrypoint: /bin/sh /scripts/bootstrap.sh
     restart: "no"
 

--- a/docker/minio/bootstrap.sh
+++ b/docker/minio/bootstrap.sh
@@ -82,6 +82,14 @@ if [ ! -d "${REPO_ROOT}/docker" ]; then
 fi
 echo "[bootstrap] REPO_ROOT=${REPO_ROOT}"
 
+# SECRETS_DIR: where SA key files are written. Defaults to the repo's
+# docker/services/secrets for local dev (REPO_ROOT is /workspace in the
+# minio-bootstrap container, the host repo root otherwise). Coolify sets
+# this to an absolute host path (/opt/maple/secrets) so both the
+# maple-infra and maple-apps resources read the same files — repo-relative
+# paths break under Coolify's deploy dir. See ADR-732.
+SECRETS_DIR="${SECRETS_DIR:-${REPO_ROOT}/docker/services/secrets}"
+
 declare -A SA_TO_MODULE=(
   [ext-api]=ext-api
   [calculator]=calculator
@@ -89,8 +97,8 @@ declare -A SA_TO_MODULE=(
   [cleanup]=cleanup
 )
 
-mkdir -p "${REPO_ROOT}/docker/services/secrets"
-chmod 700 "${REPO_ROOT}/docker/services/secrets"
+mkdir -p "${SECRETS_DIR}"
+chmod 700 "${SECRETS_DIR}"
 
 for sa in "${!sa_secret_keys[@]}"; do
   secret="${sa_secret_keys[$sa]}"
@@ -98,9 +106,9 @@ for sa in "${!sa_secret_keys[@]}"; do
 
   # Mode 0444 so the container's non-root user (maple, UID 1000) can read
   # the secret. Compose v3.8 secret mounts preserve the source file's mode.
-  printf '%s' "${secret}" > "${REPO_ROOT}/docker/services/secrets/sa-${module}.key"
-  chmod 0444 "${REPO_ROOT}/docker/services/secrets/sa-${module}.key"
-  echo "[bootstrap] wrote ${REPO_ROOT}/docker/services/secrets/sa-${module}.key"
+  printf '%s' "${secret}" > "${SECRETS_DIR}/sa-${module}.key"
+  chmod 0444 "${SECRETS_DIR}/sa-${module}.key"
+  echo "[bootstrap] wrote ${SECRETS_DIR}/sa-${module}.key"
 done
 
 echo "[bootstrap] complete"

--- a/docs/01_ADR/ADR-732_coolify-apps-image-pipeline.md
+++ b/docs/01_ADR/ADR-732_coolify-apps-image-pipeline.md
@@ -1,0 +1,84 @@
+# ADR-732: Apps under Coolify with CI→GHCR image pipeline
+
+- Status: Accepted
+- Date: 2026-06-22
+- Owner: zbnerd
+
+---
+
+## 1. Background / Problem
+
+### Background
+
+- Phase 1 (ADR-731) put infra under Coolify with 3-layer self-healing. The 4 app services still run via `nohup java -jar` or manual `docker compose up`, not under Coolify.
+- `build.sh` produces local-only images (`maple/<svc>:dev` + `:sha-<7>`). There is no registry, no server-side image source.
+
+### Problem
+
+- Apps are not Coolify-managed → no Sentinel restart, no UI, no auto-deploy, no L3 self-healing.
+- MinIO SA keys live at repo-relative `./docker/services/secrets/`. Coolify copies compose to its own deploy dir, so this path resolves differently per resource and the apps cannot reliably read the keys the infra resource's `minio-bootstrap` wrote.
+
+### Goal
+
+- Apps deploy from a registry image via Coolify; SA keys sit on a stable absolute host path shared by both resources; every app has the L3 healthcheck + autoheal label.
+
+---
+
+## 2. Decision
+
+> Build images in CI, push to GHCR; reference them in compose via per-service image env vars; move SA keys to a `SECRETS_DIR`-driven absolute path.
+
+```text
+push to develop
+  → GitHub Actions: bootJar → build.sh (local maple/<svc>:sha-<7>)
+  → re-tag + push ghcr.io/zbnerd/maple-<svc>:{sha-<7>,latest}
+Coolify maple-apps resource (image env → ghcr path) → docker compose up
+SA keys: bootstrap writes $SECRETS_DIR; apps read $SECRETS_DIR_HOST via secrets: file:
+```
+
+---
+
+## 3. Trade-offs
+
+### Sensitivity
+
+* GHCR availability — Coolify deploy blocks if registry unreachable (imagePullBackOff). Mitigation: `:latest` + `:sha` both pushed; pin to sha for audit, latest for auto-deploy.
+* `/opt/maple/secrets` must exist + be backed up — losing it = no app SA access.
+
+### Trade-off
+
+| 선택 | 얻는 것 | 포기한 것 |
+| -- | ---- | ----- |
+| CI→GHCR over Coolify-internal build | thin server, sha audit, clean rollback | registry dependency + CI build minutes |
+| Per-service `${IMAGE_<SVC>}` env var | full image control, no path-separator bugs | 4 env vars instead of 1 prefix |
+| Absolute SA path over repo-relative | shared by both Coolify resources | local dev needs SECRETS_DIR unset (default preserves old behavior) |
+
+### Risk
+
+* GHCR package visibility defaults to inherited/private — Coolify must be authorized to pull. Mitigation: set package visibility + Coolify pull token in ops runbook.
+
+### Non-Risk
+
+* docker-smoke CI job — uses local `maple/<svc>:dev` (IMAGE_* unset); unaffected.
+* Local dev — SECRETS_DIR/SECRETS_DIR_HOST unset → defaults to repo-relative path; unchanged workflow.
+
+---
+
+## 4. Result / Evidence
+
+### Metrics
+
+| Metric | Value | Notes |
+| ------ | ----: | ----- |
+| apps under Coolify (before) | 0 | nohup/manual compose |
+| image source (before) | local only | no registry |
+
+### Observed Result
+
+Code changes merged (Phase 2). Operator live-migration (GHCR package publish on first develop push, `maple-apps` Coolify resource deploy + L3 recovery verification) pending on the Coolify host (runbook R-1..R-6 in the Phase 2 plan).
+
+---
+
+## 5. Summary
+
+> Deploy the 4 apps from GHCR images under Coolify, with SA keys on a shared absolute path and L3 healthchecks, so the app layer gains the same self-healing the infra layer has.


### PR DESCRIPTION
## Summary

Brings the 4 Spring Boot services under Coolify with the same 3-layer self-healing as the infra layer, and establishes a CI→GHCR image pipeline so Coolify can deploy the apps.

**Apps layer (ADR-732):**
- `bootstrap.sh` honors a `SECRETS_DIR` env (default repo-relative for local dev). Coolify sets it to `/opt/maple/secrets` so the maple-infra + maple-apps resources share SA keys.
- `minio-bootstrap` gets a `SECRETS_DIR` env + a bind mount of the secrets host dir.
- `docker-compose.services.yml`: each app image is referenced via `${IMAGE_<SVC>}` (default `maple/<svc>:dev` so local dev + docker-smoke are unchanged). SA key paths route through `${SECRETS_DIR_HOST}`. Each app gains the L3 `/actuator/health` healthcheck (runtime-verified: `$$`-escaped `SERVER_PORT`, GNU wget + grep present in the JRE alpine base) + `autoheal: "true"` label.

**Image pipeline (CI):**
- New `build-and-push` job gated to `push` to `develop` (does NOT gate PRs). Builds jars + images via the existing `build.sh`, re-tags and pushes `ghcr.io/zbnerd/maple-<svc>:{sha-<7>,latest}`. Adds `packages: write` permission; uses the auto-provided `GITHUB_TOKEN` for GHCR login. Docker-smoke (PR) is unaffected — still uses local `:dev` images.

**Grill-me review applied:**
- Runtime-verified the `$$` escape passes `${SERVER_PORT}` to the container (not compose-interpolated). Verified eclipse-temurin:21-jre-alpine ships GNU wget + grep and the fetch+grep pattern works. Verified combined stack parses in both default and Coolify-mode (IMAGE_* + SECRETS_DIR set). GHCR owner `zbnerd` matches git remote; build.sh tags (`maple/<mod>:sha-${SHA}`) match the build-and-push tag references.

**Operator runbook (not in this PR's automation):** seed `/opt/maple/secrets` from existing keys, create the `maple-apps` Coolify resource (env: `IMAGE_*` → ghcr paths, `SECRETS_DIR*` → `/opt/maple/secrets`, Secrets: `DB_ROOT_PASSWORD`, `NEXON_API_KEY`), deploy + verify L3 recovery.

## Test plan
- [x] `docker compose -f docker-compose.yml config` parses
- [x] `docker compose -f docker-compose.yml -f docker-compose.services.yml config` parses (default + Coolify-mode env)
- [x] `bash -n docker/minio/bootstrap.sh` syntax OK; SECRETS_DIR default + override verified
- [x] IMAGE_* defaults = `maple/<svc>:dev`; Coolify-mode = `ghcr.io/zbnerd/maple-<svc>:latest`
- [x] App healthcheck command runs in eclipse-temurin:21-jre-alpine (GNU wget + grep)
- [x] 4 app healthchecks + 4 `autoheal: "true"` labels; minio-bootstrap excluded
- [x] ci.yml YAML valid; 5 jobs (`test`, `security-scan`, `minio-it`, `docker-smoke`, `build-and-push`); `packages: write`
- [ ] CI: docker-smoke green; build-and-push job runs on first develop merge and publishes 4 GHCR packages
- [ ] Operator: `maple-apps` Coolify resource deploys all 4 apps healthy; L3 soft-failure recovery verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)