### PR TITLE
fix(pipeline-test): guard docker mode on PR #1324 infra files

### DIFF
--- a/.claude/skills/pipeline-test/SKILL.md
+++ b/.claude/skills/pipeline-test/SKILL.md
@@ -157,6 +157,22 @@ if [ "${START_MODE}" = "docker" ]; then
     exit 7
   fi
 
+  # Ensure docker-mode infra files exist. Added by PR #1324 (commit 556017399,
+  # 2026-06-22). A working tree on an older commit (e.g. detached HEAD before
+  # 556017399) has no `docker-compose.services.yml` and `docker compose ... up`
+  # below silently fails with "no such file" instead of a clear error.
+  # Verified 2026-06-23: main worktree on 4be816e99 hit this after PR #1331
+  # merged because the local `develop` ref was stale relative to origin/develop.
+  for f in docker-compose.services.yml docker/services/build.sh; do
+    if [ ! -f "$f" ]; then
+      echo "ERROR: $f missing. PR #1324 (commit 556017399) added docker-mode infra." >&2
+      echo "Fix one of:" >&2
+      echo "  - Switch to latest develop:  git checkout origin/develop" >&2
+      echo "  - Use nohup mode instead:    START_MODE=nohup $0" >&2
+      exit 7
+    fi
+  done
+
   # Build images if missing or stale.
   ./docker/services/build.sh
 


### PR DESCRIPTION
## Summary
- Add fail-fast guard at start of `START_MODE=docker` branch in step 3: if `docker-compose.services.yml` or `docker/services/build.sh` is missing, exit 7 with an actionable error pointing to PR #1324 (commit `556017399`) + two concrete fixes.
- Mirrors the existing secrets guard so docker-mode failures surface clearly instead of silently falling through.

## Background
PR #1331 set `START_MODE=docker` as the default. It relies on `docker-compose.services.yml` + `docker/services/build.sh`, both added by PR #1324 (`556017399`). A working tree on an older commit (detached HEAD, stale local `develop`) carries the post-#1331 SKILL.md but not the services files — `docker compose ... up` then fails cryptically.

Verified 2026-06-23: main worktree on `4be816e99` hit this because the local `develop` ref was stale relative to `origin/develop`.

## Test plan
- [x] Guard fires when `docker-compose.services.yml` is moved aside → exit 7 with expected error (verified locally)
- [x] Guard passes when both files present → exit 0 (verified locally)
- [ ] CI: pipeline-test skill on fresh worktree at latest `develop` to confirm docker mode works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)