### PR TITLE
feat(airflow): phase-separated DAGs (5 single-purpose DAGs)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,30 @@ services:
       retries: 3
       start_period: 30s
 
+  # cAdvisor — per-container metrics for restart-rate alerting (ADR-733).
+  # Exposes container_start_time_seconds (a gauge that jumps on each restart);
+  # prometheus evaluates ContainerRestartThrashing via changes() on it.
+  # Host port 8086 (container internal 8080) to avoid app-port conflicts.
+  # No healthcheck (observability infra; crash recovery = restart:always).
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:latest
+    container_name: maple-cadvisor
+    restart: always
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+      - /dev/disk/:/dev/disk:ro
+    devices:
+      - /dev/kmsg
+    ports:
+      - "8086:8080"
+    labels:
+      logging: "promtail"
+    networks:
+      - maple-network
+
   # PostgreSQL + PGMQ (Primary Database - Issue #589, #590, #591)
   # Replaced: MySQL, MongoDB, Redis Queue
   postgres:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -203,6 +203,8 @@ services:
       - ./docker/promtail/config.yml:/etc/promtail/config.yml:ro
       - .:/var/log/app:ro
       - ./data:/var/log/data:ro
+      # Docker socket for docker_sd_configs container-stdout discovery (ADR-733).
+      - /var/run/docker.sock:/var/run/docker.sock:ro
     networks:
       - maple-network
     depends_on:
@@ -249,6 +251,8 @@ services:
     image: willfarrell/autoheal:latest
     container_name: maple-autoheal
     restart: always
+    labels:
+      logging: "promtail"
     environment:
       AUTOHEAL_CONTAINER_LABEL: autoheal
       AUTOHEAL_INTERVAL: 5

--- a/docker/airflow/dags/character_basic_pipeline.py
+++ b/docker/airflow/dags/character_basic_pipeline.py
@@ -1,0 +1,15 @@
+"""CHARACTER_BASIC phase DAG with once / count=N / infinite modes.
+
+Mode is selected via dag_run.conf['mode']. See parse_mode for validation.
+
+Refs: docs/superpowers/specs/2026-06-22-dag-restructure-design.md §4.2
+"""
+import airflow  # noqa: F401  (required for DagBag safe_mode heuristic)
+
+from phase_pipeline_factory import make_phase_dag
+
+
+character_basic_dag = make_phase_dag(
+    phase="CHARACTER_BASIC",
+    dag_id="character_basic_pipeline",
+)

--- a/docker/airflow/dags/daily_collection_pipeline.py
+++ b/docker/airflow/dags/daily_collection_pipeline.py
@@ -1,10 +1,18 @@
-"""
-Daily Nexon data collection pipeline.
+"""Daily Nexon data collection pipeline (DEPRECATED 2026-06-22).
 
-Trigger → Poll run-status with run_id correlation → Wait for synchronizer chunk consumed event → Trigger cleanup.
+DEPRECATED: Use the phase-separated DAGs instead:
+  - daily_full_pipeline              — scheduled daily chain (mode=once for all phases)
+  - ranking_ocid_lookup_pipeline     — manual RANKING + OCID chain
+  - character_basic_pipeline         — CHARACTER_BASIC with mode=once|count=N|infinite
+  - item_equipment_pipeline          — ITEM_EQUIPMENT with mode=once|count=N|infinite
+  - stop_loop_pipeline               — graceful stop for mode=infinite loops
 
-Control Plane: Airflow triggers and monitors.
-Data Plane: Kafka handles chunk processing, retry, backpressure.
+Removal target: next release cycle. See docs/21_Operations/dag-migration.md
+for operator migration guide.
+
+This DAG remains parseable for one release cycle to avoid breaking operators
+who trigger it directly. Its FULL_DAILY path duplicates daily_full_pipeline's
+behavior; its scope/run_steps paths are superseded by phase DAGs.
 """
 
 from datetime import datetime, timedelta
@@ -361,9 +369,9 @@ with DAG(
         "retries": 0,
     },
     start_date=datetime(2026, 5, 29),
-    schedule="0 18 * * *",  # UTC 18:00 = KST 03:00
+    schedule=None,  # schedule moved to daily_full_pipeline; legacy is manual-only
     catchup=False,
-    tags=["pipeline", "daily"],
+    tags=["pipeline", "daily", "deprecated"],
 ) as dag:
 
     check_external_api = HttpSensor(

--- a/docker/airflow/dags/daily_full_pipeline.py
+++ b/docker/airflow/dags/daily_full_pipeline.py
@@ -1,0 +1,76 @@
+"""Daily full-pipeline wrapper.
+
+Chains ranking_ocid_lookup_pipeline → character_basic_pipeline(mode=once) →
+item_equipment_pipeline(mode=once) → daily_cleanup_pipeline via
+TriggerDagRunOperator (wait_for_completion=True). Scheduled at 18:00 UTC
+(KST 03:00) — same cron as legacy daily_collection_pipeline.
+
+Refs: docs/superpowers/specs/2026-06-22-dag-restructure-design.md §4.3
+"""
+import airflow  # noqa: F401  (required for DagBag safe_mode heuristic)
+from airflow import DAG
+from airflow.providers.http.sensors.http import HttpSensor
+from airflow.operators.trigger_dagrun import TriggerDagRunOperator
+
+from datetime import datetime
+
+
+default_args = {
+    "owner": "maple-pipeline",
+    "retries": 0,
+}
+
+
+with DAG(
+    dag_id="daily_full_pipeline",
+    default_args=default_args,
+    start_date=datetime(2026, 5, 29),
+    schedule="0 18 * * *",  # UTC 18:00 = KST 03:00
+    catchup=False,
+    tags=["pipeline", "daily"],
+) as dag:
+
+    check_external_api = HttpSensor(
+        task_id="check_external_api",
+        http_conn_id="external_api",
+        endpoint="actuator/health",
+        request_params={},
+        response_check=lambda r: r.status_code == 200,
+        poke_interval=30,
+        timeout=120,
+    )
+
+    trigger_ranking_ocid = TriggerDagRunOperator(
+        task_id="trigger_ranking_ocid_lookup",
+        trigger_dag_id="ranking_ocid_lookup_pipeline",
+        wait_for_completion=True,
+        reset_dag_run=True,
+    )
+
+    trigger_character_basic = TriggerDagRunOperator(
+        task_id="trigger_character_basic",
+        trigger_dag_id="character_basic_pipeline",
+        conf={"mode": "once"},
+        wait_for_completion=True,
+        reset_dag_run=True,
+    )
+
+    trigger_item_equipment = TriggerDagRunOperator(
+        task_id="trigger_item_equipment",
+        trigger_dag_id="item_equipment_pipeline",
+        conf={"mode": "once"},
+        wait_for_completion=True,
+        reset_dag_run=True,
+    )
+
+    trigger_cleanup = TriggerDagRunOperator(
+        task_id="trigger_cleanup",
+        trigger_dag_id="daily_cleanup_pipeline",
+        wait_for_completion=True,  # fail loud if cleanup errors (Bug #6 fix)
+        reset_dag_run=True,
+    )
+
+    check_external_api >> trigger_ranking_ocid
+    trigger_ranking_ocid >> trigger_character_basic
+    trigger_character_basic >> trigger_item_equipment
+    trigger_item_equipment >> trigger_cleanup

--- a/docker/airflow/dags/item_equipment_pipeline.py
+++ b/docker/airflow/dags/item_equipment_pipeline.py
@@ -1,0 +1,15 @@
+"""ITEM_EQUIPMENT phase DAG with once / count=N / infinite modes.
+
+Mode is selected via dag_run.conf['mode']. See parse_mode for validation.
+
+Refs: docs/superpowers/specs/2026-06-22-dag-restructure-design.md §4.2
+"""
+import airflow  # noqa: F401  (required for DagBag safe_mode heuristic)
+
+from phase_pipeline_factory import make_phase_dag
+
+
+item_equipment_dag = make_phase_dag(
+    phase="ITEM_EQUIPMENT",
+    dag_id="item_equipment_pipeline",
+)

--- a/docker/airflow/dags/per_phase_tasks.py
+++ b/docker/airflow/dags/per_phase_tasks.py
@@ -1,10 +1,15 @@
-"""Per-phase Airflow task factories for ext-api.
+"""Per-phase Airflow task factories (LEGACY — used by deprecated daily_collection_pipeline).
 
-Drives the per-phase endpoints from #1289/1290/1291 via Airflow's
-BranchPythonOperator in daily_collection_pipeline.py.
+This module is retained for backward compatibility with operators still
+triggering daily_collection_pipeline -c '{"scope":[...]}' directly.
+Removal target: next release cycle after operators migrate to the
+phase-separated DAGs.
 
-Spec: docs/superpowers/specs/2026-06-18-issue-1292-per-phase-dag-design.md
-ADR: docs/01_ADR/ADR-393-airflow-per-phase-dag.md
+New DAGs (ranking_ocid_lookup_pipeline, character_basic_pipeline,
+item_equipment_pipeline, daily_full_pipeline, stop_loop_pipeline) use
+phase_pipeline_factory instead.
+
+Ref: docs/superpowers/specs/2026-06-22-dag-restructure-design.md §6.6
 """
 from datetime import timedelta
 import json
@@ -47,6 +52,8 @@ def get_external_api_base() -> str:
     return f"http://{conn.host}:{conn.port}"
 
 
+# LEGACY: superseded by phase_pipeline_factory.parse_mode.
+# Kept for daily_collection_pipeline scope path.
 def parse_scope(conf: dict) -> list:
     """Validate dag_run.conf['scope']. Returns list of scope values.
 
@@ -73,6 +80,8 @@ def parse_scope(conf: dict) -> list:
     return list(scope)
 
 
+# LEGACY: superseded by phase_pipeline_factory + ordered TaskGroup in v2.
+# Kept for daily_collection_pipeline run_steps path.
 def parse_steps(conf: dict) -> list:
     """Validate dag_run.conf['steps']. Returns list of step dicts.
 
@@ -197,6 +206,7 @@ def wait_for_phase_terminal(
         time.sleep(poll_interval)
 
 
+# LEGACY: superseded by phase_pipeline_factory.make_trigger_once_task.
 def make_trigger_task(phase: str) -> PythonOperator:
     """Single-shot phase trigger via /trigger/phase/{phase}.
 
@@ -252,6 +262,7 @@ def make_trigger_task(phase: str) -> PythonOperator:
     )
 
 
+# LEGACY: superseded by phase_pipeline_factory.make_trigger_loop_task.
 def make_loop_task(phase: str) -> PythonOperator:
     """Start loop via /loop/phase/{phase}.
 
@@ -299,6 +310,7 @@ def make_loop_task(phase: str) -> PythonOperator:
     )
 
 
+# LEGACY: superseded by phase_pipeline_factory.make_stop_loop_task.
 def make_stop_task(phase: str) -> PythonOperator:
     """Stop via /stop/phase/{phase}.
 
@@ -338,6 +350,7 @@ def make_stop_task(phase: str) -> PythonOperator:
     )
 
 
+# LEGACY: superseded by phase_pipeline_factory._wait_terminal_fn (in make_phase_dag).
 def make_is_phase_terminal(phase: str):
     """PythonSensor callable: returns True when triggered runId reaches terminal.
 

--- a/docker/airflow/dags/phase_pipeline_factory.py
+++ b/docker/airflow/dags/phase_pipeline_factory.py
@@ -8,6 +8,8 @@ Ref: docs/superpowers/specs/2026-06-22-dag-restructure-design.md
 """
 from __future__ import annotations
 
+import json as _json
+import os
 from datetime import timedelta
 from typing import Tuple
 
@@ -15,6 +17,8 @@ import requests
 from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
 from airflow.operators.python import PythonOperator
+from airflow.sensors.python import PythonSensor
+from kafka import KafkaConsumer
 
 
 _VALID_MODES = frozenset({"once", "count", "infinite"})
@@ -196,4 +200,66 @@ def make_trigger_loop_task(phase: str) -> PythonOperator:
         retries=0,
         execution_timeout=timedelta(seconds=60),
         do_xcom_push=True,
+    )
+
+
+# Phase → endpoint mapping for Kafka chunk-ready event filtering.
+# The synchronizer publishes to synchronizer.chunk.consumed with endpoint
+# field set to one of these values. Must match module-synchronizer publish code.
+_PHASE_TO_ENDPOINT = {
+    "CHARACTER_BASIC": "character-basic",
+    "ITEM_EQUIPMENT": "item-equipment",
+}
+
+# Per-chunk processing P99 (empirically observed ~3-5min on production
+# hardware). The count sensor timeout is set to 12h, which covers up to
+# ~138 chunks at 5min/chunk — well beyond any reasonable mode=count value.
+# Operators specifying count > 100 should use mode=infinite + stop_loop_pipeline.
+_COUNT_SENSOR_MAX_TIMEOUT = timedelta(hours=12)
+
+
+def _make_count_sensor_runtime(phase: str) -> PythonSensor:
+    """Count sensor that reads count from dag_run.conf at runtime.
+
+    Single sensor handles any count value (1..N where N * 5min + 30min <= 12h).
+    The parse-time alternative (one sensor per count value) would inflate the
+    DAG graph and require DAG-serialization support we don't have.
+
+    Implementation: the _poke callable calls parse_mode(ctx.conf) to read the
+    operator-passed count, then polls Kafka synchronizer.chunk.consumed for
+    matching events.
+    """
+    endpoint = _PHASE_TO_ENDPOINT[phase]
+
+    def _poke(**ctx):
+        _, count = parse_mode(ctx["dag_run"].conf or {})
+        consumer = KafkaConsumer(
+            "synchronizer.chunk.consumed",
+            bootstrap_servers=os.environ["KAFKA_BOOTSTRAP_SERVERS"],
+            auto_offset_reset="latest",
+            enable_auto_commit=False,
+            group_id=(
+                f"airflow-count-sensor-{phase.lower()}-"
+                f"{ctx['dag_run'].run_id[:8]}"
+            ),
+            value_deserializer=lambda m: _json.loads(m.decode("utf-8")),
+        )
+        try:
+            received = 0
+            for message in consumer:
+                event = message.value
+                if event.get("endpoint") == endpoint:
+                    received += 1
+                    if received >= count:
+                        return True
+        finally:
+            consumer.close()
+        return False  # iterator exhausted; reschedule
+
+    return PythonSensor(
+        task_id=f"count_sensor_{phase.lower()}",
+        python_callable=_poke,
+        mode="reschedule",
+        poke_interval=30,
+        timeout=_COUNT_SENSOR_MAX_TIMEOUT,
     )

--- a/docker/airflow/dags/phase_pipeline_factory.py
+++ b/docker/airflow/dags/phase_pipeline_factory.py
@@ -1,0 +1,65 @@
+"""Helpers for phase-separated Airflow DAGs.
+
+Used by character_basic_pipeline.py and item_equipment_pipeline.py to build
+once/count=N/infinite mode DAGs from a single factory. Also used by
+stop_loop_pipeline.py for the loop-stop sensor.
+
+Ref: docs/superpowers/specs/2026-06-22-dag-restructure-design.md
+"""
+from __future__ import annotations
+
+from typing import Tuple
+
+from airflow.exceptions import AirflowException
+
+
+_VALID_MODES = frozenset({"once", "count", "infinite"})
+
+
+def parse_mode(conf: dict) -> Tuple[str, int]:
+    """Validate dag_run.conf for phase DAGs.
+
+    Returns:
+        (mode, count): mode ∈ {"once","count","infinite"}; count is the
+            integer for mode=count, else 0.
+
+    Raises:
+        AirflowException: missing/invalid mode, or mode=count without a
+            valid count.
+    """
+    if not isinstance(conf, dict):
+        raise AirflowException(
+            f"dag_run.conf must be a dict, got {type(conf).__name__}"
+        )
+
+    mode = conf.get("mode")
+    if mode is None:
+        raise AirflowException(
+            "mode is required. Allowed: 'once', 'count', 'infinite'"
+        )
+    if not isinstance(mode, str):
+        raise AirflowException(
+            f"mode must be a string, got {type(mode).__name__}"
+        )
+    if mode not in _VALID_MODES:
+        raise AirflowException(
+            f"invalid mode='{mode}'. Allowed: {sorted(_VALID_MODES)}"
+        )
+
+    if mode != "count":
+        return (mode, 0)
+
+    count = conf.get("count")
+    if count is None:
+        raise AirflowException(
+            "count is required when mode='count'"
+        )
+    if not isinstance(count, int) or isinstance(count, bool):
+        raise AirflowException(
+            f"count must be an integer, got {type(count).__name__}"
+        )
+    if count < 1:
+        raise AirflowException(
+            f"count must be >= 1, got {count}"
+        )
+    return ("count", count)

--- a/docker/airflow/dags/phase_pipeline_factory.py
+++ b/docker/airflow/dags/phase_pipeline_factory.py
@@ -10,13 +10,16 @@ from __future__ import annotations
 
 import json as _json
 import os
-from datetime import timedelta
+import time
+from datetime import datetime, timedelta
 from typing import Tuple
 
 import requests
+from airflow import DAG
 from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
-from airflow.operators.python import PythonOperator
+from airflow.operators.python import BranchPythonOperator, PythonOperator
+from airflow.providers.http.sensors.http import HttpSensor
 from airflow.sensors.python import PythonSensor
 from kafka import KafkaConsumer
 
@@ -348,3 +351,159 @@ def make_wait_loop_stopped_sensor(phase: str) -> PythonSensor:
         poke_interval=10,
         timeout=30 * 60,  # 30 minutes
     )
+
+
+def make_branch_on_mode_for_phase(phase: str) -> BranchPythonOperator:
+    """BranchPythonOperator that routes by mode for a specific phase.
+
+    Task_ids returned:
+      - mode=once    → 'trigger_<phase>'
+      - mode=count   → 'trigger_loop_<phase>' (continues into count_sensor + stop_loop)
+      - mode=infinite → 'trigger_loop_infinite_<phase>' (leaf; DAG ends here)
+    """
+    def _branch(**ctx):
+        mode, _ = parse_mode(ctx["dag_run"].conf or {})
+        if mode == "once":
+            return f"trigger_{phase.lower()}"
+        if mode == "infinite":
+            return f"trigger_loop_infinite_{phase.lower()}"
+        return f"trigger_loop_{phase.lower()}"  # mode=count
+
+    return BranchPythonOperator(
+        task_id="branch_on_mode",
+        python_callable=_branch,
+    )
+
+
+def _wait_terminal_fn(phase: str):
+    """Inner: poll /run-status until phase slot reaches terminal state.
+
+    Returns True once terminal. Raises RuntimeError on FAILED, TimeoutError on
+    4h deadline. Ported from per_phase_tasks.make_is_phase_terminal (legacy).
+    """
+    def _wait(**ctx):
+        ti = ctx["ti"]
+        trigger_resp = ti.xcom_pull(task_ids=f"trigger_{phase.lower()}")
+        if isinstance(trigger_resp, str):
+            trigger_resp = _json.loads(trigger_resp)
+        run_id = (trigger_resp or {}).get("runId")
+        if not run_id:
+            raise RuntimeError(
+                f"Sensor for {phase} triggered but no runId xcom'd"
+            )
+
+        run_group_prefix = "-".join(run_id.split("-")[:2]) + "-"
+        base = get_external_api_base()
+        deadline = time.monotonic() + 4 * 60 * 60  # 4h
+
+        while True:
+            try:
+                resp = requests.get(
+                    f"{base}/api/internal/run-status", timeout=10
+                )
+                resp.raise_for_status()
+                data = resp.json()
+            except Exception:
+                time.sleep(30)
+                continue
+
+            slot = (
+                (data.get("slots") or {}).get(phase)
+                or (data.get("lastCompletedByPhase") or {}).get(phase)
+            )
+            if not slot or not (
+                slot.get("runId") or ""
+            ).startswith(run_group_prefix):
+                if time.monotonic() >= deadline:
+                    raise TimeoutError(
+                        f"Phase {phase} did not acquire runId {run_id} within 4h"
+                    )
+                time.sleep(30)
+                continue
+
+            if slot.get("phase") == "FAILED":
+                raise RuntimeError(
+                    f"Run {run_group_prefix}* phase {phase} failed: "
+                    f"{slot.get('errorMessage', 'unknown')}"
+                )
+            if slot.get("terminal"):
+                return True
+            if time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"Phase {phase} did not reach terminal within 4h"
+                )
+            time.sleep(30)
+
+    return _wait
+
+
+def make_phase_dag(phase: str, dag_id: str) -> DAG:
+    """Build a phase DAG with mode=once / mode=count / mode=infinite branches.
+
+    Args:
+        phase: PipelinePhase name (CHARACTER_BASIC or ITEM_EQUIPMENT).
+        dag_id: Airflow DAG id.
+
+    Mode routing (via make_branch_on_mode_for_phase):
+      - mode=once     → trigger_<phase> >> wait_terminal_<phase>
+      - mode=count    → trigger_loop_<phase> >> count_sensor >> stop_loop
+      - mode=infinite → trigger_loop_infinite_<phase> (leaf; DAG ends here)
+    """
+    default_args = {
+        "owner": "maple-pipeline",
+        "retries": 0,
+    }
+
+    dag = DAG(
+        dag_id=dag_id,
+        default_args=default_args,
+        start_date=datetime(2026, 5, 29),
+        schedule=None,
+        catchup=False,
+        tags=["pipeline", "phase", phase.lower().replace("_", "-")],
+    )
+
+    with dag:
+        check_external_api = HttpSensor(
+            task_id="check_external_api",
+            http_conn_id="external_api",
+            endpoint="actuator/health",
+            request_params={},
+            response_check=lambda r: r.status_code == 200,
+            poke_interval=30,
+            timeout=120,
+        )
+
+        branch = make_branch_on_mode_for_phase(phase)
+
+        # once branch
+        trigger_once = make_trigger_once_task(phase)
+        wait_terminal = PythonSensor(
+            task_id=f"wait_terminal_{phase.lower()}",
+            python_callable=_wait_terminal_fn(phase),
+            mode="reschedule",
+            poke_interval=60,
+            timeout=4 * 60 * 60,
+        )
+
+        # count branch: trigger_loop → count_sensor (runtime count from conf) → stop_loop
+        trigger_loop_count = make_trigger_loop_task(phase)
+        count_sensor = _make_count_sensor_runtime(phase)
+        stop_loop = make_stop_loop_task(phase)
+
+        # infinite branch: trigger_loop_infinite (leaf; DAG succeeds here)
+        trigger_loop_infinite = PythonOperator(
+            task_id=f"trigger_loop_infinite_{phase.lower()}",
+            python_callable=_trigger_loop_fn(phase),
+            retries=0,
+            execution_timeout=timedelta(seconds=60),
+            do_xcom_push=True,
+        )
+
+        # Wiring
+        check_external_api >> branch
+        branch >> trigger_once >> wait_terminal
+        branch >> trigger_loop_count >> count_sensor >> stop_loop
+        branch >> trigger_loop_infinite
+
+    return dag

--- a/docker/airflow/dags/phase_pipeline_factory.py
+++ b/docker/airflow/dags/phase_pipeline_factory.py
@@ -8,9 +8,13 @@ Ref: docs/superpowers/specs/2026-06-22-dag-restructure-design.md
 """
 from __future__ import annotations
 
+from datetime import timedelta
 from typing import Tuple
 
+import requests
 from airflow.exceptions import AirflowException
+from airflow.hooks.base import BaseHook
+from airflow.operators.python import PythonOperator
 
 
 _VALID_MODES = frozenset({"once", "count", "infinite"})
@@ -63,3 +67,133 @@ def parse_mode(conf: dict) -> Tuple[str, int]:
             f"count must be >= 1, got {count}"
         )
     return ("count", count)
+
+
+def get_external_api_base() -> str:
+    """Resolve ext-api base URL from Airflow Connection 'external_api'."""
+    conn = BaseHook.get_connection("external_api")
+    return f"http://{conn.host}:{conn.port}"
+
+
+def _trigger_once_fn(phase: str):
+    """Inner: trigger phase once via POST /trigger/phase/{phase}.
+
+    Reads upstream_run_id from xcom (task_id='upstream_run_id') if
+    present — OCID_LOOKUP and downstream phases require X-Upstream-Run-Id.
+    RANKING_FETCH ignores the header (it IS the upstream).
+    """
+    def _trigger(**ctx):
+        conf = ctx["dag_run"].conf or {}
+        base = get_external_api_base()
+        ti = ctx.get("ti")
+        upstream_run_id = ti.xcom_pull(task_ids="upstream_run_id") if ti else None
+
+        headers = {}
+        if upstream_run_id and phase != "RANKING_FETCH":
+            headers["X-Upstream-Run-Id"] = upstream_run_id
+
+        try:
+            resp = requests.post(
+                f"{base}/api/internal/trigger/phase/{phase}",
+                headers=headers,
+                timeout=30,
+            )
+        except requests.RequestException as exc:
+            raise AirflowException(f"Trigger {phase} failed: {exc}") from exc
+
+        if resp.status_code in (200, 202):
+            return resp.json()
+
+        if resp.status_code == 409:
+            try:
+                status_resp = requests.get(
+                    f"{base}/api/internal/run-status", timeout=10
+                )
+                status_resp.raise_for_status()
+                data = status_resp.json()
+            except (requests.RequestException, ValueError) as exc:
+                raise AirflowException(
+                    f"409 from trigger {phase} but /run-status fetch failed: {exc}"
+                ) from exc
+            slot = (data.get("slots") or {}).get(phase) or {}
+            return {
+                "runId": slot.get("runId"),
+                "phase": phase,
+                "status": "ALREADY_ACTIVE",
+            }
+
+        if resp.status_code == 400:
+            raise AirflowException(
+                f"Trigger {phase} rejected (INVALID_PHASE): {resp.text[:500]}"
+            )
+
+        raise AirflowException(
+            f"Trigger {phase} failed: HTTP {resp.status_code} "
+            f"{resp.reason}: {resp.text[:500]}"
+        )
+
+    return _trigger
+
+
+def make_trigger_once_task(phase: str) -> PythonOperator:
+    """Build a PythonOperator that triggers phase once.
+
+    Caller wires `>>` between upstream's xcom pusher and this task.
+    """
+    return PythonOperator(
+        task_id=f"trigger_{phase.lower()}",
+        python_callable=_trigger_once_fn(phase),
+        retries=0,
+        execution_timeout=timedelta(seconds=60),
+        do_xcom_push=True,
+    )
+
+
+def _trigger_loop_fn(phase: str):
+    """Inner: start infinite loop via POST /loop/phase/{phase}.
+
+    mode=count and mode=infinite both start the loop. The count sensor
+    (mode=count) or operator action (mode=infinite) handles termination.
+    """
+    def _loop(**ctx):
+        base = get_external_api_base()
+        try:
+            resp = requests.post(
+                f"{base}/api/internal/loop/phase/{phase}", timeout=30
+            )
+        except requests.RequestException as exc:
+            raise AirflowException(f"Loop start {phase} failed: {exc}") from exc
+
+        if resp.status_code == 202:
+            return resp.json()
+
+        if resp.status_code == 409:
+            body = resp.json()
+            return {**body, "status": "ALREADY_LOOPING"}
+
+        if resp.status_code == 400:
+            raise AirflowException(
+                f"Loop start {phase} rejected (INVALID_PHASE): {resp.text[:500]}"
+            )
+
+        raise AirflowException(
+            f"Loop start {phase} failed: HTTP {resp.status_code} "
+            f"{resp.reason}: {resp.text[:500]}"
+        )
+
+    return _loop
+
+
+def make_trigger_loop_task(phase: str) -> PythonOperator:
+    """Build a PythonOperator that starts the loop for `phase`.
+
+    Fire-and-forget at HTTP layer; termination is operator-controlled via
+    stop_loop_pipeline or mode=count's count sensor.
+    """
+    return PythonOperator(
+        task_id=f"trigger_loop_{phase.lower()}",
+        python_callable=_trigger_loop_fn(phase),
+        retries=0,
+        execution_timeout=timedelta(seconds=60),
+        do_xcom_push=True,
+    )

--- a/docker/airflow/dags/phase_pipeline_factory.py
+++ b/docker/airflow/dags/phase_pipeline_factory.py
@@ -263,3 +263,88 @@ def _make_count_sensor_runtime(phase: str) -> PythonSensor:
         poke_interval=30,
         timeout=_COUNT_SENSOR_MAX_TIMEOUT,
     )
+
+
+def _stop_loop_fn(phase: str):
+    """Inner: POST /stop/loop/phase/{phase}."""
+    def _stop(**ctx):
+        base = get_external_api_base()
+        try:
+            resp = requests.post(
+                f"{base}/api/internal/stop/loop/phase/{phase}", timeout=30
+            )
+        except requests.RequestException as exc:
+            raise AirflowException(f"Stop loop {phase} failed: {exc}") from exc
+
+        if resp.status_code == 202:
+            return {**resp.json(), "status": "STOP_REQUESTED"}
+
+        if resp.status_code == 200:
+            body = resp.json()
+            return {**body, "status": "NOT_LOOPING"}
+
+        if resp.status_code == 400:
+            raise AirflowException(
+                f"Stop loop {phase} rejected (INVALID_PHASE): {resp.text[:500]}"
+            )
+
+        raise AirflowException(
+            f"Stop loop {phase} failed: HTTP {resp.status_code} "
+            f"{resp.reason}: {resp.text[:500]}"
+        )
+
+    return _stop
+
+
+def make_stop_loop_task(phase: str) -> PythonOperator:
+    """Build a PythonOperator that stops the loop for `phase`."""
+    return PythonOperator(
+        task_id=f"stop_loop_{phase.lower()}",
+        python_callable=_stop_loop_fn(phase),
+        retries=0,
+        execution_timeout=timedelta(seconds=60),
+        do_xcom_push=True,
+    )
+
+
+def _wait_loop_stopped_fn(phase: str):
+    """Inner: poll /run-status until loopSummaries[phase].status == STOPPED."""
+    def _poke(**ctx):
+        try:
+            resp = requests.get(
+                f"{get_external_api_base()}/api/internal/run-status", timeout=10
+            )
+            resp.raise_for_status()
+            data = resp.json()
+        except Exception:
+            return False  # transient → reschedule
+
+        summaries = data.get("loopSummaries") or {}
+        entry = summaries.get(phase)
+        if not entry:
+            return True  # no loop was active; idempotent success
+
+        status = entry.get("status")
+        if status == "STOPPED":
+            return True
+        if status == "FAILED":
+            raise RuntimeError(
+                f"Loop for {phase} failed: {entry.get('lastError', 'unknown')}"
+            )
+        return False
+
+    return _poke
+
+
+def make_wait_loop_stopped_sensor(phase: str) -> PythonSensor:
+    """Sensor that returns True when loopSummaries[phase].status == STOPPED.
+
+    Returns True immediately if no loop is active for `phase` (idempotent).
+    """
+    return PythonSensor(
+        task_id=f"wait_loop_stopped_{phase.lower()}",
+        python_callable=_wait_loop_stopped_fn(phase),
+        mode="reschedule",
+        poke_interval=10,
+        timeout=30 * 60,  # 30 minutes
+    )

--- a/docker/airflow/dags/phase_pipeline_factory.py
+++ b/docker/airflow/dags/phase_pipeline_factory.py
@@ -269,8 +269,20 @@ def _make_count_sensor_runtime(phase: str) -> PythonSensor:
 
 
 def _stop_loop_fn(phase: str):
-    """Inner: POST /stop/loop/phase/{phase}."""
+    """Inner: POST /stop/loop/phase/{phase}.
+
+    Skips (returns None) when dag_run.conf['phase'] is set but does not
+    match `phase` — single DAG handles both CHARACTER_BASIC and
+    ITEM_EQUIPMENT, gated by conf. Operators trigger with
+    ``-c '{"phase":"ITEM_EQUIPMENT"}'`` to stop only one.
+    """
     def _stop(**ctx):
