### PR TITLE
feat(coolify): Phase 3 — cAdvisor restart alert + promtail docker_sd + ops guide

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,30 @@ services:
       retries: 3
       start_period: 30s
 
+  # cAdvisor — per-container metrics for restart-rate alerting (ADR-733).
+  # Exposes container_start_time_seconds (a gauge that jumps on each restart);
+  # prometheus evaluates ContainerRestartThrashing via changes() on it.
+  # Host port 8086 (container internal 8080) to avoid app-port conflicts.
+  # No healthcheck (observability infra; crash recovery = restart:always).
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:latest
+    container_name: maple-cadvisor
+    restart: always
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+      - /dev/disk/:/dev/disk:ro
+    devices:
+      - /dev/kmsg
+    ports:
+      - "8086:8080"
+    labels:
+      logging: "promtail"
+    networks:
+      - maple-network
+
   # PostgreSQL + PGMQ (Primary Database - Issue #589, #590, #591)
   # Replaced: MySQL, MongoDB, Redis Queue
   postgres:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -203,6 +203,8 @@ services:
       - ./docker/promtail/config.yml:/etc/promtail/config.yml:ro
       - .:/var/log/app:ro
       - ./data:/var/log/data:ro
+      # Docker socket for docker_sd_configs container-stdout discovery (ADR-733).
+      - /var/run/docker.sock:/var/run/docker.sock:ro
     networks:
       - maple-network
     depends_on:
@@ -249,6 +251,8 @@ services:
     image: willfarrell/autoheal:latest
     container_name: maple-autoheal
     restart: always
+    labels:
+      logging: "promtail"
     environment:
       AUTOHEAL_CONTAINER_LABEL: autoheal
       AUTOHEAL_INTERVAL: 5

--- a/docker/prometheus/prometheus.yml
+++ b/docker/prometheus/prometheus.yml
@@ -71,3 +71,16 @@ scrape_configs:
       - targets: ['node-exporter:9100']
         labels:
           component: 'system'
+
+  # ============================================
+  # cAdvisor - per-container metrics (restart-rate alerting, ADR-733)
+  # Reached via the host port (prometheus uses network_mode: host).
+  # ============================================
+  - job_name: 'cadvisor'
+    scrape_interval: 15s
+    scrape_timeout: 10s
+    metrics_path: '/metrics'
+    static_configs:
+      - targets: ['localhost:8086']
+        labels:
+          component: 'containers'

--- a/docker/prometheus/rules/alert_rules.yml
+++ b/docker/prometheus/rules/alert_rules.yml
@@ -242,3 +242,18 @@ groups:
         annotations:
           summary: "Large sync queue size"
           description: "Sync queue size is {{ $value }} for more than 5 minutes"
+
+      # ============================================
+      # Container Restart Thrashing (ADR-733)
+      # cAdvisor's container_start_time_seconds jumps on each container
+      # restart; changes() counts those jumps over the window.
+      # ============================================
+      - alert: ContainerRestartThrashing
+        expr: changes(container_start_time_seconds{container!="",container!="POD"}[5m]) > 2
+        for: 1m
+        labels:
+          severity: warning
+          category: system
+        annotations:
+          summary: "Container {{ $labels.name }} is restarting repeatedly"
+          description: "{{ $labels.name }} restarted {{ $value }} times in the last 5m"

--- a/docker/promtail/config.yml
+++ b/docker/promtail/config.yml
@@ -57,3 +57,33 @@ scrape_configs:
           job: artifact-logs
           app: maple-expectation
           __path__: /var/log/data/runs/**/*.log
+
+  # Container stdout collection (ADR-733). opt-in: only containers carrying
+  # the label logging=promtail are scraped, so the file-tailed module logs
+  # above are NOT duplicated. Targets the docker socket.
+  - job_name: docker_containers
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 30s
+        filters:
+          - name: label
+            values: ["logging=promtail"]
+    relabel_configs:
+      - source_labels: ["__meta_docker_container_name"]
+        regex: '/(.*)'
+        target_label: container
+      - source_labels: ["__meta_docker_container_label_com_docker_compose_service"]
+        target_label: service
+    pipeline_stages:
+      - json:
+          expressions:
+            level: level
+            message: message
+            timestamp: timestamp
+          on_error: continue
+      - labels:
+          level:
+      - timestamp:
+          source: timestamp
+          format: '2006-01-02T15:04:05.999999999Z07:00'
+          on_failure: continue

