### PR TITLE
fix(airflow): per-phase gate passes on lastCompletedByPhase.terminal

### DIFF
--- a/docker/airflow/dags/phase_pipeline_factory.py
+++ b/docker/airflow/dags/phase_pipeline_factory.py
@@ -523,6 +523,20 @@ def _wait_phase_terminal_fn(phase: str):
             if current_idx > target_idx:
                 return True
 
+            # No active run (current=null after daily chain finished) but
+            # a prior run reached `phase` terminal — accept as gate pass.
+            # Without this, standalone per-phase DAGs triggered after the
+            # daily chain completes can't pass the upstream sensor because
+            # `current` is null and `current_idx > target_idx` never holds.
+            # Verified 2026-06-23: item_equipment_pipeline stuck on
+            # wait_upstream_terminal_character_basic for 4h timeout because
+            # /run-status returned current=null after daily success.
+            if not current_run_id:
+                lcbp = data.get("lastCompletedByPhase") or {}
+                slot = lcbp.get(phase) or {}
+                if slot.get("terminal"):
+                    return True
+
             if time.monotonic() >= deadline:
                 raise TimeoutError(
                     f"Upstream phase {phase} did not reach terminal within 4h "


### PR DESCRIPTION
## Summary
- `_wait_phase_terminal_fn` in `phase_pipeline_factory.py` now also passes when `current=null` AND `lastCompletedByPhase[phase].terminal=true`.
- Allows standalone per-phase DAGs (e.g. `item_equipment_pipeline`) to run after the daily chain completes, not only mid-chain.

## Background
The phase DAG upstream sensor only checked `current.phase` strictly after the upstream phase in `_PHASE_ORDER`. After the daily chain completes, ext-api returns `current=null`, so the gate can never pass for standalone per-phase triggers. Verified 2026-06-23: two `item_equipment_pipeline` runs stuck on `wait_upstream_terminal_character_basic` waiting for a current run that wouldn't come.

## Test plan
- [x] Verified `/run-status` returns `lastCompletedByPhase.CHARACTER_BASIC.terminal=true` for today's run
- [ ] After merge: restart scheduler container so DAG module reloads; stuck DAGs should auto-unblock via the new path
- [ ] Manual: trigger `item_equipment_pipeline` with `{"mode":"infinite"}` and confirm it advances past the upstream sensor

🤖 Generated with [Claude Code](https://claude.com/claude-code)