### PR TITLE
fix(pipeline-test): install kafka-python-ng in webserver too

### DIFF
--- a/.claude/skills/pipeline-test/SKILL.md
+++ b/.claude/skills/pipeline-test/SKILL.md
@@ -373,8 +373,14 @@ fi
 Airflow is the control plane for pipeline scheduling and monitoring. **Already running** from step 1b (docker-first) — this step only configures connections and triggers the DAG.
 
 ```bash
-# Install Kafka Python client (needed for SNAPSHOT_RUN_COMPLETED event consumption)
+# Install Kafka Python client (needed for SNAPSHOT_RUN_COMPLETED event consumption).
+# Both scheduler AND webserver: webserver scans DAGS_FOLDER at request time and
+# imports each .py to list DAGs; per-phase DAGs (character_basic_pipeline,
+# item_equipment_pipeline, etc.) import kafka via phase_pipeline_factory, so
+# missing kafka in webserver → 5 import errors → those DAGs invisible in web UI
+# (scheduler still shows them via serialized_dag table). Verified 2026-06-23.
 docker exec maple-airflow-scheduler python3 -m pip install kafka-python-ng --quiet
+docker exec maple-airflow-webserver python3 -m pip install kafka-python-ng --quiet
 
 # Initialize Airflow DB and connections (first run only)
 docker exec maple-airflow-scheduler airflow db migrate


### PR DESCRIPTION
## Summary
- Step 5 of `pipeline-test` skill now installs `kafka-python-ng` in **both** scheduler and webserver containers.

## Background
Scheduler + webserver share the same image (apache/airflow:2.10.5-python3.12) and DAGS_FOLDER mount. Webserver imports each .py on UI requests to populate the DAG list. Per-phase DAGs (character/item_equipment/ranking_ocid_lookup/stop_loop) import kafka via phase_pipeline_factory.py — missing kafka in webserver → 5 import errors → those DAGs vanish from web UI while scheduler still shows them (via serialized_dag table).

Verified 2026-06-23: webserver showed 3 DAGs (legacy daily_*); scheduler showed 7. After `pip install kafka-python-ng` + restart in webserver: 7/7 visible, 0 import errors.

## Test plan
- [x] Step 5 installs in both containers
- [x] Webserver shows 7 DAGs post-restart
- [x] `airflow dags list-import-errors` clean on both

🤖 Generated with [Claude Code](https://claude.com/claude-code)