+        dag_run = ctx.get("dag_run")
+        conf = (dag_run.conf if dag_run else None) or {}
+        target_phase = conf.get("phase")
+        if target_phase is not None and target_phase != phase:
+            return None  # skip; this task is for another phase
+
         base = get_external_api_base()
         try:
             resp = requests.post(

--- a/docker/airflow/dags/ranking_ocid_lookup_pipeline.py
+++ b/docker/airflow/dags/ranking_ocid_lookup_pipeline.py
@@ -1,0 +1,87 @@
+"""RANKING_FETCH → OCID_LOOKUP sequential pipeline.
+
+OCID_LOOKUP requires X-Upstream-Run-Id from RANKING_FETCH (ext-api
+InternalApiController rejects with MISSING_UPSTREAM 400 otherwise), so
+these two phases are always chained. Manual trigger only.
+
+Refs: docs/superpowers/specs/2026-06-22-dag-restructure-design.md §4.1
+"""
+from datetime import datetime
+
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+from airflow.providers.http.sensors.http import HttpSensor
+from airflow.sensors.python import PythonSensor
+
+from per_phase_tasks import make_is_phase_terminal
+from phase_pipeline_factory import make_trigger_once_task
+
+
+default_args = {
+    "owner": "maple-pipeline",
+    "retries": 0,
+}
+
+
+with DAG(
+    dag_id="ranking_ocid_lookup_pipeline",
+    default_args=default_args,
+    start_date=datetime(2026, 5, 29),
+    schedule=None,  # manual trigger (or via daily_full_pipeline wrapper)
+    catchup=False,
+    tags=["pipeline", "phase", "ranking-ocid"],
+) as dag:
+
+    check_external_api = HttpSensor(
+        task_id="check_external_api",
+        http_conn_id="external_api",
+        endpoint="actuator/health",
+        request_params={},
+        response_check=lambda r: r.status_code == 200,
+        poke_interval=30,
+        timeout=120,
+    )
+
+    # RANKING_FETCH — no upstream required. Uses factory helper so its
+    # task_id is `trigger_ranking_fetch` (matches factory convention).
+    trigger_ranking_fetch = make_trigger_once_task("RANKING_FETCH")
+    wait_ranking_fetch_terminal = PythonSensor(
+        task_id="wait_ranking_fetch_terminal",
+        python_callable=make_is_phase_terminal("RANKING_FETCH"),
+        mode="reschedule",
+        poke_interval=60,
+        timeout=4 * 60 * 60,
+    )
+
+    # OCID_LOOKUP — requires X-Upstream-Run-Id from RANKING_FETCH trigger.
+    # The factory's _trigger_once_fn xcom_pulls from task_id="upstream_run_id"
+    # (must match exactly — Bug #4 fix). Add a tiny task to push the runId
+    # into that slot:
+    def _push_upstream_run_id(**ctx):
+        import json
+
+        ti = ctx["ti"]
+        trigger_resp = ti.xcom_pull(task_ids="trigger_ranking_fetch")
+        if isinstance(trigger_resp, str):
+            trigger_resp = json.loads(trigger_resp)
+        return trigger_resp.get("runId") if trigger_resp else None
+
+    push_upstream = PythonOperator(
+        task_id="upstream_run_id",  # must match factory's xcom_pull task_id
+        python_callable=_push_upstream_run_id,
+    )
+
+    trigger_ocid_lookup = make_trigger_once_task("OCID_LOOKUP")
+    wait_ocid_lookup_terminal = PythonSensor(
+        task_id="wait_ocid_lookup_terminal",
+        python_callable=make_is_phase_terminal("OCID_LOOKUP"),
+        mode="reschedule",
+        poke_interval=60,
+        timeout=4 * 60 * 60,
+    )
+
+    check_external_api >> trigger_ranking_fetch
+    trigger_ranking_fetch >> wait_ranking_fetch_terminal
+    wait_ranking_fetch_terminal >> push_upstream
+    push_upstream >> trigger_ocid_lookup
+    trigger_ocid_lookup >> wait_ocid_lookup_terminal

--- a/docker/airflow/dags/stop_loop_pipeline.py
+++ b/docker/airflow/dags/stop_loop_pipeline.py
@@ -1,0 +1,65 @@
+"""Stop any active loop for a given phase.
+
+Used to terminate mode=infinite loops started by character_basic_pipeline or
+item_equipment_pipeline. POSTs /stop/loop/phase/{phase} and waits for the
+loop to drain current chunk + transition to STOPPED.
+
+Use:
+  airflow dags trigger stop_loop_pipeline -c '{"phase":"ITEM_EQUIPMENT"}'
+
+The conf['phase'] is consumed by make_stop_loop_task's skip pattern
+(_stop_loop_fn gates on conf.phase); the unmatched sibling returns None
+(Airflow skip) so both branches can run in parallel without an extra
+_validate_phase task.
+
+Refs: docs/superpowers/specs/2026-06-22-dag-restructure-design.md §4.4
+"""
+import airflow  # noqa: F401  (required for DagBag safe_mode heuristic)
+from datetime import datetime
+
+from airflow import DAG
+from airflow.providers.http.sensors.http import HttpSensor
+
+from phase_pipeline_factory import (
+    make_stop_loop_task,
+    make_wait_loop_stopped_sensor,
+)
+
+
+default_args = {
+    "owner": "maple-pipeline",
+    "retries": 0,
+}
+
+
+with DAG(
+    dag_id="stop_loop_pipeline",
+    default_args=default_args,
+    start_date=datetime(2026, 5, 29),
+    schedule=None,
+    catchup=False,
+    tags=["pipeline", "control", "stop"],
+) as dag:
+
+    check_external_api = HttpSensor(
+        task_id="check_external_api",
+        http_conn_id="external_api",
+        endpoint="actuator/health",
+        request_params={},
+        response_check=lambda r: r.status_code == 200,
+        poke_interval=30,
+        timeout=120,
+    )
+
+    # Single DAG handles both CHARACTER_BASIC and ITEM_EQUIPMENT via conf.
+    # Each task's _stop_loop_fn checks conf.phase and returns None (skip) if
+    # it doesn't match — so only the targeted phase actually stops.
+    stop_character_basic = make_stop_loop_task("CHARACTER_BASIC")
+    stop_item_equipment = make_stop_loop_task("ITEM_EQUIPMENT")
+
+    wait_character_basic = make_wait_loop_stopped_sensor("CHARACTER_BASIC")
+    wait_item_equipment = make_wait_loop_stopped_sensor("ITEM_EQUIPMENT")
+
+    check_external_api >> [stop_character_basic, stop_item_equipment]
+    stop_character_basic >> wait_character_basic
+    stop_item_equipment >> wait_item_equipment

--- a/docker/airflow/dags/tests/test_dag_imports.py
+++ b/docker/airflow/dags/tests/test_dag_imports.py
@@ -1,0 +1,42 @@
+"""DAG import smoke test for CI.
+
+Asserts all expected DAGs (new + legacy) parse without import errors.
+"""
+from airflow.models import DagBag
+
+
+DAG_FOLDER = "/home/maple/probabilistic-valuation-engine/docker/airflow/dags"
+
+
+EXPECTED_DAG_IDS = {
+    # New phase-separated DAGs (2026-06-22 restructure)
+    "ranking_ocid_lookup_pipeline",
+    "character_basic_pipeline",
+    "item_equipment_pipeline",
+    "daily_full_pipeline",
+    "stop_loop_pipeline",
+    # Existing DAGs (unchanged)
+    "daily_cleanup_pipeline",
+    # Legacy (deprecated; must still parse)
+    "daily_collection_pipeline",
+}
+
+
+def test_all_expected_dags_import():
+    dagbag = DagBag(dag_folder=DAG_FOLDER, include_examples=False)
+    assert dagbag.import_errors == {}, (
+        f"DAG import errors: {dagbag.import_errors}"
+    )
+    for dag_id in EXPECTED_DAG_IDS:
+        assert dag_id in dagbag.dags, (
+            f"Expected DAG '{dag_id}' missing from DagBag. "
+            f"Loaded: {sorted(dagbag.dags.keys())}"
+        )
+
+
+def test_no_unexpected_dags():
+    """Sanity: only known DAGs in the folder."""
+    dagbag = DagBag(dag_folder=DAG_FOLDER, include_examples=False)
+    loaded = set(dagbag.dags.keys())
+    unexpected = loaded - EXPECTED_DAG_IDS
+    assert not unexpected, f"Unexpected DAGs in folder: {unexpected}"

--- a/docker/airflow/dags/tests/test_phase_dag_structure.py
+++ b/docker/airflow/dags/tests/test_phase_dag_structure.py
@@ -1,0 +1,68 @@
+"""DAG-structure tests via DagBag parse.
+
+These run against the actual DAG files in docker/airflow/dags/, not the
+in-memory factory. They catch import errors and topology regressions.
+"""
+import pytest
+from airflow.models import DagBag
+
+
+DAG_FOLDER = "/home/maple/probabilistic-valuation-engine/docker/airflow/dags"
+
+
+@pytest.fixture(scope="module")
+def dagbag():
+    return DagBag(dag_folder=DAG_FOLDER, include_examples=False)
+
+
+def test_character_basic_pipeline_parses(dagbag):
+    dag = dagbag.get_dag("character_basic_pipeline")
+    assert dag is not None
+    ids = {t.task_id for t in dag.tasks}
+    assert "branch_on_mode" in ids
+    assert "trigger_character_basic" in ids
+    assert "trigger_loop_infinite_character_basic" in ids
+
+
+def test_item_equipment_pipeline_parses(dagbag):
+    dag = dagbag.get_dag("item_equipment_pipeline")
+    assert dag is not None
+    ids = {t.task_id for t in dag.tasks}
+    assert "trigger_item_equipment" in ids
+    assert "trigger_loop_infinite_item_equipment" in ids
+    assert "count_sensor_item_equipment" in ids
+
+
+def test_daily_full_pipeline_parses(dagbag):
+    dag = dagbag.get_dag("daily_full_pipeline")
+    assert dag is not None
+    trigger_ids = [t.task_id for t in dag.tasks if t.task_id.startswith("trigger_")]
+    assert len(trigger_ids) == 4
+
+
+def test_stop_loop_pipeline_parses(dagbag):
+    dag = dagbag.get_dag("stop_loop_pipeline")
+    assert dag is not None
+    ids = {t.task_id for t in dag.tasks}
+    assert "stop_loop_character_basic" in ids
+    assert "stop_loop_item_equipment" in ids
+    assert "wait_loop_stopped_character_basic" in ids
+    assert "wait_loop_stopped_item_equipment" in ids
+
+
+def test_ranking_ocid_lookup_pipeline_parses(dagbag):
+    dag = dagbag.get_dag("ranking_ocid_lookup_pipeline")
+    assert dag is not None
+    ids = {t.task_id for t in dag.tasks}
+    assert "trigger_ranking_fetch" in ids
+    assert "wait_ranking_fetch_terminal" in ids
+    assert "trigger_ocid_lookup" in ids
+    assert "wait_ocid_lookup_terminal" in ids
+    assert "upstream_run_id" in ids
+
+
+def test_legacy_dag_still_parses(dagbag):
+    """daily_collection_pipeline must still parse for one release cycle."""
+    dag = dagbag.get_dag("daily_collection_pipeline")
+    assert dag is not None
+    assert "deprecated" in dag.tags

--- a/docker/airflow/dags/tests/test_phase_pipeline_factory.py
+++ b/docker/airflow/dags/tests/test_phase_pipeline_factory.py
@@ -285,9 +285,10 @@ class TestMakeCountSensorRuntime:
 
 
 class TestMakeStopLoopTask:
-    def _get_callable(self, phase):
+    def _call(self, phase, conf=None):
         op = make_stop_loop_task(phase)
-        return op.python_callable
+        with patch("phase_pipeline_factory.get_external_api_base", return_value="http://test"):
+            return op.python_callable(dag_run=MagicMock(conf=conf or {"phase": phase}))
 
     def test_202_stop_requested(self):
         with patch("phase_pipeline_factory.requests.post") as mock_post:
@@ -300,7 +301,7 @@ class TestMakeStopLoopTask:
                 "iterationCount": 42,
             }
             mock_post.return_value = mock_resp
-            result = self._get_callable("ITEM_EQUIPMENT")()
+            result = self._call("ITEM_EQUIPMENT")
         assert result["status"] == "STOP_REQUESTED"
 
     def test_200_not_looping_idempotent(self):
@@ -309,8 +310,23 @@ class TestMakeStopLoopTask:
             mock_resp.status_code = 200
             mock_resp.json.return_value = {"status": "NOT_LOOPING", "phase": "ITEM_EQUIPMENT"}
             mock_post.return_value = mock_resp
-            result = self._get_callable("ITEM_EQUIPMENT")()
+            result = self._call("ITEM_EQUIPMENT")
         assert result["status"] == "NOT_LOOPING"
+
+    def test_skip_when_conf_targets_other_phase(self):
+        """If conf.phase != this task's phase, return None (skip)."""
+        result = self._call("CHARACTER_BASIC", conf={"phase": "ITEM_EQUIPMENT"})
+        assert result is None
+
+    def test_no_conf_phase_runs_anyway(self):
+        """If conf.phase is unset, the task runs (legacy behavior)."""
+        with patch("phase_pipeline_factory.requests.post") as mock_post:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 202
+            mock_resp.json.return_value = {"loopId": "loop-1"}
+            mock_post.return_value = mock_resp
+            result = self._call("ITEM_EQUIPMENT", conf={})
+        assert result["status"] == "STOP_REQUESTED"
 
     def test_400_invalid_phase_raises(self):
         with patch("phase_pipeline_factory.requests.post") as mock_post:
@@ -319,7 +335,7 @@ class TestMakeStopLoopTask:
             mock_resp.text = "INVALID_PHASE"
             mock_post.return_value = mock_resp
             with pytest.raises(AirflowException):
-                self._get_callable("RANKING_FETCH")()
+                self._call("RANKING_FETCH")
 
     def test_5xx_raises(self):
         with patch("phase_pipeline_factory.requests.post") as mock_post:
@@ -329,7 +345,7 @@ class TestMakeStopLoopTask:
             mock_resp.reason = "Bad Gateway"
             mock_post.return_value = mock_resp
             with pytest.raises(AirflowException):
-                self._get_callable("ITEM_EQUIPMENT")()
+                self._call("ITEM_EQUIPMENT")
 
 
 class TestMakeWaitLoopStoppedSensor:

--- a/docker/airflow/dags/tests/test_phase_pipeline_factory.py
+++ b/docker/airflow/dags/tests/test_phase_pipeline_factory.py
@@ -8,8 +8,10 @@ from phase_pipeline_factory import (
     _make_count_sensor_runtime,
     _PHASE_TO_ENDPOINT,
     get_external_api_base,
+    make_stop_loop_task,
     make_trigger_loop_task,
     make_trigger_once_task,
+    make_wait_loop_stopped_sensor,
     parse_mode,
 )
 
@@ -277,3 +279,100 @@ class TestMakeCountSensorRuntime:
         ctx = {"dag_run": MagicMock(conf={})}
         with pytest.raises(AirflowException):
             callable_fn(**ctx)
+
+
+class TestMakeStopLoopTask:
+    def _get_callable(self, phase):
+        op = make_stop_loop_task(phase)
+        return op.python_callable
+
+    def test_202_stop_requested(self):
+        with patch("phase_pipeline_factory.requests.post") as mock_post:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 202
+            mock_resp.json.return_value = {
+                "status": "STOP_REQUESTED",
+                "phase": "ITEM_EQUIPMENT",
+                "loopId": "loop-1",
+                "iterationCount": 42,
+            }
+            mock_post.return_value = mock_resp
+            result = self._get_callable("ITEM_EQUIPMENT")()
+        assert result["status"] == "STOP_REQUESTED"
+
+    def test_200_not_looping_idempotent(self):
+        with patch("phase_pipeline_factory.requests.post") as mock_post:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = {"status": "NOT_LOOPING", "phase": "ITEM_EQUIPMENT"}
+            mock_post.return_value = mock_resp
+            result = self._get_callable("ITEM_EQUIPMENT")()
+        assert result["status"] == "NOT_LOOPING"
+
+    def test_400_invalid_phase_raises(self):
+        with patch("phase_pipeline_factory.requests.post") as mock_post:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 400
+            mock_resp.text = "INVALID_PHASE"
+            mock_post.return_value = mock_resp
+            with pytest.raises(AirflowException):
+                self._get_callable("RANKING_FETCH")()
+
+    def test_5xx_raises(self):
+        with patch("phase_pipeline_factory.requests.post") as mock_post:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 502
+            mock_resp.text = "bad gateway"
+            mock_resp.reason = "Bad Gateway"
+            mock_post.return_value = mock_resp
+            with pytest.raises(AirflowException):
+                self._get_callable("ITEM_EQUIPMENT")()
+
+
+class TestMakeWaitLoopStoppedSensor:
+    def _get_callable(self, phase):
+        op = make_wait_loop_stopped_sensor(phase)
+        return op.python_callable
+
+    def test_returns_true_when_no_loop_active(self):
+        with patch("phase_pipeline_factory.requests.get") as mock_get:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = {"loopSummaries": {}}
+            mock_get.return_value = mock_resp
+            assert self._get_callable("ITEM_EQUIPMENT")() is True
+
+    def test_returns_true_when_status_stopped(self):
+        with patch("phase_pipeline_factory.requests.get") as mock_get:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = {
+                "loopSummaries": {
+                    "ITEM_EQUIPMENT": {"loopId": "x", "status": "STOPPED"}
+                }
+            }
+            mock_get.return_value = mock_resp
+            assert self._get_callable("ITEM_EQUIPMENT")() is True
+
+    def test_returns_false_when_still_running(self):
+        with patch("phase_pipeline_factory.requests.get") as mock_get:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = {
+                "loopSummaries": {
+                    "ITEM_EQUIPMENT": {"loopId": "x", "status": "RUNNING"}
+                }
+            }
+            mock_get.return_value = mock_resp
+            assert self._get_callable("ITEM_EQUIPMENT")() is False
+
+    def test_returns_false_on_transient_http_error(self):
+        with patch("phase_pipeline_factory.requests.get") as mock_get:
+            mock_get.side_effect = Exception("connection refused")
+            assert self._get_callable("ITEM_EQUIPMENT")() is False
+
+    def test_timeout_is_30_minutes(self):
+        op = make_wait_loop_stopped_sensor("ITEM_EQUIPMENT")
+        assert op.timeout == 30 * 60
+        assert op.mode == "reschedule"
+        assert op.poke_interval == 10

