### PR TITLE
feat(pipeline-test): docker-first startup + Airflow DAG pytest wrapper

### DIFF
--- a/.claude/skills/pipeline-test/SKILL.md
+++ b/.claude/skills/pipeline-test/SKILL.md
@@ -42,7 +42,7 @@ Airflow (Control Plane)          Spring Boot Services (Data Plane)
 
 - `.env` file exists with DB_URL, NEXON_API_KEY, STORAGE_BACKEND, MINIO_* vars
 - No existing processes on ports 8081, 8082, 8083, 8084, 8180
-- MinIO server running (default `http://localhost:9000` from `docker compose up minio`)
+- **Step 1b starts docker services automatically** (Airflow DB, webserver, scheduler, MinIO, Kafka). Manual `docker compose up` is no longer required before invoking this skill.
 - PostgreSQL accessible at the URL in `.env` `DB_URL` (uses `.env`, not hardcoded local)
 - Docker Compose v2 for MinIO + Airflow services
 - Data directory `../data` clean for fresh runs
@@ -105,6 +105,35 @@ rule_count=$(mc ilm ls "local/${MINIO_BUCKET}/" 2>&1 | grep -cE "(Enabled|Disabl
 ```
 
 **Local storage (legacy)**: Set `STORAGE_BACKEND=local` in `.env` to fall back to the local filesystem backend. The MinIO pre-check above is skipped, and module health will not show `minioHealthIndicator`. The MinIO prefix + storage-error verifications (steps 4a, 9a) are also skipped.
+
+### 1b. Start docker services (docker-first)
+
+All control-plane + storage infrastructure runs in Docker (Airflow, Kafka, MinIO, Airflow DB). Bring these up **before** Spring Boot modules boot so MinIO healthchecks pass at Spring Boot startup and Airflow is ready to trigger.
+
+```bash
+# Compose order matters: airflow-db → airflow-webserver/scheduler (healthcheck-gated);
+# minio + kafka are independent.
+docker compose -f docker-compose.yml -f docker-compose.airflow.yml up -d \
+  airflow-db airflow-webserver airflow-scheduler minio kafka
+
+# Wait for Airflow DB
+until docker inspect maple-airflow-db --format '{{.State.Health.Status}}' 2>/dev/null | grep -q healthy; do
+  sleep 2
+done
+
+# Wait for Airflow webserver
+until curl -sf http://localhost:8180/health > /dev/null 2>&1; do sleep 3; done
+echo "Airflow ready on 8180"
+
+# Wait for MinIO (only if STORAGE_BACKEND=minio)
+if [ "${STORAGE_BACKEND:-minio}" != "local" ]; then
+  : "${MINIO_ENDPOINT:?MINIO_ENDPOINT required}"
+  until curl -sf "${MINIO_ENDPOINT}/minio/health/ready" > /dev/null 2>&1; do sleep 2; done
+  echo "MinIO ready at ${MINIO_ENDPOINT}"
+fi
+```
+
+**Why docker-first:** Spring Boot modules' `MinioHealthIndicator` (step 4a) probes MinIO at boot. If MinIO is down, modules boot but report DOWN → fail-fast loop. Booting docker first guarantees clean Spring Boot startup. Airflow is also up before step 5 DAG trigger, so trigger / sensor / cleanup_pipeline chain has no cold-start gap.
 
 ### 2. Build JARs
 
@@ -323,18 +352,11 @@ if echo "${last}" | grep -q "no runs found at prefix=runs"; then
 fi
 ```
 
-### 5. Start Airflow
+### 5. Configure Airflow + trigger DAG
 
-Airflow is the control plane for pipeline scheduling and monitoring. Always start it as part of the pipeline test.
+Airflow is the control plane for pipeline scheduling and monitoring. **Already running** from step 1b (docker-first) — this step only configures connections and triggers the DAG.
 
 ```bash
-# Start Airflow services (requires docker compose + maple-network)
-docker compose -f docker-compose.yml -f docker-compose.airflow.yml up -d airflow-webserver airflow-scheduler
-
-# Wait for Airflow webserver
-until curl -sf http://localhost:8180/health > /dev/null 2>&1; do sleep 3; done
-echo "Airflow ready on 8180"
-
 # Install Kafka Python client (needed for SNAPSHOT_RUN_COMPLETED event consumption)
 docker exec maple-airflow-scheduler python3 -m pip install kafka-python-ng --quiet
 

--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ scripts/*
 !scripts/dev-bootstrap.sh
 !scripts/install-git-hooks.sh
 !scripts/install-systemd-units.sh
+!scripts/run-pipeline-tests.sh
 !scripts/validate-minio-vs3.sh
 !scripts/lib/
 !scripts/systemd/

--- a/scripts/run-pipeline-tests.sh
+++ b/scripts/run-pipeline-tests.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# scripts/run-pipeline-tests.sh
+#
+# Run Airflow DAG pytests inside the maple-airflow-scheduler container with
+# docker-first enforcement. Fail-fast if scheduler is not running so tests
+# never silently execute against a stale container.
+#
+# Why this exists: pytest under docker/airflow/dags/tests/ depends on the
+# `airflow` package + plugins (kafka, http) installed in the scheduler image.
+# Running pytest on the host fails with ImportError; running pytest inside
+# `maple-airflow-scheduler` succeeds. Earlier workflow invoked the long
+# `docker exec ... pytest ...` command directly from memory, with no
+# container-alive check — a stopped scheduler surfaced as a confusing
+# `Error response from daemon: container not started` rather than the
+# actionable `docker compose up -d airflow-scheduler`.
+#
+# Usage:
+#   scripts/run-pipeline-tests.sh                       # all tests
+#   scripts/run-pipeline-tests.sh tests/test_phase_pipeline_factory.py
+#   scripts/run-pipeline-tests.sh tests/ -k TestMakePhaseDag -v
+#
+# Exit codes:
+#   0  all tests passed
+#   1  pytest failures
+#   2  scheduler container missing / not running
+#   3  airflow dags list sanity check failed (scheduler process stuck)
+#
+# Pre-req: docker compose for Airflow services has been started at least once
+# (so the `maple-airflow-scheduler` container exists). Use:
+#   docker compose -f docker-compose.yml -f docker-compose.airflow.yml \
+#     up -d airflow-webserver airflow-scheduler
+# Or run the `pipeline-test` skill — its step 1b does this automatically.
+
+set -uo pipefail
+
+CONTAINER="maple-airflow-scheduler"
+DAGS_DIR="/opt/airflow/dags"
+TESTS_DIR="${DAGS_DIR}/tests"
+
+# 1) Container exists + running. Filter on both name and status so a stopped
+# container (status=exited) does not silently pass the check.
+if ! docker ps --filter "name=^${CONTAINER}$" --filter "status=running" --format '{{.Names}}' | grep -q "^${CONTAINER}$"; then
+  echo "ERROR: ${CONTAINER} is not running." >&2
+  echo "Start it via:" >&2
+  echo "  docker compose -f docker-compose.yml -f docker-compose.airflow.yml up -d airflow-webserver airflow-scheduler" >&2
+  echo "Or invoke the pipeline-test skill (step 1b brings all docker services up)." >&2
+  exit 2
+fi
+
+# 2) Scheduler process responsive. Proves the scheduler is not stuck in a
+# crashloop and that `airflow` CLI is on PATH inside the container.
+if ! docker exec "${CONTAINER}" airflow dags list > /dev/null 2>&1; then
+  echo "ERROR: ${CONTAINER} responds but `airflow dags list` failed." >&2
+  echo "Scheduler likely in crashloop. Check logs:" >&2
+  echo "  docker logs ${CONTAINER} --tail 50" >&2
+  exit 3
+fi
+echo "${CONTAINER}: docker-first pre-check passed"
+
+# 3) Run pytest. Forward all CLI args so users can pass -k, --co, file paths, etc.
+# Default to `tests/` when no positional arg given.
+if [ "$#" -eq 0 ]; then
+  set -- "${TESTS_DIR}"
+fi
+
+exec docker exec "${CONTAINER}" \
+  bash -c "cd ${DAGS_DIR} && python3 -m pytest $*"


### PR DESCRIPTION
## Summary
- **Skill**: new step `1b. Start docker services (docker-first)` runs `docker compose up airflow-db airflow-webserver airflow-scheduler minio kafka` + healthcheck waits BEFORE Spring Boot modules boot. `MinioHealthIndicator` passes at boot; Airflow ready for trigger with no cold-start gap.
- **Skill**: step 5 renamed `Configure Airflow + trigger DAG` — drops its docker-compose-up block (now owned by 1b). Prerequisites line updated to reflect automatic docker startup.
- **Script**: new `scripts/run-pipeline-tests.sh` wraps the `docker exec maple-airflow-scheduler pytest` invocation with a docker-first pre-check (exit 2 if container missing, exit 3 if scheduler stuck). Forwards all pytest args; defaults to `tests/` when none given.
- **`.gitignore`**: allowlist `!scripts/run-pipeline-tests.sh` next to existing allowlisted scripts.

## Test plan
- [ ] `./gradlew compileKotlin compileJava --continue` (no Java/Kotlin touched — should be no-op)
- [ ] Inspect `pipeline-test` skill section numbering: `1 → 1a → 1b → 2 → 3 → 4 → 5 → 6 → 7 → 8 → 9 → 10 → 10a` (verified locally)
- [ ] `bash -n scripts/run-pipeline-tests.sh` syntax check
- [ ] Container-not-running case: `scripts/run-pipeline-tests.sh` prints actionable `docker compose up ... airflow-scheduler` and exits 2 (verified locally — container absent on this host)
- [ ] End-to-end pipeline test: bring up docker services via skill step 1b, then run `pipeline-test` step 3+ on real env to confirm no regression
- [ ] Run `scripts/run-pipeline-tests.sh tests/test_phase_pipeline_factory.py::TestMakePhaseDag -v` after scheduler is up

🤖 Generated with [Claude Code](https://claude.com/claude-code)