--- a/docs/01_ADR/ADR-733_coolify-observability-autodeploy.md
+++ b/docs/01_ADR/ADR-733_coolify-observability-autodeploy.md
@@ -1,0 +1,85 @@
+# ADR-733: Observability (cAdvisor restart alert) + apps auto-deploy
+
+- Status: Accepted
+- Date: 2026-06-22
+- Owner: zbnerd
+
+---
+
+## 1. Background / Problem
+
+### Background
+
+- Phases 1–2 (ADR-731/732) gave infra + apps 3-layer self-healing under Coolify. Visibility into restarts was a noted gap (spec Section 8).
+
+### Problem
+
+- No metric tells us when containers are thrashing (restart loops). The autoheal/restart policies work silently.
+- Container stdout (e.g., autoheal restart events) is not collected — promtail only tails module log files.
+- App deploys are still manual; push-to-develop should redeploy.
+- No single ops document for the Coolify topology.
+
+### Goal
+
+- A restart-rate alert; opt-in container stdout logging; apps auto-deploy; a setup guide.
+
+---
+
+## 2. Decision
+
+> Add cAdvisor for per-container metrics + a `ContainerRestartThrashing` alert on `container_start_time_seconds`; add a promtail `docker_sd_configs` job opt-in via label; enable Coolify auto-deploy for `maple-apps`; write `docs/21_Operations/coolify-setup-guide.md`.
+
+```text
+cAdvisor (container_start_time_seconds) → prometheus → ContainerRestartThrashing rule
+container stdout (label logging=promtail) → promtail docker_sd → Loki
+push to develop → GHCR image → Coolify maple-apps auto-deploy
+```
+
+Restart detection: cAdvisor exposes `container_start_time_seconds` (a gauge that jumps on each restart). `changes(...[5m])` counts those jumps; >2 in 5m fires the alert.
+
+---
+
+## 3. Trade-offs
+
+### Sensitivity
+
+* cAdvisor mounts `/` (rootfs) read-only + docker socket paths — broad host read access (standard cAdvisor requirement; read-only).
+* promtail now reads the Docker socket (ro) for discovery — same trust class as autoheal.
+* `changes()` on a gauge can count non-restart value fluctuations in edge cases; `for: 1m` + threshold >2 dampens false positives.
+
+### Trade-off
+
+| 선택 | 얻는 것 | 포기한 것 |
+| -- | ---- | ----- |
+| cAdvisor `container_start_time_seconds` + `changes()` | per-container restart visibility, no extra exporter | gauge-based counting (not a true restart_counter) |
+| opt-in `logging=promtail` label | avoids duplicating file-tailed module logs | only labeled containers' stdout is collected |
+| auto-deploy ON for apps | push-to-deploy | bad commit auto-redeploys; mitigated by sha rollback |
+
+### Risk
+
+* alertmanager is referenced by prometheus but NOT running (only in the legacy `docker-compose.observability.yml` overlay). The restart alert will be evaluated and visible in the prometheus UI, but delivery (Slack/email) requires wiring alertmanager — deferred.
+
+### Non-Risk
+
+* cAdvisor itself — covered by `restart: always` (no healthcheck; avoids a false restart-loop on images lacking the probe binary).
+
+---
+
+## 4. Result / Evidence
+
+### Metrics
+
+| Metric | Value | Notes |
+| ------ | ----: | ----- |
+| restart-rate metric (before) | none | silent thrashing |
+| container stdout collection (before) | none | file-tailed module logs only |
+
+### Observed Result
+
+Code changes merged (Phase 3). Operator verification (cAdvisor target up, alert fires on a forced-restart test, promtail ships container stdout to Loki) pending on the Coolify host (runbook R-2/R-3 in the Phase 3 plan).
+
+---
+
+## 5. Summary
+
+> Add cAdvisor-based restart alerting, opt-in container stdout logging, apps auto-deploy, and a setup guide to complete Coolify self-healing observability.