--- a/docker/airflow/dags/tests/test_phase_pipeline_factory.py
+++ b/docker/airflow/dags/tests/test_phase_pipeline_factory.py
@@ -5,6 +5,8 @@ import pytest
 from airflow.exceptions import AirflowException
 
 from phase_pipeline_factory import (
+    _make_count_sensor_runtime,
+    _PHASE_TO_ENDPOINT,
     get_external_api_base,
     make_trigger_loop_task,
     make_trigger_once_task,
@@ -202,3 +204,76 @@ class TestMakeTriggerLoopTask:
                 self._get_callable("ITEM_EQUIPMENT")(
                     dag_run=MagicMock(conf={})
                 )
+
+
+class TestPhaseToEndpoint:
+    def test_character_basic(self):
+        assert _PHASE_TO_ENDPOINT["CHARACTER_BASIC"] == "character-basic"
+
+    def test_item_equipment(self):
+        assert _PHASE_TO_ENDPOINT["ITEM_EQUIPMENT"] == "item-equipment"
+
+
+class TestMakeCountSensorRuntime:
+    """Tests the runtime count sensor (reads count from dag_run.conf)."""
+
+    def _get_callable_and_op(self, phase):
+        op = _make_count_sensor_runtime(phase)
+        return op.python_callable, op
+
+    def test_returns_true_after_count_events(self):
+        """Sensor returns True after `count` matching events received."""
+        from datetime import timedelta
+
+        callable_fn, op = self._get_callable_and_op("ITEM_EQUIPMENT")
+
+        fake_msg1 = MagicMock()
+        fake_msg1.value = {"endpoint": "item-equipment", "runId": "r1"}
+        fake_msg2 = MagicMock()
+        fake_msg2.value = {"endpoint": "item-equipment", "runId": "r2"}
+        fake_msg3 = MagicMock()
+        fake_msg3.value = {"endpoint": "item-equipment", "runId": "r3"}
+
+        ctx = {
+            "dag_run": MagicMock(conf={"mode": "count", "count": 2}, run_id="20260622-x"),
+        }
+        with patch("phase_pipeline_factory.KafkaConsumer") as mock_consumer_cls:
+            instance = MagicMock()
+            instance.__iter__ = MagicMock(
+                return_value=iter([fake_msg1, fake_msg2, fake_msg3])
+            )
+            mock_consumer_cls.return_value = instance
+            result = callable_fn(**ctx)
+        assert result is True
+        # Airflow stores sensor timeout as float seconds internally.
+        assert op.timeout == 12 * 60 * 60
+        assert op.mode == "reschedule"
+        assert op.poke_interval == 30
+
+    def test_filters_by_endpoint(self):
+        callable_fn, op = self._get_callable_and_op("CHARACTER_BASIC")
+
+        fake_msg_other = MagicMock()
+        fake_msg_other.value = {"endpoint": "item-equipment", "runId": "r1"}
+        fake_msg_match = MagicMock()
+        fake_msg_match.value = {"endpoint": "character-basic", "runId": "r2"}
+
+        ctx = {
+            "dag_run": MagicMock(
+                conf={"mode": "count", "count": 1}, run_id="20260622-x"
+            ),
+        }
+        with patch("phase_pipeline_factory.KafkaConsumer") as mock_consumer_cls:
+            instance = MagicMock()
+            instance.__iter__ = MagicMock(
+                return_value=iter([fake_msg_other, fake_msg_match])
+            )
+            mock_consumer_cls.return_value = instance
+            result = callable_fn(**ctx)
+        assert result is True
+
+    def test_raises_for_invalid_conf(self):
+        callable_fn, op = self._get_callable_and_op("ITEM_EQUIPMENT")
+        ctx = {"dag_run": MagicMock(conf={})}
+        with pytest.raises(AirflowException):
+            callable_fn(**ctx)

--- a/docker/airflow/dags/tests/test_phase_pipeline_factory.py
+++ b/docker/airflow/dags/tests/test_phase_pipeline_factory.py
@@ -7,7 +7,10 @@ from airflow.exceptions import AirflowException
 from phase_pipeline_factory import (
     _make_count_sensor_runtime,
     _PHASE_TO_ENDPOINT,
+    _wait_terminal_fn,
     get_external_api_base,
+    make_branch_on_mode_for_phase,
+    make_phase_dag,
     make_stop_loop_task,
     make_trigger_loop_task,
     make_trigger_once_task,
@@ -376,3 +379,120 @@ class TestMakeWaitLoopStoppedSensor:
         assert op.timeout == 30 * 60
         assert op.mode == "reschedule"
         assert op.poke_interval == 10
+
+
+class TestMakeBranchOnModeForPhase:
+    def _branch_fn(self, phase):
+        op = make_branch_on_mode_for_phase(phase)
+        return op.python_callable
+
+    def test_mode_once_routes_to_trigger_character_basic(self):
+        fn = self._branch_fn("CHARACTER_BASIC")
+        ctx = {"dag_run": MagicMock(conf={"mode": "once"})}
+        assert fn(**ctx) == "trigger_character_basic"
+
+    def test_mode_count_routes_to_trigger_loop(self):
+        fn = self._branch_fn("ITEM_EQUIPMENT")
+        ctx = {"dag_run": MagicMock(conf={"mode": "count", "count": 5})}
+        assert fn(**ctx) == "trigger_loop_item_equipment"
+
+    def test_mode_infinite_routes_to_trigger_loop_infinite(self):
+        """mode=infinite must route to a separate leaf task_id so count_sensor
+        does not run when count is not specified."""
+        fn = self._branch_fn("ITEM_EQUIPMENT")
+        ctx = {"dag_run": MagicMock(conf={"mode": "infinite"})}
+        assert fn(**ctx) == "trigger_loop_infinite_item_equipment"
+
+    def test_invalid_conf_raises(self):
+        fn = self._branch_fn("CHARACTER_BASIC")
+        ctx = {"dag_run": MagicMock(conf={})}
+        with pytest.raises(AirflowException):
+            fn(**ctx)
+
+
+class TestWaitTerminalFn:
+    def test_returns_true_when_terminal(self):
+        with patch("phase_pipeline_factory.requests.get") as mock_get, \
+             patch("phase_pipeline_factory.time") as mock_time:
+            mock_time.monotonic.return_value = 0
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = {
+                "slots": {
+                    "CHARACTER_BASIC": {
+                        "runId": "20260622-120000-x",
+                        "phase": "CHARACTER_BASIC",
+                        "terminal": True,
+                    }
+                },
+                "lastCompletedByPhase": {},
+            }
+            mock_get.return_value = mock_resp
+            ti = MagicMock()
+            ti.xcom_pull.return_value = {"runId": "20260622-120000-x"}
+            ctx = {"ti": ti}
+            result = _wait_terminal_fn("CHARACTER_BASIC")(**ctx)
+        assert result is True
+
+    def test_raises_when_failed(self):
+        with patch("phase_pipeline_factory.requests.get") as mock_get, \
+             patch("phase_pipeline_factory.time") as mock_time:
+            mock_time.monotonic.return_value = 0
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = {
+                "slots": {
+                    "CHARACTER_BASIC": {
+                        "runId": "20260622-120000-x",
+                        "phase": "FAILED",
+                        "terminal": True,
+                        "errorMessage": "boom",
+                    }
+                },
+                "lastCompletedByPhase": {},
+            }
+            mock_get.return_value = mock_resp
+            ti = MagicMock()
+            ti.xcom_pull.return_value = {"runId": "20260622-120000-x"}
+            with pytest.raises(RuntimeError, match="failed"):
+                _wait_terminal_fn("CHARACTER_BASIC")(ti=ti)
+
+
+class TestMakePhaseDag:
+    """Test the DAG object structure."""
+
+    def test_dag_has_expected_task_ids_for_character_basic(self):
+        dag = make_phase_dag("CHARACTER_BASIC", "character_basic_pipeline")
+        ids = {t.task_id for t in dag.tasks}
+        expected = {
+            "check_external_api",
+            "branch_on_mode",
+            "trigger_character_basic",
+            "wait_terminal_character_basic",
+            "trigger_loop_character_basic",
+            "count_sensor_character_basic",
+            "stop_loop_character_basic",
+            "trigger_loop_infinite_character_basic",
+        }
+        assert expected.issubset(ids)
+
+    def test_infinite_branch_is_leaf(self):
+        """trigger_loop_infinite_<phase> must have no downstream tasks."""
+        dag = make_phase_dag(
+            "ITEM_EQUIPMENT", "item_equipment_pipeline"
+        )
+        leaf = dag.get_task("trigger_loop_infinite_item_equipment")
+        # Airflow returns downstream_task_ids as a set; assert it's empty.
+        assert not leaf.downstream_task_ids, (
+            f"infinite branch should be leaf, got downstream={leaf.downstream_task_ids}"
+        )
+
+    def test_count_branch_wires_count_sensor_then_stop_loop(self):
+        dag = make_phase_dag(
+            "ITEM_EQUIPMENT", "item_equipment_pipeline"
+        )
+        trigger_loop = dag.get_task("trigger_loop_item_equipment")
+        count_sensor = dag.get_task("count_sensor_item_equipment")
+        stop_loop = dag.get_task("stop_loop_item_equipment")
+        assert count_sensor.task_id in trigger_loop.downstream_task_ids
+        assert stop_loop.task_id in count_sensor.downstream_task_ids

--- a/docker/airflow/dags/tests/test_phase_pipeline_factory.py
+++ b/docker/airflow/dags/tests/test_phase_pipeline_factory.py
@@ -1,0 +1,57 @@
+"""Unit tests for phase_pipeline_factory helpers."""
+import pytest
+from airflow.exceptions import AirflowException
+
+from phase_pipeline_factory import parse_mode
+
+
+class TestParseMode:
+    def test_default_empty_conf_raises(self):
+        with pytest.raises(AirflowException, match="mode is required"):
+            parse_mode({})
+
+    def test_mode_once(self):
+        assert parse_mode({"mode": "once"}) == ("once", 0)
+
+    def test_mode_count_valid(self):
+        assert parse_mode({"mode": "count", "count": 5}) == ("count", 5)
+
+    def test_mode_count_missing_count_raises(self):
+        with pytest.raises(AirflowException, match="count is required"):
+            parse_mode({"mode": "count"})
+
+    def test_mode_count_zero_raises(self):
+        with pytest.raises(AirflowException, match="count must be >= 1"):
+            parse_mode({"mode": "count", "count": 0})
+
+    def test_mode_count_negative_raises(self):
+        with pytest.raises(AirflowException, match="count must be >= 1"):
+            parse_mode({"mode": "count", "count": -1})
+
+    def test_mode_infinite(self):
+        assert parse_mode({"mode": "infinite"}) == ("infinite", 0)
+
+    def test_mode_infinite_ignores_count(self):
+        assert parse_mode({"mode": "infinite", "count": 999}) == ("infinite", 0)
+
+    def test_mode_invalid_raises(self):
+        with pytest.raises(AirflowException, match="invalid mode"):
+            parse_mode({"mode": "foo"})
+
+    def test_mode_wrong_type_raises(self):
+        with pytest.raises(AirflowException):
+            parse_mode({"mode": 123})
+
+    @pytest.mark.parametrize(
+        "conf",
+        [
+            {"mode": "count"},          # missing count
+            {"mode": "count", "count": 0},
+            {"mode": "count", "count": -3},
+            {"mode": "INVALID"},
+            {"mode": "ONCE"},            # case-sensitive
+        ],
+    )
+    def test_invalid_confs_raise(self, conf):
+        with pytest.raises(AirflowException):
+            parse_mode(conf)

--- a/docker/airflow/dags/tests/test_phase_pipeline_factory.py
+++ b/docker/airflow/dags/tests/test_phase_pipeline_factory.py
@@ -85,12 +85,21 @@ class TestGetExternalApiBase:
 class TestMakeTriggerOnceTask:
     """Tests via the underlying PythonOperator callable (callable._trigger)."""
 
+    @staticmethod
+    def _patch_api_base():
+        """Patch get_external_api_base so requests.get/post can run without Airflow Connection."""
+        return patch(
+            "phase_pipeline_factory.get_external_api_base",
+            return_value="http://test:8081",
+        )
+
     def _get_callable(self, phase):
         op = make_trigger_once_task(phase)
         return op.python_callable
 
     def test_success_returns_run_id(self):
-        with patch("phase_pipeline_factory.requests.post") as mock_post:
+        with self._patch_api_base(), \
+             patch("phase_pipeline_factory.requests.post") as mock_post:
             mock_resp = MagicMock()
             mock_resp.status_code = 202
             mock_resp.json.return_value = {"runId": "abc-123", "status": "STARTED"}
@@ -101,7 +110,8 @@ class TestMakeTriggerOnceTask:
         assert result == {"runId": "abc-123", "status": "STARTED"}
 
     def test_409_already_active_returns_active_run_id(self):
-        with patch("phase_pipeline_factory.requests.post") as mock_post, \
+        with self._patch_api_base(), \
+             patch("phase_pipeline_factory.requests.post") as mock_post, \
              patch("phase_pipeline_factory.requests.get") as mock_get:
             post_resp = MagicMock()
             post_resp.status_code = 409
@@ -120,7 +130,8 @@ class TestMakeTriggerOnceTask:
         assert result["runId"] == "active-run"
 
     def test_400_raises(self):
-        with patch("phase_pipeline_factory.requests.post") as mock_post:
+        with self._patch_api_base(), \
+             patch("phase_pipeline_factory.requests.post") as mock_post:
             mock_resp = MagicMock()
             mock_resp.status_code = 400
             mock_resp.text = "INVALID_PHASE"
@@ -131,7 +142,8 @@ class TestMakeTriggerOnceTask:
                 )
 
     def test_500_raises(self):
-        with patch("phase_pipeline_factory.requests.post") as mock_post:
+        with self._patch_api_base(), \
+             patch("phase_pipeline_factory.requests.post") as mock_post:
             mock_resp = MagicMock()
             mock_resp.status_code = 500
             mock_resp.text = "internal error"
@@ -144,7 +156,8 @@ class TestMakeTriggerOnceTask:
 
     def test_includes_upstream_header_when_run_id_provided(self):
         """When upstream_run_id xcom is passed, send X-Upstream-Run-Id header."""
-        with patch("phase_pipeline_factory.requests.post") as mock_post:
+        with self._patch_api_base(), \
+             patch("phase_pipeline_factory.requests.post") as mock_post:
             mock_resp = MagicMock()
             mock_resp.status_code = 202
             mock_resp.json.return_value = {"runId": "child"}
@@ -158,12 +171,20 @@ class TestMakeTriggerOnceTask:
 
 
 class TestMakeTriggerLoopTask:
+    @staticmethod
+    def _patch_api_base():
+        return patch(
+            "phase_pipeline_factory.get_external_api_base",
+            return_value="http://test:8081",
+        )
+
     def _get_callable(self, phase):
         op = make_trigger_loop_task(phase)
         return op.python_callable
 
     def test_success_returns_loop_id(self):
-        with patch("phase_pipeline_factory.requests.post") as mock_post:
+        with self._patch_api_base(), \
+             patch("phase_pipeline_factory.requests.post") as mock_post:
             mock_resp = MagicMock()
             mock_resp.status_code = 202
             mock_resp.json.return_value = {
@@ -176,7 +197,8 @@ class TestMakeTriggerLoopTask:
         assert result["loopId"] == "loop-1"
 
     def test_409_already_looping(self):
-        with patch("phase_pipeline_factory.requests.post") as mock_post:
+        with self._patch_api_base(), \
+             patch("phase_pipeline_factory.requests.post") as mock_post:
             mock_resp = MagicMock()
             mock_resp.status_code = 409
             mock_resp.json.return_value = {"loopId": "existing", "phase": "ITEM_EQUIPMENT"}
@@ -188,7 +210,8 @@ class TestMakeTriggerLoopTask:
         assert result["loopId"] == "existing"
 
     def test_400_invalid_phase_raises(self):
-        with patch("phase_pipeline_factory.requests.post") as mock_post:
+        with self._patch_api_base(), \
+             patch("phase_pipeline_factory.requests.post") as mock_post:
             mock_resp = MagicMock()
             mock_resp.status_code = 400
             mock_resp.text = "INVALID_PHASE"
@@ -199,7 +222,8 @@ class TestMakeTriggerLoopTask:
                 )
 
     def test_500_raises(self):
-        with patch("phase_pipeline_factory.requests.post") as mock_post:
+        with self._patch_api_base(), \
+             patch("phase_pipeline_factory.requests.post") as mock_post:
             mock_resp = MagicMock()
             mock_resp.status_code = 503
             mock_resp.text = "service unavailable"
@@ -349,12 +373,20 @@ class TestMakeStopLoopTask:
 
 
 class TestMakeWaitLoopStoppedSensor:
+    @staticmethod
+    def _patch_api_base():
+        return patch(
+            "phase_pipeline_factory.get_external_api_base",
+            return_value="http://test:8081",
+        )
+
     def _get_callable(self, phase):
         op = make_wait_loop_stopped_sensor(phase)
         return op.python_callable
 
     def test_returns_true_when_no_loop_active(self):
-        with patch("phase_pipeline_factory.requests.get") as mock_get:
+        with self._patch_api_base(), \
+             patch("phase_pipeline_factory.requests.get") as mock_get:
             mock_resp = MagicMock()
             mock_resp.status_code = 200
             mock_resp.json.return_value = {"loopSummaries": {}}
@@ -362,7 +394,8 @@ class TestMakeWaitLoopStoppedSensor:
             assert self._get_callable("ITEM_EQUIPMENT")() is True
 
     def test_returns_true_when_status_stopped(self):
-        with patch("phase_pipeline_factory.requests.get") as mock_get:
+        with self._patch_api_base(), \
+             patch("phase_pipeline_factory.requests.get") as mock_get:
             mock_resp = MagicMock()
             mock_resp.status_code = 200
             mock_resp.json.return_value = {
@@ -374,7 +407,8 @@ class TestMakeWaitLoopStoppedSensor:
             assert self._get_callable("ITEM_EQUIPMENT")() is True
 
     def test_returns_false_when_still_running(self):
-        with patch("phase_pipeline_factory.requests.get") as mock_get:
+        with self._patch_api_base(), \
+             patch("phase_pipeline_factory.requests.get") as mock_get:
             mock_resp = MagicMock()
             mock_resp.status_code = 200
             mock_resp.json.return_value = {
@@ -386,7 +420,8 @@ class TestMakeWaitLoopStoppedSensor:
             assert self._get_callable("ITEM_EQUIPMENT")() is False
 
     def test_returns_false_on_transient_http_error(self):
-        with patch("phase_pipeline_factory.requests.get") as mock_get:
+        with self._patch_api_base(), \
+             patch("phase_pipeline_factory.requests.get") as mock_get:
             mock_get.side_effect = Exception("connection refused")
             assert self._get_callable("ITEM_EQUIPMENT")() is False
 
@@ -427,8 +462,16 @@ class TestMakeBranchOnModeForPhase:
 
 
 class TestWaitTerminalFn:
+    @staticmethod
+    def _patch_api_base():
+        return patch(
+            "phase_pipeline_factory.get_external_api_base",
+            return_value="http://test:8081",
+        )
+
     def test_returns_true_when_terminal(self):
-        with patch("phase_pipeline_factory.requests.get") as mock_get, \
+        with self._patch_api_base(), \
+             patch("phase_pipeline_factory.requests.get") as mock_get, \
              patch("phase_pipeline_factory.time") as mock_time:
             mock_time.monotonic.return_value = 0
             mock_resp = MagicMock()
@@ -451,7 +494,8 @@ class TestWaitTerminalFn:
         assert result is True
 
     def test_raises_when_failed(self):
-        with patch("phase_pipeline_factory.requests.get") as mock_get, \
+        with self._patch_api_base(), \
+             patch("phase_pipeline_factory.requests.get") as mock_get, \
              patch("phase_pipeline_factory.time") as mock_time:
             mock_time.monotonic.return_value = 0
             mock_resp = MagicMock()

--- a/docker/airflow/dags/tests/test_phase_pipeline_factory.py
+++ b/docker/airflow/dags/tests/test_phase_pipeline_factory.py
@@ -1,8 +1,15 @@
 """Unit tests for phase_pipeline_factory helpers."""
+from unittest.mock import MagicMock, patch
+
 import pytest
 from airflow.exceptions import AirflowException
 
-from phase_pipeline_factory import parse_mode
+from phase_pipeline_factory import (
+    get_external_api_base,
+    make_trigger_loop_task,
+    make_trigger_once_task,
+    parse_mode,
+)
 
 
 class TestParseMode:
@@ -55,3 +62,143 @@ class TestParseMode:
     def test_invalid_confs_raise(self, conf):
         with pytest.raises(AirflowException):
             parse_mode(conf)
+
+
+class TestGetExternalApiBase:
+    def test_returns_http_url(self):
+        with patch("phase_pipeline_factory.BaseHook") as mock_hook:
+            mock_conn = MagicMock()
+            mock_conn.host = "external-api"
+            mock_conn.port = 8081
+            mock_hook.get_connection.return_value = mock_conn
+            url = get_external_api_base()
+        assert url == "http://external-api:8081"
+
+
+class TestMakeTriggerOnceTask:
+    """Tests via the underlying PythonOperator callable (callable._trigger)."""
+
+    def _get_callable(self, phase):
+        op = make_trigger_once_task(phase)
+        return op.python_callable
+
+    def test_success_returns_run_id(self):
+        with patch("phase_pipeline_factory.requests.post") as mock_post:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 202
+            mock_resp.json.return_value = {"runId": "abc-123", "status": "STARTED"}
+            mock_post.return_value = mock_resp
+            result = self._get_callable("CHARACTER_BASIC")(
+                dag_run=MagicMock(conf={})
+            )
+        assert result == {"runId": "abc-123", "status": "STARTED"}
+
+    def test_409_already_active_returns_active_run_id(self):
+        with patch("phase_pipeline_factory.requests.post") as mock_post, \
+             patch("phase_pipeline_factory.requests.get") as mock_get:
+            post_resp = MagicMock()
+            post_resp.status_code = 409
+            mock_post.return_value = post_resp
+            get_resp = MagicMock()
+            get_resp.status_code = 200
+            get_resp.json.return_value = {
+                "slots": {"CHARACTER_BASIC": {"runId": "active-run", "phase": "CHARACTER_BASIC"}},
+                "lastCompletedByPhase": {},
+            }
+            mock_get.return_value = get_resp
+            result = self._get_callable("CHARACTER_BASIC")(
+                dag_run=MagicMock(conf={})
+            )
+        assert result["status"] == "ALREADY_ACTIVE"
+        assert result["runId"] == "active-run"
+
+    def test_400_raises(self):
+        with patch("phase_pipeline_factory.requests.post") as mock_post:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 400
+            mock_resp.text = "INVALID_PHASE"
+            mock_post.return_value = mock_resp
+            with pytest.raises(AirflowException, match="rejected"):
+                self._get_callable("CHARACTER_BASIC")(
+                    dag_run=MagicMock(conf={})
+                )
+
+    def test_500_raises(self):
+        with patch("phase_pipeline_factory.requests.post") as mock_post:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 500
+            mock_resp.text = "internal error"
+            mock_resp.reason = "Internal Server Error"
+            mock_post.return_value = mock_resp
+            with pytest.raises(AirflowException):
+                self._get_callable("CHARACTER_BASIC")(
+                    dag_run=MagicMock(conf={})
+                )
+
+    def test_includes_upstream_header_when_run_id_provided(self):
+        """When upstream_run_id xcom is passed, send X-Upstream-Run-Id header."""
+        with patch("phase_pipeline_factory.requests.post") as mock_post:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 202
+            mock_resp.json.return_value = {"runId": "child"}
+            mock_post.return_value = mock_resp
+            self._get_callable("OCID_LOOKUP")(
+                dag_run=MagicMock(conf={}),
+                ti=MagicMock(xcom_pull=MagicMock(return_value="upstream-123")),
+            )
+        call_kwargs = mock_post.call_args.kwargs
+        assert call_kwargs["headers"]["X-Upstream-Run-Id"] == "upstream-123"
+
+
+class TestMakeTriggerLoopTask:
+    def _get_callable(self, phase):
+        op = make_trigger_loop_task(phase)
+        return op.python_callable
+
+    def test_success_returns_loop_id(self):
+        with patch("phase_pipeline_factory.requests.post") as mock_post:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 202
+            mock_resp.json.return_value = {
+                "loopId": "loop-1", "phase": "ITEM_EQUIPMENT", "iterationCount": 0,
+            }
+            mock_post.return_value = mock_resp
+            result = self._get_callable("ITEM_EQUIPMENT")(
+                dag_run=MagicMock(conf={})
+            )
+        assert result["loopId"] == "loop-1"
+
+    def test_409_already_looping(self):
+        with patch("phase_pipeline_factory.requests.post") as mock_post:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 409
+            mock_resp.json.return_value = {"loopId": "existing", "phase": "ITEM_EQUIPMENT"}
+            mock_post.return_value = mock_resp
+            result = self._get_callable("ITEM_EQUIPMENT")(
+                dag_run=MagicMock(conf={})
+            )
+        assert result["status"] == "ALREADY_LOOPING"
+        assert result["loopId"] == "existing"
+
+    def test_400_invalid_phase_raises(self):
+        with patch("phase_pipeline_factory.requests.post") as mock_post:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 400
+            mock_resp.text = "INVALID_PHASE"
+            mock_post.return_value = mock_resp
+            with pytest.raises(AirflowException):
+                self._get_callable("RANKING_FETCH")(
+                    dag_run=MagicMock(conf={})
+                )
+
+    def test_500_raises(self):
+        with patch("phase_pipeline_factory.requests.post") as mock_post:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 503
+            mock_resp.text = "service unavailable"
+            mock_resp.reason = "Service Unavailable"
+            mock_post.return_value = mock_resp
+            with pytest.raises(AirflowException):
+                self._get_callable("ITEM_EQUIPMENT")(
+                    dag_run=MagicMock(conf={})
+                )

--- a/docker/airflow/dags/tests/test_sequence_steps.py
+++ b/docker/airflow/dags/tests/test_sequence_steps.py
@@ -88,7 +88,8 @@ def test_parse_steps_rejects_non_dict_step():
 
 def test_wait_for_phase_terminal_returns_on_terminal_true():
     """Polls once, finds terminal=True, returns."""
-    with patch("per_phase_tasks.requests.get") as mock_get:
+    with patch("per_phase_tasks.get_external_api_base", return_value="http://test:8081"), \
+         patch("per_phase_tasks.requests.get") as mock_get:
         mock_resp = MagicMock()
         mock_resp.json.return_value = {
             "slots": {
@@ -107,7 +108,8 @@ def test_wait_for_phase_terminal_returns_on_terminal_true():
 
 def test_wait_for_phase_terminal_uses_run_group_prefix():
     """runId's date-time prefix identifies the run across 4 phases."""
-    with patch("per_phase_tasks.requests.get") as mock_get:
+    with patch("per_phase_tasks.get_external_api_base", return_value="http://test:8081"), \
+         patch("per_phase_tasks.requests.get") as mock_get:
         mock_resp = MagicMock()
         mock_resp.json.return_value = {
             "slots": {
@@ -131,7 +133,8 @@ def test_wait_for_phase_terminal_uses_run_group_prefix():
 
 def test_wait_for_phase_terminal_raises_on_failed():
     """FAILED phase → RuntimeError."""
-    with patch("per_phase_tasks.requests.get") as mock_get:
+    with patch("per_phase_tasks.get_external_api_base", return_value="http://test:8081"), \
+         patch("per_phase_tasks.requests.get") as mock_get:
         mock_resp = MagicMock()
         mock_resp.json.return_value = {
             "slots": {
@@ -152,7 +155,8 @@ def test_wait_for_phase_terminal_raises_on_failed():
 
 def test_wait_for_phase_terminal_times_out():
     """If phase never reaches terminal within timeout, raise."""
-    with patch("per_phase_tasks.requests.get") as mock_get:
+    with patch("per_phase_tasks.get_external_api_base", return_value="http://test:8081"), \
+         patch("per_phase_tasks.requests.get") as mock_get:
         mock_resp = MagicMock()
         mock_resp.json.return_value = {
             "slots": {

--- a/docker/prometheus/prometheus.yml
+++ b/docker/prometheus/prometheus.yml
@@ -71,3 +71,16 @@ scrape_configs:
       - targets: ['node-exporter:9100']
         labels:
           component: 'system'
+
+  # ============================================
+  # cAdvisor - per-container metrics (restart-rate alerting, ADR-733)
+  # Reached via the host port (prometheus uses network_mode: host).
+  # ============================================
+  - job_name: 'cadvisor'
+    scrape_interval: 15s
+    scrape_timeout: 10s
+    metrics_path: '/metrics'
+    static_configs:
+      - targets: ['localhost:8086']
+        labels:
+          component: 'containers'

--- a/docker/prometheus/rules/alert_rules.yml
+++ b/docker/prometheus/rules/alert_rules.yml
@@ -242,3 +242,18 @@ groups:
         annotations:
           summary: "Large sync queue size"
           description: "Sync queue size is {{ $value }} for more than 5 minutes"
+
+      # ============================================
+      # Container Restart Thrashing (ADR-733)
+      # cAdvisor's container_start_time_seconds jumps on each container
+      # restart; changes() counts those jumps over the window.
+      # ============================================
+      - alert: ContainerRestartThrashing
+        expr: changes(container_start_time_seconds{container!="",container!="POD"}[5m]) > 2
+        for: 1m
+        labels:
+          severity: warning
+          category: system
+        annotations:
+          summary: "Container {{ $labels.name }} is restarting repeatedly"
+          description: "{{ $labels.name }} restarted {{ $value }} times in the last 5m"

--- a/docker/promtail/config.yml
+++ b/docker/promtail/config.yml
@@ -57,3 +57,33 @@ scrape_configs:
           job: artifact-logs
           app: maple-expectation
           __path__: /var/log/data/runs/**/*.log
+
+  # Container stdout collection (ADR-733). opt-in: only containers carrying
+  # the label logging=promtail are scraped, so the file-tailed module logs
+  # above are NOT duplicated. Targets the docker socket.
+  - job_name: docker_containers
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 30s
+        filters:
+          - name: label
+            values: ["logging=promtail"]
+    relabel_configs:
+      - source_labels: ["__meta_docker_container_name"]
+        regex: '/(.*)'
+        target_label: container
+      - source_labels: ["__meta_docker_container_label_com_docker_compose_service"]
+        target_label: service
+    pipeline_stages:
+      - json:
+          expressions:
+            level: level
+            message: message
+            timestamp: timestamp
+          on_error: continue
+      - labels:
+          level:
+      - timestamp:
+          source: timestamp
+          format: '2006-01-02T15:04:05.999999999Z07:00'
+          on_failure: continue

--- a/docs/01_ADR/ADR-733_coolify-observability-autodeploy.md
+++ b/docs/01_ADR/ADR-733_coolify-observability-autodeploy.md
@@ -1,0 +1,85 @@
+# ADR-733: Observability (cAdvisor restart alert) + apps auto-deploy
+
+- Status: Accepted
+- Date: 2026-06-22
+- Owner: zbnerd
+
+---
+
+## 1. Background / Problem
+
+### Background
+
+- Phases 1–2 (ADR-731/732) gave infra + apps 3-layer self-healing under Coolify. Visibility into restarts was a noted gap (spec Section 8).
+
+### Problem
+
+- No metric tells us when containers are thrashing (restart loops). The autoheal/restart policies work silently.
+- Container stdout (e.g., autoheal restart events) is not collected — promtail only tails module log files.
+- App deploys are still manual; push-to-develop should redeploy.
+- No single ops document for the Coolify topology.
+
+### Goal
+
+- A restart-rate alert; opt-in container stdout logging; apps auto-deploy; a setup guide.
+
+---
+
+## 2. Decision
+
+> Add cAdvisor for per-container metrics + a `ContainerRestartThrashing` alert on `container_start_time_seconds`; add a promtail `docker_sd_configs` job opt-in via label; enable Coolify auto-deploy for `maple-apps`; write `docs/21_Operations/coolify-setup-guide.md`.
+
+```text
+cAdvisor (container_start_time_seconds) → prometheus → ContainerRestartThrashing rule
+container stdout (label logging=promtail) → promtail docker_sd → Loki
+push to develop → GHCR image → Coolify maple-apps auto-deploy
+```
+
+Restart detection: cAdvisor exposes `container_start_time_seconds` (a gauge that jumps on each restart). `changes(...[5m])` counts those jumps; >2 in 5m fires the alert.
+
+---
+
+## 3. Trade-offs
+
+### Sensitivity
+
+* cAdvisor mounts `/` (rootfs) read-only + docker socket paths — broad host read access (standard cAdvisor requirement; read-only).
+* promtail now reads the Docker socket (ro) for discovery — same trust class as autoheal.
+* `changes()` on a gauge can count non-restart value fluctuations in edge cases; `for: 1m` + threshold >2 dampens false positives.
+
+### Trade-off
+
+| 선택 | 얻는 것 | 포기한 것 |
+| -- | ---- | ----- |
+| cAdvisor `container_start_time_seconds` + `changes()` | per-container restart visibility, no extra exporter | gauge-based counting (not a true restart_counter) |
+| opt-in `logging=promtail` label | avoids duplicating file-tailed module logs | only labeled containers' stdout is collected |
+| auto-deploy ON for apps | push-to-deploy | bad commit auto-redeploys; mitigated by sha rollback |
+
+### Risk
+
+* alertmanager is referenced by prometheus but NOT running (only in the legacy `docker-compose.observability.yml` overlay). The restart alert will be evaluated and visible in the prometheus UI, but delivery (Slack/email) requires wiring alertmanager — deferred.
+
+### Non-Risk
+
+* cAdvisor itself — covered by `restart: always` (no healthcheck; avoids a false restart-loop on images lacking the probe binary).
+
+---
+
+## 4. Result / Evidence
+
+### Metrics
+
+| Metric | Value | Notes |
+| ------ | ----: | ----- |
+| restart-rate metric (before) | none | silent thrashing |
+| container stdout collection (before) | none | file-tailed module logs only |
+
+### Observed Result
+
+Code changes merged (Phase 3). Operator verification (cAdvisor target up, alert fires on a forced-restart test, promtail ships container stdout to Loki) pending on the Coolify host (runbook R-2/R-3 in the Phase 3 plan).
+
+---
+
+## 5. Summary
+
+> Add cAdvisor-based restart alerting, opt-in container stdout logging, apps auto-deploy, and a setup guide to complete Coolify self-healing observability.

--- a/docs/01_ADR/ADR-734_phase-separated-dags.md
+++ b/docs/01_ADR/ADR-734_phase-separated-dags.md
@@ -1,0 +1,109 @@
+# ADR-734: Phase-Separated Airflow DAGs
+
+- Status: Accepted
+- Date: 2026-06-22
+- Owner: pipeline
+
+---
+
+## 1. Background / Problem
+
+### Background
+
+The single `daily_collection_pipeline` DAG dispatched 3 fundamentally different
+workflows (full daily chain, per-phase parallel fan-out, ordered steps) via a
+`branch_on_scope` operator that parsed JSON `scope` / `steps` config at
+runtime. Operators reading the Airflow UI could not tell what a DAG run would
+do without inspecting `dag_run.conf`. The DAG graph materialized 17 task
+definitions even when 14 were skipped.
+
+### Problem
+
+DAG ergonomics for operators: each workflow intent (run once, run N times,
+run forever) required writing a JSON scope config rather than selecting a
+pre-built DAG.
+
+### Goal
+
+Each Airflow DAG has a single workflow intent visible from its DAG id and
+tags. Operator selects intent by DAG id, not by parsing JSON.
+
+---
+
+## 2. Decision
+
+> Replace `daily_collection_pipeline` with five single-purpose DAGs.
+
+```text
+ranking_ocid_lookup_pipeline (manual; RANKING → OCID sequential)
+character_basic_pipeline      (manual; mode=once|count=N|infinite)
+item_equipment_pipeline       (manual; mode=once|count=N|infinite)
+daily_full_pipeline           (cron; chains the 3 above + cleanup)
+stop_loop_pipeline            (manual; stops mode=infinite loops)
+```
+
+Loop state continues to live in ext-api's in-memory `PhaseLoopController`.
+Airflow sensors count chunk-ready events to bound `mode=count`; `stop_loop_pipeline`
+provides the kill switch for `mode=infinite`. Legacy `daily_collection_pipeline`
+retained as deprecated for one release cycle.
+
+---
+
+## 3. Trade-offs
+
+### Sensitivity
+
+* DAG count: 5 new + 1 legacy + 1 cleanup = 7 DAGs vs 1 today.
+* Operator JSON scope parsing: eliminated at trigger time (mode parameter on
+  conf is the only free-form input).
+* Loop termination latency: `stop_loop_pipeline` waits up to 30min for current
+  chunk to drain. Operators wanting immediate stop use ext-api's
+  `POST /stop/loop/phase/{phase}` directly.
+
+### Trade-off
+
+| 선택 | 얻는 것 | 포기한 것 |
+| -- | ---- | ----- |
+| 5 DAGs vs 1 | Single-responsibility per DAG, clean Airflow UI, intent visible from DAG id, no JSON parsing | 4 extra DAG parses per scheduler cycle (~30s/parse), slight cognitive load from choosing the right DAG |
+| Airflow sensor counting chunks (mode=count) | Zero ext-api changes, observable in Airflow logs, bounded slot occupancy | DAG occupies worker slot for `count*5min+30min` |
+| Ext-api keeps loop state | Reuses existing `PhaseLoopController`, no behavior change | Loop dies with ext-api restart (pre-existing limitation per #1291 §13) |
+
+### Risk
+
+* Legacy `daily_collection_pipeline` bit rot if not exercised by CI: mitigated
+  by `test_dag_imports.py` asserting legacy DAG still parses.
+* 5 DAGs → operator confusion about which to trigger: mitigated by runbook
+  `docs/21_Operations/dag-migration.md`.
+* `count_sensor` timeout mis-tuned (5min/chunk P99 wrong): verified during
+  pipeline-test; constant documented in runbook.
+
+### Non-Risk
+
+* `daily_full_pipeline` cron duplicate (both legacy + new trigger at 18:00 UTC):
+  mitigated by setting legacy `schedule=None`.
+* DAG graph complexity from branch operators: each phase DAG has 1 branch +
+  ~6 tasks, well under any Airflow UI rendering limit.
+
+---
+
+## 4. Result / Evidence
+
+### Metrics
+
+| Metric | Value | Notes |
+| ------ | ----: | ----- |
+| DAG count | 7 (5 new + 1 legacy + 1 cleanup) | vs 1 before |
+| Task count per phase DAG | ~7 (1 health + 1 branch + 2-3 once + 1-3 count + 1-2 stop) | vs 17 in legacy |
+| `parse_mode` test coverage | 14 cases | empty/invalid/missing count/zero/negative/case |
+| Operator migration window | 1 release cycle | legacy DAG tagged deprecated |
+
+### Observed Result
+
+Pending — measured after pipeline-test skill E2E run.
+
+---
+
+## 5. Summary
+
+> Five single-purpose DAGs replace one overloaded DAG; loop state stays in ext-api;
+> operators select workflow by DAG id, not by JSON config.

--- a/docs/21_Operations/coolify-setup-guide.md
+++ b/docs/21_Operations/coolify-setup-guide.md
@@ -1,0 +1,75 @@
+# Coolify Setup Guide — Self-Healing Maple Stack
+
+How the maple stack runs under Coolify (3-layer self-healing) and how to operate it. Covers Phases 1–3 (ADRs 731, 732, 733).
+
+## Topology
+
+Two Coolify **Docker Compose** resources, one shared external network, one autoheal sidecar.
+
+| Resource | Compose file | Containers | Auto-deploy |
+|----------|--------------|------------|-------------|
+| `maple-infra` | `docker-compose.yml` | postgres, minio, kafka, redis, prometheus, grafana, loki, promtail, cadvisor, autoheal, minio-bootstrap | OFF (manual) |
+| `maple-apps` | `docker-compose.services.yml` | external-api, calculator, synchronizer, cleanup | ON (push to `develop`) |
+
+Network: `maple-network` is **external** — create once before first deploy:
+```bash
+docker network create --subnet=172.20.0.0/16 maple-network
+```
+
+## 3-Layer self-healing
+
+| Layer | Owner | Fires on | Action |
+|-------|-------|----------|--------|
+| L1 Docker restart policy | Docker daemon | container exit | instant restart |
+| L2 Coolify Sentinel | Coolify server setting | stopped/abnormal-exit container | restart |
+| L3 autoheal | autoheal sidecar | `health_status=unhealthy` (labeled containers) | `docker restart` |
+
+Every persistent container has a `healthcheck` + the `autoheal: "true"` label. Excluded: `minio-bootstrap` (one-shot), `autoheal` (cannot restart itself), `cadvisor` (observability infra; `restart: always` only — no healthcheck, to avoid false restart-loops on images lacking the probe binary).
+
+## Secrets
+
+| Tier | Mechanism | Examples |
+|------|-----------|----------|
+| A. Coolify Secrets (encrypted) | Coolify UI → env | `DB_ROOT_PASSWORD`, `NEXON_API_KEY`, `MINIO_ROOT_USER/PASSWORD`, `GRAFANA_ADMIN_*`, `SA_*_SECRET_KEY` |
+| B. File secret (SA keys) | bind mount at `SECRETS_DIR_HOST` (`/opt/maple/secrets`) | `sa-<module>.key` (4 files) |
+| C. Plain config | Coolify env | `DB_URL`, `KAFKA_BOOTSTRAP_SERVERS`, image refs, `SECRETS_DIR` |
+
+`/opt/maple/secrets/` is written by `minio-bootstrap` (infra resource) and read by the apps (apps resource) via the compose `secrets:` directive. **Back it up** alongside the volumes.
+
+## Deploy order
+
+1. `docker network create --subnet=172.20.0.0/16 maple-network` (one-time)
+2. Deploy `maple-infra` → wait all healthy.
+3. Deploy `maple-apps` → wait all healthy. If infra not ready, apps crash→restart until it is.
+
+## Image pipeline (apps)
+
+```
+push to develop
+  → GitHub Actions: bootJar → build.sh → tag/push ghcr.io/zbnerd/maple-<svc>:{sha,latest}
+Coolify maple-apps (auto-deploy) → docker compose pull + up
+```
+
+Image refs in compose use `${IMAGE_<SVC>}` (default `maple/<svc>:dev` for local dev).
+
+## Rollback
+
+- **Apps:** set `IMAGE_<SVC>=ghcr.io/zbnerd/maple-<svc>:sha-<prior>` in the `maple-apps` resource env, redeploy. Or use Coolify's Rollback UI.
+- **Infra:** NOT a rollback target — postgres/kafka version downgrades risk data. Fix-forward or restore from volume backup.
+
+## Recovery verification
+
+- **Hard crash:** `docker kill maple-redis` → it restarts within seconds (L1/L2).
+- **Soft failure (unhealthy):** break a probe target or pause the service; within ~90–150s autoheal restarts it (L3). Watch `docker logs -f maple-autoheal`.
+- **Restart-rate alert:** `ContainerRestartThrashing` (cAdvisor `container_start_time_seconds`, `changes() > 2` in 5m) in the prometheus UI.
+
+## Observability gaps (pre-existing, separate cleanup)
+
+- **alertmanager:** referenced by `prometheus.yml` (`alertmanager:9093`) but only defined in the legacy `docker-compose.observability.yml` overlay; not running. Alerts evaluate in prometheus but are not delivered until alertmanager is wired into the active `docker-compose.yml`.
+- **node-exporter:** scraped by `prometheus.yml` but only defined in the legacy overlay; not running. System metrics alerts (`HighCpuUsage`, etc.) have no data until it is wired in.
+
+## Backup checklist
+
+- Named volumes: `postgres_data`, `minio_data`, `kafka_data`, `redis_data`, `loki_data`, `grafana_data`, `prometheus_data`.
+- `/opt/maple/secrets/` (SA keys).
+- Coolify resource configs (export from UI).

--- a/docs/21_Operations/dag-migration.md
+++ b/docs/21_Operations/dag-migration.md
@@ -1,0 +1,76 @@
+# DAG Migration Guide — Phase-Separated Pipelines
+
+As of 2026-06-22, the legacy `daily_collection_pipeline` is deprecated.
+This guide maps common operator workflows to the new phase-separated DAGs.
+
+## Mapping table
+
+| Old (legacy) | New | Trigger command |
+|--------------|-----|-----------------|
+| `daily_collection_pipeline -c '{}'` (scheduled daily) | `daily_full_pipeline` (scheduled at KST 03:00) | Auto. No operator action needed. |
+| `daily_collection_pipeline -c '{"scope":["ITEM_EQUIPMENT_LOOP"]}'` (start loop) | `item_equipment_pipeline -c '{"mode":"infinite"}'` | `airflow dags trigger item_equipment_pipeline -c '{"mode":"infinite"}'` |
+| `daily_collection_pipeline -c '{"scope":["ITEM_EQUIPMENT_LOOP", "OCID_LOOKUP_STOP"]}'` (mixed) | (compose) Trigger each phase DAG separately | `airflow dags trigger item_equipment_pipeline -c '{"mode":"infinite"}'` then `airflow dags trigger ranking_ocid_lookup_pipeline -c '{}'` (note: no current way to stop OCID via new DAGs — use ext-api directly or open an issue) |
+| `daily_collection_pipeline -c '{"scope":["ITEM_EQUIPMENT"]}'` (run once) | `item_equipment_pipeline -c '{"mode":"once"}'` | `airflow dags trigger item_equipment_pipeline -c '{"mode":"once"}'` |
+| `daily_collection_pipeline -c '{"steps":[{...},{...}]}'` (ordered sequence) | Compose phase DAGs sequentially | (no direct equivalent — see "Ordered sequences" below) |
+| `daily_collection_pipeline -c '{"scope":["ITEM_EQUIPMENT_STOP"]}'` (stop loop) | `stop_loop_pipeline -c '{"phase":"ITEM_EQUIPMENT"}'` | `airflow dags trigger stop_loop_pipeline -c '{"phase":"ITEM_EQUIPMENT"}'` |
+
+## Mode parameter reference
+
+For `character_basic_pipeline` and `item_equipment_pipeline`:
+
+| Mode | Behavior | DAG duration |
+|------|----------|--------------|
+| `{"mode":"once"}` | Trigger phase, wait terminal | Until phase completes (typically 30-90min for once) |
+| `{"mode":"count","count":N}` | Trigger loop, count N chunk-ready events, stop | `N × ~5min + 30min buffer` (e.g., count=3 → ~45min) |
+| `{"mode":"infinite"}` | Trigger loop, DAG succeeds immediately | <1min (loop continues in ext-api) |
+
+`count` must be an integer >= 1. `mode` must be one of `once`, `count`, `infinite` (case-sensitive).
+
+## Ordered sequences
+
+The old `steps` config (e.g., `RANKING_FETCH → OCID_LOOKUP → ITEM_EQUIPMENT_LOOP`) is replaced by **explicit sequential triggering**:
+
+```bash
+# Trigger ranking_ocid first; wait for it to finish; then trigger item_equipment loop
+airflow dags trigger ranking_ocid_lookup_pipeline -c '{}'
+# ... wait for completion ...
+airflow dags trigger item_equipment_pipeline -c '{"mode":"infinite"}'
+```
+
+For an automated sequential chain, use the wrapper:
+
+```bash
+airflow dags trigger daily_full_pipeline -c '{}'
+```
+
+This runs `ranking_ocid → character_basic(once) → item_equipment(once) → cleanup`. There is no built-in way to chain with `mode=count` or `mode=infinite` — those require operator judgment.
+
+## Stopping an infinite loop
+
+```bash
+# Check active loops
+curl -s http://localhost:8081/api/internal/run-status | jq '.loopSummaries'
+
+# Stop a loop
+airflow dags trigger stop_loop_pipeline -c '{"phase":"ITEM_EQUIPMENT"}'
+# Waits up to 30min for current chunk to drain + loop to finalize.
+```
+
+`stop_loop_pipeline` is idempotent: triggering it when no loop is active for the given phase succeeds immediately.
+
+## Verification
+
+After triggering any new DAG, verify in Airflow UI:
+1. DAG run shows in DAG's "Runs" tab.
+2. Task graph shows expected branch (once/count/infinite).
+3. For mode=count, the `count_N_<phase>` sensor task shows progress in logs.
+4. For mode=infinite, DAG run succeeds at `trigger_loop_<phase>` task; loop continues in ext-api.
+
+## Migration timeline
+
+- **Now (2026-06-22):** New DAGs active; legacy `daily_collection_pipeline` parseable + manually triggerable. Legacy DAG tagged `deprecated` in UI.
+- **One release cycle later:** Remove legacy `daily_collection_pipeline` + `per_phase_tasks.py` legacy symbols. Migrate any remaining operators first.
+
+## Questions?
+
+Open a GitHub issue with the `airflow` label.

--- a/docs/superpowers/plans/2026-06-22-dag-restructure.md
+++ b/docs/superpowers/plans/2026-06-22-dag-restructure.md
@@ -1,0 +1,2616 @@
+# Airflow DAG Restructure — Phase-Separated Pipelines Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the single multi-path `daily_collection_pipeline` DAG with five single-purpose DAGs (`ranking_ocid_lookup_pipeline`, `character_basic_pipeline`, `item_equipment_pipeline`, `daily_full_pipeline`, `stop_loop_pipeline`), each parameterized by a `mode` (once/count=N/infinite) or `phase` conf.
+
+**Architecture:** New `phase_pipeline_factory.py` provides reusable helper functions (parse_mode, make_trigger_once_task, make_count_sensor, make_stop_loop_task, make_phase_dag). Each new DAG is a thin file calling the factory. Legacy `daily_collection_pipeline` retained as deprecated with `tags=["deprecated"]` for one release cycle. Loop state continues to live in ext-api's in-memory `PhaseLoopController` (no ext-api changes). N-count mode uses Airflow PythonSensor polling Kafka `synchronizer.chunk.consumed` for chunk-ready events, then calls `POST /stop/loop/phase/{phase}`.
+
+**Tech Stack:** Python 3.11, Apache Airflow 2.x (LocalExecutor inside Docker), existing `requests` + `kafka-python-ng` deps, existing ext-api endpoints (`/trigger/phase/{phase}`, `/loop/phase/{phase}`, `/stop/loop/phase/{phase}`, `/run-status`).
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|----------------|
+| `docker/airflow/dags/phase_pipeline_factory.py` | Pure helpers: `parse_mode`, `make_trigger_once_task`, `make_trigger_loop_task`, `make_count_sensor`, `make_stop_loop_task`, `make_wait_loop_stopped_sensor`, `make_branch_on_mode`, `make_phase_dag`. No DAG object. |
+| `docker/airflow/dags/ranking_ocid_lookup_pipeline.py` | DAG with RANKING_FETCH → OCID_LOOKUP sequential chain. |
+| `docker/airflow/dags/character_basic_pipeline.py` | DAG calling `make_phase_dag("CHARACTER_BASIC", ...)`. |
+| `docker/airflow/dags/item_equipment_pipeline.py` | DAG calling `make_phase_dag("ITEM_EQUIPMENT", ...)`. |
+| `docker/airflow/dags/daily_full_pipeline.py` | Wrapper DAG with 4 `TriggerDagRunOperator` tasks. |
+| `docker/airflow/dags/stop_loop_pipeline.py` | DAG with stop_loop + wait_loop_stopped sensor. |
+| `docker/airflow/dags/daily_collection_pipeline.py` | Modify: add `tags=["deprecated"]` and updated docstring. No code path changes. |
+| `docker/airflow/dags/per_phase_tasks.py` | Modify: add `_legacy` module docstring note and per-symbol comments. No symbol changes. |
+| `docker/airflow/dags/tests/test_phase_pipeline_factory.py` | New: unit tests for factory helpers. |
+| `docker/airflow/dags/tests/test_dag_imports.py` | Modify: assert 5 new DAG ids parse. |
+| `docker/airflow/dags/tests/test_phase_dag_structure.py` | New: assert each phase DAG has expected branches. |
+| `docs/21_Operations/dag-migration.md` | New: operator runbook with legacy → new mapping. |
+| `docs/01_ADR/ADR-734_phase-separated-dags.md` | New: ADR with decision, trade-offs, evidence. |
+
+---
+
+## Task 1: Factory — `parse_mode` + tests
+
+**Files:**
+- Create: `docker/airflow/dags/phase_pipeline_factory.py`
+- Create: `docker/airflow/dags/tests/test_phase_pipeline_factory.py`
+
+- [ ] **Step 1: Create test file with parse_mode failing tests**
+
+`docker/airflow/dags/tests/test_phase_pipeline_factory.py`:
+
+```python
+"""Unit tests for phase_pipeline_factory helpers."""
+import pytest
+from airflow.exceptions import AirflowException
+
+from phase_pipeline_factory import parse_mode
+
+
+class TestParseMode:
+    def test_default_empty_conf_raises(self):
+        with pytest.raises(AirflowException, match="mode is required"):
+            parse_mode({})
+
+    def test_mode_once(self):
+        assert parse_mode({"mode": "once"}) == ("once", 0)
+
+    def test_mode_count_valid(self):
+        assert parse_mode({"mode": "count", "count": 5}) == ("count", 5)
+
+    def test_mode_count_missing_count_raises(self):
+        with pytest.raises(AirflowException, match="count is required"):
+            parse_mode({"mode": "count"})
+
+    def test_mode_count_zero_raises(self):
+        with pytest.raises(AirflowException, match="count must be >= 1"):
+            parse_mode({"mode": "count", "count": 0})
+
+    def test_mode_count_negative_raises(self):
+        with pytest.raises(AirflowException, match="count must be >= 1"):
+            parse_mode({"mode": "count", "count": -1})
+
+    def test_mode_infinite(self):
+        assert parse_mode({"mode": "infinite"}) == ("infinite", 0)
+
+    def test_mode_infinite_ignores_count(self):
+        assert parse_mode({"mode": "infinite", "count": 999}) == ("infinite", 0)
+
+    def test_mode_invalid_raises(self):
+        with pytest.raises(AirflowException, match="invalid mode"):
+            parse_mode({"mode": "foo"})
+
+    def test_mode_wrong_type_raises(self):
+        with pytest.raises(AirflowException):
+            parse_mode({"mode": 123})
+
+    @pytest.mark.parametrize(
+        "conf",
+        [
+            {"mode": "count"},          # missing count
+            {"mode": "count", "count": 0},
+            {"mode": "count", "count": -3},
+            {"mode": "INVALID"},
+            {"mode": "ONCE"},            # case-sensitive
+        ],
+    )
+    def test_invalid_confs_raise(self, conf):
+        with pytest.raises(AirflowException):
+            parse_mode(conf)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine && \
+  PYTHONPATH=docker/airflow/dags python3 -m pytest docker/airflow/dags/tests/test_phase_pipeline_factory.py -v
+```
+
+Expected: `ModuleNotFoundError: No module named 'phase_pipeline_factory'`.
+
+- [ ] **Step 3: Implement `parse_mode` (minimal)**
+
+`docker/airflow/dags/phase_pipeline_factory.py`:
+
+```python
+"""Helpers for phase-separated Airflow DAGs.
+
+Used by character_basic_pipeline.py and item_equipment_pipeline.py to build
+once/count=N/infinite mode DAGs from a single factory. Also used by
+stop_loop_pipeline.py for the loop-stop sensor.
+
+Ref: docs/superpowers/specs/2026-06-22-dag-restructure-design.md
+"""
+from __future__ import annotations
+
+from typing import Tuple
+
+from airflow.exceptions import AirflowException
+
+
+_VALID_MODES = frozenset({"once", "count", "infinite"})
+
+
+def parse_mode(conf: dict) -> Tuple[str, int]:
+    """Validate dag_run.conf for phase DAGs.
+
+    Returns:
+        (mode, count): mode ∈ {"once","count","infinite"}; count is the
+            integer for mode=count, else 0.
+
+    Raises:
+        AirflowException: missing/invalid mode, or mode=count without a
+            valid count.
+    """
+    if not isinstance(conf, dict):
+        raise AirflowException(
+            f"dag_run.conf must be a dict, got {type(conf).__name__}"
+        )
+
+    mode = conf.get("mode")
+    if mode is None:
+        raise AirflowException(
+            "mode is required. Allowed: 'once', 'count', 'infinite'"
+        )
+    if not isinstance(mode, str):
+        raise AirflowException(
+            f"mode must be a string, got {type(mode).__name__}"
+        )
+    if mode not in _VALID_MODES:
+        raise AirflowException(
+            f"invalid mode='{mode}'. Allowed: {sorted(_VALID_MODES)}"
+        )
+
+    if mode != "count":
+        return (mode, 0)
+
+    count = conf.get("count")
+    if count is None:
+        raise AirflowException(
+            "count is required when mode='count'"
+        )
+    if not isinstance(count, int) or isinstance(count, bool):
+        raise AirflowException(
+            f"count must be an integer, got {type(count).__name__}"
+        )
+    if count < 1:
+        raise AirflowException(
+            f"count must be >= 1, got {count}"
+        )
+    return ("count", count)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine && \
+  PYTHONPATH=docker/airflow/dags python3 -m pytest docker/airflow/dags/tests/test_phase_pipeline_factory.py -v
+```
+
+Expected: all 14 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine && \
+  git add docker/airflow/dags/phase_pipeline_factory.py \
+          docker/airflow/dags/tests/test_phase_pipeline_factory.py && \
+  git commit -m "feat(airflow): add parse_mode helper for phase DAGs
+
+Validates dag_run.conf for character_basic_pipeline and item_equipment_pipeline.
+Returns (mode, count) tuple; raises AirflowException on invalid input.
+14 unit tests covering: missing mode, invalid mode, missing/zero/negative count,
+type errors, case sensitivity.
+
+Refs: docs/superpowers/specs/2026-06-22-dag-restructure-design.md §6.1
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Factory — `get_external_api_base` + `make_trigger_once_task` + `make_trigger_loop_task` + tests
+
+**Files:**
+- Modify: `docker/airflow/dags/phase_pipeline_factory.py`
+- Modify: `docker/airflow/dags/tests/test_phase_pipeline_factory.py`
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `docker/airflow/dags/tests/test_phase_pipeline_factory.py`:
+
+```python
+from unittest.mock import patch, MagicMock
+
+from phase_pipeline_factory import (
+    make_trigger_once_task,
+    make_trigger_loop_task,
+    get_external_api_base,
+)
+
+
+class TestGetExternalApiBase:
+    def test_returns_http_url(self):
+        with patch("phase_pipeline_factory.BaseHook") as mock_hook:
+            mock_conn = MagicMock()
+            mock_conn.host = "external-api"
+            mock_conn.port = 8081
+            mock_hook.get_connection.return_value = mock_conn
+            url = get_external_api_base()
+        assert url == "http://external-api:8081"
+
+
+class TestMakeTriggerOnceTask:
+    """Tests via the underlying PythonOperator callable (callable._trigger)."""
+
+    def _get_callable(self, phase):
+        op = make_trigger_once_task(phase)
+        return op.python_callable
+
+    def test_success_returns_run_id(self):
+        with patch("phase_pipeline_factory.requests.post") as mock_post:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 202
+            mock_resp.json.return_value = {"runId": "abc-123", "status": "STARTED"}
+            mock_post.return_value = mock_resp
+            result = self._get_callable("CHARACTER_BASIC")(
+                dag_run=MagicMock(conf={})
+            )
+        assert result == {"runId": "abc-123", "status": "STARTED"}
+
+    def test_409_already_active_returns_active_run_id(self):
+        with patch("phase_pipeline_factory.requests.post") as mock_post, \
+             patch("phase_pipeline_factory.requests.get") as mock_get:
+            post_resp = MagicMock()
+            post_resp.status_code = 409
+            mock_post.return_value = post_resp
+            get_resp = MagicMock()
+            get_resp.status_code = 200
+            get_resp.json.return_value = {
+                "slots": {"CHARACTER_BASIC": {"runId": "active-run", "phase": "CHARACTER_BASIC"}},
+                "lastCompletedByPhase": {},
+            }
+            mock_get.return_value = get_resp
+            result = self._get_callable("CHARACTER_BASIC")(
+                dag_run=MagicMock(conf={})
+            )
+        assert result["status"] == "ALREADY_ACTIVE"
+        assert result["runId"] == "active-run"
+
+    def test_400_raises(self):
+        from airflow.exceptions import AirflowException
+        with patch("phase_pipeline_factory.requests.post") as mock_post:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 400
+            mock_resp.text = "INVALID_PHASE"
+            mock_post.return_value = mock_resp
+            with pytest.raises(AirflowException, match="rejected"):
+                self._get_callable("CHARACTER_BASIC")(
+                    dag_run=MagicMock(conf={})
+                )
+
+    def test_500_raises(self):
+        from airflow.exceptions import AirflowException
+        with patch("phase_pipeline_factory.requests.post") as mock_post:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 500
+            mock_resp.text = "internal error"
+            mock_resp.reason = "Internal Server Error"
+            mock_post.return_value = mock_resp
+            with pytest.raises(AirflowException):
+                self._get_callable("CHARACTER_BASIC")(
+                    dag_run=MagicMock(conf={})
+                )
+
+    def test_includes_upstream_header_when_run_id_provided(self):
+        """When upstream_run_id xcom is passed, send X-Upstream-Run-Id header."""
+        with patch("phase_pipeline_factory.requests.post") as mock_post:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 202
+            mock_resp.json.return_value = {"runId": "child"}
+            mock_post.return_value = mock_resp
+            self._get_callable("OCID_LOOKUP")(
+                dag_run=MagicMock(conf={}),
+                ti=MagicMock(xcom_pull=MagicMock(return_value="upstream-123")),
+            )
+        call_kwargs = mock_post.call_args.kwargs
+        assert call_kwargs["headers"]["X-Upstream-Run-Id"] == "upstream-123"
+
+
+class TestMakeTriggerLoopTask:
+    def _get_callable(self, phase):
+        op = make_trigger_loop_task(phase)
+        return op.python_callable
+
+    def test_success_returns_loop_id(self):
+        with patch("phase_pipeline_factory.requests.post") as mock_post:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 202
+            mock_resp.json.return_value = {
+                "loopId": "loop-1", "phase": "ITEM_EQUIPMENT", "iterationCount": 0,
+            }
+            mock_post.return_value = mock_resp
+            result = self._get_callable("ITEM_EQUIPMENT")(
+                dag_run=MagicMock(conf={})
+            )
+        assert result["loopId"] == "loop-1"
+
+    def test_409_already_looping(self):
+        with patch("phase_pipeline_factory.requests.post") as mock_post:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 409
+            mock_resp.json.return_value = {"loopId": "existing", "phase": "ITEM_EQUIPMENT"}
+            mock_post.return_value = mock_resp
+            result = self._get_callable("ITEM_EQUIPMENT")(
+                dag_run=MagicMock(conf={})
+            )
+        assert result["status"] == "ALREADY_LOOPING"
+        assert result["loopId"] == "existing"
+
+    def test_400_invalid_phase_raises(self):
+        from airflow.exceptions import AirflowException
+        with patch("phase_pipeline_factory.requests.post") as mock_post:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 400
+            mock_resp.text = "INVALID_PHASE"
+            mock_post.return_value = mock_resp
+            with pytest.raises(AirflowException):
+                self._get_callable("RANKING_FETCH")(
+                    dag_run=MagicMock(conf={})
+                )
+
+    def test_500_raises(self):
+        from airflow.exceptions import AirflowException
+        with patch("phase_pipeline_factory.requests.post") as mock_post:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 503
+            mock_resp.text = "service unavailable"
+            mock_resp.reason = "Service Unavailable"
+            mock_post.return_value = mock_resp
+            with pytest.raises(AirflowException):
+                self._get_callable("ITEM_EQUIPMENT")(
+                    dag_run=MagicMock(conf={})
+                )
+```
+
+- [ ] **Step 2: Run new tests to verify they fail**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine && \
+  PYTHONPATH=docker/airflow/dags python3 -m pytest docker/airflow/dags/tests/test_phase_pipeline_factory.py -v -k "GetExternalApiBase or MakeTrigger"
+```
+
+Expected: `ImportError` (helpers not yet defined).
+
+- [ ] **Step 3: Implement helpers in `phase_pipeline_factory.py`**
+
+Append to `docker/airflow/dags/phase_pipeline_factory.py`:
+
+```python
+import os
+from datetime import timedelta
+
+import requests
+from airflow.hooks.base import BaseHook
+from airflow.operators.python import PythonOperator
+
+
+def get_external_api_base() -> str:
+    """Resolve ext-api base URL from Airflow Connection 'external_api'."""
+    conn = BaseHook.get_connection("external_api")
+    return f"http://{conn.host}:{conn.port}"
+
+
+def _trigger_once_fn(phase: str):
+    """Inner: trigger phase once via POST /trigger/phase/{phase}.
+
+    Reads upstream_run_id from xcom (task_id='upstream_run_id_pusher') if
+    present — OCID_LOOKUP and downstream phases require X-Upstream-Run-Id.
+    RANKING_FETCH ignores the header (it IS the upstream).
+    """
+    def _trigger(**ctx):
+        conf = ctx["dag_run"].conf or {}
+        # parse_mode is the upstream branch task; conf is already validated
+        # there. Skip re-parse here.
+        base = get_external_api_base()
+        ti = ctx.get("ti")
+        upstream_run_id = ti.xcom_pull(task_ids="upstream_run_id") if ti else None
+
+        headers = {}
+        if upstream_run_id and phase != "RANKING_FETCH":
+            headers["X-Upstream-Run-Id"] = upstream_run_id
+
+        try:
+            resp = requests.post(
+                f"{base}/api/internal/trigger/phase/{phase}",
+                headers=headers,
+                timeout=30,
+            )
+        except requests.RequestException as exc:
+            raise AirflowException(f"Trigger {phase} failed: {exc}") from exc
+
+        if resp.status_code in (200, 202):
+            return resp.json()
+
+        if resp.status_code == 409:
+            try:
+                status_resp = requests.get(
+                    f"{base}/api/internal/run-status", timeout=10
+                )
+                status_resp.raise_for_status()
+                data = status_resp.json()
+            except (requests.RequestException, ValueError) as exc:
+                raise AirflowException(
+                    f"409 from trigger {phase} but /run-status fetch failed: {exc}"
+                ) from exc
+            slot = (data.get("slots") or {}).get(phase) or {}
+            return {
+                "runId": slot.get("runId"),
+                "phase": phase,
+                "status": "ALREADY_ACTIVE",
+            }
+
+        raise AirflowException(
+            f"Trigger {phase} failed: HTTP {resp.status_code} "
+            f"{resp.reason}: {resp.text[:500]}"
+        )
+
+    return _trigger
+
+
+def make_trigger_once_task(phase: str) -> PythonOperator:
+    """Build a PythonOperator that triggers phase once.
+
+    Caller wires `>>` between upstream's xcom pusher and this task.
+    """
+    return PythonOperator(
+        task_id=f"trigger_{phase.lower()}",
+        python_callable=_trigger_once_fn(phase),
+        retries=0,
+        execution_timeout=timedelta(seconds=60),
+        do_xcom_push=True,
+    )
+
+
+def _trigger_loop_fn(phase: str):
+    """Inner: start infinite loop via POST /loop/phase/{phase}.
+
+    mode=count and mode=infinite both start the loop. The count sensor
+    (mode=count) or operator action (mode=infinite) handles termination.
+    """
+    def _loop(**ctx):
+        base = get_external_api_base()
+        try:
+            resp = requests.post(
+                f"{base}/api/internal/loop/phase/{phase}", timeout=30
+            )
+        except requests.RequestException as exc:
+            raise AirflowException(f"Loop start {phase} failed: {exc}") from exc
+
+        if resp.status_code == 202:
+            return resp.json()
+
+        if resp.status_code == 409:
+            body = resp.json()
+            return {**body, "status": "ALREADY_LOOPING"}
+
+        if resp.status_code == 400:
+            raise AirflowException(
+                f"Loop start {phase} rejected (INVALID_PHASE): {resp.text[:500]}"
+            )
+
+        raise AirflowException(
+            f"Loop start {phase} failed: HTTP {resp.status_code} "
+            f"{resp.reason}: {resp.text[:500]}"
+        )
+
+    return _loop
+
+
+def make_trigger_loop_task(phase: str) -> PythonOperator:
+    """Build a PythonOperator that starts the loop for `phase`.
+
+    Fire-and-forget at HTTP layer; termination is operator-controlled via
+    stop_loop_pipeline or mode=count's count sensor.
+    """
+    return PythonOperator(
+        task_id=f"trigger_loop_{phase.lower()}",
+        python_callable=_trigger_loop_fn(phase),
+        retries=0,
+        execution_timeout=timedelta(seconds=60),
+        do_xcom_push=True,
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine && \
+  PYTHONPATH=docker/airflow/dags python3 -m pytest docker/airflow/dags/tests/test_phase_pipeline_factory.py -v
+```
+
+Expected: all 14 parse_mode tests + 9 trigger tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine && \
+  git add docker/airflow/dags/phase_pipeline_factory.py \
+          docker/airflow/dags/tests/test_phase_pipeline_factory.py && \
+  git commit -m "feat(airflow): add trigger_once + trigger_loop helpers
+
+get_external_api_base resolves the external_api Connection.
+make_trigger_once_task POSTs /trigger/phase/{phase} with optional
+X-Upstream-Run-Id header from xcom. 200/202 → xcom. 409 → idempotent
+discovery via /run-status. 400/5xx → AirflowException.
+
+make_trigger_loop_task POSTs /loop/phase/{phase}. 202 → loopId xcom.
+409 → ALREADY_LOOPING with existing loopId. 400 INVALID_PHASE → fail.
+
+Refs: docs/superpowers/specs/2026-06-22-dag-restructure-design.md §6.1
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Factory — `make_count_sensor` + tests
+
+**Files:**
+- Modify: `docker/airflow/dags/phase_pipeline_factory.py`
+- Modify: `docker/airflow/dags/tests/test_phase_pipeline_factory.py`
+
+- [ ] **Step 1: Append failing tests**
+
+Append to test file:
+
+```python
+from phase_pipeline_factory import make_count_sensor, _compute_count_timeout
+
+
+class TestComputeCountTimeout:
+    def test_formula(self):
+        # count * 5min + 30min buffer
+        assert _compute_count_timeout(1) == timedelta(minutes=5 + 30)
+        assert _compute_count_timeout(3) == timedelta(minutes=15 + 30)
+        assert _compute_count_timeout(10) == timedelta(minutes=50 + 30)
+        assert _compute_count_timeout(0) == timedelta(minutes=30)
+
+
+class TestMakeCountSensor:
+    """Tests the inner _poke callable returned by the factory."""
+
+    def _get_callable(self, phase, count):
+        op = make_count_sensor(phase, count)
+        return op.python_callable, op
+
+    def test_returns_true_after_count_events(self):
+        """Sensor returns True after `count` matching events received."""
+        from kafka import KafkaConsumer
+        callable_fn, op = self._get_callable("ITEM_EQUIPMENT", 2)
+
+        # Fake consumer yielding 2 matching messages
+        fake_msg1 = MagicMock()
+        fake_msg1.value = {"endpoint": "item-equipment", "runId": "r1"}
+        fake_msg2 = MagicMock()
+        fake_msg2.value = {"endpoint": "item-equipment", "runId": "r2"}
+        fake_msg3 = MagicMock()
+        fake_msg3.value = {"endpoint": "item-equipment", "runId": "r3"}
+
+        with patch.object(KafkaConsumer, "__iter__", return_value=iter([fake_msg1, fake_msg2, fake_msg3])):
+            result = callable_fn()
+        assert result is True
+
+    def test_filters_by_endpoint(self):
+        """Sensor ignores events for other endpoints."""
+        callable_fn, op = self._get_callable("CHARACTER_BASIC", 1)
+
+        fake_msg_other = MagicMock()
+        fake_msg_other.value = {"endpoint": "item-equipment", "runId": "r1"}
+        fake_msg_match = MagicMock()
+        fake_msg_match.value = {"endpoint": "character-basic", "runId": "r2"}
+
+        with patch("phase_pipeline_factory.KafkaConsumer") as mock_consumer_cls:
+            instance = MagicMock()
+            instance.__iter__ = MagicMock(return_value=iter([fake_msg_other, fake_msg_match]))
+            mock_consumer_cls.return_value = instance
+            result = callable_fn()
+        assert result is True
+
+    def test_timeout_set_correctly(self):
+        _, op = self._get_callable("ITEM_EQUIPMENT", 5)
+        # count=5 → 25 + 30 = 55min
+        assert op.timeout == timedelta(minutes=55)
+        assert op.mode == "reschedule"
+        assert op.poke_interval == 30
+```
+
+- [ ] **Step 2: Run new tests to verify they fail**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine && \
+  PYTHONPATH=docker/airflow/dags python3 -m pytest docker/airflow/dags/tests/test_phase_pipeline_factory.py -v -k "Count or Timeout"
+```
+
+Expected: ImportError on `make_count_sensor` / `_compute_count_timeout`.
+
+- [ ] **Step 3: Implement count sensor**
+
+Append to `phase_pipeline_factory.py`:
+
+```python
+import json as _json
+from typing import Tuple
+
+from airflow.sensors.python import PythonSensor
+
+
+# Phase → endpoint mapping for Kafka chunk-ready event filtering.
+# The synchronizer publishes to synchronizer.chunk.consumed with endpoint
+# field set to one of these values. Must match module-synchronizer publish code.
+_PHASE_TO_ENDPOINT = {
+    "CHARACTER_BASIC": "character-basic",
+    "ITEM_EQUIPMENT": "item-equipment",
+}
+
+# Per-chunk processing P99 (empirically observed ~3-5min on production
+# hardware). Used as the basis for the count timeout formula.
+_CHUNK_PROCESSING_MINUTES = 5
+_COUNT_TIMEOUT_BUFFER_MINUTES = 30
+
+
+def _compute_count_timeout(count: int) -> timedelta:
+    """count * CHUNK_PROCESSING_MINUTES + BUFFER. Bounded by count=0 = buffer."""
+    minutes = max(count, 0) * _CHUNK_PROCESSING_MINUTES + _COUNT_TIMEOUT_BUFFER_MINUTES
+    return timedelta(minutes=minutes)
+
+
+def _count_sensor_fn(phase: str, count: int):
+    """Inner: poll Kafka synchronizer.chunk.consumed for `count` events."""
+    from kafka import KafkaConsumer
+
+    endpoint = _PHASE_TO_ENDPOINT[phase]
+
+    def _poke(**ctx):
+        consumer = KafkaConsumer(
+            "synchronizer.chunk.consumed",
+            bootstrap_servers=os.environ["KAFKA_BOOTSTRAP_SERVERS"],
+            auto_offset_reset="latest",
+            enable_auto_commit=False,
+            group_id=(
+                f"airflow-count-sensor-{phase.lower()}-"
+                f"{ctx['dag_run'].run_id[:8]}"
+            ),
+            value_deserializer=lambda m: _json.loads(m.decode("utf-8")),
+        )
+        try:
+            received = 0
+            for message in consumer:
+                event = message.value
+                if event.get("endpoint") == endpoint:
+                    received += 1
+                    if received >= count:
+                        return True
+        finally:
+            consumer.close()
+        return False  # iterator exhausted without count reached (timeout)
+
+    return _poke
+
+
+def make_count_sensor(phase: str, count: int) -> PythonSensor:
+    """Sensor that returns True after `count` chunk-ready events for phase."""
+    return PythonSensor(
+        task_id=f"count_{count}_{phase.lower()}",
+        python_callable=_count_sensor_fn(phase, count),
+        mode="reschedule",
+        poke_interval=30,
+        timeout=int(_compute_count_timeout(count).total_seconds()),
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine && \
+  PYTHONPATH=docker/airflow/dags python3 -m pytest docker/airflow/dags/tests/test_phase_pipeline_factory.py -v
+```
+
+Expected: all previous tests + new count tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine && \
+  git add docker/airflow/dags/phase_pipeline_factory.py \
+          docker/airflow/dags/tests/test_phase_pipeline_factory.py && \
+  git commit -m "feat(airflow): add count_sensor for mode=count loops
+
+make_count_sensor(phase, count) returns PythonSensor that polls
+synchronizer.chunk.consumed for `count` events matching the phase's
+endpoint, then returns True. Timeout = count*5min + 30min buffer.
+Phase→endpoint mapping (CHARACTER_BASIC→character-basic,
+ITEM_EQUIPMENT→item-equipment).
+
+Refs: docs/superpowers/specs/2026-06-22-dag-restructure-design.md §3.2
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Factory — `make_stop_loop_task` + `make_wait_loop_stopped_sensor` + tests
+
+**Files:**
+- Modify: `docker/airflow/dags/phase_pipeline_factory.py`
+- Modify: `docker/airflow/dags/tests/test_phase_pipeline_factory.py`
+
+- [ ] **Step 1: Append failing tests**
+
+Append:
+
+```python
+from phase_pipeline_factory import make_stop_loop_task, make_wait_loop_stopped_sensor
+
+
+class TestMakeStopLoopTask:
+    def _get_callable(self, phase):
+        op = make_stop_loop_task(phase)
+        return op.python_callable
+
+    def test_202_stop_requested(self):
+        with patch("phase_pipeline_factory.requests.post") as mock_post:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 202
+            mock_resp.json.return_value = {
+                "status": "STOP_REQUESTED",
+                "phase": "ITEM_EQUIPMENT",
+                "loopId": "loop-1",
+                "iterationCount": 42,
+            }
+            mock_post.return_value = mock_resp
+            result = self._get_callable("ITEM_EQUIPMENT")()
+        assert result["status"] == "STOP_REQUESTED"
+
+    def test_200_not_looping_idempotent(self):
+        with patch("phase_pipeline_factory.requests.post") as mock_post:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = {"status": "NOT_LOOPING", "phase": "ITEM_EQUIPMENT"}
+            mock_post.return_value = mock_resp
+            result = self._get_callable("ITEM_EQUIPMENT")()
+        assert result["status"] == "NOT_LOOPING"
+
+    def test_400_invalid_phase_raises(self):
+        from airflow.exceptions import AirflowException
+        with patch("phase_pipeline_factory.requests.post") as mock_post:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 400
+            mock_resp.text = "INVALID_PHASE"
+            mock_post.return_value = mock_resp
+            with pytest.raises(AirflowException):
+                self._get_callable("RANKING_FETCH")()
+
+    def test_5xx_raises(self):
+        from airflow.exceptions import AirflowException
+        with patch("phase_pipeline_factory.requests.post") as mock_post:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 502
+            mock_resp.text = "bad gateway"
+            mock_resp.reason = "Bad Gateway"
+            mock_post.return_value = mock_resp
+            with pytest.raises(AirflowException):
+                self._get_callable("ITEM_EQUIPMENT")()
+
+
+class TestMakeWaitLoopStoppedSensor:
+    def _get_callable(self, phase):
+        op = make_wait_loop_stopped_sensor(phase)
+        return op.python_callable
+
+    def test_returns_true_when_no_loop_active(self):
+        with patch("phase_pipeline_factory.requests.get") as mock_get:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = {"loopSummaries": {}}
+            mock_get.return_value = mock_resp
+            assert self._get_callable("ITEM_EQUIPMENT")() is True
+
+    def test_returns_true_when_status_stopped(self):
+        with patch("phase_pipeline_factory.requests.get") as mock_get:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = {
+                "loopSummaries": {
+                    "ITEM_EQUIPMENT": {"loopId": "x", "status": "STOPPED"}
+                }
+            }
+            mock_get.return_value = mock_resp
+            assert self._get_callable("ITEM_EQUIPMENT")() is True
+
+    def test_returns_false_when_still_running(self):
+        with patch("phase_pipeline_factory.requests.get") as mock_get:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = {
+                "loopSummaries": {
+                    "ITEM_EQUIPMENT": {"loopId": "x", "status": "RUNNING"}
+                }
+            }
+            mock_get.return_value = mock_resp
+            assert self._get_callable("ITEM_EQUIPMENT")() is False
+
+    def test_returns_false_on_transient_http_error(self):
+        with patch("phase_pipeline_factory.requests.get") as mock_get:
+            mock_get.side_effect = Exception("connection refused")
+            assert self._get_callable("ITEM_EQUIPMENT")() is False
+
+    def test_timeout_is_30_minutes(self):
+        op = make_wait_loop_stopped_sensor("ITEM_EQUIPMENT")
+        assert op.timeout == timedelta(minutes=30)
+        assert op.mode == "reschedule"
+        assert op.poke_interval == 10
+```
+
+- [ ] **Step 2: Run new tests to verify they fail**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine && \
+  PYTHONPATH=docker/airflow/dags python3 -m pytest docker/airflow/dags/tests/test_phase_pipeline_factory.py -v -k "Stop or Wait"
+```
+
+Expected: ImportError.
+
+- [ ] **Step 3: Implement stop loop helpers**
+
+Append to `phase_pipeline_factory.py`:
+
+```python
+def _stop_loop_fn(phase: str):
+    """Inner: POST /stop/loop/phase/{phase}."""
+    def _stop(**ctx):
+        base = get_external_api_base()
+        try:
+            resp = requests.post(
+                f"{base}/api/internal/stop/loop/phase/{phase}", timeout=30
+            )
+        except requests.RequestException as exc:
+            raise AirflowException(f"Stop loop {phase} failed: {exc}") from exc
+
+        if resp.status_code == 202:
+            return {**resp.json(), "status": "STOP_REQUESTED"}
+
+        if resp.status_code == 200:
+            body = resp.json()
+            return {**body, "status": "NOT_LOOPING"}
+
+        if resp.status_code == 400:
+            raise AirflowException(
+                f"Stop loop {phase} rejected (INVALID_PHASE): {resp.text[:500]}"
+            )
+
+        raise AirflowException(
+            f"Stop loop {phase} failed: HTTP {resp.status_code} "
+            f"{resp.reason}: {resp.text[:500]}"
+        )
+
+    return _stop
+
+
+def make_stop_loop_task(phase: str) -> PythonOperator:
+    """Build a PythonOperator that stops the loop for `phase`."""
+    return PythonOperator(
+        task_id=f"stop_loop_{phase.lower()}",
+        python_callable=_stop_loop_fn(phase),
+        retries=0,
+        execution_timeout=timedelta(seconds=60),
+        do_xcom_push=True,
+    )
+
+
+def _wait_loop_stopped_fn(phase: str):
+    """Inner: poll /run-status until loopSummaries[phase].status == STOPPED."""
+    def _poke(**ctx):
+        try:
+            resp = requests.get(
+                f"{get_external_api_base()}/api/internal/run-status", timeout=10
+            )
+            resp.raise_for_status()
+            data = resp.json()
+        except (requests.RequestException, ValueError):
+            return False  # transient → reschedule
+
+        summaries = data.get("loopSummaries") or {}
+        entry = summaries.get(phase)
+        if not entry:
+            return True  # no loop was active; idempotent success
+
+        status = entry.get("status")
+        if status == "STOPPED":
+            return True
+        if status == "FAILED":
+            raise RuntimeError(
+                f"Loop for {phase} failed: {entry.get('lastError', 'unknown')}"
+            )
+        return False
+
+    return _poke
+
+
+def make_wait_loop_stopped_sensor(phase: str) -> PythonSensor:
+    """Sensor that returns True when loopSummaries[phase].status == STOPPED.
+
+    Returns True immediately if no loop is active for `phase` (idempotent).
+    """
+    return PythonSensor(
+        task_id=f"wait_loop_stopped_{phase.lower()}",
+        python_callable=_wait_loop_stopped_fn(phase),
+        mode="reschedule",
+        poke_interval=10,
+        timeout=30 * 60,  # 30 minutes
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine && \
+  PYTHONPATH=docker/airflow/dags python3 -m pytest docker/airflow/dags/tests/test_phase_pipeline_factory.py -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine && \
+  git add docker/airflow/dags/phase_pipeline_factory.py \
+          docker/airflow/dags/tests/test_phase_pipeline_factory.py && \
+  git commit -m "feat(airflow): add stop_loop helpers for mode=infinite kill switch
+
+make_stop_loop_task POSTs /stop/loop/phase/{phase}. 202 STOP_REQUESTED,
+200 NOT_LOOPING (idempotent), 400 INVALID_PHASE, 5xx → AirflowException.
+
+make_wait_loop_stopped_sensor polls /run-status.loopSummaries[phase] until
+status==STOPPED (timeout 30min, mode=reschedule, poke 10s). Returns True
+immediately if no loop active (idempotent). FAILED → RuntimeError hard fail.
+
+Used by mode=count (auto-stop after N chunks) and stop_loop_pipeline DAG
+(operator-initiated stop for mode=infinite).
+
+Refs: docs/superpowers/specs/2026-06-22-dag-restructure-design.md §3.3
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Factory — `make_branch_on_mode` + `make_phase_dag` + tests
+
+**Files:**
+- Modify: `docker/airflow/dags/phase_pipeline_factory.py`
+- Create: `docker/airflow/dags/tests/test_phase_dag_structure.py`
+
+- [ ] **Step 1: Append failing branch + DAG tests**
+
+Append to `test_phase_pipeline_factory.py`:
+
+```python
+from phase_pipeline_factory import (
+    make_branch_on_mode,
+    make_phase_dag,
+)
+
+
+class TestMakeBranchOnMode:
+    def _get_callable(self):
+        op = make_branch_on_mode()
+        return op.python_callable
+
+    def test_mode_once_routes_to_trigger(self):
+        fn = self._get_callable()
+        ctx = {"dag_run": MagicMock(conf={"mode": "once"})}
+        assert fn(**ctx) == "trigger_character_basic"
+
+    def test_mode_count_routes_to_trigger_loop(self):
+        fn = self._get_callable()
+        ctx = {"dag_run": MagicMock(conf={"mode": "count", "count": 3})}
+        assert fn(**ctx) == "trigger_loop_character_basic"
+
+    def test_mode_infinite_routes_to_trigger_loop(self):
+        fn = self._get_callable()
+        ctx = {"dag_run": MagicMock(conf={"mode": "infinite"})}
+        assert fn(**ctx) == "trigger_loop_character_basic"
+
+    def test_invalid_conf_raises(self):
+        from airflow.exceptions import AirflowException
+        fn = self._get_callable()
+        ctx = {"dag_run": MagicMock(conf={})}
+        with pytest.raises(AirflowException):
+            fn(**ctx)
+
+
+class TestMakePhaseDag:
+    """Test the DAG object structure."""
+
+    def test_dag_has_expected_task_ids_for_character_basic(self):
+        dag = make_phase_dag("CHARACTER_BASIC", "character_basic_pipeline")
+        task_ids = {t.task_id for t in dag.tasks}
+        expected = {
+            "check_external_api",
+            "branch_on_mode",
+            "trigger_character_basic",
+            "wait_terminal_character_basic",
+            "trigger_loop_character_basic",
+            "stop_loop_character_basic",
+            "count_3_character_basic",   # default test count
+        }
+        # Only the mode=count sensor for the default test count
+        # is asserted; other counts are parametrized.
+        # Re-call factory with explicit counts:
+        dag2 = make_phase_dag(
+            "CHARACTER_BASIC",
+            "character_basic_pipeline",
+            default_test_count=5,
+        )
+        ids2 = {t.task_id for t in dag2.tasks}
+        assert "count_5_character_basic" in ids2
+
+    def test_dag_for_item_equipment_uses_correct_phase(self):
+        dag = make_phase_dag("ITEM_EQUIPMENT", "item_equipment_pipeline")
+        trigger_task = dag.get_task("trigger_item_equipment")
+        assert "ITEM_EQUIPMENT" in trigger_task.task_id
+
+    def test_infinite_branch_does_not_have_count_sensor(self):
+        """mode=infinite branch ends at trigger_loop; no count sensor."""
+        dag = make_phase_dag(
+            "ITEM_EQUIPMENT", "item_equipment_pipeline", default_test_count=3
+        )
+        ids = {t.task_id for t in dag.tasks}
+        # count sensor exists for test purposes but isn't in the once/infinite path
+        # The once branch is: trigger_item_equipment >> wait_terminal_item_equipment
+        # The infinite branch is: trigger_loop_item_equipment (terminal)
+        once_downstream = set(
+            dag.get_task("trigger_item_equipment").downstream_task_ids
+        )
+        assert "wait_terminal_item_equipment" in once_downstream
+        infinite_downstream = set(
+            dag.get_task("trigger_loop_item_equipment").downstream_task_ids
+        )
+        assert "stop_loop_item_equipment" in infinite_downstream
+```
+
+Also create `test_phase_dag_structure.py` for DagBag-level checks:
+
+```python
+"""DAG-structure tests via DagBag parse.
+
+These run against the actual DAG files in docker/airflow/dags/, not the
+in-memory factory. They catch import errors and topology regressions.
+"""
+import pytest
+from airflow.models import DagBag
+
+
+DAG_FOLDER = "/home/maple/probabilistic-valuation-engine/docker/airflow/dags"
+
+
+@pytest.fixture(scope="module")
+def dagbag():
+    return DagBag(dag_folder=DAG_FOLDER, include_examples=False)
+
+
+def test_character_basic_pipeline_parses(dagbag):
+    dag = dagbag.get_dag("character_basic_pipeline")
+    assert dag is not None
+    ids = {t.task_id for t in dag.tasks}
+    assert "branch_on_mode" in ids
+    assert "trigger_character_basic" in ids
+    assert "trigger_loop_character_basic" in ids
+
+
+def test_item_equipment_pipeline_parses(dagbag):
+    dag = dagbag.get_dag("item_equipment_pipeline")
+    assert dag is not None
+    ids = {t.task_id for t in dag.tasks}
+    assert "trigger_item_equipment" in ids
+    assert "trigger_loop_item_equipment" in ids
+
+
+def test_daily_full_pipeline_parses(dagbag):
+    dag = dagbag.get_dag("daily_full_pipeline")
+    assert dag is not None
+    # 4 TriggerDagRunOperator tasks
+    trigger_ids = [t.task_id for t in dag.tasks if "trigger" in t.task_id]
+    assert len(trigger_ids) == 4
+
+
+def test_stop_loop_pipeline_parses(dagbag):
+    dag = dagbag.get_dag("stop_loop_pipeline")
+    assert dag is not None
+    ids = {t.task_id for t in dag.tasks}
+    assert "stop_loop" in ids
+    assert "wait_loop_stopped" in ids
+
+
+def test_ranking_ocid_lookup_pipeline_parses(dagbag):
+    dag = dagbag.get_dag("ranking_ocid_lookup_pipeline")
+    assert dag is not None
+    ids = {t.task_id for t in dag.tasks}
+    assert "trigger_ranking_fetch" in ids
+    assert "wait_ranking_fetch_terminal" in ids
+    assert "trigger_ocid_lookup" in ids
+    assert "wait_ocid_lookup_terminal" in ids
+
+
+def test_legacy_dag_still_parses(dagbag):
+    """daily_collection_pipeline must still parse for one release cycle."""
+    dag = dagbag.get_dag("daily_collection_pipeline")
+    assert dag is not None
+    assert "deprecated" in dag.tags
+```
+
+- [ ] **Step 2: Run new tests to verify they fail**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine && \
+  PYTHONPATH=docker/airflow/dags python3 -m pytest \
+    docker/airflow/dags/tests/test_phase_pipeline_factory.py \
+    docker/airflow/dags/tests/test_phase_dag_structure.py \
+    -v 2>&1 | head -50
+```
+
+Expected: ImportError on `make_branch_on_mode` / `make_phase_dag`. DAG tests will fail (no DAG files yet).
+
+- [ ] **Step 3: Implement branch + factory DAG**
+
+Append to `phase_pipeline_factory.py`:
+
+```python
+from airflow import DAG
+from airflow.operators.empty import EmptyOperator
+from airflow.operators.python import BranchPythonOperator, PythonOperator
+from airflow.providers.http.sensors.http import HttpSensor
+
+
+def make_branch_on_mode() -> BranchPythonOperator:
+    """BranchPythonOperator: routes to once/count/infinite branch.
+
+    Validates conf via parse_mode; raises AirflowException on invalid (the
+    branch task fails before any HTTP call).
+    """
+    def _branch(**ctx):
+        mode, _ = parse_mode(ctx["dag_run"].conf or {})
+        phase = ctx["dag_run"].conf.get("__phase__", "")
+        # The factory injects __phase__ into conf at DAG construction so
+        # the branch knows which phase's task_ids to route to.
+        if mode == "once":
+            return f"trigger_{phase.lower()}"
+        # mode in (count, infinite) → trigger_loop_<phase>
+        return f"trigger_loop_{phase.lower()}"
+
+    return BranchPythonOperator(
+        task_id="branch_on_mode",
+        python_callable=_branch,
+    )
+
+
+def _wait_terminal_fn(phase: str):
+    """Inner: poll /run-status until phase slot has terminal runId."""
+    import time as _time
+
+    def _wait(**ctx):
+        ti = ctx["ti"]
+        trigger_resp = ti.xcom_pull(task_ids=f"trigger_{phase.lower()}")
+        if isinstance(trigger_resp, str):
+            trigger_resp = _json.loads(trigger_resp)
+        run_id = (trigger_resp or {}).get("runId")
+        if not run_id:
+            raise RuntimeError(
+                f"Sensor for {phase} triggered but no runId xcom'd"
+            )
+
+        run_group_prefix = "-".join(run_id.split("-")[:2]) + "-"
+        base = get_external_api_base()
+        deadline = _time.monotonic() + 4 * 60 * 60  # 4h
+
+        while True:
+            try:
+                resp = requests.get(
+                    f"{base}/api/internal/run-status", timeout=10
+                )
+                resp.raise_for_status()
+                data = resp.json()
+            except (requests.RequestException, ValueError):
+                _time.sleep(30)
+                continue
+
+            slot = (
+                (data.get("slots") or {}).get(phase)
+                or (data.get("lastCompletedByPhase") or {}).get(phase)
+            )
+            if not slot or not (
+                slot.get("runId") or ""
+            ).startswith(run_group_prefix):
+                if _time.monotonic() >= deadline:
+                    raise TimeoutError(
+                        f"Phase {phase} did not acquire runId {run_id} within 4h"
+                    )
+                _time.sleep(30)
+                continue
+
+            if slot.get("phase") == "FAILED":
+                raise RuntimeError(
+                    f"Run {run_group_prefix}* phase {phase} failed: "
+                    f"{slot.get('errorMessage', 'unknown')}"
+                )
+            if slot.get("terminal"):
+                return True
+            if _time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"Phase {phase} did not reach terminal within 4h"
+                )
+            _time.sleep(30)
+
+    return _wait
+
+
+def make_phase_dag(
+    phase: str,
+    dag_id: str,
+    default_test_count: int = 3,
+) -> DAG:
+    """Build a phase DAG with mode=once / mode=count / mode=infinite branches.
+
+    Args:
+        phase: PipelinePhase name (CHARACTER_BASIC or ITEM_EQUIPMENT).
+        dag_id: Airflow DAG id.
+        default_test_count: The count value materialized as a sensor task for
+            testability. Operators pass count via dag_run.conf; the count_sensor
+            is created at DAG-parse time using this default. A future enhancement
+            could generate sensors per-conf-value via DAG serialization, but
+            that's out of scope for v1.
+    """
+    default_args = {
+        "owner": "maple-pipeline",
+        "retries": 0,
+    }
+
+    dag = DAG(
+        dag_id=dag_id,
+        default_args=default_args,
+        start_date=datetime(2026, 5, 29),
+        schedule=None,  # manual trigger only
+        catchup=False,
+        tags=["pipeline", "phase", phase.lower().replace("_", "-")],
+    )
+
+    with dag:
+        check_external_api = HttpSensor(
+            task_id="check_external_api",
+            http_conn_id="external_api",
+            endpoint="actuator/health",
+            request_params={},
+            response_check=lambda r: r.status_code == 200,
+            poke_interval=30,
+            timeout=120,
+        )
+
+        branch = make_branch_on_mode()
+
+        # once branch
+        trigger_once = make_trigger_once_task(phase)
+        wait_terminal = PythonSensor(
+            task_id=f"wait_terminal_{phase.lower()}",
+            python_callable=_wait_terminal_fn(phase),
+            mode="reschedule",
+            poke_interval=60,
+            timeout=4 * 60 * 60,
+        )
+
+        # count + infinite branch share trigger_loop
+        trigger_loop = make_trigger_loop_task(phase)
+        count_sensor = make_count_sensor(phase, default_test_count)
+        stop_loop = make_stop_loop_task(phase)
+
+        # Wiring
+        check_external_api >> branch
+        branch >> trigger_once >> wait_terminal
+
+        # count branch: trigger_loop → count_sensor → stop_loop
+        branch >> trigger_loop
+        trigger_loop >> count_sensor >> stop_loop
+
+        # infinite branch: trigger_loop (terminal — DAG succeeds immediately)
+        # This is implicit: branch routes to trigger_loop_<phase> for both
+        # count and infinite. For count, downstream count_sensor + stop_loop
+        # execute. For infinite, no further downstream; DAG ends at trigger_loop.
+        # However, since trigger_loop is also a downstream of count branch,
+        # we need to mark trigger_loop as a join point with trigger_rule that
+        # tolerates infinite branch terminating. Use trigger_rule='none_skipped'.
+        # Simplest: rely on Airflow's default for PythonOperator (all_success
+        # upstream) and note that infinite mode's "no further task" means the
+        # DAG's last task is trigger_loop itself. Acceptable.
+
+        # Inject __phase__ into the branch callable's runtime by patching
+        # the parse_mode path. The branch callable reads ctx['dag_run'].conf
+        # which we don't modify here — instead, branch uses a closure over
+        # `phase` via __phase__ injection. Update _branch:
+        original_branch_fn = branch.python_callable
+
+        def _branch_with_phase(**ctx):
+            ctx_copy = dict(ctx)
+            conf = dict(ctx_copy.get("dag_run").conf or {})
+            conf["__phase__"] = phase
+            ctx_copy["dag_run"] = MagicMock(conf=conf) if False else ctx["dag_run"]
+            # We can't easily mock dag_run here; instead, use a thread-local
+            # or pass phase via env. Simplest: re-implement branch inline:
+            mode, _ = parse_mode(ctx["dag_run"].conf or {})
+            if mode == "once":
+                return f"trigger_{phase.lower()}"
+            return f"trigger_loop_{phase.lower()}"
+
+        branch.python_callable = _branch_with_phase
+
+    return dag
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine && \
+  PYTHONPATH=docker/airflow/dags python3 -m pytest \
+    docker/airflow/dags/tests/test_phase_pipeline_factory.py -v
+```
+
+Expected: parse_mode + trigger + count + stop + branch tests pass. `test_phase_dag_structure.py` will fail because the DAG files don't exist yet — expected. Will pass in Tasks 7-11.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine && \
+  git add docker/airflow/dags/phase_pipeline_factory.py \
+          docker/airflow/dags/tests/test_phase_pipeline_factory.py \
+          docker/airflow/dags/tests/test_phase_dag_structure.py && \
+  git commit -m "feat(airflow): add branch_on_mode + make_phase_dag factory
+
+make_branch_on_mode returns BranchPythonOperator that routes by parse_mode
+result: once→trigger_<phase>, count|infinite→trigger_loop_<phase>.
+
+make_phase_dag(phase, dag_id, default_test_count=3) builds a DAG with:
+  check_external_api >> branch_on_mode
+    >> trigger_<phase> >> wait_terminal_<phase>           (mode=once)
+    >> trigger_loop_<phase>                                (mode=count|infinite)
+       >> count_<N>_<phase> >> stop_loop_<phase>           (mode=count)
+       >> [terminal]                                       (mode=infinite)
+
+default_test_count materializes a count sensor at DAG-parse time for
+testability. Operators override count via dag_run.conf at trigger time;
+the sensor task is created once with default but the runtime poke filter
+honors the conf value via xcom (future enhancement: per-conf sensors).
+
+Refs: docs/superpowers/specs/2026-06-22-dag-restructure-design.md §6.1
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: `ranking_ocid_lookup_pipeline.py` DAG
+
+**Files:**
+- Create: `docker/airflow/dags/ranking_ocid_lookup_pipeline.py`
+
+- [ ] **Step 1: Write the DAG file**
+
+```python
+"""RANKING_FETCH → OCID_LOOKUP sequential pipeline.
+
+OCID_LOOKUP requires X-Upstream-Run-Id from RANKING_FETCH (ext-api
+InternalApiController rejects with MISSING_UPSTREAM 400 otherwise), so
+these two phases are always chained. Manual trigger only.
+
+Refs: docs/superpowers/specs/2026-06-22-dag-restructure-design.md §4.1
+"""
+from datetime import datetime, timedelta
+
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+from airflow.providers.http.sensors.http import HttpSensor
+from airflow.sensors.python import PythonSensor
+
+from per_phase_tasks import (
+    make_is_phase_terminal,
+    make_trigger_task,
+)
+
+
+default_args = {
+    "owner": "maple-pipeline",
+    "retries": 0,
+}
+
+
+with DAG(
+    dag_id="ranking_ocid_lookup_pipeline",
+    default_args=default_args,
+    start_date=datetime(2026, 5, 29),
+    schedule=None,  # manual trigger (or via daily_full_pipeline wrapper)
+    catchup=False,
+    tags=["pipeline", "phase", "ranking-ocid"],
+) as dag:
+
+    check_external_api = HttpSensor(
+        task_id="check_external_api",
+        http_conn_id="external_api",
+        endpoint="actuator/health",
+        request_params={},
+        response_check=lambda r: r.status_code == 200,
+        poke_interval=30,
+        timeout=120,
+    )
+
+    # RANKING_FETCH — no upstream required.
+    trigger_ranking_fetch = make_trigger_task("RANKING_FETCH")
+    wait_ranking_fetch_terminal = PythonSensor(
+        task_id="wait_ranking_fetch_terminal",
+        python_callable=make_is_phase_terminal("RANKING_FETCH"),
+        mode="reschedule",
+        poke_interval=60,
+        timeout=4 * 60 * 60,
+    )
+
+    # OCID_LOOKUP — requires X-Upstream-Run-Id from RANKING_FETCH trigger.
+    # The X-Upstream-Run-Id header is set via the trigger_task callable
+    # reading xcom from `trigger_ranking_fetch`. make_trigger_task already
+    # handles this — it reads `upstream_run_id_pusher` xcom. Add a tiny
+    # task to push the runId into the upstream slot:
+    def _push_upstream_run_id(**ctx):
+        ti = ctx["ti"]
+        trigger_resp = ti.xcom_pull(task_ids="per_phase_trigger_ranking_fetch")
+        if isinstance(trigger_resp, str):
+            import json
+            trigger_resp = json.loads(trigger_resp)
+        return trigger_resp.get("runId") if trigger_resp else None
+
+    push_upstream = PythonOperator(
+        task_id="upstream_run_id_pusher",
+        python_callable=_push_upstream_run_id,
+    )
+
+    trigger_ocid_lookup = make_trigger_task("OCID_LOOKUP")
+    wait_ocid_lookup_terminal = PythonSensor(
+        task_id="wait_ocid_lookup_terminal",
+        python_callable=make_is_phase_terminal("OCID_LOOKUP"),
+        mode="reschedule",
+        poke_interval=60,
+        timeout=4 * 60 * 60,
+    )
+
+    check_external_api >> trigger_ranking_fetch
+    trigger_ranking_fetch >> wait_ranking_fetch_terminal
+    wait_ranking_fetch_terminal >> push_upstream
+    push_upstream >> trigger_ocid_lookup
+    trigger_ocid_lookup >> wait_ocid_lookup_terminal
+```
+
+- [ ] **Step 2: Run structure test**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine && \
+  PYTHONPATH=docker/airflow/dags python3 -m pytest \
+    docker/airflow/dags/tests/test_phase_dag_structure.py::test_ranking_ocid_lookup_pipeline_parses -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine && \
+  git add docker/airflow/dags/ranking_ocid_lookup_pipeline.py && \
+  git commit -m "feat(airflow): add ranking_ocid_lookup_pipeline DAG
+
+Sequential RANKING_FETCH → OCID_LOOKUP. OCID requires X-Upstream-Run-Id
+header from RANKING trigger, so phases are hard-chained. Manual trigger
+(or via daily_full_pipeline wrapper). Uses per_phase_tasks helpers.
+
+Refs: docs/superpowers/specs/2026-06-22-dag-restructure-design.md §4.1
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: `character_basic_pipeline.py` DAG
+
+**Files:**
+- Create: `docker/airflow/dags/character_basic_pipeline.py`
+
+- [ ] **Step 1: Write the DAG file**
+
+```python
+"""CHARACTER_BASIC phase DAG with once / count=N / infinite modes.
+
+Mode is selected via dag_run.conf['mode']. See parse_mode for validation.
+
+Refs: docs/superpowers/specs/2026-06-22-dag-restructure-design.md §4.2
+"""
+from phase_pipeline_factory import make_phase_dag
+
+
+character_basic_dag = make_phase_dag(
+    phase="CHARACTER_BASIC",
+    dag_id="character_basic_pipeline",
+    default_test_count=3,
+)
+```
+
+- [ ] **Step 2: Run structure test**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine && \
+  PYTHONPATH=docker/airflow/dags python3 -m pytest \
+    docker/airflow/dags/tests/test_phase_dag_structure.py::test_character_basic_pipeline_parses -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine && \
+  git add docker/airflow/dags/character_basic_pipeline.py && \
+  git commit -m "feat(airflow): add character_basic_pipeline DAG
+
+Wraps make_phase_dag(CHARACTER_BASIC, character_basic_pipeline).
+Mode-driven (once|count=N|infinite) via dag_run.conf.
+
+Refs: docs/superpowers/specs/2026-06-22-dag-restructure-design.md §4.2
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: `item_equipment_pipeline.py` DAG
+
+**Files:**
+- Create: `docker/airflow/dags/item_equipment_pipeline.py`
+
+- [ ] **Step 1: Write the DAG file**
+
+```python
+"""ITEM_EQUIPMENT phase DAG with once / count=N / infinite modes.
+
+Mode is selected via dag_run.conf['mode']. See parse_mode for validation.
+
+Refs: docs/superpowers/specs/2026-06-22-dag-restructure-design.md §4.2
+"""
+from phase_pipeline_factory import make_phase_dag
+
+
+item_equipment_dag = make_phase_dag(
+    phase="ITEM_EQUIPMENT",
+    dag_id="item_equipment_pipeline",
+    default_test_count=3,
+)
+```
+
+- [ ] **Step 2: Run structure test**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine && \
+  PYTHONPATH=docker/airflow/dags python3 -m pytest \
+    docker/airflow/dags/tests/test_phase_dag_structure.py::test_item_equipment_pipeline_parses -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine && \
+  git add docker/airflow/dags/item_equipment_pipeline.py && \
+  git commit -m "feat(airflow): add item_equipment_pipeline DAG
+
+Wraps make_phase_dag(ITEM_EQUIPMENT, item_equipment_pipeline).
+Mode-driven (once|count=N|infinite) via dag_run.conf.
+
+Refs: docs/superpowers/specs/2026-06-22-dag-restructure-design.md §4.2
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: `daily_full_pipeline.py` wrapper DAG
+
+**Files:**
+- Create: `docker/airflow/dags/daily_full_pipeline.py`
+
+- [ ] **Step 1: Write the DAG file**
+
+```python
+"""Daily full-pipeline wrapper.
+
+Chains ranking_ocid_lookup_pipeline → character_basic_pipeline(mode=once) →
+item_equipment_pipeline(mode=once) → daily_cleanup_pipeline via
+TriggerDagRunOperator (wait_for_completion=True). Scheduled at 18:00 UTC
+(KST 03:00) — same cron as legacy daily_collection_pipeline.
+
+Refs: docs/superpowers/specs/2026-06-22-dag-restructure-design.md §4.3
+"""
+from datetime import datetime
+
+from airflow import DAG
+from airflow.providers.http.sensors.http import HttpSensor
+from airflow.operators.trigger_dagrun import TriggerDagRunOperator
+
+
+default_args = {
+    "owner": "maple-pipeline",
+    "retries": 0,
+}
+
+
+with DAG(
+    dag_id="daily_full_pipeline",
+    default_args=default_args,
+    start_date=datetime(2026, 5, 29),
+    schedule="0 18 * * *",  # UTC 18:00 = KST 03:00
+    catchup=False,
+    tags=["pipeline", "daily"],
+) as dag:
+
+    check_external_api = HttpSensor(
+        task_id="check_external_api",
+        http_conn_id="external_api",
+        endpoint="actuator/health",
+        request_params={},
+        response_check=lambda r: r.status_code == 200,
+        poke_interval=30,
+        timeout=120,
+    )
+
+    trigger_ranking_ocid = TriggerDagRunOperator(
+        task_id="trigger_ranking_ocid_lookup",
+        trigger_dag_id="ranking_ocid_lookup_pipeline",
+        wait_for_completion=True,
+        reset_dag_run=True,
+    )
+
+    trigger_character_basic = TriggerDagRunOperator(
+        task_id="trigger_character_basic",
+        trigger_dag_id="character_basic_pipeline",
+        conf={"mode": "once"},
+        wait_for_completion=True,
+        reset_dag_run=True,
+    )
+
+    trigger_item_equipment = TriggerDagRunOperator(
+        task_id="trigger_item_equipment",
+        trigger_dag_id="item_equipment_pipeline",
+        conf={"mode": "once"},
+        wait_for_completion=True,
+        reset_dag_run=True,
+    )
+
+    trigger_cleanup = TriggerDagRunOperator(
+        task_id="trigger_cleanup",
+        trigger_dag_id="daily_cleanup_pipeline",
+        wait_for_completion=False,  # fire-and-forget; cleanup has its own schedule
+        reset_dag_run=True,
+    )
+
+    check_external_api >> trigger_ranking_ocid
+    trigger_ranking_ocid >> trigger_character_basic
+    trigger_character_basic >> trigger_item_equipment
+    trigger_item_equipment >> trigger_cleanup
+```
+
+- [ ] **Step 2: Run structure test**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine && \
+  PYTHONPATH=docker/airflow/dags python3 -m pytest \
+    docker/airflow/dags/tests/test_phase_dag_structure.py::test_daily_full_pipeline_parses -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine && \
+  git add docker/airflow/dags/daily_full_pipeline.py && \
+  git commit -m "feat(airflow): add daily_full_pipeline wrapper DAG
+
+Chains 4 TriggerDagRunOperator tasks:
+  ranking_ocid_lookup_pipeline
+  >> character_basic_pipeline (conf: {mode:once})
+  >> item_equipment_pipeline (conf: {mode:once})
+  >> daily_cleanup_pipeline (fire-and-forget)
+
+Scheduled at 0 18 * * * (KST 03:00). Replaces the scheduled leg of
+legacy daily_collection_pipeline; that DAG is kept deprecated for
+operator migration (one release cycle).
+
+Refs: docs/superpowers/specs/2026-06-22-dag-restructure-design.md §4.3
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: `stop_loop_pipeline.py` DAG
+
+**Files:**
+- Create: `docker/airflow/dags/stop_loop_pipeline.py`
+
+- [ ] **Step 1: Write the DAG file**
+
+```python
+"""Stop any active loop for a given phase.
+
+Used to terminate mode=infinite loops started by character_basic_pipeline or
+item_equipment_pipeline. POSTs /stop/loop/phase/{phase} and waits for the
+loop to drain current chunk + transition to STOPPED.
+
+Refs: docs/superpowers/specs/2026-06-22-dag-restructure-design.md §4.4
+"""
+from datetime import datetime
+
+from airflow import DAG
+from airflow.exceptions import AirflowException
+from airflow.providers.http.sensors.http import HttpSensor
+
+from phase_pipeline_factory import (
+    LOOPABLE_PHASES,
+    make_stop_loop_task,
+    make_wait_loop_stopped_sensor,
+)
+
+
+default_args = {
+    "owner": "maple-pipeline",
+    "retries": 0,
+}
+
+
+def _validate_phase(**ctx):
+    conf = ctx["dag_run"].conf or {}
+    phase = conf.get("phase")
+    if phase not in LOOPABLE_PHASES:
+        raise AirflowException(
+            f"phase='{phase}' invalid. Allowed: {sorted(LOOPABLE_PHASES)}"
+        )
+    return phase
+
+
+with DAG(
+    dag_id="stop_loop_pipeline",
+    default_args=default_args,
+    start_date=datetime(2026, 5, 29),
+    schedule=None,
+    catchup=False,
+    tags=["pipeline", "control", "stop"],
+) as dag:
+
+    check_external_api = HttpSensor(
+        task_id="check_external_api",
+        http_conn_id="external_api",
+        endpoint="actuator/health",
+        request_params={},
+        response_check=lambda r: r.status_code == 200,
+        poke_interval=30,
+        timeout=120,
+    )
+
+    # Single DAG handles both CHARACTER_BASIC and ITEM_EQUIPMENT via conf.
+    # Validate phase at trigger time, then route to the right stop task.
+    # For simplicity, always create both stop tasks; the conf determines
+    # which one runs (skip pattern).
+    stop_character_basic = make_stop_loop_task("CHARACTER_BASIC")
+    stop_item_equipment = make_stop_loop_task("ITEM_EQUIPMENT")
+
+    wait_character_basic = make_wait_loop_stopped_sensor("CHARACTER_BASIC")
+    wait_item_equipment = make_wait_loop_stopped_sensor("ITEM_EQUIPMENT")
+
+    check_external_api >> [stop_character_basic, stop_item_equipment]
+    stop_character_basic >> wait_character_basic
+    stop_item_equipment >> wait_item_equipment
+```
+
+- [ ] **Step 2: Add `LOOPABLE_PHASES` constant + task gate**
+
+Append to `phase_pipeline_factory.py`:
+
+```python
+# Phase names that ext-api accepts on /loop/phase/{phase} (matches
+# PhaseLoopController.loopablePhases). Used by stop_loop_pipeline DAG
+# for conf validation.
+LOOPABLE_PHASES = frozenset({"CHARACTER_BASIC", "ITEM_EQUIPMENT"})
+```
+
+Update `make_stop_loop_task` and the new stop_loop DAG to add skip pattern:
+
+In `phase_pipeline_factory.py`, modify `_stop_loop_fn`:
+
+```python
+def _stop_loop_fn(phase: str):
+    """Inner: POST /stop/loop/phase/{phase}. Skips if conf doesn't target this phase."""
+    def _stop(**ctx):
+        conf = ctx.get("dag_run", MagicMock(conf={})).conf or {}
+        target_phase = conf.get("phase")
+        if target_phase != phase:
+            return None  # skip; this task is for another phase
+        # ... rest of original logic
+        base = get_external_api_base()
+        try:
+            resp = requests.post(
+                f"{base}/api/internal/stop/loop/phase/{phase}", timeout=30
+            )
+        except requests.RequestException as exc:
+            raise AirflowException(f"Stop loop {phase} failed: {exc}") from exc
+
+        if resp.status_code == 202:
+            return {**resp.json(), "status": "STOP_REQUESTED"}
+        if resp.status_code == 200:
+            return {**resp.json(), "status": "NOT_LOOPING"}
+        if resp.status_code == 400:
+            raise AirflowException(
+                f"Stop loop {phase} rejected: {resp.text[:500]}"
+            )
+        raise AirflowException(
+            f"Stop loop {phase} failed: HTTP {resp.status_code} "
+            f"{resp.reason}: {resp.text[:500]}"
+        )
+
+    return _stop
+```
+
+Update `test_phase_pipeline_factory.py::TestMakeStopLoopTask::test_202_stop_requested` and others to pass `dag_run` arg with conf matching the phase. Update tests accordingly:
+
+```python
+class TestMakeStopLoopTask:
+    def _call(self, phase, conf):
+        op = make_stop_loop_task(phase)
+        return op.python_callable(dag_run=MagicMock(conf=conf))
+
+    def test_202_stop_requested(self):
+        with patch("phase_pipeline_factory.requests.post") as mock_post:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 202
+            mock_resp.json.return_value = {
+                "status": "STOP_REQUESTED", "phase": "ITEM_EQUIPMENT",
+                "loopId": "loop-1", "iterationCount": 42,
+            }
+            mock_post.return_value = mock_resp
+            result = self._call("ITEM_EQUIPMENT", {"phase": "ITEM_EQUIPMENT"})
+        assert result["status"] == "STOP_REQUESTED"
+
+    def test_200_not_looping_idempotent(self):
+        with patch("phase_pipeline_factory.requests.post") as mock_post:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = {"status": "NOT_LOOPING"}
+            mock_post.return_value = mock_resp
+            result = self._call("ITEM_EQUIPMENT", {"phase": "ITEM_EQUIPMENT"})
+        assert result["status"] == "NOT_LOOPING"
+
+    def test_skip_when_conf_targets_other_phase(self):
+        """If conf.phase != this task's phase, return None (skip)."""
+        result = self._call("CHARACTER_BASIC", {"phase": "ITEM_EQUIPMENT"})
+        assert result is None
+
+    def test_400_invalid_phase_raises(self):
+        from airflow.exceptions import AirflowException
+        with patch("phase_pipeline_factory.requests.post") as mock_post:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 400
+            mock_resp.text = "INVALID_PHASE"
+            mock_post.return_value = mock_resp
+            with pytest.raises(AirflowException):
+                self._call("ITEM_EQUIPMENT", {"phase": "ITEM_EQUIPMENT"})
+
+    def test_5xx_raises(self):
+        from airflow.exceptions import AirflowException
+        with patch("phase_pipeline_factory.requests.post") as mock_post:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 502
+            mock_resp.text = "bad gateway"
+            mock_resp.reason = "Bad Gateway"
+            mock_post.return_value = mock_resp
+            with pytest.raises(AirflowException):
+                self._call("ITEM_EQUIPMENT", {"phase": "ITEM_EQUIPMENT"})
+```
+
+- [ ] **Step 3: Run structure test**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine && \
+  PYTHONPATH=docker/airflow/dags python3 -m pytest \
+    docker/airflow/dags/tests/test_phase_dag_structure.py::test_stop_loop_pipeline_parses -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine && \
+  git add docker/airflow/dags/stop_loop_pipeline.py \
+          docker/airflow/dags/phase_pipeline_factory.py \
+          docker/airflow/dags/tests/test_phase_pipeline_factory.py && \
+  git commit -m "feat(airflow): add stop_loop_pipeline DAG + LOOPABLE_PHASES
+
+Single DAG with stop_loop_character_basic and stop_loop_item_equipment
+tasks, gated by dag_run.conf['phase'] (skip if not matching). Each
+stop is followed by a wait_loop_stopped_<phase> sensor (30min timeout).
+
+Use:
+  airflow dags trigger stop_loop_pipeline -c '{\"phase\":\"ITEM_EQUIPMENT\"}'
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11: Update `test_dag_imports.py` to assert new DAGs
+
+**Files:**
+- Modify: `docker/airflow/dags/tests/test_dag_imports.py`
+
+- [ ] **Step 1: Read existing test file**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine && \
+  cat docker/airflow/dags/tests/test_dag_imports.py
+```
+
+- [ ] **Step 2: Modify to include all expected DAGs**
+
+Replace contents with:
+
+```python
+"""DAG import smoke test for CI.
+
+Asserts all expected DAGs (new + legacy) parse without import errors.
+"""
+from airflow.models import DagBag
+
+
+DAG_FOLDER = "/home/maple/probabilistic-valuation-engine/docker/airflow/dags"
+
+
+EXPECTED_DAG_IDS = {
+    # New phase-separated DAGs (2026-06-22 restructure)
+    "ranking_ocid_lookup_pipeline",
+    "character_basic_pipeline",
+    "item_equipment_pipeline",
+    "daily_full_pipeline",
+    "stop_loop_pipeline",
+    # Existing DAGs (unchanged)
+    "daily_cleanup_pipeline",
+    # Legacy (deprecated; must still parse)
+    "daily_collection_pipeline",
+}
+
+
+def test_all_expected_dags_import():
+    dagbag = DagBag(dag_folder=DAG_FOLDER, include_examples=False)
+    assert dagbag.import_errors == {}, (
+        f"DAG import errors: {dagbag.import_errors}"
+    )
+    for dag_id in EXPECTED_DAG_IDS:
+        assert dag_id in dagbag.dags, (
+            f"Expected DAG '{dag_id}' missing from DagBag. "
+            f"Loaded: {sorted(dagbag.dags.keys())}"
+        )
+
+
+def test_no_unexpected_dags():
+    """Sanity: only known DAGs in the folder."""
+    dagbag = DagBag(dag_folder=DAG_FOLDER, include_examples=False)
+    loaded = set(dagbag.dags.keys())
+    unexpected = loaded - EXPECTED_DAG_IDS
+    assert not unexpected, f"Unexpected DAGs in folder: {unexpected}"
+```
+
+- [ ] **Step 3: Run the test**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine && \
+  PYTHONPATH=docker/airflow/dags python3 -m pytest \
+    docker/airflow/dags/tests/test_dag_imports.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine && \
+  git add docker/airflow/dags/tests/test_dag_imports.py && \
+  git commit -m "test(airflow): update test_dag_imports for new DAG ids
+
+Asserts all 5 new phase-separated DAGs + cleanup + legacy still parse.
+Catches broken imports in CI before runtime.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 12: Deprecate legacy `daily_collection_pipeline.py`
+
+**Files:**
+- Modify: `docker/airflow/dags/daily_collection_pipeline.py`
+
+- [ ] **Step 1: Update module docstring + DAG tags**
+
+Edit `docker/airflow/dags/daily_collection_pipeline.py`. At the top of the file, replace the docstring (lines 1-8) with:
+
+```python
+"""Daily Nexon data collection pipeline (DEPRECATED 2026-06-22).
+
+DEPRECATED: Use the phase-separated DAGs instead:
+  - daily_full_pipeline              — scheduled daily chain (mode=once for all phases)
+  - ranking_ocid_lookup_pipeline     — manual RANKING + OCID chain
+  - character_basic_pipeline         — CHARACTER_BASIC with mode=once|count=N|infinite
+  - item_equipment_pipeline          — ITEM_EQUIPMENT with mode=once|count=N|infinite
+  - stop_loop_pipeline               — graceful stop for mode=infinite loops
+
+Removal target: next release cycle. See docs/21_Operations/dag-migration.md
+for operator migration guide.
+
+This DAG remains parseable for one release cycle to avoid breaking operators
+who trigger it directly. Its FULL_DAILY path duplicates daily_full_pipeline's
+behavior; its scope/run_steps paths are superseded by phase DAGs.
+"""
+```
+
+Then in the `with DAG(...)` block, modify the `tags=` argument:
+
+```python
+with DAG(
+    dag_id="daily_collection_pipeline",
+    default_args={
+        "owner": "maple-pipeline",
+        "retries": 0,
+    },
+    start_date=datetime(2026, 5, 29),
+    schedule=None,  # schedule moved to daily_full_pipeline; legacy is manual-only
+    catchup=False,
+    tags=["pipeline", "daily", "deprecated"],
+) as dag:
+```
+
+(Set `schedule=None` so the legacy DAG doesn't double-trigger at 18:00 UTC; `daily_full_pipeline` owns that schedule.)
+
+- [ ] **Step 2: Run DAG import test**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine && \
+  PYTHONPATH=docker/airflow/dags python3 -m pytest \
+    docker/airflow/dags/tests/test_dag_imports.py -v
+```
+
+Expected: PASS (legacy still parses, tagged deprecated, schedule=None).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine && \
+  git add docker/airflow/dags/daily_collection_pipeline.py && \
+  git commit -m "feat(airflow): deprecate legacy daily_collection_pipeline
+
+Add 'deprecated' tag, set schedule=None (daily_full_pipeline owns the
+18:00 UTC schedule now). Docstring redirects operators to phase DAGs.
+Legacy DAG still parseable + runnable for one release cycle to allow
+gradual operator migration.
+
+Refs: docs/superpowers/specs/2026-06-22-dag-restructure-design.md §3.4
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 13: Update `per_phase_tasks.py` with `_legacy` notes
+
+**Files:**
+- Modify: `docker/airflow/dags/per_phase_tasks.py`
+
+- [ ] **Step 1: Update module docstring**
+
+Replace the existing docstring (lines 1-8) with:
+
+```python
+"""Per-phase Airflow task factories (LEGACY — used by deprecated daily_collection_pipeline).
+
+This module is retained for backward compatibility with operators still
+triggering daily_collection_pipeline -c '{"scope":[...]}' directly.
+Removal target: next release cycle after operators migrate to the
+phase-separated DAGs.
+
+New DAGs (ranking_ocid_lookup_pipeline, character_basic_pipeline,
+item_equipment_pipeline, daily_full_pipeline, stop_loop_pipeline) use
+phase_pipeline_factory instead.
+
+Ref: docs/superpowers/specs/2026-06-22-dag-restructure-design.md §6.6
+"""
+```
+
+- [ ] **Step 2: Add legacy note above `parse_scope`**
+
+Add comment block above `def parse_scope`:
+
+```python
+# LEGACY: superseded by phase_pipeline_factory.parse_mode.
+# Kept for daily_collection_pipeline scope path.
+def parse_scope(conf: dict) -> list:
+```
+
+- [ ] **Step 3: Add legacy note above `parse_steps`**
+
+```python
+# LEGACY: superseded by phase_pipeline_factory + ordered TaskGroup in v2.
+# Kept for daily_collection_pipeline run_steps path.
+def parse_steps(conf: dict) -> list:
+```
+
+- [ ] **Step 4: Add legacy notes to factory functions**
+
+```python
+# LEGACY: superseded by phase_pipeline_factory.make_trigger_once_task.
+def make_trigger_task(phase: str) -> PythonOperator:
+
+# LEGACY: superseded by phase_pipeline_factory.make_trigger_loop_task.
+def make_loop_task(phase: str) -> PythonOperator:
+
+# LEGACY: superseded by phase_pipeline_factory.make_stop_loop_task.
+def make_stop_task(phase: str) -> PythonOperator:
+
+# LEGACY: superseded by phase_pipeline_factory._wait_terminal_fn (in make_phase_dag).
+def make_is_phase_terminal(phase: str):
+```
+
+- [ ] **Step 5: Run DAG import test**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine && \
+  PYTHONPATH=docker/airflow/dags python3 -m pytest \
+    docker/airflow/dags/tests/ -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine && \
+  git add docker/airflow/dags/per_phase_tasks.py && \
+  git commit -m "docs(airflow): mark per_phase_tasks as legacy
+
+Add _legacy module docstring + per-symbol comments. Symbols unchanged.
+Removal target: next release cycle.
+
+Refs: docs/superpowers/specs/2026-06-22-dag-restructure-design.md §6.6
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 14: Write operator runbook `docs/21_Operations/dag-migration.md`
+
+**Files:**
+- Create: `docs/21_Operations/dag-migration.md`
+
+- [ ] **Step 1: Write the runbook**
+
+```markdown
+# DAG Migration Guide — Phase-Separated Pipelines
+
+As of 2026-06-22, the legacy `daily_collection_pipeline` is deprecated.
+This guide maps common operator workflows to the new phase-separated DAGs.
+
+## Mapping table
+
+| Old (legacy) | New | Trigger command |
+|--------------|-----|-----------------|
+| `daily_collection_pipeline -c '{}'` (scheduled daily) | `daily_full_pipeline` (scheduled at KST 03:00) | Auto. No operator action needed. |
+| `daily_collection_pipeline -c '{"scope":["ITEM_EQUIPMENT_LOOP"]}'` (start loop) | `item_equipment_pipeline -c '{"mode":"infinite"}'` | `airflow dags trigger item_equipment_pipeline -c '{"mode":"infinite"}'` |
+| `daily_collection_pipeline -c '{"scope":["ITEM_EQUIPMENT_LOOP", "OCID_LOOKUP_STOP"]}'` (mixed) | (compose) Trigger each phase DAG separately | `airflow dags trigger item_equipment_pipeline -c '{"mode":"infinite"}'` then `airflow dags trigger ranking_ocid_lookup_pipeline -c '{}'` (note: no current way to stop OCID via new DAGs — use ext-api directly or open an issue) |
+| `daily_collection_pipeline -c '{"scope":["ITEM_EQUIPMENT"]}'` (run once) | `item_equipment_pipeline -c '{"mode":"once"}'` | `airflow dags trigger item_equipment_pipeline -c '{"mode":"once"}'` |
+| `daily_collection_pipeline -c '{"steps":[{...},{...}]}'` (ordered sequence) | Compose phase DAGs sequentially | (no direct equivalent — see "Ordered sequences" below) |
+| `daily_collection_pipeline -c '{"scope":["ITEM_EQUIPMENT_STOP"]}'` (stop loop) | `stop_loop_pipeline -c '{"phase":"ITEM_EQUIPMENT"}'` | `airflow dags trigger stop_loop_pipeline -c '{"phase":"ITEM_EQUIPMENT"}'` |
+
+## Mode parameter reference
+
+For `character_basic_pipeline` and `item_equipment_pipeline`:
+
+| Mode | Behavior | DAG duration |
+|------|----------|--------------|
+| `{"mode":"once"}` | Trigger phase, wait terminal | Until phase completes (typically 30-90min for once) |
+| `{"mode":"count","count":N}` | Trigger loop, count N chunk-ready events, stop | `N × ~5min + 30min buffer` (e.g., count=3 → ~45min) |
+| `{"mode":"infinite"}` | Trigger loop, DAG succeeds immediately | <1min (loop continues in ext-api) |
+
+`count` must be an integer >= 1. `mode` must be one of `once`, `count`, `infinite` (case-sensitive).
+
+## Ordered sequences
+
+The old `steps` config (e.g., `RANKING_FETCH → OCID_LOOKUP → ITEM_EQUIPMENT_LOOP`) is replaced by **explicit sequential triggering**:
+
+```bash
+# Trigger ranking_ocid first; wait for it to finish; then trigger item_equipment loop
+airflow dags trigger ranking_ocid_lookup_pipeline -c '{}'
+# ... wait for completion ...
+airflow dags trigger item_equipment_pipeline -c '{"mode":"infinite"}'
+```
+
+For an automated sequential chain, use the wrapper:
+
+```bash
+airflow dags trigger daily_full_pipeline -c '{}'
+```
+
+This runs `ranking_ocid → character_basic(once) → item_equipment(once) → cleanup`. There is no built-in way to chain with `mode=count` or `mode=infinite` — those require operator judgment.
+
+## Stopping an infinite loop
+
+```bash
+# Check active loops
+curl -s http://localhost:8081/api/internal/run-status | jq '.loopSummaries'
+
+# Stop a loop
+airflow dags trigger stop_loop_pipeline -c '{"phase":"ITEM_EQUIPMENT"}'
+# Waits up to 30min for current chunk to drain + loop to finalize.
+```
+
+`stop_loop_pipeline` is idempotent: triggering it when no loop is active for the given phase succeeds immediately.
+
+## Verification
+
+After triggering any new DAG, verify in Airflow UI:
+1. DAG run shows in DAG's "Runs" tab.
+2. Task graph shows expected branch (once/count/infinite).
+3. For mode=count, the `count_N_<phase>` sensor task shows progress in logs.
+4. For mode=infinite, DAG run succeeds at `trigger_loop_<phase>` task; loop continues in ext-api.
+
+## Migration timeline
+
+- **Now (2026-06-22):** New DAGs active; legacy `daily_collection_pipeline` parseable + manually triggerable. Legacy DAG tagged `deprecated` in UI.
+- **One release cycle later:** Remove legacy `daily_collection_pipeline` + `per_phase_tasks.py` legacy symbols. Migrate any remaining operators first.
+
+## Questions?
+
+Open a GitHub issue with the `airflow` label.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine && \
+  git add docs/21_Operations/dag-migration.md && \
+  git commit -m "docs(operations): add DAG migration guide
+
+Maps legacy daily_collection_pipeline triggers to phase-separated DAGs.
+Documents mode parameter semantics, ordered sequence workaround, and
+stop_loop_pipeline usage. One release cycle deprecation timeline.
+
+Refs: docs/superpowers/specs/2026-06-22-dag-restructure-design.md §14
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 15: Write ADR-734
+
+**Files:**
+- Create: `docs/01_ADR/ADR-734_phase-separated-dags.md`
+
+- [ ] **Step 1: Write the ADR following project conventions**
+
+Per `.claude/rules/adr-conventions.md`:
+
+```markdown
+# ADR-734: Phase-Separated Airflow DAGs
+
+- Status: Accepted
+- Date: 2026-06-22
+- Owner: pipeline
+
+---
+
+## 1. Background / Problem
+
+### Background
+
+The single `daily_collection_pipeline` DAG dispatched 3 fundamentally different
+workflows (full daily chain, per-phase parallel fan-out, ordered steps) via a
+`branch_on_scope` operator that parsed JSON `scope` / `steps` config at
+runtime. Operators reading the Airflow UI could not tell what a DAG run would
+do without inspecting `dag_run.conf`. The DAG graph materialized 17 task
+definitions even when 14 were skipped.
+
+### Problem
+
+DAG ergonomics for operators: each workflow intent (run once, run N times,
+run forever) required writing a JSON scope config rather than selecting a
+pre-built DAG.
+
+### Goal
+
+Each Airflow DAG has a single workflow intent visible from its DAG id and
+tags. Operator selects intent by DAG id, not by parsing JSON.
+
+---
+
+## 2. Decision
+
+> Replace `daily_collection_pipeline` with five single-purpose DAGs.
+
+```text
+ranking_ocid_lookup_pipeline (manual; RANKING → OCID sequential)
+character_basic_pipeline      (manual; mode=once|count=N|infinite)
+item_equipment_pipeline       (manual; mode=once|count=N|infinite)
+daily_full_pipeline           (cron; chains the 3 above + cleanup)
+stop_loop_pipeline            (manual; stops mode=infinite loops)
+```
+
+Loop state continues to live in ext-api's in-memory `PhaseLoopController`.
+Airflow sensors count chunk-ready events to bound `mode=count`; `stop_loop_pipeline`
+provides the kill switch for `mode=infinite`. Legacy `daily_collection_pipeline`
+retained as deprecated for one release cycle.
+
+---
+
+## 3. Trade-offs
+
+### Sensitivity
+
+* DAG count: 5 new + 1 legacy + 1 cleanup = 7 DAGs vs 1 today.
+* Operator JSON scope parsing: eliminated at trigger time (mode parameter on
+  conf is the only free-form input).
+* Loop termination latency: `stop_loop_pipeline` waits up to 30min for current
+  chunk to drain. Operators wanting immediate stop use ext-api's
+  `POST /stop/loop/phase/{phase}` directly.
+
+### Trade-off
+
+| 선택 | 얻는 것 | 포기한 것 |
+| -- | ---- | ----- |
+| 5 DAGs vs 1 | Single-responsibility per DAG, clean Airflow UI, intent visible from DAG id, no JSON parsing | 4 extra DAG parses per scheduler cycle (~30s/parse), slight cognitive load from choosing the right DAG |
+| Airflow sensor counting chunks (mode=count) | Zero ext-api changes, observable in Airflow logs, bounded slot occupancy | DAG occupies worker slot for `count*5min+30min` |
+| Ext-api keeps loop state | Reuses existing `PhaseLoopController`, no behavior change | Loop dies with ext-api restart (pre-existing limitation per #1291 §13) |
+
+### Risk
+
+* Legacy `daily_collection_pipeline` bit rot if not exercised by CI: mitigated
+  by `test_dag_imports.py` asserting legacy DAG still parses.
+* 5 DAGs → operator confusion about which to trigger: mitigated by runbook
+  `docs/21_Operations/dag-migration.md`.
+* `count_sensor` timeout mis-tuned (5min/chunk P99 wrong): verified during
+  pipeline-test; constant documented in runbook.
+
+### Non-Risk
+
+* `daily_full_pipeline` cron duplicate (both legacy + new trigger at 18:00 UTC):
+  mitigated by setting legacy `schedule=None`.
+* DAG graph complexity from branch operators: each phase DAG has 1 branch +
+  ~6 tasks, well under any Airflow UI rendering limit.
+
+---
+
+## 4. Result / Evidence
+
+### Metrics
+
+| Metric | Value | Notes |
+| ------ | ----: | ----- |
+| DAG count | 7 (5 new + 1 legacy + 1 cleanup) | vs 1 before |
+| Task count per phase DAG | ~7 (1 health + 1 branch + 2-3 once + 1-3 count + 1-2 stop) | vs 17 in legacy |
+| `parse_mode` test coverage | 14 cases | empty/invalid/missing count/zero/negative/case |
+| Operator migration window | 1 release cycle | legacy DAG tagged deprecated |
+
+### Observed Result
+
+Pending — measured after pipeline-test skill E2E run.
+
+---
+
+## 5. Summary
+
+> Five single-purpose DAGs replace one overloaded DAG; loop state stays in ext-api;
+> operators select workflow by DAG id, not by JSON config.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine && \
+  git add docs/01_ADR/ADR-734_phase-separated-dags.md && \
+  git commit -m "docs(adr): ADR-734 phase-separated Airflow DAGs
+
+Decision: replace overloaded daily_collection_pipeline with 5 single-purpose
+DAGs. Loop state stays in ext-api (no behavior change). Legacy DAG deprecated
+for one release cycle. Runbook + factory helpers + tests included.
+
+Refs: docs/superpowers/specs/2026-06-22-dag-restructure-design.md
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 16: Run full DAG test suite
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run all DAG tests**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine && \
+  PYTHONPATH=docker/airflow/dags python3 -m pytest docker/airflow/dags/tests/ -v 2>&1 | tail -50
+```
+
+Expected: all tests pass. Approximate count: ~40 tests across parse_mode (14), trigger (9), count (8), stop (8), wait (5), branch (4), DAG structure (6), imports (2).
+
+- [ ] **Step 2: Verify no leftover placeholders**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine && \
+  grep -rnE "TODO|FIXME|XXX|TBD" docker/airflow/dags/phase_pipeline_factory.py \
+    docker/airflow/dags/ranking_ocid_lookup_pipeline.py \
+    docker/airflow/dags/character_basic_pipeline.py \
+    docker/airflow/dags/item_equipment_pipeline.py \
+    docker/airflow/dags/daily_full_pipeline.py \
+    docker/airflow/dags/stop_loop_pipeline.py
+```
+
+Expected: no output.
+
+---
+
+## Task 17: Run pipeline-test skill E2E verification
+
+This task is performed by the operator (you) using the existing
+`.claude/skills/pipeline-test/SKILL.md` skill. Verification table per
+spec §9.4.
+
+- [ ] **Step 1: Start the stack**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine && \
+  ./claude/skills/pipeline-test/scripts/start.sh
+```
+
+(Or follow the skill's workflow manually per `.claude/skills/pipeline-test/SKILL.md`.)
+
+- [ ] **Step 2: Trigger each new DAG and verify**
+
+Per spec §9.4, trigger each:
+
+```bash
+# 1. ranking_ocid_lookup_pipeline (sequential RANKING + OCID)
+docker exec maple-airflow-scheduler airflow dags trigger ranking_ocid_lookup_pipeline
+
+# 2. character_basic_pipeline mode=once
+docker exec maple-airflow-scheduler airflow dags trigger character_basic_pipeline \
+  -c '{"mode":"once"}'
+
+# 3. item_equipment_pipeline mode=count
+docker exec maple-airflow-scheduler airflow dags trigger item_equipment_pipeline \
+  -c '{"mode":"count","count":3}'
+
+# 4. item_equipment_pipeline mode=infinite, then stop
+docker exec maple-airflow-scheduler airflow dags trigger item_equipment_pipeline \
+  -c '{"mode":"infinite"}'
+# Wait for DAG to succeed (~1min); verify loop still active
+curl -s http://localhost:8081/api/internal/run-status | jq '.loopSummaries'
+docker exec maple-airflow-scheduler airflow dags trigger stop_loop_pipeline \
+  -c '{"phase":"ITEM_EQUIPMENT"}'
+
+# 5. daily_full_pipeline (full chain)
+docker exec maple-airflow-scheduler airflow dags trigger daily_full_pipeline
+
+# 6. Legacy daily_collection_pipeline still works
+docker exec maple-airflow-scheduler airflow dags trigger daily_collection_pipeline \
+  -c '{}'
+```
+
+- [ ] **Step 3: Verify each run in Airflow UI**
+
+Open http://localhost:8180 (admin/admin). For each DAG run, verify:
+- DAG run shows correct task graph (branch resolved per conf).
+- For mode=count, `count_3_item_equipment` sensor task runs and exits True.
+- For mode=infinite, DAG succeeds at `trigger_loop_item_equipment` task.
+- For stop_loop, `wait_loop_stopped_item_equipment` sensor exits True after loop finalizes.
+- Legacy `daily_collection_pipeline` triggers the existing FULL_DAILY chain.
+
+- [ ] **Step 4: Document results in PR description**
+
+Note which DAGs verified successfully. If any fail, capture error output and fix before PR.
+
+---
+
+## Task 18: Create PR + merge to develop
+
+- [ ] **Step 1: Push branch**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine && \
+  git push -u origin feat/dag-restructure
+```
+
+- [ ] **Step 2: Create PR**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine && \
+  gh pr create \
+    --base develop \
+    --title "feat(airflow): phase-separated DAGs (5 single-purpose DAGs)" \
+    --body "$(cat <<'EOF'
+## Summary
+
+Replace `daily_collection_pipeline` (one DAG, 3 workflow intents via JSON `scope`/`steps`) with 5 single-purpose DAGs:
+
+- `ranking_ocid_lookup_pipeline` — sequential RANKING + OCID
+- `character_basic_pipeline` — mode=once|count=N|infinite
+- `item_equipment_pipeline` — mode=once|count=N|infinite
+- `daily_full_pipeline` — wrapper cron DAG (KST 03:00)
+- `stop_loop_pipeline` — graceful stop for mode=infinite
+
+Loop state stays in ext-api (no ext-api changes). N-count mode uses Airflow PythonSensor polling Kafka chunk-ready events; mode=infinite is fire-and-forget with separate stop DAG.
+
+Legacy `daily_collection_pipeline` retained as `tags=["deprecated"]` for one release cycle. `per_phase_tasks.py` marked `_legacy`.
+
+## Test plan
+
+- [ ] All DAG imports parse (CI test_dag_imports.py)
+- [ ] `parse_mode` unit tests (14 cases)
+- [ ] trigger / count / stop helpers unit tests (~25 cases)
+- [ ] Branch + DAG structure tests (DagBag-level)
+- [ ] Manual pipeline-test E2E per spec §9.4 (ranking_ocid, character_basic mode=once, item_equipment mode=count, mode=infinite + stop_loop, daily_full, legacy still works)
+
+## Refs
+
+- Spec: `docs/superpowers/specs/2026-06-22-dag-restructure-design.md`
+- Plan: `docs/superpowers/plans/2026-06-22-dag-restructure.md`
+- ADR: `docs/01_ADR/ADR-734_phase-separated-dags.md`
+- Runbook: `docs/21_Operations/dag-migration.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Wait for CI**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine && \
+  gh pr checks --watch
+```
+
+Expected: all checks green.
+
+- [ ] **Step 4: Merge to develop**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine && \
+  gh pr merge --squash --delete-branch
+```
+
+- [ ] **Step 5: Verify merged**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine && \
+  git log --oneline develop | head -5
+```
+
+Expected: merge commit visible on develop.

--- a/docs/superpowers/plans/2026-06-22-dag-restructure.md
+++ b/docs/superpowers/plans/2026-06-22-dag-restructure.md
@@ -405,7 +405,7 @@ def get_external_api_base() -> str:
 def _trigger_once_fn(phase: str):
     """Inner: trigger phase once via POST /trigger/phase/{phase}.
 
-    Reads upstream_run_id from xcom (task_id='upstream_run_id_pusher') if
+    Reads upstream_run_id from xcom (task_id='upstream_run_id') if
     present — OCID_LOOKUP and downstream phases require X-Upstream-Run-Id.
     RANKING_FETCH ignores the header (it IS the upstream).
     """
@@ -566,31 +566,31 @@ Co-Authored-By: Claude <noreply@anthropic.com>"
 Append to test file:
 
 ```python
-from phase_pipeline_factory import make_count_sensor, _compute_count_timeout
+from phase_pipeline_factory import (
+    _make_count_sensor_runtime,
+    _PHASE_TO_ENDPOINT,
+)
 
 
-class TestComputeCountTimeout:
-    def test_formula(self):
-        # count * 5min + 30min buffer
-        assert _compute_count_timeout(1) == timedelta(minutes=5 + 30)
-        assert _compute_count_timeout(3) == timedelta(minutes=15 + 30)
-        assert _compute_count_timeout(10) == timedelta(minutes=50 + 30)
-        assert _compute_count_timeout(0) == timedelta(minutes=30)
+class TestPhaseToEndpoint:
+    def test_character_basic(self):
+        assert _PHASE_TO_ENDPOINT["CHARACTER_BASIC"] == "character-basic"
+
+    def test_item_equipment(self):
+        assert _PHASE_TO_ENDPOINT["ITEM_EQUIPMENT"] == "item-equipment"
 
 
-class TestMakeCountSensor:
-    """Tests the inner _poke callable returned by the factory."""
+class TestMakeCountSensorRuntime:
+    """Tests the runtime count sensor (reads count from dag_run.conf)."""
 
-    def _get_callable(self, phase, count):
-        op = make_count_sensor(phase, count)
+    def _get_callable_and_op(self, phase):
+        op = _make_count_sensor_runtime(phase)
         return op.python_callable, op
 
     def test_returns_true_after_count_events(self):
         """Sensor returns True after `count` matching events received."""
-        from kafka import KafkaConsumer
-        callable_fn, op = self._get_callable("ITEM_EQUIPMENT", 2)
+        callable_fn, op = self._get_callable_and_op("ITEM_EQUIPMENT")
 
-        # Fake consumer yielding 2 matching messages
         fake_msg1 = MagicMock()
         fake_msg1.value = {"endpoint": "item-equipment", "runId": "r1"}
         fake_msg2 = MagicMock()
@@ -598,32 +598,53 @@ class TestMakeCountSensor:
         fake_msg3 = MagicMock()
         fake_msg3.value = {"endpoint": "item-equipment", "runId": "r3"}
 
-        with patch.object(KafkaConsumer, "__iter__", return_value=iter([fake_msg1, fake_msg2, fake_msg3])):
-            result = callable_fn()
+        ctx = {
+            "dag_run": MagicMock(conf={"mode": "count", "count": 2}, run_id="20260622-x"),
+        }
+        with patch("phase_pipeline_factory.KafkaConsumer") as mock_consumer_cls:
+            instance = MagicMock()
+            instance.__iter__ = MagicMock(
+                return_value=iter([fake_msg1, fake_msg2, fake_msg3])
+            )
+            mock_consumer_cls.return_value = instance
+            result = callable_fn(**ctx)
         assert result is True
 
     def test_filters_by_endpoint(self):
-        """Sensor ignores events for other endpoints."""
-        callable_fn, op = self._get_callable("CHARACTER_BASIC", 1)
+        callable_fn, op = self._get_callable_and_op("CHARACTER_BASIC")
 
         fake_msg_other = MagicMock()
         fake_msg_other.value = {"endpoint": "item-equipment", "runId": "r1"}
         fake_msg_match = MagicMock()
         fake_msg_match.value = {"endpoint": "character-basic", "runId": "r2"}
 
+        ctx = {
+            "dag_run": MagicMock(
+                conf={"mode": "count", "count": 1}, run_id="20260622-x"
+            ),
+        }
         with patch("phase_pipeline_factory.KafkaConsumer") as mock_consumer_cls:
             instance = MagicMock()
-            instance.__iter__ = MagicMock(return_value=iter([fake_msg_other, fake_msg_match]))
+            instance.__iter__ = MagicMock(
+                return_value=iter([fake_msg_other, fake_msg_match])
+            )
             mock_consumer_cls.return_value = instance
-            result = callable_fn()
+            result = callable_fn(**ctx)
         assert result is True
 
-    def test_timeout_set_correctly(self):
-        _, op = self._get_callable("ITEM_EQUIPMENT", 5)
-        # count=5 → 25 + 30 = 55min
-        assert op.timeout == timedelta(minutes=55)
+    def test_timeout_is_12_hours_upper_bound(self):
+        _, op = self._get_callable_and_op("ITEM_EQUIPMENT")
+        # Single fixed timeout regardless of count (12h covers up to ~138 chunks).
+        assert op.timeout == timedelta(hours=12)
         assert op.mode == "reschedule"
         assert op.poke_interval == 30
+
+    def test_raises_for_invalid_conf(self):
+        from airflow.exceptions import AirflowException
+        callable_fn, op = self._get_callable_and_op("ITEM_EQUIPMENT")
+        ctx = {"dag_run": MagicMock(conf={})}
+        with pytest.raises(AirflowException):
+            callable_fn(**ctx)
 ```
 
 - [ ] **Step 2: Run new tests to verify they fail**
@@ -633,7 +654,7 @@ cd /home/maple/probabilistic-valuation-engine && \
   PYTHONPATH=docker/airflow/dags python3 -m pytest docker/airflow/dags/tests/test_phase_pipeline_factory.py -v -k "Count or Timeout"
 ```
 
-Expected: ImportError on `make_count_sensor` / `_compute_count_timeout`.
+Expected: ImportError on `_make_count_sensor_runtime` / `_PHASE_TO_ENDPOINT`.
 
 - [ ] **Step 3: Implement count sensor**
 
@@ -655,24 +676,29 @@ _PHASE_TO_ENDPOINT = {
 }
 
 # Per-chunk processing P99 (empirically observed ~3-5min on production
-# hardware). Used as the basis for the count timeout formula.
-_CHUNK_PROCESSING_MINUTES = 5
-_COUNT_TIMEOUT_BUFFER_MINUTES = 30
+# hardware). The count sensor timeout is set to 12h, which covers up to
+# ~138 chunks at 5min/chunk — well beyond any reasonable mode=count value.
+# Operators specifying count > 100 should use mode=infinite + stop_loop_pipeline.
+_COUNT_SENSOR_MAX_TIMEOUT = timedelta(hours=12)
 
 
-def _compute_count_timeout(count: int) -> timedelta:
-    """count * CHUNK_PROCESSING_MINUTES + BUFFER. Bounded by count=0 = buffer."""
-    minutes = max(count, 0) * _CHUNK_PROCESSING_MINUTES + _COUNT_TIMEOUT_BUFFER_MINUTES
-    return timedelta(minutes=minutes)
+def _make_count_sensor_runtime(phase: str) -> PythonSensor:
+    """Count sensor that reads count from dag_run.conf at runtime.
 
+    Single sensor handles any count value (1..N where N * 5min + 30min <= 12h).
+    The parse-time alternative (one sensor per count value) would inflate the
+    DAG graph and require DAG-serialization support we don't have.
 
-def _count_sensor_fn(phase: str, count: int):
-    """Inner: poll Kafka synchronizer.chunk.consumed for `count` events."""
+    Implementation: the _poke callable calls parse_mode(ctx.conf) to read the
+    operator-passed count, then polls Kafka synchronizer.chunk.consumed for
+    matching events.
+    """
     from kafka import KafkaConsumer
 
     endpoint = _PHASE_TO_ENDPOINT[phase]
 
     def _poke(**ctx):
+        _, count = parse_mode(ctx["dag_run"].conf or {})
         consumer = KafkaConsumer(
             "synchronizer.chunk.consumed",
             bootstrap_servers=os.environ["KAFKA_BOOTSTRAP_SERVERS"],
@@ -694,19 +720,14 @@ def _count_sensor_fn(phase: str, count: int):
                         return True
         finally:
             consumer.close()
-        return False  # iterator exhausted without count reached (timeout)
+        return False  # iterator exhausted; reschedule
 
-    return _poke
-
-
-def make_count_sensor(phase: str, count: int) -> PythonSensor:
-    """Sensor that returns True after `count` chunk-ready events for phase."""
     return PythonSensor(
-        task_id=f"count_{count}_{phase.lower()}",
-        python_callable=_count_sensor_fn(phase, count),
+        task_id=f"count_sensor_{phase.lower()}",
+        python_callable=_poke,
         mode="reschedule",
         poke_interval=30,
-        timeout=int(_compute_count_timeout(count).total_seconds()),
+        timeout=int(_COUNT_SENSOR_MAX_TIMEOUT.total_seconds()),
     )
 ```
 
@@ -986,7 +1007,7 @@ Co-Authored-By: Claude <noreply@anthropic.com>"
 
 ---
 
-## Task 5: Factory — `make_branch_on_mode` + `make_phase_dag` + tests
+## Task 5: Factory — `make_branch_on_mode_for_phase` + `make_phase_dag` + tests
 
 **Files:**
 - Modify: `docker/airflow/dags/phase_pipeline_factory.py`
@@ -998,37 +1019,88 @@ Append to `test_phase_pipeline_factory.py`:
 
 ```python
 from phase_pipeline_factory import (
-    make_branch_on_mode,
+    make_branch_on_mode_for_phase,
     make_phase_dag,
+    _wait_terminal_fn,
 )
 
 
-class TestMakeBranchOnMode:
-    def _get_callable(self):
-        op = make_branch_on_mode()
+class TestMakeBranchOnModeForPhase:
+    def _branch_fn(self, phase):
+        op = make_branch_on_mode_for_phase(phase)
         return op.python_callable
 
-    def test_mode_once_routes_to_trigger(self):
-        fn = self._get_callable()
+    def test_mode_once_routes_to_trigger_character_basic(self):
+        fn = self._branch_fn("CHARACTER_BASIC")
         ctx = {"dag_run": MagicMock(conf={"mode": "once"})}
         assert fn(**ctx) == "trigger_character_basic"
 
     def test_mode_count_routes_to_trigger_loop(self):
-        fn = self._get_callable()
-        ctx = {"dag_run": MagicMock(conf={"mode": "count", "count": 3})}
-        assert fn(**ctx) == "trigger_loop_character_basic"
+        fn = self._branch_fn("ITEM_EQUIPMENT")
+        ctx = {"dag_run": MagicMock(conf={"mode": "count", "count": 5})}
+        assert fn(**ctx) == "trigger_loop_item_equipment"
 
-    def test_mode_infinite_routes_to_trigger_loop(self):
-        fn = self._get_callable()
+    def test_mode_infinite_routes_to_trigger_loop_infinite(self):
+        """mode=infinite must route to a separate leaf task_id so count_sensor
+        does not run when count is not specified."""
+        fn = self._branch_fn("ITEM_EQUIPMENT")
         ctx = {"dag_run": MagicMock(conf={"mode": "infinite"})}
-        assert fn(**ctx) == "trigger_loop_character_basic"
+        assert fn(**ctx) == "trigger_loop_infinite_item_equipment"
 
     def test_invalid_conf_raises(self):
         from airflow.exceptions import AirflowException
-        fn = self._get_callable()
+        fn = self._branch_fn("CHARACTER_BASIC")
         ctx = {"dag_run": MagicMock(conf={})}
         with pytest.raises(AirflowException):
             fn(**ctx)
+
+
+class TestWaitTerminalFn:
+    def test_returns_true_when_terminal(self):
+        with patch("phase_pipeline_factory.requests.get") as mock_get, \
+             patch("phase_pipeline_factory.time") as mock_time:
+            mock_time.monotonic.return_value = 0  # never exceed deadline
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = {
+                "slots": {
+                    "CHARACTER_BASIC": {
+                        "runId": "20260622-120000-x",
+                        "phase": "CHARACTER_BASIC",
+                        "terminal": True,
+                    }
+                },
+                "lastCompletedByPhase": {},
+            }
+            mock_get.return_value = mock_resp
+            ti = MagicMock()
+            ti.xcom_pull.return_value = {"runId": "20260622-120000-x"}
+            ctx = {"ti": ti}
+            result = _wait_terminal_fn("CHARACTER_BASIC")(**ctx)
+        assert result is True
+
+    def test_raises_when_failed(self):
+        with patch("phase_pipeline_factory.requests.get") as mock_get, \
+             patch("phase_pipeline_factory.time") as mock_time:
+            mock_time.monotonic.return_value = 0
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = {
+                "slots": {
+                    "CHARACTER_BASIC": {
+                        "runId": "20260622-120000-x",
+                        "phase": "FAILED",
+                        "terminal": True,
+                        "errorMessage": "boom",
+                    }
+                },
+                "lastCompletedByPhase": {},
+            }
+            mock_get.return_value = mock_resp
+            ti = MagicMock()
+            ti.xcom_pull.return_value = {"runId": "20260622-120000-x"}
+            with pytest.raises(RuntimeError, match="failed"):
+                _wait_terminal_fn("CHARACTER_BASIC")(ti=ti)
 
 
 class TestMakePhaseDag:
@@ -1036,49 +1108,38 @@ class TestMakePhaseDag:
 
     def test_dag_has_expected_task_ids_for_character_basic(self):
         dag = make_phase_dag("CHARACTER_BASIC", "character_basic_pipeline")
-        task_ids = {t.task_id for t in dag.tasks}
+        ids = {t.task_id for t in dag.tasks}
         expected = {
             "check_external_api",
             "branch_on_mode",
             "trigger_character_basic",
             "wait_terminal_character_basic",
-            "trigger_loop_character_basic",
-            "stop_loop_character_basic",
-            "count_3_character_basic",   # default test count
+            "trigger_loop_character_basic",       # mode=count path start
+            "count_sensor_character_basic",       # mode=count sensor
+            "stop_loop_character_basic",          # mode=count stop
+            "trigger_loop_infinite_character_basic",  # mode=infinite leaf
         }
-        # Only the mode=count sensor for the default test count
-        # is asserted; other counts are parametrized.
-        # Re-call factory with explicit counts:
-        dag2 = make_phase_dag(
-            "CHARACTER_BASIC",
-            "character_basic_pipeline",
-            default_test_count=5,
-        )
-        ids2 = {t.task_id for t in dag2.tasks}
-        assert "count_5_character_basic" in ids2
+        assert expected.issubset(ids)
 
-    def test_dag_for_item_equipment_uses_correct_phase(self):
-        dag = make_phase_dag("ITEM_EQUIPMENT", "item_equipment_pipeline")
-        trigger_task = dag.get_task("trigger_item_equipment")
-        assert "ITEM_EQUIPMENT" in trigger_task.task_id
-
-    def test_infinite_branch_does_not_have_count_sensor(self):
-        """mode=infinite branch ends at trigger_loop; no count sensor."""
+    def test_infinite_branch_is_leaf(self):
+        """trigger_loop_infinite_<phase> must have no downstream tasks."""
         dag = make_phase_dag(
-            "ITEM_EQUIPMENT", "item_equipment_pipeline", default_test_count=3
+            "ITEM_EQUIPMENT", "item_equipment_pipeline"
         )
-        ids = {t.task_id for t in dag.tasks}
-        # count sensor exists for test purposes but isn't in the once/infinite path
-        # The once branch is: trigger_item_equipment >> wait_terminal_item_equipment
-        # The infinite branch is: trigger_loop_item_equipment (terminal)
-        once_downstream = set(
-            dag.get_task("trigger_item_equipment").downstream_task_ids
+        leaf = dag.get_task("trigger_loop_infinite_item_equipment")
+        assert leaf.downstream_task_ids == [], (
+            f"infinite branch should be leaf, got downstream={leaf.downstream_task_ids}"
         )
-        assert "wait_terminal_item_equipment" in once_downstream
-        infinite_downstream = set(
-            dag.get_task("trigger_loop_item_equipment").downstream_task_ids
+
+    def test_count_branch_wires_count_sensor_then_stop_loop(self):
+        dag = make_phase_dag(
+            "ITEM_EQUIPMENT", "item_equipment_pipeline"
         )
-        assert "stop_loop_item_equipment" in infinite_downstream
+        trigger_loop = dag.get_task("trigger_loop_item_equipment")
+        count_sensor = dag.get_task("count_sensor_item_equipment")
+        stop_loop = dag.get_task("stop_loop_item_equipment")
+        assert count_sensor.task_id in trigger_loop.downstream_task_ids
+        assert stop_loop.task_id in count_sensor.downstream_task_ids
 ```
 
 Also create `test_phase_dag_structure.py` for DagBag-level checks:
@@ -1107,7 +1168,7 @@ def test_character_basic_pipeline_parses(dagbag):
     ids = {t.task_id for t in dag.tasks}
     assert "branch_on_mode" in ids
     assert "trigger_character_basic" in ids
-    assert "trigger_loop_character_basic" in ids
+    assert "trigger_loop_infinite_character_basic" in ids
 
 
 def test_item_equipment_pipeline_parses(dagbag):
@@ -1115,14 +1176,15 @@ def test_item_equipment_pipeline_parses(dagbag):
     assert dag is not None
     ids = {t.task_id for t in dag.tasks}
     assert "trigger_item_equipment" in ids
-    assert "trigger_loop_item_equipment" in ids
+    assert "trigger_loop_infinite_item_equipment" in ids
+    assert "count_sensor_item_equipment" in ids
 
 
 def test_daily_full_pipeline_parses(dagbag):
     dag = dagbag.get_dag("daily_full_pipeline")
     assert dag is not None
-    # 4 TriggerDagRunOperator tasks
-    trigger_ids = [t.task_id for t in dag.tasks if "trigger" in t.task_id]
+    # 4 TriggerDagRunOperator tasks (ranking_ocid, char_basic, item_equip, cleanup)
+    trigger_ids = [t.task_id for t in dag.tasks if t.task_id.startswith("trigger_")]
     assert len(trigger_ids) == 4
 
 
@@ -1130,8 +1192,10 @@ def test_stop_loop_pipeline_parses(dagbag):
     dag = dagbag.get_dag("stop_loop_pipeline")
     assert dag is not None
     ids = {t.task_id for t in dag.tasks}
-    assert "stop_loop" in ids
-    assert "wait_loop_stopped" in ids
+    assert "stop_loop_character_basic" in ids
+    assert "stop_loop_item_equipment" in ids
+    assert "wait_loop_stopped_character_basic" in ids
+    assert "wait_loop_stopped_item_equipment" in ids
 
 
 def test_ranking_ocid_lookup_pipeline_parses(dagbag):
@@ -1142,6 +1206,8 @@ def test_ranking_ocid_lookup_pipeline_parses(dagbag):
     assert "wait_ranking_fetch_terminal" in ids
     assert "trigger_ocid_lookup" in ids
     assert "wait_ocid_lookup_terminal" in ids
+    # The upstream_run_id task that pushes RANKING's runId for OCID's header
+    assert "upstream_run_id" in ids
 
 
 def test_legacy_dag_still_parses(dagbag):
@@ -1161,9 +1227,9 @@ cd /home/maple/probabilistic-valuation-engine && \
     -v 2>&1 | head -50
 ```
 
-Expected: ImportError on `make_branch_on_mode` / `make_phase_dag`. DAG tests will fail (no DAG files yet).
+Expected: ImportError on `make_branch_on_mode_for_phase` / `make_phase_dag` / `_wait_terminal_fn`. DAG tests will fail (no DAG files yet).
 
-- [ ] **Step 3: Implement branch + factory DAG**
+- [ ] **Step 3: Implement branch + factory DAG (with infinite-path separation)**
 
 Append to `phase_pipeline_factory.py`:
 
@@ -1172,23 +1238,31 @@ from airflow import DAG
 from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import BranchPythonOperator, PythonOperator
 from airflow.providers.http.sensors.http import HttpSensor
+import time as _time
 
 
-def make_branch_on_mode() -> BranchPythonOperator:
-    """BranchPythonOperator: routes to once/count/infinite branch.
+# Upper bound on mode=count sensor runtime. Generous so any operator-passed
+# count up to ~135 chunks (12h - 30min buffer = 11.5h = 690min = 138 chunks)
+# fits. Operators specifying count > 100 chunks should use mode=infinite +
+# stop_loop_pipeline instead.
+_COUNT_SENSOR_MAX_TIMEOUT = timedelta(hours=12)
 
-    Validates conf via parse_mode; raises AirflowException on invalid (the
-    branch task fails before any HTTP call).
+
+def make_branch_on_mode_for_phase(phase: str) -> BranchPythonOperator:
+    """BranchPythonOperator that routes by mode for a specific phase.
+
+    Task_ids returned:
+      - mode=once    → 'trigger_<phase>'
+      - mode=count   → 'trigger_loop_<phase>' (continues into count_sensor + stop_loop)
+      - mode=infinite → 'trigger_loop_infinite_<phase>' (leaf; DAG ends here)
     """
     def _branch(**ctx):
         mode, _ = parse_mode(ctx["dag_run"].conf or {})
-        phase = ctx["dag_run"].conf.get("__phase__", "")
-        # The factory injects __phase__ into conf at DAG construction so
-        # the branch knows which phase's task_ids to route to.
         if mode == "once":
             return f"trigger_{phase.lower()}"
-        # mode in (count, infinite) → trigger_loop_<phase>
-        return f"trigger_loop_{phase.lower()}"
+        if mode == "infinite":
+            return f"trigger_loop_infinite_{phase.lower()}"
+        return f"trigger_loop_{phase.lower()}"  # mode=count
 
     return BranchPythonOperator(
         task_id="branch_on_mode",
@@ -1197,9 +1271,11 @@ def make_branch_on_mode() -> BranchPythonOperator:
 
 
 def _wait_terminal_fn(phase: str):
-    """Inner: poll /run-status until phase slot has terminal runId."""
-    import time as _time
+    """Inner: poll /run-status until phase slot reaches terminal state.
 
+    Returns True once terminal. Raises RuntimeError on FAILED, TimeoutError on
+    4h deadline. Ported from per_phase_tasks.make_is_phase_terminal (legacy).
+    """
     def _wait(**ctx):
         ti = ctx["ti"]
         trigger_resp = ti.xcom_pull(task_ids=f"trigger_{phase.lower()}")
@@ -1256,21 +1332,62 @@ def _wait_terminal_fn(phase: str):
     return _wait
 
 
-def make_phase_dag(
-    phase: str,
-    dag_id: str,
-    default_test_count: int = 3,
-) -> DAG:
+def _make_count_sensor_runtime(phase: str) -> PythonSensor:
+    """Count sensor that reads count from dag_run.conf at runtime.
+
+    Single sensor handles all count values (1..N where N * 5min + 30min
+    <= 12h). Uses the runtime conf value, not a parse-time default.
+    """
+    from kafka import KafkaConsumer
+
+    endpoint = _PHASE_TO_ENDPOINT[phase]
+
+    def _poke(**ctx):
+        _, count = parse_mode(ctx["dag_run"].conf or {})
+        # Sanity: count >= 1 already validated by parse_mode.
+        consumer = KafkaConsumer(
+            "synchronizer.chunk.consumed",
+            bootstrap_servers=os.environ["KAFKA_BOOTSTRAP_SERVERS"],
+            auto_offset_reset="latest",
+            enable_auto_commit=False,
+            group_id=(
+                f"airflow-count-sensor-{phase.lower()}-"
+                f"{ctx['dag_run'].run_id[:8]}"
+            ),
+            value_deserializer=lambda m: _json.loads(m.decode("utf-8")),
+        )
+        try:
+            received = 0
+            for message in consumer:
+                event = message.value
+                if event.get("endpoint") == endpoint:
+                    received += 1
+                    if received >= count:
+                        return True
+        finally:
+            consumer.close()
+        return False  # iterator exhausted; reschedule
+
+    return PythonSensor(
+        task_id=f"count_sensor_{phase.lower()}",
+        python_callable=_poke,
+        mode="reschedule",
+        poke_interval=30,
+        timeout=int(_COUNT_SENSOR_MAX_TIMEOUT.total_seconds()),
+    )
+
+
+def make_phase_dag(phase: str, dag_id: str) -> DAG:
     """Build a phase DAG with mode=once / mode=count / mode=infinite branches.
 
     Args:
         phase: PipelinePhase name (CHARACTER_BASIC or ITEM_EQUIPMENT).
         dag_id: Airflow DAG id.
-        default_test_count: The count value materialized as a sensor task for
-            testability. Operators pass count via dag_run.conf; the count_sensor
-            is created at DAG-parse time using this default. A future enhancement
-            could generate sensors per-conf-value via DAG serialization, but
-            that's out of scope for v1.
+
+    Mode routing (via make_branch_on_mode_for_phase):
+      - mode=once     → trigger_<phase> >> wait_terminal_<phase>
+      - mode=count    → trigger_loop_<phase> >> count_sensor >> stop_loop
+      - mode=infinite → trigger_loop_infinite_<phase> (leaf; DAG ends here)
     """
     default_args = {
         "owner": "maple-pipeline",
@@ -1281,7 +1398,7 @@ def make_phase_dag(
         dag_id=dag_id,
         default_args=default_args,
         start_date=datetime(2026, 5, 29),
-        schedule=None,  # manual trigger only
+        schedule=None,
         catchup=False,
         tags=["pipeline", "phase", phase.lower().replace("_", "-")],
     )
@@ -1297,7 +1414,7 @@ def make_phase_dag(
             timeout=120,
         )
 
-        branch = make_branch_on_mode()
+        branch = make_branch_on_mode_for_phase(phase)
 
         # once branch
         trigger_once = make_trigger_once_task(phase)
@@ -1309,49 +1426,25 @@ def make_phase_dag(
             timeout=4 * 60 * 60,
         )
 
-        # count + infinite branch share trigger_loop
-        trigger_loop = make_trigger_loop_task(phase)
-        count_sensor = make_count_sensor(phase, default_test_count)
+        # count branch: trigger_loop → count_sensor (runtime count from conf) → stop_loop
+        trigger_loop_count = make_trigger_loop_task(phase)
+        count_sensor = _make_count_sensor_runtime(phase)
         stop_loop = make_stop_loop_task(phase)
+
+        # infinite branch: trigger_loop_infinite (leaf; DAG succeeds here)
+        trigger_loop_infinite = PythonOperator(
+            task_id=f"trigger_loop_infinite_{phase.lower()}",
+            python_callable=_trigger_loop_fn(phase),  # same callable; fires-and-exits
+            retries=0,
+            execution_timeout=timedelta(seconds=60),
+            do_xcom_push=True,
+        )
 
         # Wiring
         check_external_api >> branch
         branch >> trigger_once >> wait_terminal
-
-        # count branch: trigger_loop → count_sensor → stop_loop
-        branch >> trigger_loop
-        trigger_loop >> count_sensor >> stop_loop
-
-        # infinite branch: trigger_loop (terminal — DAG succeeds immediately)
-        # This is implicit: branch routes to trigger_loop_<phase> for both
-        # count and infinite. For count, downstream count_sensor + stop_loop
-        # execute. For infinite, no further downstream; DAG ends at trigger_loop.
-        # However, since trigger_loop is also a downstream of count branch,
-        # we need to mark trigger_loop as a join point with trigger_rule that
-        # tolerates infinite branch terminating. Use trigger_rule='none_skipped'.
-        # Simplest: rely on Airflow's default for PythonOperator (all_success
-        # upstream) and note that infinite mode's "no further task" means the
-        # DAG's last task is trigger_loop itself. Acceptable.
-
-        # Inject __phase__ into the branch callable's runtime by patching
-        # the parse_mode path. The branch callable reads ctx['dag_run'].conf
-        # which we don't modify here — instead, branch uses a closure over
-        # `phase` via __phase__ injection. Update _branch:
-        original_branch_fn = branch.python_callable
-
-        def _branch_with_phase(**ctx):
-            ctx_copy = dict(ctx)
-            conf = dict(ctx_copy.get("dag_run").conf or {})
-            conf["__phase__"] = phase
-            ctx_copy["dag_run"] = MagicMock(conf=conf) if False else ctx["dag_run"]
-            # We can't easily mock dag_run here; instead, use a thread-local
-            # or pass phase via env. Simplest: re-implement branch inline:
-            mode, _ = parse_mode(ctx["dag_run"].conf or {})
-            if mode == "once":
-                return f"trigger_{phase.lower()}"
-            return f"trigger_loop_{phase.lower()}"
-
-        branch.python_callable = _branch_with_phase
+        branch >> trigger_loop_count >> count_sensor >> stop_loop
+        branch >> trigger_loop_infinite
 
     return dag
 ```
@@ -1364,7 +1457,7 @@ cd /home/maple/probabilistic-valuation-engine && \
     docker/airflow/dags/tests/test_phase_pipeline_factory.py -v
 ```
 
-Expected: parse_mode + trigger + count + stop + branch tests pass. `test_phase_dag_structure.py` will fail because the DAG files don't exist yet — expected. Will pass in Tasks 7-11.
+Expected: parse_mode + trigger + count + stop + branch + wait_terminal tests pass. `test_phase_dag_structure.py` will fail because the DAG files don't exist yet — expected. Will pass in Tasks 7-11.
 
 - [ ] **Step 5: Commit**
 
@@ -1373,22 +1466,20 @@ cd /home/maple/probabilistic-valuation-engine && \
   git add docker/airflow/dags/phase_pipeline_factory.py \
           docker/airflow/dags/tests/test_phase_pipeline_factory.py \
           docker/airflow/dags/tests/test_phase_dag_structure.py && \
-  git commit -m "feat(airflow): add branch_on_mode + make_phase_dag factory
+  git commit -m "feat(airflow): add branch_on_mode_for_phase + make_phase_dag factory
 
-make_branch_on_mode returns BranchPythonOperator that routes by parse_mode
-result: once→trigger_<phase>, count|infinite→trigger_loop_<phase>.
+Three-branch routing via closure over phase:
+  mode=once     → trigger_<phase> >> wait_terminal_<phase>
+  mode=count    → trigger_loop_<phase> >> count_sensor >> stop_loop
+  mode=infinite → trigger_loop_infinite_<phase> (leaf; DAG ends here)
 
-make_phase_dag(phase, dag_id, default_test_count=3) builds a DAG with:
-  check_external_api >> branch_on_mode
-    >> trigger_<phase> >> wait_terminal_<phase>           (mode=once)
-    >> trigger_loop_<phase>                                (mode=count|infinite)
-       >> count_<N>_<phase> >> stop_loop_<phase>           (mode=count)
-       >> [terminal]                                       (mode=infinite)
+count_sensor reads count from dag_run.conf at runtime (single sensor
+handles any count). Timeout fixed at 12h upper bound (covers up to
+~138 chunks). trigger_loop_infinite is a separate leaf task so count_sensor
+does not run for mode=infinite (Bug #7 fix).
 
-default_test_count materializes a count sensor at DAG-parse time for
-testability. Operators override count via dag_run.conf at trigger time;
-the sensor task is created once with default but the runtime poke filter
-honors the conf value via xcom (future enhancement: per-conf sensors).
+wait_terminal_fn ported from per_phase_tasks.make_is_phase_terminal
+(legacy module delegates in Task 13).
 
 Refs: docs/superpowers/specs/2026-06-22-dag-restructure-design.md §6.1
 
@@ -1462,10 +1553,9 @@ with DAG(
     )
 
     # OCID_LOOKUP — requires X-Upstream-Run-Id from RANKING_FETCH trigger.
-    # The X-Upstream-Run-Id header is set via the trigger_task callable
-    # reading xcom from `trigger_ranking_fetch`. make_trigger_task already
-    # handles this — it reads `upstream_run_id_pusher` xcom. Add a tiny
-    # task to push the runId into the upstream slot:
+    # The factory's _trigger_once_fn xcom_pulls from task_id="upstream_run_id"
+    # (must match exactly — Bug #4 fix). Add a tiny task to push the runId
+    # into that slot:
     def _push_upstream_run_id(**ctx):
         ti = ctx["ti"]
         trigger_resp = ti.xcom_pull(task_ids="per_phase_trigger_ranking_fetch")
@@ -1475,7 +1565,7 @@ with DAG(
         return trigger_resp.get("runId") if trigger_resp else None
 
     push_upstream = PythonOperator(
-        task_id="upstream_run_id_pusher",
+        task_id="upstream_run_id",  # must match factory's xcom_pull task_id
         python_callable=_push_upstream_run_id,
     )
 
@@ -1543,7 +1633,6 @@ from phase_pipeline_factory import make_phase_dag
 character_basic_dag = make_phase_dag(
     phase="CHARACTER_BASIC",
     dag_id="character_basic_pipeline",
-    default_test_count=3,
 )
 ```
 
@@ -1594,7 +1683,6 @@ from phase_pipeline_factory import make_phase_dag
 item_equipment_dag = make_phase_dag(
     phase="ITEM_EQUIPMENT",
     dag_id="item_equipment_pipeline",
-    default_test_count=3,
 )
 ```
 
@@ -1700,7 +1788,7 @@ with DAG(
     trigger_cleanup = TriggerDagRunOperator(
         task_id="trigger_cleanup",
         trigger_dag_id="daily_cleanup_pipeline",
-        wait_for_completion=False,  # fire-and-forget; cleanup has its own schedule
+        wait_for_completion=True,  # fail loud if cleanup errors (Bug #6 fix)
         reset_dag_run=True,
     )
 
@@ -1779,16 +1867,6 @@ default_args = {
 }
 
 
-def _validate_phase(**ctx):
-    conf = ctx["dag_run"].conf or {}
-    phase = conf.get("phase")
-    if phase not in LOOPABLE_PHASES:
-        raise AirflowException(
-            f"phase='{phase}' invalid. Allowed: {sorted(LOOPABLE_PHASES)}"
-        )
-    return phase
-
-
 with DAG(
     dag_id="stop_loop_pipeline",
     default_args=default_args,
@@ -1809,9 +1887,9 @@ with DAG(
     )
 
     # Single DAG handles both CHARACTER_BASIC and ITEM_EQUIPMENT via conf.
-    # Validate phase at trigger time, then route to the right stop task.
-    # For simplicity, always create both stop tasks; the conf determines
-    # which one runs (skip pattern).
+    # Phase validation happens in make_stop_loop_task's skip pattern (Bug #5
+    # fix: removed standalone _validate_phase; _stop_loop_fn returns None
+    # if conf.phase != this task's phase, Airflow marks as success-skipped).
     stop_character_basic = make_stop_loop_task("CHARACTER_BASIC")
     stop_item_equipment = make_stop_loop_task("ITEM_EQUIPMENT")
 
@@ -2528,7 +2606,7 @@ docker exec maple-airflow-scheduler airflow dags trigger daily_collection_pipeli
 
 Open http://localhost:8180 (admin/admin). For each DAG run, verify:
 - DAG run shows correct task graph (branch resolved per conf).
-- For mode=count, `count_3_item_equipment` sensor task runs and exits True.
+- For mode=count, `count_sensor_item_equipment` sensor task runs and exits True.
 - For mode=infinite, DAG succeeds at `trigger_loop_item_equipment` task.
 - For stop_loop, `wait_loop_stopped_item_equipment` sensor exits True after loop finalizes.
 - Legacy `daily_collection_pipeline` triggers the existing FULL_DAILY chain.

--- a/docs/superpowers/specs/2026-06-22-dag-restructure-design.md
+++ b/docs/superpowers/specs/2026-06-22-dag-restructure-design.md
@@ -1,0 +1,444 @@
+# Airflow DAG Restructure — Phase-Separated Pipelines
+
+- Date: 2026-06-22
+- Status: Draft (pending grill-me review)
+- Shape: B (replace branch_on_scope with phase-separated DAGs)
+- Blocked-by: none (additive; legacy DAG retained as deprecated)
+
+---
+
+## 1. Goal
+
+Replace the single multi-path `daily_collection_pipeline` DAG (FULL_DAILY / scope / run_steps) with **5 small DAGs**, each with a single responsibility. Operators trigger the DAG matching their intent directly from the UI or CLI without parsing scope configs.
+
+**Why:** The current `branch_on_scope` operator dispatches 3 fundamentally different workflows (full daily chain, per-phase parallel fan-out, ordered steps) through one DAG with JSON `scope` parsing at runtime. The DAG graph materializes 17 task definitions even when 14 are skipped. Operators reading the Airflow UI cannot tell what a DAG run will do without inspecting the conf JSON.
+
+**Use cases:**
+- Daily cron at 03:00 KST: full chain RANKING → OCID → CHARACTER_BASIC → ITEM_EQUIPMENT (once each).
+- Gap-fill run: trigger CHARACTER_BASIC 3× (count=3) to catch up on a backlog.
+- Steady-state hot loop: trigger ITEM_EQUIPMENT with mode=infinite; operator stops later via `stop_loop_pipeline`.
+- Stop any active loop: `stop_loop_pipeline -c '{"phase":"ITEM_EQUIPMENT"}'`.
+
+---
+
+## 2. DAG inventory
+
+| DAG id | Schedule | Trigger conf | Purpose |
+|--------|----------|--------------|---------|
+| `ranking_ocid_lookup_pipeline` | manual | `{}` | Sequential RANKING_FETCH → OCID_LOOKUP. OCID depends on RANKING output (upstream_runId header chain), so always chained. |
+| `character_basic_pipeline` | manual | `{mode: "once"\|"count"\|"infinite", count?: int}` | CHARACTER_BASIC phase in chosen mode. |
+| `item_equipment_pipeline` | manual | `{mode: "once"\|"count"\|"infinite", count?: int}` | ITEM_EQUIPMENT phase in chosen mode. |
+| `daily_full_pipeline` | `0 18 * * *` (UTC = KST 03:00) | `{}` | Chains `ranking_ocid_lookup_pipeline` → `character_basic_pipeline`(mode=once) → `item_equipment_pipeline`(mode=once) → `daily_cleanup_pipeline`. Primary scheduled workflow. |
+| `stop_loop_pipeline` | manual | `{phase: "CHARACTER_BASIC"\|"ITEM_EQUIPMENT"}` | Calls `POST /stop/loop/phase/{phase}` and waits for `loopSummaries[phase].status == "STOPPED"`. |
+
+`daily_cleanup_pipeline` (existing, schedule `0 */6 * * *`) unchanged.
+
+`daily_collection_pipeline` (legacy) **retained**, marked `tags=["deprecated"]`, docstring warns removal in next release. Operator migration runbook: `docs/21_Operations/dag-migration.md`.
+
+---
+
+## 3. Architecture
+
+### 3.1 Loop location: ext-api (unchanged)
+
+Per Q1 decision. `POST /loop/phase/{phase}` starts an infinite loop in ext-api's `PhaseLoopController` (in-memory `LoopState`). Airflow DAGs do not reimplement loop logic. Restart of ext-api loses loop state — pre-existing behavior per #1291 §13.
+
+### 3.2 N-count mechanism: Airflow sensor counting chunk-ready events
+
+Per Q2 decision. `character_basic_pipeline` and `item_equipment_pipeline` with `mode=count`:
+
+```
+trigger_loop (POST /loop/phase/{phase}) →
+  count_sensor (PythonSensor, mode=reschedule, poke Kafka synchronizer.chunk.consumed):
+    for i in 1..N:
+      wait one item-equipment or character-basic chunk-ready event from synchronizer
+    return True
+  stop_loop (POST /stop/loop/phase/{phase}) → DAG success
+```
+
+Loop state continues running in ext-api during the sensor poke window. `iterationCount` is observable via `GET /api/internal/run-status.loopSummaries[phase].iterationCount`.
+
+Trade-off: DAG occupies an Airflow worker slot during the count window. N-count runs are bounded (operator-specified), so slot occupancy is finite and predictable. No ext-api changes.
+
+### 3.3 Infinite loop kill switch: dedicated `stop_loop_pipeline` DAG
+
+Per Q3 decision. Operator triggers from Airflow UI or CLI:
+```bash
+docker exec maple-airflow-scheduler airflow dags trigger stop_loop_pipeline -c '{"phase":"ITEM_EQUIPMENT"}'
+```
+
+DAG calls `POST /stop/loop/phase/{phase}` (graceful chunk-boundary halt), waits for `loopSummaries[phase].status == "STOPPED"` (sensor mode=reschedule, timeout 30min), then DAG success. If no loop is active, endpoint returns 200 NOT_LOOPING — DAG succeeds immediately (idempotent).
+
+### 3.4 Backward compatibility: deprecated legacy DAG
+
+Per Q4 decision. `daily_collection_pipeline` retained with `tags=["deprecated","pipeline"]`. UI shows yellow warning in DAG docstring:
+> DEPRECATED 2026-06-22. Use `daily_full_pipeline` for scheduled daily chain, or trigger phase DAGs directly for ad-hoc. Removal in next release. See `docs/21_Operations/dag-migration.md`.
+
+`per_phase_tasks.py` (parse_scope, parse_steps, route_scope, run_steps_task) retained — legacy path depends on them. Marked internal `_legacy` in module docstring.
+
+---
+
+## 4. DAG topology (canonical shape)
+
+Each new DAG follows the same template:
+
+```
+[health_check_sensor] >> [phase_action_task(s)] >> [terminal_or_count_sensor] >> [cleanup_task?]
+```
+
+### 4.1 `ranking_ocid_lookup_pipeline`
+
+```
+check_external_api (HttpSensor)
+  >> trigger_ranking_fetch (PythonOperator)
+  >> wait_ranking_terminal (PythonSensor, mode=reschedule, timeout=4h)
+  >> trigger_ocid_lookup (PythonOperator, X-Upstream-Run-Id header)
+  >> wait_ocid_terminal (PythonSensor, mode=reschedule, timeout=4h)
+```
+
+RANKING_FETCH requires no upstream_runId header (it's the first phase). OCID_LOOKUP requires `X-Upstream-Run-Id` header set to the runId xcom'd from the RANKING_FETCH trigger. InternalApiController rejects without header (`MISSING_UPSTREAM` 400).
+
+### 4.2 `character_basic_pipeline` (and `item_equipment_pipeline`)
+
+```
+check_external_api (HttpSensor)
+  >> branch_on_mode (BranchPythonOperator)
+        ├── mode_once:
+        │     trigger_phase (PythonOperator)
+        │     >> wait_terminal (PythonSensor, mode=reschedule, timeout=4h)
+        ├── mode_count:
+        │     trigger_loop (PythonOperator)
+        │     >> count_sensor (PythonSensor, mode=reschedule, timeout=N*5min+30min buffer)
+        │     >> stop_loop (PythonOperator)
+        └── mode_infinite:
+              trigger_loop (PythonOperator)  # fire-and-forget; DAG succeeds
+```
+
+`branch_on_mode` validates `dag_run.conf`:
+- `mode` ∈ `{once, count, infinite}` else `AirflowException`.
+- `mode=count` requires integer `count >= 1` else `AirflowException`.
+- Other modes ignore `count`.
+
+The two phase DAGs share a single implementation parameterized by `phase` constant in a factory. Same shape, same sensors, same conf validation — only the phase name and the chunk-ready event filter differ.
+
+### 4.3 `daily_full_pipeline`
+
+```
+check_external_api (HttpSensor)
+  >> TriggerDagRunOperator(trigger_dag_id="ranking_ocid_lookup_pipeline", wait_for_completion=True)
+  >> TriggerDagRunOperator(trigger_dag_id="character_basic_pipeline", conf='{"mode":"once"}', wait_for_completion=True)
+  >> TriggerDagRunOperator(trigger_dag_id="item_equipment_pipeline", conf='{"mode":"once"}', wait_for_completion=True)
+  >> TriggerDagRunOperator(trigger_dag_id="daily_cleanup_pipeline", wait_for_completion=True)
+```
+
+`wait_for_completion=True` blocks until the triggered DAG reaches terminal state. Failure of any step aborts the chain.
+
+### 4.4 `stop_loop_pipeline`
+
+```
+check_external_api (HttpSensor)
+  >> stop_loop (PythonOperator, POST /stop/loop/phase/{phase})
+  >> wait_loop_stopped (PythonSensor, polls loopSummaries[phase].status == "STOPPED", timeout=30min)
+```
+
+`wait_loop_stopped` returns True immediately if `loopSummaries[phase]` is absent (no loop was running) — idempotent.
+
+---
+
+## 5. Configuration schema
+
+### 5.1 `character_basic_pipeline` / `item_equipment_pipeline` conf
+
+```json
+{
+  "mode": "once" | "count" | "infinite",
+  "count": <integer, required if mode=count, >= 1>
+}
+```
+
+| conf | Behavior |
+|------|----------|
+| `{}` or missing | `AirflowException` (must specify mode) |
+| `{"mode": "once"}` | trigger phase, wait terminal |
+| `{"mode": "count", "count": 3}` | trigger loop, count 3 chunk-ready events, stop loop |
+| `{"mode": "infinite"}` | trigger loop, DAG succeeds (operator stops later) |
+| `{"mode": "INVALID"}` | `AirflowException` |
+| `{"mode": "count"}` (missing count) | `AirflowException` |
+| `{"mode": "count", "count": 0}` | `AirflowException` |
+
+### 5.2 `ranking_ocid_lookup_pipeline` conf
+
+```json
+{}
+```
+
+No parameters. RANKING + OCID chain is deterministic.
+
+### 5.3 `daily_full_pipeline` conf
+
+```json
+{}
+```
+
+Hardcoded mode=once for both CHARACTER_BASIC and ITEM_EQUIPMENT. Override scheduled behavior via `airflow dags trigger daily_full_pipeline -c '{"override": ...}'` (out of scope for v1; v2 if requested).
+
+### 5.4 `stop_loop_pipeline` conf
+
+```json
+{
+  "phase": "CHARACTER_BASIC" | "ITEM_EQUIPMENT"
+}
+```
+
+Only loopable phases. RANKING_FETCH / OCID_LOOKUP cannot loop (ext-api rejects with 400 INVALID_PHASE).
+
+---
+
+## 6. Components
+
+### 6.1 New: `docker/airflow/dags/phase_pipeline_factory.py`
+
+Pure helpers — no DAG object. Reused by `character_basic_pipeline.py` and `item_equipment_pipeline.py`:
+
+| Symbol | Purpose |
+|--------|---------|
+| `parse_mode(conf: dict) -> tuple[str, int]` | Returns `(mode, count)`. Validates `mode ∈ {once,count,infinite}` and `count` rules. Raises `AirflowException`. |
+| `make_trigger_once_task(phase) -> PythonOperator` | POST `/trigger/phase/{phase}` with `X-Upstream-Run-Id` from run-status if needed. 200/202 → xcom. 409 → idempotent. |
+| `make_trigger_loop_task(phase) -> PythonOperator` | POST `/loop/phase/{phase}`. 202 → xcom loopId. 409 → idempotent. |
+| `make_count_sensor(phase, count) -> PythonSensor` | Polls Kafka `synchronizer.chunk.consumed` for the phase's endpoint, returns True after `count` events. mode=reschedule, timeout=`count*5min+30min` (5min per chunk P99 + 30min buffer). |
+| `make_stop_loop_task(phase) -> PythonOperator` | POST `/stop/loop/phase/{phase}`. 202 → STOP_REQUESTED. 200 → NOT_LOOPING (idempotent). |
+| `make_wait_loop_stopped_sensor(phase) -> PythonSensor` | Polls `/run-status.loopSummaries[phase].status == "STOPPED"`. Returns True immediately if no loop active. mode=reschedule, timeout=30min. |
+| `make_branch_on_mode()` | BranchPythonOperator callable. Reads conf, returns task_id of chosen branch. |
+| `make_phase_dag(phase: str, dag_id: str) -> DAG` | Factory: builds the once/count/infinite DAG for a given phase. Used by both phase DAGs. |
+
+### 6.2 New: `docker/airflow/dags/ranking_ocid_lookup_pipeline.py`
+
+DAG with RANKING_FETCH → OCID_LOOKUP sequential tasks. Uses existing helpers from `per_phase_tasks.py` (make_trigger_task, make_is_phase_terminal) since they already implement the right shape; adds `X-Upstream-Run-Id` header plumbing.
+
+### 6.3 New: `docker/airflow/dags/daily_full_pipeline.py`
+
+DAG with 4 TriggerDagRunOperator tasks. No new helpers; reuses existing DAG ids.
+
+### 6.4 New: `docker/airflow/dags/stop_loop_pipeline.py`
+
+DAG with health check + stop_loop + wait_stopped sensor. Uses `phase_pipeline_factory.make_stop_loop_task` and `make_wait_loop_stopped_sensor`.
+
+### 6.5 Modify: `docker/airflow/dags/daily_collection_pipeline.py`
+
+Add `tags=["deprecated"]` (existing tags=["pipeline","daily"]). Update docstring to reference migration runbook. **No code path changes** — legacy FULL_DAILY / scope / run_steps paths continue to work for one release cycle.
+
+### 6.6 Modify: `docker/airflow/dags/per_phase_tasks.py`
+
+Module docstring updated to mark symbols as `_legacy`. `parse_scope`, `parse_steps`, `route_scope`, `make_trigger_task`, `make_loop_task`, `make_stop_task`, `make_is_phase_terminal`, `run_steps_task` all marked with `# Legacy: see daily_full_pipeline` comments. Imports retained.
+
+---
+
+## 7. Data flow
+
+### 7.1 Daily scheduled run (canonical happy path)
+
+```
+[03:00 KST cron]
+  daily_full_pipeline (schedule)
+    >> TriggerDagRunOperator(ranking_ocid_lookup_pipeline)
+         >> RANKING_FETCH trigger → wait terminal → OCID_LOOKUP trigger (X-Upstream-Run-Id) → wait terminal
+    >> TriggerDagRunOperator(character_basic_pipeline, conf={mode:once})
+         >> trigger CHARACTER_BASIC → wait terminal
+    >> TriggerDagRunOperator(item_equipment_pipeline, conf={mode:once})
+         >> trigger ITEM_EQUIPMENT → wait terminal
+    >> TriggerDagRunOperator(daily_cleanup_pipeline)
+         >> 3 cleanup tasks (artifact runs / calculator runs / inbox)
+```
+
+### 7.2 Gap-fill run (operator ad-hoc)
+
+```
+docker exec maple-airflow-scheduler airflow dags trigger item_equipment_pipeline \
+  -c '{"mode":"count","count":3}'
+```
+
+```
+trigger_loop ITEM_EQUIPMENT (loopId=x)
+  >> count_sensor: wait for 3 item-equipment chunk-ready events from synchronizer
+  >> stop_loop (POST /stop/loop/phase/ITEM_EQUIPMENT)
+DAG success after ~3 chunks (≈30-90min depending on chunk rate)
+```
+
+### 7.3 Steady-state loop + stop
+
+```
+# Start
+docker exec maple-airflow-scheduler airflow dags trigger item_equipment_pipeline \
+  -c '{"mode":"infinite"}'
+# DAG returns success in <1min. Loop continues in ext-api indefinitely.
+
+# ... hours later ...
+
+# Stop
+docker exec maple-airflow-scheduler airflow dags trigger stop_loop_pipeline \
+  -c '{"phase":"ITEM_EQUIPMENT"}'
+# Waits up to 30min for loop to drain current chunk + final stop.
+```
+
+---
+
+## 8. Error handling
+
+| Failure | Behavior |
+|---------|----------|
+| `parse_mode` raises (invalid mode, missing count, count=0) | branch_on_mode task fails; DAG fails before any HTTP call. |
+| `mode=count` sensor times out | Sensor fails after `count*5min+30min`; DAG fails. Loop may still be active in ext-api. Operator must call `stop_loop_pipeline` to clean up. |
+| `mode=infinite` triggered while another loop active for same phase | ext-api returns 409 ALREADY_LOOPING; DAG succeeds with idempotent note. (Existing PhaseLoopController behavior.) |
+| `mode=count` triggered while loop active | Same 409 path; idempotent success. |
+| Trigger response 400 INVALID_PHASE | `AirflowException`; step fails; DAG fails. Config error. |
+| Trigger response 5xx / network | `AirflowException`; Airflow task retries (default_args.retries=0 for triggers; up to operator override). |
+| Sensor times out (terminal wait) | `AirflowException` after 4h; DAG fails. |
+| `stop_loop_pipeline` triggered when no loop active | ext-api returns 200 NOT_LOOPING; wait_loop_stopped sensor returns True immediately; DAG success. |
+| Legacy `daily_collection_pipeline` still in use | Continues to work unchanged. UI tag=deprecated surfaces warning. |
+
+---
+
+## 9. Test plan
+
+### 9.1 Unit tests (`docker/airflow/dags/tests/test_phase_pipeline_factory.py`)
+
+| Test | Input | Expected |
+|------|-------|----------|
+| `parse_mode` default | `{}` | `AirflowException` |
+| `parse_mode` once | `{"mode":"once"}` | `("once", 0)` |
+| `parse_mode` count valid | `{"mode":"count","count":5}` | `("count", 5)` |
+| `parse_mode` count missing | `{"mode":"count"}` | `AirflowException` |
+| `parse_mode` count zero | `{"mode":"count","count":0}` | `AirflowException` |
+| `parse_mode` infinite | `{"mode":"infinite"}` | `("infinite", 0)` |
+| `parse_mode` invalid | `{"mode":"foo"}` | `AirflowException` |
+| `make_phase_dag` task_ids | (factory call) | All branch + terminal task_ids present |
+| `make_count_sensor` timeout | `count=3` | `timeout=15min+30min=45min` |
+
+### 9.2 DAG import smoke (CI gate)
+
+```python
+def test_all_dags_import():
+    from airflow.models import DagBag
+    dagbag = DagBag(dag_folder="docker/airflow/dags/", include_examples=False)
+    for dag_id in (
+        "ranking_ocid_lookup_pipeline",
+        "character_basic_pipeline",
+        "item_equipment_pipeline",
+        "daily_full_pipeline",
+        "stop_loop_pipeline",
+        "daily_collection_pipeline",   # legacy; must still parse
+        "daily_cleanup_pipeline",
+    ):
+        assert dag_id in dagbag.dags, f"{dag_id} missing from DagBag"
+    assert dagbag.import_errors == {}
+```
+
+### 9.3 DAG structure tests
+
+```python
+def test_phase_dag_has_three_branches():
+    dag = DagBag(...).get_dag("character_basic_pipeline")
+    branch_task = dag.get_task("branch_on_mode")
+    downstream_ids = set(branch_task.downstream_task_ids)
+    # once branch: trigger + sensor
+    assert "trigger_once" in downstream_ids
+    # count branch: trigger + sensor + stop
+    assert "trigger_loop" in downstream_ids and "stop_loop" in downstream_ids
+    # infinite branch shares trigger_loop; DAG succeeds there
+```
+
+### 9.4 Manual smoke (uses pipeline-test skill)
+
+| DAG | conf | Verify |
+|-----|------|--------|
+| `ranking_ocid_lookup_pipeline` | `{}` | RANKING + OCID slots transition active → terminal in order. |
+| `character_basic_pipeline` | `{"mode":"once"}` | CHARACTER_BASIC slot goes active → terminal. DAG success. |
+| `item_equipment_pipeline` | `{"mode":"count","count":3}` | Loop starts; `iterationCount` reaches 3; loop stops; DAG success. |
+| `item_equipment_pipeline` | `{"mode":"infinite"}` | Loop starts; DAG success in <1min. Then `stop_loop_pipeline -c '{"phase":"ITEM_EQUIPMENT"}'` → loop terminates. |
+| `daily_full_pipeline` | `{}` (or scheduled) | All 3 phase DAGs run in order; cleanup runs after. |
+| `stop_loop_pipeline` | `{"phase":"ITEM_EQUIPMENT"}` with no active loop | DAG success in <30s. |
+| Legacy `daily_collection_pipeline` | `{}` | Existing FULL_DAILY path still works. |
+
+### 9.5 Backward-compat verification
+
+Trigger `daily_collection_pipeline -c '{"scope":["ITEM_EQUIPMENT_LOOP"]}'` and confirm the legacy scope path still routes to the per_phase_loop task. Required for one release cycle of operator migration.
+
+---
+
+## 10. Acceptance criteria
+
+| AC | Section |
+|----|---------|
+| Each new DAG has a single responsibility visible from its DAG id and tags | §2, §4 |
+| No DAG requires JSON parsing of `scope` or `steps` conf to understand its behavior | §5 (mode/phase only) |
+| `daily_full_pipeline` scheduled run produces the same end-to-end behavior as today's `daily_collection_pipeline -c '{}'` | §7.1 vs current |
+| Operator can trigger `item_equipment_pipeline -c '{"mode":"count","count":3}'` from UI and see count progress in logs | §7.2 |
+| Operator can stop an active loop via `stop_loop_pipeline` without restarting ext-api | §7.3 |
+| Legacy `daily_collection_pipeline` continues to work unchanged for one release | §6.5, §9.5 |
+| DAG import smoke test passes in CI | §9.2 |
+
+---
+
+## 11. Out of scope
+
+- Conditional branching between phase DAGs (operator already controls via separate triggers).
+- Per-phase timeout overrides (sensors use canonical 4h / `count*5min+30min`).
+- Loop iteration timeouts (mode=infinite has no end; operator must call stop_loop_pipeline).
+- Auto-retry on 5xx beyond Airflow defaults.
+- Loop state recovery across ext-api restarts (acknowledged #1291 §13 limitation).
+- OAuth / API-key auth on Airflow endpoints (matches existing pattern).
+- `daily_full_pipeline` conf override (e.g., mode=infinite for hot chains) — v2 if requested.
+- Parallel CHARACTER_BASIC + ITEM_EQUIPMENT inside daily_full_pipeline (current sequential preserved).
+- Removal of `daily_collection_pipeline` (one release cycle of deprecation first).
+
+---
+
+## 12. Risks
+
+| Risk | Mitigation |
+|------|------------|
+| 5 DAGs vs 1 → operators confused which to trigger | Runbook `docs/21_Operations/dag-migration.md` with mapping table; legacy DAG marked deprecated in UI. |
+| `daily_full_pipeline` TriggerDagRunOperator chains fail mid-way (e.g., OCID OK, CHARACTER_BASIC fails) | Triggered child DAG run shows as failed in UI; operator re-triggers CHARACTER_BASIC alone with `mode=once`. Cleaner than today's monolithic failure. |
+| count_sensor timeout mis-tuned (5min/chunk P99 wrong) | Verify P99 chunk time during pipeline-test; tune constant. Document in runbook. |
+| Legacy `daily_collection_pipeline` kept in code → bit rot | Marked `_legacy` in docstrings; CI test asserts legacy DAG still parses (§9.2) so breakage surfaces immediately. |
+| 5 DAGs vs 1 DAG → Airflow scheduler overhead | Trivial — 4 extra DAG parses, no impact at this scale. |
+| Operator accidentally triggers `daily_full_pipeline` while another instance running | All DAGs idempotent (409 → success). No data corruption risk. |
+
+---
+
+## 13. Files touched
+
+| File | Change type | Lines (est.) |
+|------|-------------|--------------|
+| `docker/airflow/dags/phase_pipeline_factory.py` | new | ~280 |
+| `docker/airflow/dags/ranking_ocid_lookup_pipeline.py` | new | ~120 |
+| `docker/airflow/dags/character_basic_pipeline.py` | new | ~70 |
+| `docker/airflow/dags/item_equipment_pipeline.py` | new | ~70 |
+| `docker/airflow/dags/daily_full_pipeline.py` | new | ~90 |
+| `docker/airflow/dags/stop_loop_pipeline.py` | new | ~80 |
+| `docker/airflow/dags/daily_collection_pipeline.py` | modify | +10 (tags + docstring) |
+| `docker/airflow/dags/per_phase_tasks.py` | modify | +15 (legacy docstring/comments) |
+| `docker/airflow/dags/tests/test_phase_pipeline_factory.py` | new | ~120 |
+| `docker/airflow/dags/tests/test_dag_imports.py` | modify | +10 (5 new dag_ids) |
+| `docker/airflow/dags/tests/test_phase_dag_structure.py` | new | ~60 |
+| `docs/21_Operations/dag-migration.md` | new | ~80 (operator runbook) |
+| `docs/01_ADR/ADR-734_phase-separated-dags.md` | new | ~80 (decision record) |
+
+Total new code: ~890 lines. Total modified: ~25 lines.
+
+---
+
+## 14. Rollout
+
+1. Merge to develop. Legacy `daily_collection_pipeline` runs continue unaltered.
+2. Update `docker-compose.airflow.yml` if any new DAG-level env vars needed (none expected — reuses existing `KAFKA_BOOTSTRAP_SERVERS`, `external_api` connection).
+3. Airflow scheduler picks up new DAGs on next parse (≤30s by default).
+4. Operators test new DAGs against local stack per `pipeline-test` skill §9.4.
+5. Schedule `daily_full_pipeline` at the same cron (replaces scheduled `daily_collection_pipeline` in Airflow UI; turn off `daily_collection_pipeline` schedule via UI toggle, leave DAG definition).
+6. One release cycle later: remove `daily_collection_pipeline` + `per_phase_tasks.py` legacy symbols.
+
+---
+
+## 15. Summary
+
+Replace one overloaded DAG with five small DAGs, each with a single workflow. Operators select intent by DAG id, not by parsing JSON scope. N-count and infinite-loop modes are first-class via `mode` parameter. Loop state stays in ext-api (current pattern); Airflow sensors count chunk-ready events to bound loop mode. Legacy `daily_collection_pipeline` retained as deprecated for one release cycle.


### PR DESCRIPTION
## Summary

Replace `daily_collection_pipeline` (one DAG, 3 workflow intents via JSON `scope`/`steps`) with 5 single-purpose DAGs:

- `ranking_ocid_lookup_pipeline` — sequential RANKING + OCID
- `character_basic_pipeline` — mode=once|count=N|infinite
- `item_equipment_pipeline` — mode=once|count=N|infinite
- `daily_full_pipeline` — wrapper cron DAG (KST 03:00)
- `stop_loop_pipeline` — graceful stop for mode=infinite

Loop state stays in ext-api (no ext-api changes). N-count mode uses Airflow PythonSensor polling Kafka chunk-ready events (12h upper bound timeout); mode=infinite is fire-and-forget with separate stop DAG.

Legacy `daily_collection_pipeline` retained as `tags=["deprecated"]` for one release cycle. `per_phase_tasks.py` marked `_legacy`.

## Test plan

- [x] All DAG imports parse (CI test_dag_imports.py)
- [x] `parse_mode` unit tests (15 cases)
- [x] trigger / count / stop helpers unit tests (~33 cases)
- [x] Branch + DAG structure tests (DagBag-level, 6 cases)
- [x] 112 pytest tests pass, 0 fail
- [ ] Operator E2E per `docs/21_Operations/dag-migration.md` (ranking_ocid, character_basic mode=once, item_equipment mode=count, mode=infinite + stop_loop, daily_full, legacy still works)

## Refs

- Spec: `docs/superpowers/specs/2026-06-22-dag-restructure-design.md`
- Plan: `docs/superpowers/plans/2026-06-22-dag-restructure.md`
- ADR: `docs/01_ADR/ADR-734_phase-separated-dags.md`
- Runbook: `docs/21_Operations/dag-migration.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)