--- a/docs/21_Operations/coolify-setup-guide.md
+++ b/docs/21_Operations/coolify-setup-guide.md
@@ -1,0 +1,75 @@
+# Coolify Setup Guide — Self-Healing Maple Stack
+
+How the maple stack runs under Coolify (3-layer self-healing) and how to operate it. Covers Phases 1–3 (ADRs 731, 732, 733).
+
+## Topology
+
+Two Coolify **Docker Compose** resources, one shared external network, one autoheal sidecar.
+
+| Resource | Compose file | Containers | Auto-deploy |
+|----------|--------------|------------|-------------|
+| `maple-infra` | `docker-compose.yml` | postgres, minio, kafka, redis, prometheus, grafana, loki, promtail, cadvisor, autoheal, minio-bootstrap | OFF (manual) |
+| `maple-apps` | `docker-compose.services.yml` | external-api, calculator, synchronizer, cleanup | ON (push to `develop`) |
+
+Network: `maple-network` is **external** — create once before first deploy:
+```bash
+docker network create --subnet=172.20.0.0/16 maple-network
+```
+
+## 3-Layer self-healing
+
+| Layer | Owner | Fires on | Action |
+|-------|-------|----------|--------|
+| L1 Docker restart policy | Docker daemon | container exit | instant restart |
+| L2 Coolify Sentinel | Coolify server setting | stopped/abnormal-exit container | restart |
+| L3 autoheal | autoheal sidecar | `health_status=unhealthy` (labeled containers) | `docker restart` |
+
+Every persistent container has a `healthcheck` + the `autoheal: "true"` label. Excluded: `minio-bootstrap` (one-shot), `autoheal` (cannot restart itself), `cadvisor` (observability infra; `restart: always` only — no healthcheck, to avoid false restart-loops on images lacking the probe binary).
+
+## Secrets
+
+| Tier | Mechanism | Examples |
+|------|-----------|----------|
+| A. Coolify Secrets (encrypted) | Coolify UI → env | `DB_ROOT_PASSWORD`, `NEXON_API_KEY`, `MINIO_ROOT_USER/PASSWORD`, `GRAFANA_ADMIN_*`, `SA_*_SECRET_KEY` |
+| B. File secret (SA keys) | bind mount at `SECRETS_DIR_HOST` (`/opt/maple/secrets`) | `sa-<module>.key` (4 files) |
+| C. Plain config | Coolify env | `DB_URL`, `KAFKA_BOOTSTRAP_SERVERS`, image refs, `SECRETS_DIR` |
+
+`/opt/maple/secrets/` is written by `minio-bootstrap` (infra resource) and read by the apps (apps resource) via the compose `secrets:` directive. **Back it up** alongside the volumes.
+
+## Deploy order
+
+1. `docker network create --subnet=172.20.0.0/16 maple-network` (one-time)
+2. Deploy `maple-infra` → wait all healthy.
+3. Deploy `maple-apps` → wait all healthy. If infra not ready, apps crash→restart until it is.
+
+## Image pipeline (apps)
+
+```
+push to develop
+  → GitHub Actions: bootJar → build.sh → tag/push ghcr.io/zbnerd/maple-<svc>:{sha,latest}
+Coolify maple-apps (auto-deploy) → docker compose pull + up
+```
+
+Image refs in compose use `${IMAGE_<SVC>}` (default `maple/<svc>:dev` for local dev).
+
+## Rollback
+
+- **Apps:** set `IMAGE_<SVC>=ghcr.io/zbnerd/maple-<svc>:sha-<prior>` in the `maple-apps` resource env, redeploy. Or use Coolify's Rollback UI.
+- **Infra:** NOT a rollback target — postgres/kafka version downgrades risk data. Fix-forward or restore from volume backup.
+
+## Recovery verification
+
+- **Hard crash:** `docker kill maple-redis` → it restarts within seconds (L1/L2).
+- **Soft failure (unhealthy):** break a probe target or pause the service; within ~90–150s autoheal restarts it (L3). Watch `docker logs -f maple-autoheal`.
+- **Restart-rate alert:** `ContainerRestartThrashing` (cAdvisor `container_start_time_seconds`, `changes() > 2` in 5m) in the prometheus UI.
+
+## Observability gaps (pre-existing, separate cleanup)
+
+- **alertmanager:** referenced by `prometheus.yml` (`alertmanager:9093`) but only defined in the legacy `docker-compose.observability.yml` overlay; not running. Alerts evaluate in prometheus but are not delivered until alertmanager is wired into the active `docker-compose.yml`.
+- **node-exporter:** scraped by `prometheus.yml` but only defined in the legacy overlay; not running. System metrics alerts (`HighCpuUsage`, etc.) have no data until it is wired in.
+
+## Backup checklist
+
+- Named volumes: `postgres_data`, `minio_data`, `kafka_data`, `redis_data`, `loki_data`, `grafana_data`, `prometheus_data`.
+- `/opt/maple/secrets/` (SA keys).
+- Coolify resource configs (export from UI).


### PR DESCRIPTION
## Summary

Closes out the Coolify self-healing rollout — observability (cAdvisor restart alert + opt-in container stdout via promtail), and the operator setup guide. The Phase 3 ADRs and design were established alongside Phases 1–2; this PR ships the implementation.

**Observability (ADR-733):**
- `cAdvisor` container (host port 8086 → container 8080) exposing per-container `container_start_time_seconds`. `restart: always` only — no healthcheck (observability infra; avoids a false restart-loop on images lacking the probe binary).
- Prometheus scrape job for `cadvisor` (`localhost:8086`, 15s interval).
- `ContainerRestartThrashing` alert rule: `changes(container_start_time_seconds{container!="",container!="POD"}[5m]) > 2`, `for: 1m`, severity warning.
- `promtail` docker_sd_configs job, opt-in via the `logging=promtail` container label (avoids duplicating the file-tailed module logs). Docker socket mounted read-only into promtail.
- `autoheal` and `cadvisor` carry the `logging: "promtail"` label so their stdout is shipped to Loki.

**Ops guide:**
- `docs/21_Operations/coolify-setup-guide.md` — single operator reference for the 3-resource topology, 3-layer self-healing, secrets tiers, deploy order, image pipeline, rollback, recovery verification, and backup checklist. Records the pre-existing alertmanager/node-exporter gaps as separate cleanup (legacy overlay, not running).

**Grill-me review applied:** cAdvisor has no healthcheck (restart:always only) — same fix-B reasoning as promtail in Phase 1 (avoid false restart-loop on images lacking the probe binary). Runtime-verified the docker_sd filter syntax matches promtail's `name: label, values: ["logging=promtail"]` convention.

## Test plan
- [x] `docker compose -f docker-compose.yml config` parses (infra + full stack)
- [x] `docker/prometheus/prometheus.yml` + `alert_rules.yml` + `promtail/config.yml` YAML valid
- [x] cAdvisor service: no healthcheck, `restart: always`, `logging=promtail` label
- [x] promtail `docker_containers` job with `docker_sd_configs` (label filter) + socket ro mount
- [x] `autoheal` + `cadvisor` carry `logging: promtail`; 4 apps NOT labeled (file-tailed, avoid duplication)
- [ ] CI: docker-smoke green (P3 changes are config/service additions; smoke shouldn't regress)
- [ ] Operator: cAdvisor target up in Prometheus UI; `ContainerRestartThrashing` fires on a forced-restart test; promtail ships `container=maple-autoheal` / `container=maple-cadvisor` streams to Loki

🤖 Generated with [Claude Code](https://claude.com/claude-code)