### PR TITLE
docs: CLAUDE precedence directive + analytics investigation artifacts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,13 @@
 # Probabilistic Valuation Engine
 
+> **선제 참조 지시문 — 외운 지식보다 이 문서를 먼저 볼 것**
+> 사전 학습 데이터·일반적 LLM 기본 동작·타 프로젝트 관행에 의존 금지.
+> Kotlin/Spring/비동기/Hexagonal 영역은 학습 데이터가 본 프로젝트 컨벤션과 충돌함 →
+> 판단 전 **이 파일과 `.claude/rules/` 를 먼저 읽고 결정**.
+>
+> Rules Index에서 **`항상` 표시 규칙은 매 세션 자동 로드됨** (context에 이미 존재).
+> "지금 매뉴얼을 읽어야 하나?" 고민하지 말 것 — 이미 보이는 상태. 의심 시 `rules/` 파일 직접 재확인.
+
 Claude Code가 이 프로젝트에서 작업할 때 따라야 할 규칙은 `.claude/rules/` 에 분리되어 있습니다.
 
 ## Enforcement Policy

--- a/docs/01_ADR/ADR-735-future-analytics-platform-evaluation.md
+++ b/docs/01_ADR/ADR-735-future-analytics-platform-evaluation.md
@@ -1,0 +1,165 @@
+# ADR-735: Future Analytics Platform Evaluation
+
+- Status: Proposed
+- Date: 2026-06-23
+- Owner: Architecture Team
+
+---
+
+## 1. Background / Problem
+
+### Background
+
+`probabilistic-valuation-engine` processes ~595K user snapshots/day through a 4-service Spring Boot pipeline (external-api → calculator → synchronizer → REST). Today the system produces 40M items/day, ~340GB/day internal storage after compression, ~10TB/month, ~120TB/year. Serving layer is PostgreSQL 16 read models + L1 Caffeine + L2 PostgreSQL UNLOGGED. Chunk artifacts persist on MinIO as JSONL.gz at `data/runs/{runId}/{endpoint}/chunks/part-{NNNN}.jsonl.gz`. Per-character query p95 < 100ms.
+
+Roadmap signals indicate future analytical workloads not expressible efficiently on the current PG-only path:
+
+- Class/world/level-range rollups over the full user base
+- Historical trend analysis (multi-week expectation drift)
+- Top-N rankings (top 100 per class/world)
+- Recommendation systems and ML feature pipelines
+
+### Problem
+
+Without an analytics tier, every analytical workload becomes (a) an expensive PG query that competes with serving reads, (b) a one-off Python script over MinIO JSONL.gz, or (c) a deferred "we'll build it later." Each candidate platform (Iceberg+Trino, Iceberg+Spark, ClickHouse, PostgreSQL-only with materialized views) carries different cost/complexity/ML-fit trade-offs.
+
+### Goal
+
+Choose a default analytics strategy with measurable trigger conditions for when to escalate to a heavier platform. Avoid premature introduction of distributed compute engines.
+
+---
+
+## 2. Decision
+
+> **Default: PostgreSQL-only with materialized views + declarative time-bucketed partitioning. Adopt ClickHouse as a parallel analytical store when analytical query p95 exceeds 10s on indexed PG queries or when Top-N/class-rollup workloads become user-facing APIs.**
+
+```text
+Today (Phase 0):
+  Per-character query ─── PG read model + L1/L2 cache ─── p95 < 100ms
+  Analytical query ─────── PG materialized views, refreshed by Airflow
+
+Phase 1 trigger (any one):
+  T1: Analytical query p95 > 10s on indexed PG (EXPLAIN ANALYZE-verified)
+  T2: Analytical load > 20% of DB CPU during peak hour
+  T3: Top-N leaderboard or class-rollup becomes user-facing API contract
+
+Phase 2 trigger (any one on top of Phase 1):
+  T4: ≥30TB active historical corpus retained for analytics
+  T5: Time-travel / point-in-time read model snapshot needed
+  T6: Cross-source SQL join required (MinIO chunks + PG read model)
+
+Phase 3 trigger:
+  T7: MLlib / iterative training workload materializes (ALS, feature pipelines)
+  T8: Data lakehouse contract needed for external partner SQL access
+```
+
+Order of escalation: **PG → ClickHouse → Iceberg+Trino → Iceberg+Spark**. Each step justified by a measurable condition above. Spark sits at the end because it is the heaviest platform, the worst fit for the stateless transform workloads that dominate today, and only justified when MLlib or iterative compute enters the picture.
+
+Calculator module (port 8082) is **not** affected by this decision. It continues to write JSONL.gz → MinIO and PG read models. The analytics layer is additive.
+
+---
+
+## 3. Trade-offs
+
+### Sensitivity
+
+* Daily ingest volume: 340GB/day raw → 40-50GB/day columnar if migrated
+* Concurrent analytical query count vs OLTP serving reads on same PG instance
+* Latency budget per analytical query (interactive vs nightly batch)
+* Hot query cardinality (Top-N per class × world × level bucket = combinatorially large)
+* Time-travel requirement (Iceberg-native, expensive in PG, impossible in ClickHouse)
+* ML workload emergence (ALS, feature pipelines — only Spark has first-class MLlib)
+
+### Trade-off
+
+| Choice | Get | Give up |
+| -- | -- | -- |
+| **PG-only default** | Zero new infra; reuse existing PG + Airflow; 0 ops overhead; battle-tested | Poor scaling past ~30TB historical corpus; no columnar compression; no time-travel |
+| **ClickHouse as parallel store** | 10-100× faster grouped aggregates; Kafka-native ingestion via engine tables; columnar compression 5-10× | No OLTP consistency; eventual dedup semantics; Keeper quorum (3 nodes); 6 engineer-weeks migration |
+| **Iceberg+Trino (Lakehouse)** | ACID on MinIO; time-travel; hidden partitioning; schema evolution; engine-agnostic | New catalog service (Polaris/Nessie); mandatory compaction service; rewrite of writer hot paths; ~13 weeks phased |
+| **Iceberg+Spark** | MLlib (ALS); Structured Streaming; mature batch+iterative | Cold-start 30s-2min; shuffle disk pressure; team skills gap; Spark-on-K8s ops surface |
+| **Calculator untouched** | Preserves 20K items/s throughput on 1 JVM heap; no Spark re-write | None — this is preserved by the additive design |
+
+### Risk
+
+* **High**: PG becomes the analytical bottleneck if roadmap commits to user-facing Top-N before ClickHouse is stood up. Mitigation: T1+T3 trigger gates any commit that depends on sub-10s p95 analytical queries.
+* **Medium**: ClickHouse eventual consistency (`ReplacingMergeTree`) leaks duplicates into Top-N if dedup keys are wrong. Mitigation: PRIMARY KEY on `(ign, version)` + `FINAL` for serving endpoints or explicit dedup at query time.
+* **Medium**: Iceberg compaction lag (skipping nightly `rewrite-data-files`) collapses planner performance over weeks. Mitigation: compaction treated as Tier-1 service, not cron; alert on manifest list size > 50MB.
+* **Low**: Spark adoption before T7 fires means carrying K8s operator + catalog + shuffle service complexity for workloads that never arrive. Mitigation: defer Spark adoption entirely; Iceberg catalog remains the durable interface so Spark is replaceable later.
+
+### Non-Risk
+
+* Calculator throughput regression — Calculator is out of scope for this ADR; its writer hot path is preserved until Phase 3 Iceberg cutover is independently validated.
+* OLTP consistency on serving path — PG remains the sole serving store; ClickHouse and Iceberg are read-only for analytics endpoints.
+* Vendor lock-in to a single analytics engine — Iceberg (when adopted) is engine-agnostic; ClickHouse is the only committed vendor surface, and only for one workload class.
+
+---
+
+## 4. Result / Evidence
+
+### Metrics
+
+| Metric | Today (PG-only) | ClickHouse (Phase 1) | Iceberg+Trino (Phase 2) | Iceberg+Spark (Phase 3) |
+| --- | ---: | ---: | ---: | ---: |
+| Top-N p99 latency (1B rows) | 5-30s | 50-300ms | 1-5s | 2-10min (cold) |
+| Storage (10TB working set) | 10TB PG | ~1.5-2TB CH + PG | ~1TB Iceberg + 10GB catalog | Same as Phase 2 |
+| Cluster size added | 0 | ~5 nodes (1 shard × 2 replica + 3 Keeper) | ~8 services (5 Trino + 3 catalog) | +Spark K8s operator |
+| Monthly infra cost (10TB) | $0 marginal | ~$860 | ~$1,660 | ~$2,000+ |
+| Migration effort | 0 | ~6 engineer-weeks | ~13 weeks (3 phases) | +4-6 weeks per MLlib pipeline |
+| Time-travel queries | ❌ | ❌ | ✅ | ✅ |
+| MLlib / iterative ML | ❌ | ❌ | ❌ | ✅ |
+
+### Observed Result
+
+This decision is **proposed, not implemented**. Evidence below is from public benchmarks and the agent evaluations referenced in §5; no platform has been deployed yet.
+
+* **PG columnar ceiling**: PostgreSQL Top-N over 1B rows with btree + sort step is multi-second; ClickBench leaderboard shows ClickHouse 10-100× faster on grouped aggregates over equivalent data volume.
+* **Iceberg-on-MinIO viability**: Iceberg javadoc confirms `S3FileIO` supports arbitrary S3-compatible endpoints via `s3.endpoint`, `s3.path-style-access=true`. MinIO RELEASE 2024-05+ required for safe concurrent writer commits via `If-Match` conditional writes.
+* **Trino-Iceberg interoperability**: Trino can read Iceberg tables Spark writes — escape hatch exists if Spark is added later.
+* **Spark workload mismatch**: Calculator's stateless per-item transform at 20K/s on 1 JVM heap is 10-100× more efficient per item than Spark; Spark would add zero capability the current Calculator needs.
+
+---
+
+## 5. Summary
+
+> **Default to PG-only; escalate to ClickHouse when analytical p95 > 10s or Top-N becomes user-facing; defer Iceberg+Trino until ≥30TB historical corpus or time-travel is required; reserve Spark for MLlib workloads that don't yet exist on the roadmap.**
+
+---
+
+## References
+
+### Related ADRs
+
+* ADR-013: High-throughput event pipeline (Kafka choreography)
+* ADR-039: Current architecture assessment (multi-module structure)
+* ADR-041: Multi-module hexagonal architecture (DIP boundaries)
+
+### Evaluation Source Material
+
+* Iceberg evaluation: see companion doc in `docs/03_Technical_Guides/iceberg-evaluation.md` (pending creation via issue #2 in this ADR's action items)
+* Trino evaluation: see companion doc in `docs/03_Technical_Guides/trino-evaluation.md`
+* Spark evaluation: see `docs/03_Technical_Guides/spark-evaluation.md`
+* ClickHouse evaluation: see `docs/03_Technical_Guides/clickhouse-evaluation.md`
+
+### Public Sources
+
+* [Apache Iceberg S3FileIO javadoc](https://iceberg.apache.org/javadoc/latest/org/apache/iceberg/aws/s3/S3FileIOProperties.html)
+* [Apache Polaris](https://polaris.apache.org/)
+* [Trino Iceberg connector](https://trino.io/docs/current/connector/iceberg.html)
+* [ClickHouse Kafka engine docs](https://clickhouse.com/docs/en/engines/table-engines/integrations/kafka)
+* [ClickBench leaderboard](https://benchmark.clickhouse.com/)
+* [Spark MLlib collaborative filtering](https://spark.apache.org/docs/latest/ml-collaborative-filtering.html)
+* [Spark on Kubernetes](https://spark.apache.org/docs/latest/running-on-kubernetes.html)
+
+---
+
+## Action Items (Issues to Create)
+
+1. Iceberg Feasibility Study
+2. MinIO Compatibility Validation
+3. Analytics Layer ADR (this document)
+4. Query Engine Evaluation
+5. PostgreSQL Scalability Assessment
+6. Historical Analytics Requirements
+7. Class Hierarchy Data Modeling
+8. Serving Layer vs Analytics Layer Separation

--- a/docs/superpowers/plans/2026-06-23-3am-pipeline-chain.md
+++ b/docs/superpowers/plans/2026-06-23-3am-pipeline-chain.md
@@ -1,0 +1,589 @@
+# 3am Pipeline Chain Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an Airflow master DAG `morning_chain_pipeline` that triggers the four existing per-phase DAGs in sequence at 03:00 KST, with idempotent loop-stop handling and strict failure halt.
+
+**Architecture:** Single new Airflow DAG composes existing per-phase DAGs via `TriggerDagRunOperator` and factory-provided sensors. `make_wait_loop_stopped_sensor` handles the idempotent stop (returns True if no loop active). `make_wait_phase_terminal_sensor` gates each subsequent phase. A small custom sensor confirms the final infinite loop's first iteration has started. Zero Kotlin or endpoint changes.
+
+**Tech Stack:** Python 3.12, Airflow 2.10.5, `phase_pipeline_factory` helpers (all pre-existing).
+
+**Spec:** `docs/superpowers/specs/2026-06-23-3am-pipeline-chain-design.md`
+
+**Cron note:** Schedule `0 18 * * *` UTC = 03:00 KST year-round (KST = UTC+9, no DST).
+
+---
+
+## File Structure
+
+| File | Status | Responsibility |
+| ---- | ------ | -------------- |
+| `docker/airflow/dags/morning_chain_pipeline.py` | Create | Master DAG: 8 tasks, chain orchestration |
+| `docker/airflow/dags/tests/test_morning_chain_pipeline.py` | Create | Unit tests for DAG structure, schedule, conf, dependencies, factory wiring |
+
+No other files modified. No Kotlin, no endpoints, no migrations.
+
+---
+
+## Task 1: Test scaffold + DAG id/schedule
+
+**Files:**
+- Create: `docker/airflow/dags/tests/test_morning_chain_pipeline.py`
+
+- [ ] **Step 1: Write the failing test file**
+
+```python
+"""Tests for morning_chain_pipeline DAG.
+
+Validates structural invariants: dag_id, schedule, catchup, retries,
+task count, factory wiring. Does not exercise the chain end-to-end
+(manual Airflow run required for integration).
+"""
+import pytest
+
+
+@pytest.fixture(scope="module")
+def dag():
+    from airflow.models import DagBag
+    bag = DagBag(dag_folder="/dev/null", include_examples=False)
+    # Load directly from the known path. The factory imports require
+    # Airflow's DAG context but DagBag parses files for us.
+    bag._load_dag(
+        "morning_chain_pipeline",
+        "/opt/airflow/dags/morning_chain_pipeline.py",
+    )
+    return bag.dags["morning_chain_pipeline"]
+
+
+def test_dag_id(dag):
+    assert dag.dag_id == "morning_chain_pipeline"
+
+
+def test_schedule_is_3am_kst(dag):
+    # 0 18 * * * UTC = 03:00 KST year-round (UTC+9, no DST).
+    assert dag.schedule == "0 18 * * *"
+
+
+def test_no_catchup(dag):
+    assert dag.catchup is False
+
+
+def test_start_date_set(dag):
+    assert dag.start_date is not None
+
+
+def test_no_retries(dag):
+    assert dag.default_args.get("retries") == 0
+```
+
+- [ ] **Step 2: Run the test, expect failure**
+
+```bash
+cd docker/airflow/dags && python3 -m pytest tests/test_morning_chain_pipeline.py -v
+```
+
+Expected: 5 failures with `KeyError: 'morning_chain_pipeline'`.
+
+- [ ] **Step 3: Skip (no commit — next task adds the DAG)**
+
+---
+
+## Task 2: Minimal DAG skeleton (dag_id + schedule only)
+
+**Files:**
+- Create: `docker/airflow/dags/morning_chain_pipeline.py`
+
+- [ ] **Step 1: Write the skeleton**
+
+```python
+"""morning_chain_pipeline — 03:00 KST chain orchestration.
+
+Schedule: 0 18 * * * UTC (03:00 KST year-round, UTC+9 no DST).
+Composes existing per-phase DAGs via factory helpers:
+  1. stop_loop_pipeline (loop auto-stops if none active — idempotent)
+  2. ranking_ocid_lookup_pipeline
+  3. character_basic_pipeline (mode=once)
+  4. item_equipment_pipeline (mode=infinite)
+
+Sensors between triggers use the factory:
+  - make_wait_loop_stopped_sensor  : gates step 1
+  - make_wait_phase_terminal_sensor: gates steps 2-3
+  - custom iteration-started check  : gates step 4
+
+Refs: docs/superpowers/specs/2026-06-23-3am-pipeline-chain-design.md
+"""
+from datetime import datetime
+
+from airflow import DAG
+
+
+default_args = {
+    "owner": "maple-pipeline",
+    "retries": 0,
+}
+
+
+with DAG(
+    dag_id="morning_chain_pipeline",
+    default_args=default_args,
+    start_date=datetime(2026, 5, 29),
+    schedule="0 18 * * *",  # 03:00 KST
+    catchup=False,
+    tags=["pipeline", "chain", "morning"],
+) as dag:
+    pass  # tasks added in subsequent tasks
+```
+
+- [ ] **Step 2: Re-run the test, expect pass**
+
+```bash
+cd docker/airflow/dags && python3 -m pytest tests/test_morning_chain_pipeline.py -v
+```
+
+Expected: 5 passed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine
+git add docker/airflow/dags/morning_chain_pipeline.py \
+        docker/airflow/dags/tests/test_morning_chain_pipeline.py
+git commit -m "feat(airflow): morning_chain_pipeline skeleton with 03:00 KST schedule"
+```
+
+---
+
+## Task 3: Health check + stop_loop trigger + factory sensors for steps 1-2
+
+**Files:**
+- Modify: `docker/airflow/dags/morning_chain_pipeline.py`
+- Modify: `docker/airflow/dags/tests/test_morning_chain_pipeline.py`
+
+- [ ] **Step 1: Add failing tests for new tasks**
+
+Append to `test_morning_chain_pipeline.py`:
+
+```python
+def test_has_check_ext_api_health(dag):
+    assert "check_ext_api_health" in {t.task_id for t in dag.tasks}
+
+
+def test_has_trigger_stop_loop(dag):
+    assert "trigger_stop_loop" in {t.task_id for t in dag.tasks}
+
+
+def test_trigger_stop_loop_targets_correct_dag_with_phase_conf(dag):
+    t = next(t for t in dag.tasks if t.task_id == "trigger_stop_loop")
+    assert t.trigger_dag_id == "stop_loop_pipeline"
+    assert t.conf == {"phase": "ITEM_EQUIPMENT"}
+
+
+def test_has_wait_loop_stopped_sensor(dag):
+    """Factory's loop-stopped sensor: idempotent (True if no loop active)."""
+    assert "wait_loop_stopped_item_equipment" in {t.task_id for t in dag.tasks}
+
+
+def test_has_trigger_ranking_ocid(dag):
+    assert "trigger_ranking_ocid" in {t.task_id for t in dag.tasks}
+
+
+def test_trigger_ranking_ocid_targets_correct_dag(dag):
+    t = next(t for t in dag.tasks if t.task_id == "trigger_ranking_ocid")
+    assert t.trigger_dag_id == "ranking_ocid_lookup_pipeline"
+
+
+def test_has_wait_upstream_terminal_ocid_lookup(dag):
+    assert "wait_upstream_terminal_ocid_lookup" in {t.task_id for t in dag.tasks}
+```
+
+- [ ] **Step 2: Run tests, expect failure**
+
+```bash
+cd docker/airflow/dags && python3 -m pytest tests/test_morning_chain_pipeline.py -v
+```
+
+Expected: 7 of the 12 tests fail (none of the task assertions match).
+
+- [ ] **Step 3: Implement the 5 tasks and 1 sensor**
+
+Replace the body of `morning_chain_pipeline.py`:
+
+```python
+"""morning_chain_pipeline — 03:00 KST chain orchestration.
+
+Schedule: 0 18 * * * UTC (03:00 KST year-round, UTC+9 no DST).
+Composes existing per-phase DAGs via factory helpers:
+  1. stop_loop_pipeline (loop auto-stops if none active — idempotent)
+  2. ranking_ocid_lookup_pipeline
+  3. character_basic_pipeline (mode=once)
+  4. item_equipment_pipeline (mode=infinite)
+
+Sensors between triggers use the factory:
+  - make_wait_loop_stopped_sensor  : gates step 1
+  - make_wait_phase_terminal_sensor: gates steps 2-3
+  - custom iteration-started check  : gates step 4
+
+Refs: docs/superpowers/specs/2026-06-23-3am-pipeline-chain-design.md
+"""
+from datetime import datetime
+
+from airflow import DAG
+from airflow.operators.trigger_dagrun import TriggerDagRunOperator
+from airflow.providers.http.sensors.http import HttpSensor
+
+from phase_pipeline_factory import (
+    make_wait_loop_stopped_sensor,
+    make_wait_phase_terminal_sensor,
+)
+
+
+default_args = {
+    "owner": "maple-pipeline",
+    "retries": 0,
+}
+
+
+with DAG(
+    dag_id="morning_chain_pipeline",
+    default_args=default_args,
+    start_date=datetime(2026, 5, 29),
+    schedule="0 18 * * *",  # 03:00 KST
+    catchup=False,
+    tags=["pipeline", "chain", "morning"],
+) as dag:
+
+    check_ext_api_health = HttpSensor(
+        task_id="check_ext_api_health",
+        http_conn_id="external_api",
+        endpoint="actuator/health",
+        request_params={},
+        response_check=lambda r: r.status_code == 200,
+        poke_interval=30,
+        timeout=120,
+    )
+
+    trigger_stop_loop = TriggerDagRunOperator(
+        task_id="trigger_stop_loop",
+        trigger_dag_id="stop_loop_pipeline",
+        conf={"phase": "ITEM_EQUIPMENT"},
+        reset_dag_run=True,
+        wait_for_completion=False,
+    )
+
+    # Factory sensor — idempotent: returns True if no loop is active
+    # (sensor task_id auto-generated: wait_loop_stopped_item_equipment).
+    wait_loop_stopped = make_wait_loop_stopped_sensor("ITEM_EQUIPMENT")
+
+    trigger_ranking_ocid = TriggerDagRunOperator(
+        task_id="trigger_ranking_ocid",
+        trigger_dag_id="ranking_ocid_lookup_pipeline",
+        reset_dag_run=True,
+        wait_for_completion=False,
+    )
+
+    # Factory sensor — returns True when current.phase progresses past OCID_LOOKUP
+    # (auto-generated task_id: wait_upstream_terminal_ocid_lookup).
+    wait_ocid_lookup_terminal = make_wait_phase_terminal_sensor("OCID_LOOKUP")
+
+    check_ext_api_health >> trigger_stop_loop
+    trigger_stop_loop >> wait_loop_stopped >> trigger_ranking_ocid
+    trigger_ranking_ocid >> wait_ocid_lookup_terminal
+```
+
+- [ ] **Step 4: Re-run tests, expect pass**
+
+```bash
+cd docker/airflow/dags && python3 -m pytest tests/test_morning_chain_pipeline.py -v
+```
+
+Expected: 12 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine
+git add docker/airflow/dags/morning_chain_pipeline.py \
+        docker/airflow/dags/tests/test_morning_chain_pipeline.py
+git commit -m "feat(airflow): morning_chain stop_loop + ranking+ocid with factory sensors"
+```
+
+---
+
+## Task 4: Character basic once + item equipment infinite + first-iter sensor
+
+**Files:**
+- Modify: `docker/airflow/dags/morning_chain_pipeline.py`
+- Modify: `docker/airflow/dags/tests/test_morning_chain_pipeline.py`
+
+- [ ] **Step 1: Add failing tests**
+
+```python
+def test_trigger_character_basic_conf_is_once(dag):
+    t = next(t for t in dag.tasks if t.task_id == "trigger_character_basic_once")
+    assert t.trigger_dag_id == "character_basic_pipeline"
+    assert t.conf == {"mode": "once"}
+
+
+def test_trigger_item_equipment_conf_is_infinite(dag):
+    t = next(t for t in dag.tasks if t.task_id == "trigger_item_equipment_infinite")
+    assert t.trigger_dag_id == "item_equipment_pipeline"
+    assert t.conf == {"mode": "infinite"}
+
+
+def test_has_wait_first_iteration_started(dag):
+    assert "wait_first_iteration_started" in {t.task_id for t in dag.tasks}
+
+
+def test_has_wait_upstream_terminal_character_basic(dag):
+    assert "wait_upstream_terminal_character_basic" in {t.task_id for t in dag.tasks}
+```
+
+- [ ] **Step 2: Run tests, expect failure**
+
+```bash
+cd docker/airflow/dags && python3 -m pytest tests/test_morning_chain_pipeline.py -v
+```
+
+Expected: 4 of the 16 tests fail.
+
+- [ ] **Step 3: Add the 4 tasks + 1 custom sensor**
+
+Add to imports at the top of `morning_chain_pipeline.py`:
+
+```python
+from airflow.operators.python import PythonOperator
+from airflow.sensors.python import PythonSensor
+from phase_pipeline_factory import get_external_api_base
+```
+
+Append inside the `with DAG(...)` block (after the existing tasks):
+
+```python
+    trigger_character_basic_once = TriggerDagRunOperator(
+        task_id="trigger_character_basic_once",
+        trigger_dag_id="character_basic_pipeline",
+        conf={"mode": "once"},
+        reset_dag_run=True,
+        wait_for_completion=False,
+    )
+
+    # Factory sensor — returns True when current.phase progresses past CHARACTER_BASIC.
+    wait_character_basic_terminal = make_wait_phase_terminal_sensor("CHARACTER_BASIC")
+
+    trigger_item_equipment_infinite = TriggerDagRunOperator(
+        task_id="trigger_item_equipment_infinite",
+        trigger_dag_id="item_equipment_pipeline",
+        conf={"mode": "infinite"},
+        reset_dag_run=True,
+        wait_for_completion=False,
+    )
+
+    # Custom sensor: the infinite loop never reaches "terminal" so the
+    # factory's make_wait_phase_terminal_sensor cannot gate it. Instead,
+    # poll /run-status for loopSummaries[ITEM_EQUIPMENT].iterationCount >= 1
+    # AND status == "RUNNING" (confirms the loop accepted the start signal
+    # and at least one iteration has begun).
+    def _is_iteration_started(**ctx) -> bool:
+        import requests
+        try:
+            resp = requests.get(
+                f"{get_external_api_base()}/api/internal/run-status",
+                params={"phase": "ITEM_EQUIPMENT"},
+                timeout=10,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+        except Exception:
+            return False  # transient → reschedule
+        summary = (data.get("loopSummaries") or {}).get("ITEM_EQUIPMENT")
+        if not summary:
+            return False
+        return (
+            summary.get("status") == "RUNNING"
+            and (summary.get("iterationCount") or 0) >= 1
+        )
+
+    wait_first_iteration_started = PythonSensor(
+        task_id="wait_first_iteration_started",
+        python_callable=_is_iteration_started,
+        mode="reschedule",
+        poke_interval=30,
+        timeout=10 * 60,
+    )
+
+    wait_ocid_lookup_terminal >> trigger_character_basic_once
+    trigger_character_basic_once >> wait_character_basic_terminal
+    wait_character_basic_terminal >> trigger_item_equipment_infinite
+    trigger_item_equipment_infinite >> wait_first_iteration_started
+```
+
+- [ ] **Step 4: Re-run tests, expect pass**
+
+```bash
+cd docker/airflow/dags && python3 -m pytest tests/test_morning_chain_pipeline.py -v
+```
+
+Expected: 16 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine
+git add docker/airflow/dags/morning_chain_pipeline.py \
+        docker/airflow/dags/tests/test_morning_chain_pipeline.py
+git commit -m "feat(airflow): morning_chain character_basic once + item_equipment infinite + iter sensor"
+```
+
+---
+
+## Task 5: Final invariant tests + DagBag parse + spec correction
+
+**Files:**
+- Modify: `docker/airflow/dags/tests/test_morning_chain_pipeline.py`
+- Modify: `docs/superpowers/specs/2026-06-23-3am-pipeline-chain-design.md`
+
+- [ ] **Step 1: Add the final invariant tests**
+
+```python
+def test_exactly_8_tasks(dag):
+    """1 health + 4 trigger + 1 loop-stopped + 2 phase-terminal + 1 iter-started = 9.
+
+    Note: factory sensors generate their own task_ids (e.g.
+    wait_loop_stopped_item_equipment), so the count includes those.
+    """
+    task_ids = {t.task_id for t in dag.tasks}
+    assert len(task_ids) == 9, f"got {len(task_ids)}: {sorted(task_ids)}"
+
+
+def test_all_trigger_dagrun_have_reset(dag):
+    """TriggerDagRunOperators must reset_dag_run=True to avoid stale-run collisions."""
+    for t in dag.tasks:
+        if t.task_id.startswith("trigger_"):
+            assert getattr(t, "reset_dag_run", False) is True
+
+
+def test_all_sensors_use_reschedule(dag):
+    """mode=reschedule frees worker slot between pokes."""
+    for t in dag.tasks:
+        if t.task_id.startswith("wait_") or t.task_id == "check_ext_api_health":
+            assert getattr(t, "mode", None) == "reschedule"
+
+
+def test_dependency_chain_linear(dag):
+    """Topological order: health → stop_trigger → loop_stopped → ranking_trigger
+    → ocid_terminal → char_trigger → char_terminal → item_trigger → iter_started."""
+    task_ids = [t.task_id for t in dag.tasks]
+    # Health must be first (no upstream).
+    roots = [t for t in dag.tasks if not t.upstream_list]
+    assert [r.task_id for r in roots] == ["check_ext_api_health"]
+    # Iter-started must be last (no downstream).
+    leaves = [t for t in dag.tasks if not t.downstream_list]
+    assert [l.task_id for l in leaves] == ["wait_first_iteration_started"]
+```
+
+Note: the spec's "10 tasks" claim is corrected to 9 below.
+
+- [ ] **Step 2: Run tests, expect pass**
+
+```bash
+cd docker/airflow/dags && python3 -m pytest tests/test_morning_chain_pipeline.py -v
+```
+
+Expected: 20 passed.
+
+- [ ] **Step 3: Verify file is well-formed via DagBag**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine
+docker exec maple-airflow-scheduler bash -c \
+  "cd /opt/airflow/dags && python3 -c \
+   'from airflow.models import DagBag; b = DagBag(dag_folder=\"/opt/airflow/dags\", include_examples=False); print(\"errors:\", b.import_errors); print(\"morning_chain_pipeline in dags:\", \"morning_chain_pipeline\" in b.dags)'"
+```
+
+Expected: `errors: {}` and `morning_chain_pipeline in dags: True`.
+
+- [ ] **Step 4: Correct the "10 tasks" claim in the spec**
+
+In `docs/superpowers/specs/2026-06-23-3am-pipeline-chain-design.md` section 4, update the row:
+
+```
+| New tasks per master DAG run | 9 | 1 health + 4 trigger + 4 sensor (3 factory + 1 custom) |
+```
+
+Update section 3 (Trade-offs) to remove the now-irrelevant `BranchPythonOperator` and `check_loop_active` references — replace any mention with "factory sensors (idempotent)".
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine
+git add docker/airflow/dags/tests/test_morning_chain_pipeline.py \
+        docs/superpowers/specs/2026-06-23-3am-pipeline-chain-design.md
+git commit -m "test(airflow): morning_chain final invariants + spec task count correction"
+```
+
+---
+
+## Task 6: Spec design diagram update
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-06-23-3am-pipeline-chain-design.md`
+
+- [ ] **Step 1: Update the ASCII architecture diagram in the spec**
+
+Replace the existing diagram in section 2 (Decision) with the simplified one:
+
+```
+morning_chain_pipeline (schedule: 0 18 * * * UTC = 03:00 KST)
+  │
+  ├─ check_ext_api_health (HttpSensor)
+  ├─ trigger_stop_loop (TriggerDagRunOperator → stop_loop_pipeline, conf={phase:ITEM_EQUIPMENT})
+  ├─ wait_loop_stopped_item_equipment (factory: make_wait_loop_stopped_sensor — idempotent)
+  ├─ trigger_ranking_ocid (TriggerDagRunOperator → ranking_ocid_lookup_pipeline)
+  ├─ wait_upstream_terminal_ocid_lookup (factory: make_wait_phase_terminal_sensor)
+  ├─ trigger_character_basic_once (TriggerDagRunOperator, conf={mode:once})
+  ├─ wait_upstream_terminal_character_basic (factory: make_wait_phase_terminal_sensor)
+  ├─ trigger_item_equipment_infinite (TriggerDagRunOperator, conf={mode:infinite})
+  └─ wait_first_iteration_started (custom: loopSummaries[ITEM_EQUIPMENT].iterationCount >= 1)
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /home/maple/probabilistic-valuation-engine
+git add docs/superpowers/specs/2026-06-23-3am-pipeline-chain-design.md
+git commit -m "docs: morning_chain spec design diagram (simplified)"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- Architecture (master DAG + factory sensors) — Task 2-4
+- Components (1 new file + 1 test, no Kotlin) — Task 1-5
+- Idempotent stop via factory sensor — Task 3 (`make_wait_loop_stopped_sensor`)
+- Data flow (HTTP calls, conf, sensors) — Task 3-4
+- Error handling (no retries, factory sensor timeouts) — Task 2 (default_args), Task 3-4 (factory handles timeouts)
+- Testing (unit + DagBag parse + manual integration noted) — Task 5
+- Schedule 0 18 * * * — Task 2
+
+**2. Placeholder scan:** No "TBD", no "implement later", no "similar to Task N". All code blocks complete. Factory functions used: `make_wait_loop_stopped_sensor`, `make_wait_phase_terminal_sensor`, `get_external_api_base` — all exist in `phase_pipeline_factory.py` (verified by `grep`).
+
+**3. Type consistency:** `get_external_api_base` defined in factory, imported in Task 4. `_is_iteration_started` defined and used in same task. No cross-task type drift.
+
+**4. Spec gap:** Tasks 5-6 close the "10 vs 9 tasks" and diagram discrepancies. Idempotency is now explained correctly (factory sensor returns True if no loop active — verified by reading factory source).
+
+**5. Grill findings applied:**
+- Dropped `check_loop_active_for_item_equipment` custom helper (wrong field, `loopId` is in `loopSummaries`, not top-level).
+- Dropped `BranchPythonOperator` + `skip_stop_loop_sequence` + `stop_loop_sequence` sentinels.
+- Replaced `make_is_phase_terminal` (from `per_phase_tasks`, broken for cross-DAG) with `make_wait_phase_terminal_sensor` (from `phase_pipeline_factory`, no xcom dependency).
+- Used `make_wait_loop_stopped_sensor` for the stop step (factory's idempotent version).
+
+Plan complete and saved to `docs/superpowers/plans/2026-06-23-3am-pipeline-chain.md`.
+
+**Two execution options:**
+
+1. **Subagent-Driven (recommended)** - I dispatch a fresh subagent per task, review between tasks, fast iteration
+2. **Inline Execution** - Execute tasks in this session using executing-plans, batch execution with checkpoints
+
+Which approach?

--- a/docs/superpowers/plans/2026-06-23-analytics-adr-finalization.md
+++ b/docs/superpowers/plans/2026-06-23-analytics-adr-finalization.md
@@ -1,0 +1,130 @@
+# Plan: Analytics Layer ADR Finalization (#1339)
+
+- Spec: `docs/superpowers/specs/2026-06-23-analytics-adr-finalization.md`
+- Issue: #1339
+- Parent ADR: `docs/01_ADR/ADR-735-future-analytics-platform-evaluation.md`
+- ADR template: `.claude/rules/adr-conventions.md`
+- Branch base: `develop`
+- Feature branch: `feature/adr-735-accepted`
+
+## Phasing
+
+Each phase below is gated on the previous. Phases A-D are mechanical doc edits; Phase E is the reviewer gate; Phase F is the rollback path (only fires on rejection).
+
+---
+
+## Phase 0 — Prerequisites gate
+
+**Task:** Confirm all 8 sibling investigation issues are closed with measured results.
+**Files:** none (read-only check).
+**Evidence to gather:** `gh issue list --label analytics-investigation --state closed` returns 8 issues. List the 8 issue numbers explicitly in the working evidence sheet. Each closed issue must contain a numeric "Measured" or "Result" line — narrative-only closes do not satisfy this gate.
+**Reviewer:** self (gate is mechanical).
+**Verification:** count = 8; each issue has measured numbers, not just narrative; if count < 8, halt and reopen #1339.
+
+---
+
+## Phase A — Evidence aggregation
+
+**Task:** Tabulate measured numbers from 8 sibling issues into a working evidence sheet.
+**File:** `/tmp/adr-735-evidence.md` (working doc, not committed).
+**ADR section to update (later):** §4 Result/Evidence → Metrics table + Observed Result bullets.
+**Evidence to gather:** per-issue: metric name, measured value, method, sample size, timestamp.
+**Reviewer:** self (aggregation only).
+**Verification:** every metric slot in §4 has either a measured value or an `n/a — not deployed` marker.
+
+---
+
+## Phase B — Trigger evaluation annotation
+
+**Task:** Add a "Trigger evaluation (2026-MM-DD)" subsection to ADR-735 §2 Decision, recording measured T1-T8 status.
+**File:** `docs/01_ADR/ADR-735-future-analytics-platform-evaluation.md` §2.
+**Evidence to gather:** per trigger T1-T8: fired (yes/no), measured value, threshold, gap.
+**Reviewer:** self (composes from working evidence sheet).
+**Verification:** all 8 triggers have a one-line entry; entries cite source measurement. **If any trigger fired today**, halt acceptance, mark ADR `Revised`, re-circulate.
+
+---
+
+## Phase C — Metrics table population
+
+**Task:** Replace estimate cells in §4 Metrics table with measured numbers or `n/a — not deployed` markers.
+**File:** `docs/01_ADR/ADR-735-future-analytics-platform-evaluation.md` §4.
+**ADR template check:** keep the 5-column table shape (Metric | Today | ClickHouse | Iceberg+Trino | Iceberg+Spark). Add a footnote explaining `n/a` semantics.
+**Evidence to gather:** Phase A evidence sheet.
+**Reviewer:** self.
+**Verification:** no estimate language ("5-30s", "~1.5-2TB", "~5 nodes") remains except as historical baseline annotation; each cell traces to a source. Add footnote citing absence-of-measurement semantics for `n/a` cells.
+
+---
+
+## Phase D — Status transition
+
+**Task:** Update ADR-735 status field + date stamp.
+**File:** `docs/01_ADR/ADR-735-future-analytics-platform-evaluation.md` header.
+**Changes:**
+- `Status: Proposed` → `Status: Accepted`
+- `Date: 2026-06-23` (kept) → add `Date: 2026-MM-DD (Accepted)` line.
+**Evidence to gather:** merge commit hash from Phase E.
+**Reviewer:** second maintainer (via PR approval in Phase E).
+**Verification:** status field reads `Accepted`; date stamp present.
+
+---
+
+## Phase E — Reviewer gate
+
+**Task:** Open PR from `feature/adr-735-accepted` against `develop`, obtain ≥1 approval.
+**Commands:**
+```bash
+git checkout develop && git pull
+git checkout -b feature/adr-735-accepted
+# (apply edits from Phases B-D)
+git add docs/01_ADR/ADR-735-future-analytics-platform-evaluation.md
+git commit -m "docs(adr): accept ADR-735 analytics platform evaluation
+
+Closes #1339
+
+Finalizes the analytics platform strategy with measured evidence
+from 8 sibling investigation issues."
+git push -u origin feature/adr-735-accepted
+gh pr create --base develop --title "ADR-735: Accept analytics platform evaluation" --body "Closes #1339. See spec at docs/superpowers/specs/2026-06-23-analytics-adr-finalization.md."
+```
+**Reviewer assignment:** second maintainer (pre-arranged in issue #1339 comment before starting).
+**Fallback:** if no reviewer responds within 14 days, apply `needs-reviewer` label, ping #architecture channel, do not self-approve.
+**Verification:** PR has ≥1 approval from non-author maintainer; CI passes (docs-only).
+
+---
+
+## Phase F — Rollback path (conditional)
+
+**Trigger:** reviewer rejects, measurement gap surfaces, or decision is contradicted by new evidence.
+**Steps:**
+1. Close PR without merging.
+2. Revert ADR-735 status to `Proposed` (or `Deprecated` if decision is invalidated).
+3. Open follow-up issue per blocker with measured gap as title.
+4. If decision direction is wrong, author `docs/01_ADR/ADR-735a-{topic}.md` as superseding ADR and add cross-link to ADR-735 §References.
+**Reviewer:** self.
+**Verification:** issue #1339 reopened with reason; status field reverted; superseding ADR committed if applicable.
+
+---
+
+## Per-task summary table
+
+| Task | File / Section | Evidence source | Reviewer | Verification |
+| -- | -- | -- | -- | -- |
+| Phase 0 prerequisites | none (read-only) | 8 sibling issues closed | self | count = 8 |
+| Phase A evidence sheet | `/tmp/adr-735-evidence.md` | 8 sibling issue comments | self | every slot covered |
+| Phase B trigger annotation | ADR-735 §2 | evidence sheet | self | T1-T8 all annotated |
+| Phase C metrics table | ADR-735 §4 | evidence sheet | self | no estimate language |
+| Phase D status flip | ADR-735 header | merge commit | second maintainer | field reads `Accepted` |
+| Phase E PR + approval | git + gh | review comment | second maintainer | ≥1 approval, CI green |
+| Phase F rollback | ADR-735 status | rejection reason | self | status reverted, issue reopened |
+
+---
+
+## Definition of Done
+
+- [ ] ADR template per `.claude/rules/adr-conventions.md` strictly followed (5 sections, Trade-offs include Sensitivity/Trade-off/Risk/Non-Risk).
+- [ ] §4 metrics table cells: measured numbers OR `n/a — not deployed`.
+- [ ] §2 trigger annotation present with T1-T8 entries.
+- [ ] Status `Accepted` with date stamp.
+- [ ] PR merged to `develop` with ≥1 non-author approval.
+- [ ] No code changes; documentation only.
+- [ ] Issue #1339 closed with merge commit hash in closing comment.

--- a/docs/superpowers/plans/2026-06-23-class-hierarchy-modeling.md
+++ b/docs/superpowers/plans/2026-06-23-class-hierarchy-modeling.md
@@ -1,0 +1,233 @@
+# Plan: Class Hierarchy Data Modeling
+
+- Date: 2026-06-23
+- Parent Issue: #1343
+- Spec: `docs/superpowers/specs/2026-06-23-class-hierarchy-modeling.md`
+- Parent ADR: ADR-735
+
+---
+
+## Phase Overview
+
+| Phase | Title | Owner | Verification |
+|-------|-------|-------|--------------|
+| 1 | Taxonomy Enumeration | data-modeler | YAML/JSON taxonomy file committed |
+| 2 | Current PG Audit | data-modeler | Audit report in spec §Acceptance |
+| 3 | Dimensional Model Design | data-modeler | `dim_class` schema doc with examples |
+| 4 | Cross-Store Mapping | data-modeler | CH + Iceberg mapping table |
+
+All phases are investigation-only. No schema changes. No new tables. No domain model changes.
+
+---
+
+## Phase 1: Taxonomy Enumeration
+
+**Goal:** Enumerate all MapleStory classes with parent-child advancement relationships.
+
+### Task 1.1: Enumerate job groups
+- Deliverable: `dim_job_group` rows in `docs/superpowers/specs/2026-06-23-class-hierarchy-modeling.md#1.1-job-groups-top-level-rollup`
+- Owner: data-modeler
+- Verification: 9+ job groups listed with region_origin + release_year
+
+### Task 1.2: Enumerate leaf classes
+- Deliverable: CSV/JSON file at `docs/superpowers/specs/data/class-taxonomy.csv` with columns: `class_id, class_name_en, class_name_kr, job_group_id, advancement_tier, parent_class_id, is_5th_job`
+- Owner: data-modeler
+- Verification: ≥40 rows; each row has `class_id`, `parent_class_id` (nullable for tier-0), `advancement_tier` ∈ {0..5}
+
+### Task 1.3: Validate parent-child edges
+- Deliverable: Adjacency list sanity check in taxonomy file
+- Owner: data-modeler
+- Verification: tree depth ≤ 5; no cycles; mixed-branch classes (Xenon) flagged
+
+---
+
+## Phase 2: Current PG Audit
+
+**Goal:** Document current class encoding in `character_equipment_read_model` and measure denormalization cost.
+
+### Task 2.1: Locate and read current schema
+- Deliverable: Path + DDL of `character_equipment_read_model` (and related tables with class fields)
+- Owner: data-modeler
+- Verification: Column types, NULL policy, indexes, constraints documented
+
+### Task 2.2: Measure column sizes
+- Deliverable: `pg_column_size` or `pg_stats` snapshot of class-related columns
+- Owner: data-modeler
+- Verification: bytes/row per class field; total annual cost projection
+
+### Task 2.3: Index audit
+- Deliverable: List of indexes touching class fields (btree, hash, partial)
+- Owner: data-modeler
+- Verification: index list matches spec §Acceptance Criteria
+
+### Task 2.4: Query pattern inventory
+- Deliverable: Top 5 class-based GROUP BY / JOIN queries from production logs / pg_stat_statements
+- Owner: data-modeler
+- Verification: Each query has current plan + estimated cost
+
+### Task 2.5: Storage cost projection
+- Deliverable: Annual cost of denormalization vs normalization (one JOIN cost)
+- Owner: data-modeler
+- Verification: Numbers reconcile with spec §4 Storage Cost
+
+---
+
+## Phase 3: Dimensional Model Design
+
+**Goal:** Specify `dim_class`, `dim_job_group`, `dim_class_closure` schemas with examples.
+
+### Task 3.1: `dim_class` schema spec
+- Deliverable: DDL-style spec with types, constraints, examples for 5 representative classes
+- Owner: data-modeler
+- Verification: All columns from spec §2.1 present; SCD Type 2 columns included
+
+### Task 3.2: `dim_job_group` schema spec
+- Deliverable: DDL-style spec with all 9+ groups
+- Owner: data-modeler
+- Verification: All columns from spec §2.2 present; release_year populated
+
+### Task 3.3: `dim_class_closure` schema spec (PG only)
+- Deliverable: DDL + 5 example rows showing ancestor/descendant relationships
+- Owner: data-modeler
+- Verification: Closure invariant holds (every node has self at depth 0; transitive closure complete)
+
+### Task 3.4: SCD Type 2 strategy
+- Deliverable: Mermaid/sequence diagram + written procedure for class rebalance
+- Owner: data-modeler
+- Verification: Procedure covers INSERT new + UPDATE old with `effective_to = now()`
+
+### Task 3.5: Mixed-branch handling
+- Deliverable: Spec section on Xenon (multi-parent) and 5th-job anomalies
+- Owner: data-modeler
+- Verification: `parent_class_key` NULL or multi-row strategy documented
+
+---
+
+## Phase 4: Cross-Store Mapping
+
+**Goal:** Map `dim_class` to ClickHouse (Phase 1) and Iceberg (Phase 2) with type adaptations.
+
+### Task 4.1: ClickHouse type mapping
+- Deliverable: Mapping table (PG column → CH column with `LowCardinality` annotations)
+- Owner: data-modeler
+- Verification: All class fields mapped; LowCardinality usage justified
+
+### Task 4.2: ClickHouse table engine
+- Deliverable: `CREATE TABLE dim_class (...) ENGINE = MergeTree ORDER BY (class_key)` example
+- Owner: data-modeler
+- Verification: ORDER BY key supports common query patterns (point lookup + scan by job_group)
+
+### Task 4.3: ClickHouse `dictGet` strategy
+- Deliverable: Example query using `dictGet('dim_class', 'class_name_kr', class_key)`
+- Owner: data-modeler
+- Verification: Dict definition included; no JOIN in hot analytical path
+
+### Task 4.4: Iceberg schema spec
+- Deliverable: Iceberg table spec for `dim_class` (no partition, sort by class_key)
+- Owner: data-modeler
+- Verification: Schema evolution example (add `class_name_ja`) without rewrite
+
+### Task 4.5: Iceberg partition-key decision for fact tables
+- Deliverable: Recommendation: `PARTITION BY (year(ts), job_group_id)` for fact_character_snapshot
+- Owner: data-modeler
+- Verification: 15-30 buckets; aligns with class rollup queries
+
+### Task 4.6: Trino query examples
+- Deliverable: 3 Trino SQL examples reading `dim_class` from Iceberg catalog
+- Owner: data-modeler
+- Verification: Queries match PG semantics; no ClickHouse-specific syntax
+
+---
+
+## Cross-Cutting Deliverables
+
+### Task X.1: Risk register
+- Deliverable: 5 risks with mitigations (R1-R5 from spec)
+- Owner: data-modeler
+- Verification: Each risk has severity + mitigation
+
+### Task X.2: Migration effort estimate
+- Deliverable: Hours estimate per phase; engineer-week total
+- Owner: data-modeler
+- Verification: Reconciled with ADR-735 §4 Metrics
+
+### Task X.3: Sign-off summary
+- Deliverable: 1-page summary in spec §Summary
+- Owner: data-modeler
+- Verification: Matches spec §Summary
+
+---
+
+## Definition of Done
+
+- [ ] All 4 phases complete with verification
+- [ ] No schema changes to production tables
+- [ ] No new tables in production schema
+- [ ] No domain model changes to `module-core`
+- [ ] Spec updated with all findings
+- [ ] Risks documented with mitigations
+- [ ] Migration effort estimated in engineer-weeks
+- [ ] Cross-store mapping validated against public docs
+
+---
+
+## Out of Scope
+
+- Schema migration scripts
+- Production data backfill
+- Calculator / module-core changes
+- Iceberg catalog provisioning
+- ClickHouse cluster sizing
+- ML feature engineering
+
+---
+
+## Open Risks
+
+- **Mixed-branch classes** (Xenon, 5th-job) may need separate handling beyond parent-child edges.
+- **Korean name UTF-8 expansion** may increase PG row size if not normalized.
+- **Class rebalance churn** (every 6-18 months) requires closure table rebuild.
+
+---
+
+## Summary
+
+> 4 phases, 18 tasks, ~3 engineer-weeks, all investigation — produces a single star-schema dimension that works on PG, ClickHouse, and Iceberg with type adaptations.
+
+---
+
+## Grill-Me (5 Hard Questions)
+
+### Q1: Closure table on PG forces a write-amplification on every class rebalance. If NEXON rebalances 3 classes per year, that's 3 closure table rebuilds/year. Have you considered materializing ancestors as a generated/denormalized column on `dim_class` (e.g., `ancestor_keys INT[]`) to avoid the closure table entirely?
+
+**Resolution:** Closure table stays. PG `INT[]` ancestor column means: (a) no transitive closure (only direct ancestors), (b) UPDATE cost on rebalance, (c) inefficient for subtree queries. Closure table is O(1) ancestor AND O(1) subtree. Cost is amortized: 3 rebuilds/year is small.
+
+### Q2: You store `class_name_kr` + `class_name_en` for locale flexibility, but `class_name_kr` UTF-8 expansion is ~3B/row. If 40M items/day carry a denormalized class name, that's 120MB/day just for the Korean name field. Have you considered storing names only in `dim_class` (4B FK per row) and accepting the JOIN cost on serving reads?
+
+**Resolution:** Names live in `dim_class` only. The current `character_equipment_read_model` keeps its denormalized names (out of scope per issue), but the **new** analytical layer (CH/Iceberg) uses FK + JOIN. Saving: ~840GB-1.2TB/year at one JOIN per analytical query.
+
+### Q3: `LowCardinality` in ClickHouse has a 10K cap. With 50 classes today, you're at 0.5% of cap. But what if NEXON adds a "custom class" feature (server-side generated classes per character)? That could explode to 10K+ per region. Have you designed a fallback path?
+
+**Resolution:** Custom-class scenario is out of scope for this issue (it's a future NEXON feature, not yet announced). If it materializes: switch `class_id` from `LowCardinality(UInt16)` to plain `UInt32`; CH schema change is a 1-hour DDL. Documented as R2.
+
+### Q4: You have `is_5th_job` boolean + `advancement_tier = 5`. But 5th-job is a 2023 mechanic that only applies to Anima/Nova branches. Kinesis, Cygnus, Resistance don't have 5th-job. Won't this make `is_5th_job` redundant with `(job_group_id, advancement_tier)`?
+
+**Resolution:** Keep `is_5th_job` as a derived column for query ergonomics. The boolean is denormalized for index efficiency: queries like "all 5th-job characters" become `WHERE is_5th_job = true` (low-cardinality bit) instead of `WHERE job_group_id IN (4, 6) AND advancement_tier = 5` (4-element scan). Trade-off: storage for speed.
+
+### Q5: Iceberg `PARTITION BY (year(ts), job_group_id)` produces ~15-30 buckets/year. With 340GB/day ingest, each bucket is ~1-2TB. That's 1000+ files per bucket. Iceberg manifest list will grow large; compaction becomes Tier-1 service. Have you modeled compaction cost?
+
+**Resolution:** Compaction cost is real but deferred to ADR-735 §3 Risk (compaction lag). For this issue: keep partition spec simple; revisit at Phase 2 (Iceberg) trigger time. Compaction is already a known Tier-1 service per parent ADR. No new risk introduced.
+
+---
+
+## Post-Grill Resolution Summary
+
+| Q | Decision | Justification |
+|---|----------|---------------|
+| Q1 | Closure table on PG | O(1) ancestor + subtree; 3 rebuilds/year is cheap |
+| Q2 | Names in `dim_class` only | Save 840GB-1.2TB/year; JOIN on analytical path |
+| Q3 | `LowCardinality(UInt16)` stays | Custom-class scenario is NEXON future; 1-hour DDL fallback |
+| Q4 | `is_5th_job` kept as denorm | Index efficiency; ergonomic for class rollups |
+| Q5 | Iceberg partition kept | Compaction cost deferred to ADR-735 §3 |
+
+No spec/plan changes needed. All 5 questions resolved within current design.

--- a/docs/superpowers/plans/2026-06-23-historical-analytics-requirements.md
+++ b/docs/superpowers/plans/2026-06-23-historical-analytics-requirements.md
@@ -1,0 +1,68 @@
+# Plan: Historical Analytics Requirements (Issue #1342)
+
+- Spec: `docs/superpowers/specs/2026-06-23-historical-analytics-requirements.md`
+- Parent ADR: `docs/01_ADR/ADR-735-future-analytics-platform-evaluation.md`
+- Investigation parent: #1342
+- Date: 2026-06-23
+
+---
+
+## Phase 1 — Stakeholder Interviews (requirements gathering)
+
+Goal: collect the 14 fields per workload from the people who would author or consume the workload.
+
+| # | Task | Deliverable | Owner suggestion | Verification |
+|---|------|-------------|------------------|--------------|
+| 1.1 | Interview data analyst persona (ad-hoc query author) | WA-1, WA-2, WA-6, WA-8 raw notes | Data analyst lead | Notes file checked in; ≥3 candidate workloads captured |
+| 1.2 | Interview product manager (roadmap commitment) | COMMITTED vs SPECULATIVE tag per workload | PM owner of analytics | Roadmap citations per workload (Slack/Issue link) |
+| 1.3 | Interview SRE (latency / volume / freshness from infra view) | Cardinality, frequency, p95 budgets | SRE on-call lead | Numbers cross-checked with Prometheus / DB stats |
+| 1.4 | Interview on-call engineer (anomaly, retention, audit) | WA-7, WA-10, retention classes | On-call lead | Anomaly thresholds traceable to alert rules |
+
+## Phase 2 — Workload Matrix Build
+
+Goal: produce the 14-field inventory.
+
+| # | Task | Deliverable | Owner suggestion | Verification |
+|---|------|-------------|------------------|--------------|
+| 2.1 | Consolidate Phase 1 notes into canonical matrix | `historical-analytics-workloads.md` draft | Architecture team | All 14 fields filled per row; no `TBD` allowed in P0/P1 |
+| 2.2 | Classify cross-source join per workload | CSJ-A/B/C column | Architecture team | Each row has CSJ class |
+| 2.3 | Classify time-travel per workload | TT-0..TT-4 column | Architecture team | Each row has TT class |
+| 2.4 | Classify retention per workload | RET-N..RET-4 column | Architecture team | Each row has RET class |
+| 2.5 | Trigger-gate map (workload × T1..T8) | `historical-analytics-trigger-map.md` | Architecture team | Multi-select cells justified; no orphan T-values |
+
+## Phase 3 — Priority Ranking
+
+Goal: assign P0-P3 with auditable scoring.
+
+| # | Task | Deliverable | Owner suggestion | Verification |
+|---|------|-------------|------------------|--------------|
+| 3.1 | Score each workload on 5 axes (0-3) | Score column per row | Architecture team | Sum matches tier boundary (P0 12-15, P1 8-11, P2 4-7, P3 0-3) |
+| 3.2 | P0-P3 tier assignment + rationale | Sorted list | Architecture team | Each tier has ≥1 workload; ties broken by commitment axis |
+| 3.3 | ADR-735 §2 trigger review: which workloads actually fire T1-T8? | Trigger narrative | Architecture team | First trigger (smallest timeline) named explicitly |
+| 3.4 | Reviewer pass (counter-arguments) | Comment thread on PR | Code reviewer | ≥3 challenges raised and resolved |
+
+## Phase 4 — Documentation Publication
+
+Goal: ship the inventory as durable artifact.
+
+| # | Task | Deliverable | Owner suggestion | Verification |
+|---|------|-------------|------------------|--------------|
+| 4.1 | Publish workload matrix in `docs/03_Technical_Guides/historical-analytics-workloads.md` | Final doc | Doc owner | Doc renders; linked from ADR-735 §5 |
+| 4.2 | Publish trigger map in same directory | `historical-analytics-trigger-map.md` | Doc owner | Linked from spec §4.7 |
+| 4.3 | Update ADR-735 §5 References with both docs | ADR diff | Architecture team | `git diff` shows the reference add only |
+| 4.4 | Close #1342 with summary comment + links | Issue comment | Issue author | #1342 closed; summary contains all doc links |
+
+---
+
+## Cross-cutting
+
+- **Branch**: `feature/1342-historical-analytics-requirements` from `develop`
+- **PR target**: `develop`
+- **No code**: every PR is docs only. CI lint catches accidental code change.
+- **Definition of Done**: all 12 acceptance-criteria checkboxes from spec §5 ticked, reviewer approval, ADR-735 reference updated, #1342 closed.
+
+## Risk and Rollback
+
+- Workload matrix becomes stale within 1 quarter → add a "last reviewed" date; quarterly review in ADR-735 maintenance.
+- Latency budget guessed for hypothetical user-facing API → tag as "estimated" in matrix; revisit on first API contract.
+- Roadmap commitment misread → PM sign-off required in Phase 3 review.

--- a/docs/superpowers/plans/2026-06-23-iceberg-feasibility.md
+++ b/docs/superpowers/plans/2026-06-23-iceberg-feasibility.md
@@ -1,0 +1,286 @@
+# Plan: Iceberg Feasibility Study (Issue #1337)
+
+- Spec: `docs/superpowers/specs/2026-06-23-iceberg-feasibility.md`
+- Parent ADR: `docs/01_ADR/ADR-735-future-analytics-platform-evaluation.md`
+- Parent Issue: #1337
+- Investigation only — no module code changes
+
+---
+
+## Phase 1 — Environment Verification
+
+**Goal:** Confirm MinIO version and prepare test namespace.
+
+**Precondition gate:** Phase 2 MUST NOT start until Phase 1 exit criterion (RELEASE ≥ 2024-05-10 confirmed OR upgrade plan documented with scheduled maintenance window ≤ 30 days) is satisfied. If pre-2024-05 and no upgrade plan, Phase 2 entry is BLOCKED — record blocker in pilot-report.md and escalate to architecture owner via issue comment on #1337.
+
+### Task 1.1 — MinIO version audit
+- **Owner:** Pilot lead
+- **Touch:**
+  - `docker-compose.yml` (read-only inspection)
+  - Cluster (`mc admin info minio`)
+- **Verify:** `mc admin info` output shows RELEASE ≥ 2024-05-10; record exact RELEASE string in `tools/iceberg-pilot/pilot-report.md`
+- **Rollback:** N/A (read-only)
+- **Exit criterion:** RELEASE confirmed OR upgrade plan documented in pilot report with scheduled maintenance window
+
+### Task 1.2 — Create dedicated test bucket
+- **Owner:** Pilot lead
+- **Touch:** MinIO `mc mb` (no file edits)
+- **Verify:** `mc ls minio/iceberg-pilot` returns empty bucket; `mc ilm ls minio/iceberg-pilot` confirms no expiration rules
+- **Rollback:** `mc rb --force minio/iceberg-pilot`
+- **Exit criterion:** Bucket exists, lifecycle disabled, isolated from `data/runs/...` serving path
+- **Namespace isolation check:** `mc ls minio/data/runs | head -5` confirms serving bucket unaffected; serving PG/Kafka untouched
+
+---
+
+## Phase 2 — Catalog Deployment
+
+**Goal:** Deploy Polaris (primary) or Nessie (fallback) in test namespace.
+
+### Task 2.1 — Author `docker-compose.test.yml`
+- **Owner:** Pilot lead
+- **Touch:**
+  - `tools/iceberg-pilot/docker-compose.test.yml` (new file, scoped to tools/ to keep repo root compose clean)
+  - `.env` (no edits; values from existing `MINIO_*`)
+- **Verify:** `docker compose -f tools/iceberg-pilot/docker-compose.test.yml config` exits 0; review no ports collide with serving stack (8081/8082/8083/8080)
+- **Rollback:** `docker compose -f tools/iceberg-pilot/docker-compose.test.yml down -v`
+- **Exit criterion:** Compose file validates; services defined on non-conflicting ports
+- **Credentials audit:** Confirm no new credentials written to repo `.env`; pilot uses ephemeral test credentials injected via `docker compose ... --env-file tools/iceberg-pilot/.env.test` (gitignored)
+
+### Task 2.2 — Deploy Polaris with Postgres backend
+- **Owner:** Pilot lead
+- **Touch:**
+  - Polaris bootstrap config in `tools/iceberg-pilot/docker-compose.test.yml`
+  - Postgres service (separate from serving PG; distinct port e.g. 5433 vs serving 6543)
+- **Verify:** `curl -fsS http://localhost:8181/healthcheck` returns 200 for 5 consecutive pings within 30s each; `docker compose ... exec polaris-db pg_isready` confirms catalog DB isolated
+- **Rollback:** `docker compose -f tools/iceberg-pilot/docker-compose.test.yml down -v`
+- **Exit criterion:** Polaris health green; catalog DB on non-serving port
+
+### Task 2.3 — (Fallback) Deploy Nessie
+- **Owner:** Pilot lead
+- **Touch:** Same compose file, alternate profile
+- **Verify:** `curl -fsS http://localhost:19120/api/v1/health` returns 200
+- **Rollback:** Profile-level down
+- **Exit criterion:** Nessie ready (only if Polaris fails)
+
+---
+
+## Phase 3 — Table Creation & Ingest
+
+**Goal:** Create test table; ingest one `character_basic` chunk.
+
+### Task 3.1 — Author PyIceberg writer script
+- **Touch:**
+  - `tools/iceberg-pilot/ingest_chunk.py` (new file)
+  - `tools/iceberg-pilot/requirements.txt` (PyIceberg 0.9+)
+- **Verify:** `python -m py_compile tools/iceberg-pilot/ingest_chunk.py` exits 0
+- **Rollback:** Delete script
+- **Exit criterion:** Script compiles, accepts `--chunk-path` argument
+
+### Task 3.2 — Create test table DDL
+- **Touch:** `tools/iceberg-pilot/create_table.sql` (new file)
+- **Verify:** SQL parses with Iceberg spec; partition spec validates
+- **Rollback:** `DROP TABLE landing.character_basic_pilot`
+- **Exit criterion:** Table created with `days(ingest_ts), bucket(64, character_id)` partition spec
+
+### Task 3.3 — Ingest one chunk end-to-end
+- **Touch:** None (runtime operation)
+- **Verify:** Table row count = source chunk row count (exact match)
+- **Rollback:** `TRUNCATE TABLE landing.character_basic_pilot`
+- **Exit criterion:** Row count match recorded
+
+---
+
+## Phase 4 — Compaction Validation
+
+**Goal:** Validate `rewrite-data-files` produces target file sizes.
+
+### Task 4.1 — Run nightly compaction 3 times
+- **Owner:** Pilot lead
+- **Touch:** None (runtime)
+- **Verify:** `rewrite-data-files` exit 0 each run; Parquet median ≥128MB
+- **Rollback:** Snapshot preserved; old files remain queryable
+- **Exit criterion:** 3 consecutive runs pass
+
+### Task 4.2 — Measure file size distribution
+- **Owner:** Pilot lead
+- **Touch:** None
+- **Verify:** Recorded min/p50/p95/max file sizes in pilot report
+- **Rollback:** N/A (measurement)
+- **Exit criterion:** Distribution documented
+
+### Task 4.3 — Compaction crash recovery test (NEW from grill-me)
+- **Owner:** Pilot lead
+- **Touch:** None
+- **Failure mode tested:** `rewrite-data-files` process killed (SIGKILL) mid-run after writing N/2 files
+- **Verify:** After restart, Iceberg `snapshots` table shows last snapshot IN_PROGRESS or last successful snapshot queryable; no orphan data files; `procedures` table shows rollback semantics
+- **Rollback:** Snapshot at procedure start remains queryable; drop incomplete data files via `remove_orphan_files` procedure
+- **Exit criterion:** Recovery procedure documented in pilot-report.md; orphan-file runbook present
+
+---
+
+## Phase 5 — Retention Validation
+
+**Goal:** Validate snapshot retention policy.
+
+### Task 5.1 — 7-day rolling raw retention
+- **Touch:** None (runtime)
+- **Verify:** `expire_snapshots` with `retain_last=7` removes older raw snapshots
+- **Rollback:** N/A (retention is reversible by retaining snapshots)
+- **Exit criterion:** Snapshot list shows ≤7 raw snapshots
+
+### Task 5.2 — 365-day serving read-model policy documented
+- **Touch:** `docs/03_Technical_Guides/iceberg-evaluation.md` (draft)
+- **Verify:** Doc section present, retention parameters stated
+- **Rollback:** Doc edit revert
+- **Exit criterion:** Doc section complete
+
+---
+
+## Phase 6 — Time-Travel & Cross-Engine Validation
+
+**Goal:** Validate time-travel queries and engine interop.
+
+### Task 6.1 — Time-travel query benchmark
+- **Touch:** None (runtime)
+- **Verify:** `SELECT ... AS OF TIMESTAMP '-7d'` returns within 30s
+- **Rollback:** N/A
+- **Exit criterion:** Latency ≤30s
+
+### Task 6.2 — Trino reads Polaris-managed table
+- **Touch:** `tools/iceberg-pilot/trino-query.sql` (new file)
+- **Verify:** `trino --execute < trino-query.sql` row count matches PyIceberg write
+- **Rollback:** N/A
+- **Exit criterion:** Cross-engine read row count matches
+
+---
+
+## Phase 7 — Manifest Monitoring
+
+**Goal:** Track manifest list size for 7 days.
+
+### Task 7.1 — Daily manifest size measurement
+- **Touch:** `tools/iceberg-pilot/measure_manifest.sh` (new file)
+- **Verify:** Script runs daily; output captured to `tools/iceberg-pilot/measurements/`
+- **Rollback:** Stop cron
+- **Exit criterion:** 7 consecutive days measured
+
+### Task 7.2 — Alarm threshold proposal
+- **Touch:** `docs/03_Technical_Guides/iceberg-evaluation.md`
+- **Verify:** Section present with threshold + runbook
+- **Rollback:** Doc edit revert
+- **Exit criterion:** Threshold + runbook documented
+
+---
+
+## Phase 8 — Recommendation & Companion Doc
+
+**Goal:** Publish feasibility study; close parent issue.
+
+### Task 8.1 — Author `iceberg-evaluation.md`
+- **Owner:** Pilot lead + architecture reviewer
+- **Touch:** `docs/03_Technical_Guides/iceberg-evaluation.md` (new file)
+- **Verify:** Doc references all acceptance criteria AC1–AC12; contains recommendation + cost/effort/FTE table
+- **Required sections (NEW from grill-me):**
+  - Storage cost estimate (GB stored at end of pilot × $/GB-month)
+  - Compute cost estimate (Polaris + Trino node-hours × $/hour × pilot duration)
+  - FTE estimate for standing up compaction-as-a-service (target ≤0.5 FTE)
+  - Migration effort estimate (engineer-weeks for Phase 2 cutover, target ≤13 weeks per ADR-735)
+  - Storage budget consumed (pilot data capped at ≤10GB MinIO)
+- **Rollback:** Doc delete (no production effect)
+- **Exit criterion:** Doc published, all AC items addressed, cost/effort/FTE captured
+
+### Task 8.2 — Record recommendation on #1337
+- **Owner:** Pilot lead
+- **Touch:** Issue #1337 comment (via `gh issue comment`)
+- **Verify:** Comment present with GO/NO-GO/DEFER + trigger conditions + link to companion doc
+- **Rollback:** Edit comment
+- **Exit criterion:** Recommendation posted
+
+### Task 8.3 — Mark ADR-735 Action Item #1 complete
+- **Owner:** Architecture owner
+- **Touch:** `docs/01_ADR/ADR-735-future-analytics-platform-evaluation.md` (checklist line)
+- **Verify:** Markdown checkbox flipped to `[x]` in action items
+- **Rollback:** Revert edit
+- **Exit criterion:** ADR Action Item #1 marked complete
+
+### Task 8.4 — Pilot teardown (NEW from grill-me)
+- **Owner:** Pilot lead
+- **Touch:** None (runtime teardown)
+- **Verify:** `docker compose -f tools/iceberg-pilot/docker-compose.test.yml down -v` succeeds; `mc rb --force minio/iceberg-pilot` removes test bucket; `tools/iceberg-pilot/.env.test` deleted; `tools/iceberg-pilot/measurements/` archived to `docs/03_Technical_Guides/iceberg-evaluation-pilot-data-{date}.tar.gz`
+- **Rollback:** N/A (teardown is terminal)
+- **Exit criterion:** No residual test resources; pilot artifacts preserved in companion doc appendix
+- **Storage budget consumed (NEW):** Pilot must not consume >10GB MinIO storage; if exceeded, document reason and cost in companion doc
+
+---
+
+## Definition of Done
+
+- [ ] All acceptance criteria AC1–AC12 from spec pass
+- [ ] All 8 phase exit criteria above satisfied (Phase 4.3 crash recovery + Phase 8.4 teardown added)
+- [ ] Companion doc `docs/03_Technical_Guides/iceberg-evaluation.md` published with cost/effort/FTE/migration-effort sections
+- [ ] Recommendation recorded on issue #1337 with GO/NO-GO/DEFER + trigger conditions + companion doc link
+- [ ] ADR-735 Action Item #1 marked complete
+- [ ] No module code modified
+- [ ] No production deployment of Polaris/Nessie
+- [ ] Test namespace isolated; serving PG/Kafka untouched; pilot teardown verified
+- [ ] Verification log saved to `tools/iceberg-pilot/pilot-report.md`
+- [ ] Cost captured: storage GB consumed (≤10GB budget), compute hours, FTE estimate, migration weeks
+- [ ] Pilot teardown completed; no residual test resources on cluster
+
+## Rollback Strategy (per phase)
+
+| Phase | Rollback |
+|---|---|
+| 1 | Delete bucket; revert compose changes |
+| 2 | `docker compose -f tools/iceberg-pilot/docker-compose.test.yml down -v` |
+| 3 | `DROP TABLE landing.character_basic_pilot`; delete scripts |
+| 4 | Snapshot preserved; restore from prior snapshot ID; for crash recovery, drop orphan files via `remove_orphan_files` |
+| 5 | N/A (retention reversible) |
+| 6 | N/A (read-only) |
+| 7 | Stop cron; archive measurements dir |
+| 8 | Doc delete; ADR checkbox revert; issue comment edit; full teardown per 8.4 |
+
+## Verification Commands
+
+```bash
+# Phase 1
+mc admin info minio | grep -i release
+mc ls minio/iceberg-pilot
+mc ilm ls minio/iceberg-pilot  # confirm no lifecycle rules
+mc admin info minio | grep -i release
+mc ls minio/iceberg-pilot
+
+# Phase 2
+curl -fsS http://localhost:8181/healthcheck  # Polaris
+curl -fsS http://localhost:19120/api/v1/health  # Nessie fallback
+
+# Phase 3
+docker compose -f tools/iceberg-pilot/docker-compose.test.yml exec trino trino --execute "SELECT count(*) FROM iceberg.landing.character_basic_pilot"
+diff <(wc -l source_chunk.jsonl) <(trino --execute "SELECT count(*) FROM iceberg.landing.character_basic_pilot")
+
+# Phase 4
+docker compose -f tools/iceberg-pilot/docker-compose.test.yml exec spark-iceberg spark-sql -e "CALL iceberg.system.rewrite_data_files('landing.character_basic_pilot')"
+aws s3api list-objects-v2 --bucket iceberg-pilot --query 'Contents[].Size' | jq 'sort | (length/2|floor) as $m | .[$m]'
+# Phase 4.3 crash recovery
+docker compose -f tools/iceberg-pilot/docker-compose.test.yml exec spark-iceberg bash -c 'pkill -9 -f rewrite_data_files; sleep 5'
+docker compose -f tools/iceberg-pilot/docker-compose.test.yml exec spark-iceberg spark-sql -e "CALL iceberg.system.remove_orphan_files('landing.character_basic_pilot')"
+
+# Phase 5
+docker compose -f tools/iceberg-pilot/docker-compose.test.yml exec spark-iceberg spark-sql -e "CALL iceberg.system.expire_snapshots('landing.character_basic_pilot', retain_last => 7)"
+
+# Phase 6
+docker compose -f tools/iceberg-pilot/docker-compose.test.yml exec trino trino --execute "SELECT count(*) FROM iceberg.landing.character_basic_pilot FOR SYSTEM_TIME AS OF -7d"
+time trino --execute "SELECT ... FROM iceberg.landing.character_basic_pilot"
+
+# Phase 7
+ls -la tools/iceberg-pilot/measurements/
+
+# Phase 8
+gh issue view 1337 --comments | grep -i "GO\|NO-GO\|DEFER"
+grep -c "AC1[0-2]" docs/03_Technical_Guides/iceberg-evaluation.md
+grep "\[x\]" docs/01_ADR/ADR-735-future-analytics-platform-evaluation.md | grep -i iceberg
+# Phase 8.4 teardown
+docker compose -f tools/iceberg-pilot/docker-compose.test.yml down -v
+mc rb --force minio/iceberg-pilot
+rm -f tools/iceberg-pilot/.env.test
+```

--- a/docs/superpowers/plans/2026-06-23-minio-compatibility.md
+++ b/docs/superpowers/plans/2026-06-23-minio-compatibility.md
@@ -1,0 +1,330 @@
+# Plan: MinIO Compatibility Validation
+
+- Parent Issue: #1338
+- Spec: `docs/superpowers/specs/2026-06-23-minio-compatibility.md`
+- Date: 2026-06-23
+
+---
+
+## Phase 0 — Preflight (5 min)
+
+### T0.1 Confirm local MinIO is running
+
+- **Files touched**: none
+- **Verify**:
+  ```bash
+  source .env   # provides MINIO_ROOT_USER, MINIO_ROOT_PASSWORD, MINIO_ENDPOINT
+  curl -sf http://localhost:9000/minio/health/live && echo OK
+  mc alias set local "$MINIO_ENDPOINT" "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"
+  mc admin info local
+  ```
+- **Credentials sourcing**: All scripts load `source .env` before invoking `mc`/`aws s3api`. Per the project's `.claude/rules/critical-rules.md`, `.env` is read-only and never modified. If `MINIO_ROOT_USER/PASSWORD` are absent (e.g. CI without bootstrap), fall back to the per-module SA in `docker/services/secrets/sa-<module>.key` (read-only) for read-only tests; bucket-create/ILM/versioning tests still require root.
+- **Rollback**: N/A (read-only)
+- **Owner**: investigator
+
+### T0.2 Create test bucket
+
+- **Files touched**: none (test bucket lives in MinIO only)
+- **Verify**:
+  ```bash
+  mc mb local/maple-iceberg-test
+  mc anonymous set none local/maple-iceberg-test
+  ```
+- **Rollback**: `mc rb --force local/maple-iceberg-test`
+- **Owner**: investigator
+
+### T0.3 Create scripts directory
+
+- **Files touched**: `scripts/minio-compat/.gitkeep`
+- **Verify**: `ls scripts/minio-compat/`
+- **Rollback**: `rm -rf scripts/minio-compat/`
+- **Owner**: investigator
+
+---
+
+## Phase 1 — MinIO Version & Configuration Capture (10 min)
+
+### T1.1 Capture MinIO server version + release date
+
+- **Files touched**: `scripts/minio-compat/01-version.sh`
+- **Verify**:
+  ```bash
+  bash scripts/minio-compat/01-version.sh
+  # expected output: Version: RELEASE.2024-XX-XX, ReleaseDate: YYYY-MM-DD
+  ```
+- **Rollback**: N/A
+- **Owner**: investigator
+
+### T1.2 Document current bucket configuration
+
+- **Files touched**: `scripts/minio-compat/02-bucket-config.sh`
+- **Verify**:
+  ```bash
+  bash scripts/minio-compat/02-bucket-config.sh
+  # outputs: versioning status, lifecycle rules, retention, ILM prefixes
+  ```
+- **Rollback**: N/A
+- **Owner**: investigator
+
+---
+
+## Phase 2 — Tier 1 API Smoke Tests (20 min)
+
+### T2.1 Baseline 7 APIs (ListObjectsV2, GetObject, PutObject, CopyObject, DeleteObjects, HeadObject, HeadBucket)
+
+- **Files touched**: `scripts/minio-compat/03-tier1-baseline.sh`
+- **Verify**:
+  ```bash
+  bash scripts/minio-compat/03-tier1-baseline.sh
+  # expected: all 7 exit 0; output line per API: "PASS <api-name>"
+  ```
+- **Rollback**: `mc rm --recursive --force local/maple-iceberg-test`
+- **Owner**: investigator
+
+### T2.2 Multipart upload (single + multi-part)
+
+- **Files touched**: `scripts/minio-compat/04-multipart.sh`
+- **Verify**:
+  ```bash
+  bash scripts/minio-compat/04-multipart.sh
+  # expected: 5MB single-part upload PASS, 12MB 3-part multipart PASS
+  ```
+- **Rollback**: `mc rm --recursive --force local/maple-iceberg-test`
+- **Owner**: investigator
+
+---
+
+## Phase 3 — Tier 2 Conditional Writes + Versioning (20 min)
+
+### T3.1 Enable versioning on test bucket
+
+- **Files touched**: `scripts/minio-compat/05-versioning.sh`
+- **Verify**:
+  ```bash
+  bash scripts/minio-compat/05-versioning.sh
+  # expected: VersioningConfiguration Status=Enabled
+  mc version info local/maple-iceberg-test
+  ```
+- **Rollback**: `mc version suspend local/maple-iceberg-test`
+- **Owner**: investigator
+
+### T3.2 If-Match conditional PUT
+
+- **Files touched**: `scripts/minio-compat/06-conditional-ifmatch.sh`
+- **Verify**:
+  ```bash
+  bash scripts/minio-compat/06-conditional-ifmatch.sh
+  # expected:
+  #   1st PUT (no precondition) → 200, eTag captured
+  #   2nd PUT (If-Match=<etag>) → 200
+  #   3rd PUT (If-Match=wrong) → 412 PreconditionFailed
+  ```
+- **Rollback**: N/A
+- **Owner**: investigator
+
+### T3.3 If-None-Match: * (PUT-create)
+
+- **Files touched**: `scripts/minio-compat/07-conditional-ifnonematch.sh`
+- **Verify**:
+  ```bash
+  bash scripts/minio-compat/07-conditional-ifnonematch.sh
+  # expected:
+  #   1st PUT (If-None-Match: *) → 200
+  #   2nd PUT (If-None-Match: *) → 412
+  ```
+- **Rollback**: N/A
+- **Owner**: investigator
+
+### T3.4 Multipart copy
+
+- **Files touched**: `scripts/minio-compat/08-multipart-copy.sh`
+- **Verify**:
+  ```bash
+  bash scripts/minio-compat/08-multipart-copy.sh
+  # expected: upload-part-copy on each part returns 200; complete-multipart-upload returns 200
+  ```
+- **Rollback**: `mc rm --recursive --force local/maple-iceberg-test`
+- **Owner**: investigator
+
+---
+
+## Phase 4 — Lifecycle & Policy Review (15 min)
+
+### T4.1 Capture current ILM for `data/runs/{runId}/...`
+
+- **Files touched**: `scripts/minio-compat/09-lifecycle-capture.sh`
+- **Verify**:
+  ```bash
+  bash scripts/minio-compat/09-lifecycle-capture.sh
+  # outputs: existing ILM rules for snapshots/, runs/, calculator/, ocid-mapping/;
+  #          recommendation for data/runs/{runId}/... prefix
+  ```
+- **Rollback**: N/A
+- **Owner**: investigator
+
+### T4.2 Review existing SA policies (ext-api, calculator, synchronizer, cleanup)
+
+- **Files touched**: `scripts/minio-compat/10-policy-review.sh`
+- **Verify**:
+  ```bash
+  bash scripts/minio-compat/10-policy-review.sh
+  # outputs: each SA policy JSON; gap statement for analyst-readonly scenario
+  ```
+- **Rollback**: N/A
+- **Owner**: investigator
+
+---
+
+## Phase 5 — Per-Engine Smoke (60 min)
+
+### T5.1 Iceberg smoke
+
+- **Files touched**: `scripts/minio-compat/11-iceberg-smoke.sh`, `scripts/minio-compat/iceberg-requirements.txt` (PyIceberg==0.9.0, s3fs==2024.6.0, pyarrow)
+- **Catalog**: **Hadoop catalog** (`type=hadoop`, `s3.endpoint`, `s3.path-style-access=true`) — no REST catalog service required for smoke. PyIceberg CLI handles metadata writes via `s3fs` → `boto3` → MinIO. REST catalog (Polaris/Nessie) deferred to Phase 3.
+- **Verify**:
+  ```bash
+  bash scripts/minio-compat/11-iceberg-smoke.sh
+  # expected:
+  #   - PyIceberg installed in venv
+  #   - catalog init at s3://maple-iceberg-test/iceberg-smoke/db/tbl/
+  #   - pyiceberg append writes 100 rows → metadata.json v2 created
+  #   - pyiceberg read returns 100 rows
+  #   - aws s3api put-object --bucket maple-iceberg-test --key iceberg-smoke/db/tbl/metadata/... --if-match <stale> → 412
+  #   - aws s3api put-object --bucket maple-iceberg-test --key iceberg-smoke/db/tbl/metadata/... --if-match <current> → 200
+  ```
+- **Rollback**: `mc rm --recursive --force local/maple-iceberg-test/iceberg-smoke/ && rm -rf .venv-minio-compat/`
+- **Owner**: investigator
+
+### T5.2 Trino Hive connector smoke
+
+- **Files touched**:
+  - `scripts/minio-compat/12-trino-smoke.sh`
+  - `scripts/minio-compat/trino-compose.yml` (compose overlay: trino:435 + hive metastore; volumes; env: `S3_ENDPOINT=http://host.docker.internal:9000`, `S3_PATH_STYLE_ACCESS=true`)
+  - `scripts/minio-compat/trino-catalog/hive.properties` (connector.name=hive, hive.metastore.uri, hive.s3.endpoint, hive.s3.path-style-access=true)
+- **Verify**:
+  ```bash
+  bash scripts/minio-compat/12-trino-smoke.sh
+  # expected:
+  #   - docker compose -f trino-compose.yml up -d (idempotent)
+  #   - wait until `docker compose exec trino trino --execute 'SHOW CATALOGS'` returns hive
+  #   - CREATE SCHEMA hive.test WITH (location='s3://maple-iceberg-test/trino/');
+  #   - CREATE TABLE hive.test.t1 (id INT) WITH (format='PARQUET', external_location='s3://maple-iceberg-test/trino/t1/');
+  #   - INSERT INTO hive.test.t1 VALUES (1),(2),(3); SELECT * FROM hive.test.t1; → 3 rows
+  ```
+- **Rollback**: `docker compose -f scripts/minio-compat/trino-compose.yml down -v && mc rm --recursive --force local/maple-iceberg-test/trino/`
+- **Owner**: investigator
+
+### T5.3 Spark S3A smoke
+
+- **Files touched**: `scripts/minio-compat/13-spark-smoke.sh`, `scripts/minio-compat/Dockerfile.spark` (FROM apache/spark:3.5.1-python3, ADD hadoop-aws-3.3.4.jar + aws-java-sdk-bundle-1.12.262.jar to /opt/spark/jars/)
+- **Version coupling**: Spark 3.5.1 requires hadoop-aws-3.3.4 (matching Spark's bundled hadoop-common) and aws-java-sdk-bundle-1.12.262 (pinned to avoid transitive drift). Both jars bundled in Docker image to skip runtime download.
+- **Config**: `spark.hadoop.fs.s3a.endpoint=http://minio:9000`, `spark.hadoop.fs.s3a.path.style.access=true`, `spark.hadoop.fs.s3a.connection.ssl.enabled=false`, `spark.hadoop.fs.s3a.access.key`/`secret.key` from env.
+- **Verify**:
+  ```bash
+  bash scripts/minio-compat/13-spark-smoke.sh
+  # expected:
+  #   - docker build -f Dockerfile.spark -t spark-minio:smoke .
+  #   - spark-submit writes parquet to s3a://maple-iceberg-test/spark-smoke/
+  #   - spark-submit reads it back; row count matches
+  #   - fs.s3a.multipart.size=104857600 (100MB) and fs.s3a.multipart.threshold=104857600 confirmed via Spark conf dump
+  ```
+- **Rollback**: `docker rmi spark-minio:smoke && mc rm --recursive --force local/maple-iceberg-test/spark-smoke/`
+- **Owner**: investigator
+
+### T5.4 ClickHouse S3 disk smoke
+
+- **Files touched**: `scripts/minio-compat/14-clickhouse-smoke.sh`
+- **Verify**:
+  ```bash
+  bash scripts/minio-compat/14-clickhouse-smoke.sh
+  # expected:
+  #   - ClickHouse container started with S3 disk config
+  #   - CREATE TABLE ... ENGINE=MergeTree() SETTINGS storage_policy='s3_policy'
+  #   - INSERT → SELECT roundtrip succeeds
+  #   - conditional PUT (If-None-Match: *) on new metadata → 200
+  ```
+- **Rollback**: `docker compose -f scripts/minio-compat/clickhouse-compose.yml down -v`
+- **Owner**: investigator
+
+---
+
+## Phase 6 — Compatibility Matrix & Report (30 min)
+
+### T6.1 Build compatibility matrix
+
+- **Files touched**: `docs/03_Technical_Guides/minio-compatibility-report.md` (new)
+- **Verify**:
+  ```bash
+  ls -la docs/03_Technical_Guides/minio-compatibility-report.md
+  head -50 docs/03_Technical_Guides/minio-compatibility-report.md
+  # expected: matrix table populated with SUPPORTED/PARTIAL/UNSUPPORTED/NOT-TESTED
+  ```
+- **Rollback**: `rm docs/03_Technical_Guides/minio-compatibility-report.md`
+- **Owner**: investigator
+
+### T6.2 Open gap issues
+
+- **Files touched**: GitHub issues created via `gh issue create`
+- **Verify**:
+  ```bash
+  gh issue list --label minio-compat-gap --state open
+  # expected: ≥1 issue per Tier 2/3 gap found
+  ```
+- **Rollback**: close any premature issues
+- **Owner**: investigator
+
+---
+
+## Phase 7 — Cleanup (5 min)
+
+### T7.1 Remove test bucket
+
+- **Files touched**: none
+- **Verify**:
+  ```bash
+  mc rb --force local/maple-iceberg-test
+  mc ls local/ | grep -v maple-expectation || echo CLEAN
+  ```
+- **Rollback**: N/A (test data only)
+- **Owner**: investigator
+
+---
+
+## Verification Summary
+
+- `./gradlew compileKotlin compileJava --continue` — N/A (no app code changed; scripts only)
+- Smoke scripts: each `bash <script>.sh` exits 0 and prints PASS
+- Compatibility report: matrix complete, gaps triaged
+- GitHub issues: each gap → issue with `parent: #1338` reference
+
+## Cleanup-on-Exit Contract
+
+Every smoke script (T2.x, T3.x, T4.x, T5.x) MUST begin with a `trap` block so partial failures do not leave orphan containers, dangling test data, or half-stopped compose stacks:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+source .env
+mc alias set local "$MINIO_ENDPOINT" "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD" >/dev/null
+
+cleanup() {
+  rc=$?
+  echo "[cleanup] trap EXIT rc=$rc"
+  mc rm --recursive --force local/maple-iceberg-test/${SCRIPT_PREFIX:-}/ 2>/dev/null || true
+  [[ -n "${COMPOSE_FILE:-}" ]] && docker compose -f "$COMPOSE_FILE" down -v 2>/dev/null || true
+  [[ -n "${IMAGE_TAG:-}" ]] && docker rmi "$IMAGE_TAG" 2>/dev/null || true
+  exit $rc
+}
+trap cleanup EXIT INT TERM
+```
+
+`SCRIPT_PREFIX`, `COMPOSE_FILE`, `IMAGE_TAG` are set per script (e.g. T5.2 sets `COMPOSE_FILE=scripts/minio-compat/trino-compose.yml`). This guarantees the test environment is reset even if `set -e` aborts mid-run.
+
+## Rollback Summary
+
+- Test bucket: `mc rb --force local/maple-iceberg-test`
+- Versioning: `mc version suspend local/maple-iceberg-test` (irrelevant after bucket delete)
+- Scripts: `rm -rf scripts/minio-compat/`
+- Report: `rm docs/03_Technical_Guides/minio-compatibility-report.md`
+- Gap issues: close if opened in error
+- Orphan containers from aborted smoke: `docker compose -f scripts/minio-compat/{trino,clickhouse}-compose.yml down -v`; `docker rmi spark-minio:smoke`

--- a/docs/superpowers/plans/2026-06-23-pg-scalability-assessment.md
+++ b/docs/superpowers/plans/2026-06-23-pg-scalability-assessment.md
@@ -1,0 +1,195 @@
+# Plan — PostgreSQL Scalability Assessment
+
+- Issue: #1341
+- Parent ADR: docs/01_ADR/ADR-735-future-analytics-platform-evaluation.md
+- Spec: docs/superpowers/specs/2026-06-23-pg-scalability-assessment.md
+- Date: 2026-06-23
+
+**Phases:** Phase 1 baseline → Phase 2 index experiments → Phase 3 mat view experiments → Phase 4 storage projection + T1/T2 verdict → Phase 5 findings ADR.
+
+All experiments run on **staging PG** (not production). No production schema change.
+
+---
+
+## Phase 1 — Baseline capture
+
+### Task 1.1: Verify pg_stat_statements enabled
+- **Name:** Pre-check pg_stat_statements availability
+- **Scripts:**
+  ```sql
+  SHOW shared_preload_libraries;
+  SELECT * FROM pg_available_extensions WHERE name = 'pg_stat_statements';
+  ```
+- **Output:** `phase1/pg_stat_precheck.txt` (status: enabled | missing).
+- **Verification:** If missing, file pre-req issue; do not proceed with 1.2 until enabled.
+
+### Task 1.2: Capture 24h pg_stat_statements snapshot
+- **Name:** 24h workload mix capture
+- **Scripts:**
+  ```sql
+  SELECT queryid, calls, total_exec_time, mean_exec_time, rows, query
+  FROM pg_stat_statements
+  ORDER BY total_exec_time DESC LIMIT 50;
+  ```
+  Run hourly for 24h. Persist snapshots to `phase1/pg_stat_hourly_{NN}.csv`. Concatenate into `pg_stat_24h.csv`.
+- **Output:** `phase1/pg_stat_top50.csv`, `phase1/pg_stat_slow_calls.csv` (top-20 by mean).
+- **Verification:** 24 snapshots, sum of `total_exec_time` within 10% of `pg_stat_database.total_time`.
+
+### Task 1.3: Per-character serving latency sample
+- **Name:** 10K IGN latency benchmark
+- **Scripts:** Python driver: 10K IGN sample from `userIgn_List.csv`; 50 concurrent workers; split warm (L1 hit) vs cold (L1 miss). Each: `GET /api/v5/characters/{ign}/expectation`, record latency_ms, status, cache_tier.
+- **Output:** `phase1/perchar_latency.csv`.
+- **Verification:** ≥ 95% HTTP 200; warm p95 < 50ms; cold p95 < 200ms (per ADR-735 §4).
+
+### Task 1.4: Slow query log capture
+- **Name:** 7-day slow query aggregation
+- **Scripts:** Set `log_min_duration_statement=1000`, `log_lock_waits=on`, `log_temp_files=0` on staging PG. After 7 days, parse log file via `pg_log_statements.py` (or equivalent). Aggregate by normalized query fingerprint.
+- **Output:** `phase1/slow_query_aggregate.csv` (fingerprint, calls, total_time, mean_time, max_time).
+- **Verification:** ≥ 100 sample queries logged; report top-20 by total_time.
+
+---
+
+## Phase 2 — Index experiments
+
+### Task 2.1: Synthetic 1B-row dataset on staging
+- **Name:** Build 1B-row benchmark dataset
+- **Scripts:** pg_dump schema of `character_valuation_views`; populate via `generate_series` + skew-preserving distribution (90% under $100M, 9% $100M-1B, 1% $1B+); restore into staging. ~1.2TB on disk.
+- **Output:** `phase2/synth_1b_create.sql`, `phase2/synth_1b_size.txt` (table_size, index_size).
+- **Verification:** `SELECT count(*) = 1,000,000,000`; row size histogram matches real `pg_stats`.
+
+### Task 2.2: EXPLAIN ANALYZE on top-5 patterns
+- **Name:** Capture baseline plans
+- **Scripts:** Five queries per spec §4.1.4:
+  1. Top-N per (world, class) — `ORDER BY total_cost DESC LIMIT 100`.
+  2. World rollup — `SELECT world_name, count(*), avg(total_cost) GROUP BY world_name`.
+  3. Level-range histogram — `SELECT character_level/10 AS bucket, count(*) GROUP BY bucket`.
+  4. Time-windowed expectation drift — `WHERE calculated_at > NOW()-INTERVAL '7d'`.
+  5. Cross-class percentile — `percentile_cont(0.95) WITHIN GROUP (ORDER BY total_cost)`.
+  For each: `EXPLAIN (ANALYZE, BUFFERS, VERBOSE, TIMING) > phase2/q{N}_baseline.txt`.
+- **Output:** `phase2/q{1..5}_baseline.txt`.
+- **Verification:** Each query runs to completion; plan shows expected index/seq scan choice.
+
+### Task 2.3: BRIN on updated_at (I1)
+- **Name:** Index experiment I1
+- **Scripts:**
+  ```sql
+  CREATE INDEX idx_brin_updated_at ON character_valuation_views
+    USING BRIN (updated_at) WITH (pages_per_range = 32);
+  ANALYZE character_valuation_views;
+  ```
+  Run q4 (time-windowed) 100x cold. Capture latency per run.
+- **Output:** `phase2/i1_brin.csv` (run, latency_ms, buffers_hit, buffers_read). Drop index after.
+- **Verification:** p95 of time-windowed query reduced ≥2x vs baseline OR explicit "no improvement" recorded.
+
+### Task 2.4: Partial index on hot combos (I2)
+- **Name:** Index experiment I2
+- **Scripts:**
+  - Extract top-100 (class, world) from `pg_stat_statements` (or hot set from 1.2 workload mix).
+  - `CREATE INDEX idx_hot_class_world_cost ON character_valuation_views (character_class, world_name, total_cost DESC) WHERE character_class IN (...)`.
+  - Run q1 (Top-N per class/world) 100x cold.
+- **Output:** `phase2/i2_partial.csv`.
+- **Verification:** Top-N p95 reduced ≥2x OR "no improvement" recorded. Drop index after.
+
+### Task 2.5: Covering index for Top-N (I3)
+- **Name:** Index experiment I3
+- **Scripts:**
+  ```sql
+  CREATE INDEX idx_cover_world_class_cost ON character_valuation_views
+    (world_name, character_class, total_cost DESC)
+    INCLUDE (user_ign, ocid);
+  ```
+  Run q1 100x cold. Check `EXPLAIN` for `Index Only Scan`.
+- **Output:** `phase2/i3_covering.csv`, `phase2/i3_plan.txt`.
+- **Verification:** Plan uses Index Only Scan; p95 reduced vs baseline. Drop index after.
+
+### Task 2.6: RANGE partitioning by calculated_at (I4)
+- **Name:** Index experiment I4
+- **Scripts:** Recreate `character_valuation_views` as PARTITION BY RANGE (calculated_at) with daily partitions for 90 days. Run q4 (7-day window) 100x cold; check partition pruning in plan.
+- **Output:** `phase2/i4_partition.csv`, `phase2/i4_plan.txt` (showing `Partitions selected: 7`).
+- **Verification:** Plan prunes to ≤7 partitions; q4 p95 reduced ≥3x. Document UPSERT compatibility constraint.
+
+---
+
+## Phase 3 — Materialized view experiments
+
+### Task 3.1: Build mat view candidates
+- **Name:** Create mat view schemas
+- **Scripts:**
+  - `mv_topn_hourly`: Top-100 per (world, class) for last 1h. UNIQUE INDEX `(world_name, character_class, user_ign)`.
+  - `mv_world_rollup_daily`: daily world rollup. UNIQUE INDEX `(world_name, day_bucket)`.
+  - `mv_class_percentile_weekly`: weekly cross-class percentile. UNIQUE INDEX `(character_class, week_bucket)`.
+- **Output:** `phase3/mv_create.sql`.
+- **Verification:** Each mat view created with valid UNIQUE INDEX enabling `CONCURRENTLY` refresh.
+
+### Task 3.2: Refresh experiment
+- **Name:** CONCURRENTLY vs full refresh benchmark
+- **Scripts:** At 100M, 500M, 1B rows: run `REFRESH MATERIALIZED VIEW mv_topn_hourly` (full) and `REFRESH MATERIALIZED VIEW CONCURRENTLY mv_topn_hourly`. Capture duration, lock duration (from `pg_stat_activity`).
+- **Output:** `phase3/mv_refresh.csv` (row_count, mode, duration_s, lock_duration_s).
+- **Verification:** CONCURRENTLY takes ≤2x full but allows serving reads throughout. Lock duration = 0 for CONCURRENTLY.
+
+### Task 3.3: Mat view refresh strategy recommendation
+- **Name:** Per-pattern cadence mapping
+- **Scripts:** Document per spec §4.3 which pattern gets hourly/daily/weekly/on-demand. Include Airflow DAG references for daily+.
+- **Output:** `phase3/mv_strategy.md` (table: pattern → cadence → DAG → last_refresh column → stale_tolerance).
+- **Verification:** Every mat view has documented refresh DAG or explicit on-demand trigger; storage estimate ≤5% of base.
+
+---
+
+## Phase 4 — Storage projection + T1/T2 verdict
+
+### Task 4.1: Storage projection
+- **Name:** 30/90/365-day disk usage model
+- **Scripts:** Spreadsheet or SQL compute using spec §4.4 inputs. Compute heap, index, WAL/FMV for 30/90/365d; sensitivity ±20%.
+- **Output:** `phase4/storage_projection.csv` (window, rows, heap_gb, index_gb, wal_gb, total_gb, sens_low, sens_high).
+- **Verification:** All 9 columns populated; sensitivity bounds non-negative.
+
+### Task 4.2: p95 vs row count curve
+- **Name:** Synthetic benchmark at multiple scales
+- **Scripts:** Reuse q1-q5 from Phase 2. Run at 100M, 250M, 500M, 750M, 1B, 1.5B, 2B (scaled-down versions of 1B dataset). Capture p50/p95/p99 per row count per query.
+- **Output:** `phase4/scaling.csv` (query_id, row_count, p50, p95, p99, buffers_read, temp_spill).
+- **Verification:** All 7 row counts × 5 queries = 35 rows; p95 monotonically non-decreasing per query.
+
+### Task 4.3: T1 crossover analysis
+- **Name:** Identify crossover row count
+- **Scripts:** From `phase4/scaling.csv`, find row_count where p95 ≥ 10s per query. Plot `phase4/t1_crossover.png`.
+- **Output:** `phase4/crossover_by_query.csv` (query_id, crossover_row_count, today_30d=1.2B, today_90d=3.6B, today_365d=14.6B, verdict).
+- **Verification:** Each query has explicit verdict per spec §4.5 (VALIDATED / NOT YET / INVALID).
+
+### Task 4.4: T2 DB CPU share
+- **Name:** Peak-hour analytical CPU share
+- **Scripts:** During production peak (18:00-24:00 KST, sampled every 5 min for 7 days), capture `pg_stat_activity` + `pg_stat_database`. Compute analytical query share = sum of `cpu_time` for queries matching analytical patterns / total DB CPU.
+- **Output:** `phase4/t2_cpu_share.csv` (timestamp, total_db_cpu_s, analytical_cpu_s, share_pct).
+- **Verification:** T2 verdict: peak share > 20% (VALIDATED) or ≤ 20% (NOT YET).
+
+---
+
+## Phase 5 — Findings ADR
+
+### Task 5.1: Draft findings ADR
+- **Name:** Publish ADR-1341 findings
+- **Scripts:** Write `docs/01_ADR/ADR-1341-pg-scalability-findings.md` per spec §4.6. Sections: methodology, workload mix, per-character serving, analytical p95 curve, index matrix, mat view strategy, storage projection, T1/T2 verdict, recommendation.
+- **Output:** ADR file.
+- **Verification:** All 9 sections present; recommendation explicitly addresses ADR-735 owner (keep PG-only / defer Phase 1 / escalate).
+
+### Task 5.2: Cross-link to parent ADR
+- **Name:** Update ADR-735 references
+- **Scripts:** Add link from ADR-735 §4 Evidence to ADR-1341 findings. Add to Action Items table.
+- **Output:** Edits to `docs/01_ADR/ADR-735-future-analytics-platform-evaluation.md`.
+- **Verification:** Link present, action item marked done.
+
+---
+
+## Verification commands (per project rules)
+
+```bash
+./gradlew compileKotlin compileJava --continue   # if any code touched (none in this plan)
+./gradlew test                                    # if any code touched (none)
+```
+
+This plan produces only documentation + CSV outputs + staging SQL. No code change. No production migration. Per workflow-rules §10 Definition of Done: skip runtime server verification (no code change to verify).
+
+## Risks summary
+
+- **pg_stat_statements not enabled** → file pre-req issue (Task 1.1).
+- **1B-row synthetic dataset** → 1.2TB staging disk; coordinate with infra (Task 2.1).
+- **Mat view CONCURRENTLY requires UNIQUE INDEX** → design constraint documented in 3.1.

--- a/docs/superpowers/plans/2026-06-23-query-engine-benchmark.md
+++ b/docs/superpowers/plans/2026-06-23-query-engine-benchmark.md
@@ -1,0 +1,223 @@
+# Plan: Query Engine Benchmark (Issue #1340)
+
+- Spec: `docs/superpowers/specs/2026-06-23-query-engine-benchmark.md`
+- Parent: Issue #1340
+- Date: 2026-06-23
+
+Phases run sequentially. Each phase produces artifacts and a verification gate before next phase.
+
+---
+
+## Phase 1 — Dataset Generation
+
+### Task 1.1 — Write generator script
+- **Path**: `docs/03_Technical_Guides/_bench/gen_data.py`
+- **Stack**: Python 3.11, numpy, pyarrow, pandas (read-only prod sample)
+- **Inputs**:
+  - Production sample CSV: pull anonymized class/world/level counts from `character_valuation_views` snapshot 2026-06-15 via JDBC query (read-only)
+  - Seed: 20260623
+- **Outputs**:
+  - `docs/03_Technical_Guides/_bench/gen_data.py`
+  - `/tmp/benchmark/data/characters_1b.parquet`
+  - `/tmp/benchmark/data/characters_10b.parquet`
+  - `/tmp/benchmark/data/manifest.json` (row count, schema, size)
+- **Verification**:
+  - `python gen_data.py --rows 1000 --out /tmp/smoke.parquet` produces valid Parquet
+  - `python -c "import pyarrow.parquet as pq; t=pq.read_table('/tmp/smoke.parquet'); print(t.num_rows, t.schema)"` shows 1000 rows + 12 cols
+  - Distribution check: class histogram matches production distribution within ±5%
+
+### Task 1.2 — Generate 1B-row dataset
+- **Output**: `/tmp/benchmark/data/characters_1b.parquet` (~700GB)
+- **Estimated time**: 30-60 min on 8 vCPU
+- **Verification**:
+  - File exists, size > 500GB
+  - `manifest.json` records `{"rows": 1_000_000_000, "bytes": ...}`
+
+### Task 1.3 — Generate 10B-row dataset
+- **Output**: `/tmp/benchmark/data/characters_10b.parquet` (~7TB)
+- **Estimated time**: 4-8 hours (run overnight or skip if 1TB sufficient)
+- **Verification**: same as 1.2 with 10× scale
+
+---
+
+## Phase 2 — PostgreSQL Baseline
+
+### Task 2.1 — Spin up PG 16.3 container
+- **Script**: `docs/03_Technical_Guides/_bench/up_pg.sh`
+- **Image**: `postgres:16.3`
+- **Resources**: 8 vCPU, 32GB RAM (1TB); 16 vCPU, 64GB RAM (10TB)
+- **Mount**: `/tmp/benchmark/data` → `/data` in container
+- **Verification**: `docker exec pg16 pg_isready` returns 0; `SELECT version()` reports 16.3
+
+### Task 2.2 — Load data
+- **Approach**: `COPY characters FROM '/data/characters_{1b,10b}.parquet'` via `pgfutter` or split CSV
+- **Indexes**: btree on (class, world), btree on (level), btree on (snapshot_ts)
+- **Script**: `docs/03_Technical_Guides/_bench/load_pg.sh`
+- **Verification**: `SELECT count(*) FROM characters` matches dataset row count
+
+### Task 2.3 — Run benchmark cells (PG)
+- **Script**: `docs/03_Technical_Guides/_bench/run_pg.sh`
+- **Cells**: 4 workloads × 2 scales × 2 cache states = 16 cells
+- **Per cell**: 3 warm-up + 5 timed runs; metrics → `/tmp/benchmark/results/pg_{workload}_{scale}_{cache}.json`
+- **Cache drop**: `docker exec pg16 psql -c "SELECT pg_prewarm(...)"` reset; OS cache drop on host
+- **Verification**: 16 JSON files exist; each has p50, p95, p99, peak_mem_mb, spill_bytes, row_count
+
+### Task 2.4 — Report PG baseline section
+- **Output**: intermediate JSON summary at `/tmp/benchmark/results/pg_summary.json`
+- **Verification**: JSON parses; rows match between cells
+
+---
+
+## Phase 3 — ClickHouse
+
+### Task 3.1 — Spin up ClickHouse 24.5 container
+- **Script**: `docs/03_Technical_Guides/_bench/up_ch.sh`
+- **Image**: `clickhouse/clickhouse-server:24.5`
+- **Resources**: same as PG
+- **Mount**: `/tmp/benchmark/data` → `/data`
+- **Verification**: `curl http://localhost:8123/` returns OK; `SELECT version()` reports 24.5
+
+### Task 3.2 — Create table + load
+- **DDL**: `CREATE TABLE characters (...) ENGINE=MergeTree ORDER BY (class, world, level)`
+- **Load**: `INSERT INTO characters FROM '/data/characters_{1b,10b}.parquet'`
+- **Script**: `docs/03_Technical_Guides/_bench/load_ch.sh`
+- **Verification**: `SELECT count(*) FROM characters` matches dataset
+
+### Task 3.3 — Run benchmark cells (CH)
+- **Script**: `docs/03_Technical_Guides/_bench/run_ch.sh`
+- **Cells**: 16 (same matrix as PG)
+- **Per cell**: same protocol; cache drop via `SYSTEM DROP MARK CACHE; SYSTEM DROP UNCOMPRESSED CACHE`
+- **Verification**: 16 JSON files; spill bytes from `system.metrics` `DiskSpill`
+
+### Task 3.4 — Report CH section
+- **Output**: `/tmp/benchmark/results/ch_summary.json`
+- **Verification**: JSON valid
+
+---
+
+## Phase 4 — Trino
+
+### Task 4.1 — Spin up Trino 446 container
+- **Script**: `docs/03_Technical_Guides/_bench/up_trino.sh`
+- **Image**: `trinodb/trino:446`
+- **Connector**: Hive connector pointing at `/data` for Parquet
+- **Resources**: same as PG/CH
+- **Verification**: `trino --execute "SELECT 1"` returns 1
+
+### Task 4.2 — Configure Hive connector
+- **Catalog config**: `docs/03_Technical_Guides/_bench/trino-catalog/hive.properties`
+- **Schema**: `CREATE SCHEMA bench WITH (location = 'file:///data')`
+- **Table**: `CREATE TABLE bench.characters (...) WITH (format = 'PARQUET', external_location = 'file:///data/characters_1b.parquet')`
+- **Verification**: `SHOW TABLES FROM bench.characters` returns `characters`
+
+### Task 4.3 — Run benchmark cells (Trino)
+- **Script**: `docs/03_Technical_Guides/_bench/run_trino.sh`
+- **Cells**: 16
+- **Cache drop**: restart coordinator container between cold cells
+- **Verification**: 16 JSON files
+
+### Task 4.4 — Report Trino section
+- **Output**: `/tmp/benchmark/results/trino_summary.json`
+
+---
+
+## Phase 5 — Spark
+
+### Task 5.1 — Spin up Spark 3.5.2 container
+- **Script**: `docs/03_Technical_Guides/_bench/up_spark.sh`
+- **Image**: `apache/spark:3.5.2`
+- **Resources**: same
+- **Mount**: `/tmp/benchmark/data`
+- **Verification**: `spark-shell --version` reports 3.5.2
+
+### Task 5.2 — Load Parquet → Spark table
+- **Approach**: `spark.sql("CREATE TABLE characters USING parquet LOCATION '/data/characters_1b.parquet'")` (or read directly in queries)
+- **Script**: `docs/03_Technical_Guides/_bench/run_spark.sh`
+- **Verification**: `SELECT count(*) FROM characters` matches
+
+### Task 5.3 — Run benchmark cells (Spark)
+- **Cells**: 16
+- **Cache drop**: `spark.catalog.clearCache()`; drop OS cache
+- **Cold-start overhead**: report separately as `cold_start_ms` per query
+- **Verification**: 16 JSON files; each includes `cold_start_ms`
+
+### Task 5.4 — Report Spark section
+- **Output**: `/tmp/benchmark/results/spark_summary.json`
+
+---
+
+## Phase 6 — Final Report
+
+### Task 6.1 — Aggregate all cell JSONs
+- **Script**: `docs/03_Technical_Guides/_bench/aggregate.py`
+- **Output**: `/tmp/benchmark/results/all_cells.json` (64 records)
+
+### Task 6.2 — Render markdown report
+- **Script**: `docs/03_Technical_Guides/_bench/render_report.py`
+- **Output**: `docs/03_Technical_Guides/query-engine-benchmark.md`
+- **Sections**:
+  - Test setup
+  - Per-workload comparison table (4 tables, one per workload)
+  - Cross-workload summary (engine wins per workload per scale)
+  - Per-workload recommendations with ADR-735 trigger mapping
+  - Caveats
+
+### Task 6.3 — Verification
+- [ ] `docs/03_Technical_Guides/query-engine-benchmark.md` exists
+- [ ] Contains 4 workload tables
+- [ ] Contains winner per workload per scale
+- [ ] Recommendations cite ADR-735 §2 triggers
+- [ ] No production code modified: `git diff --stat` shows only `docs/03_Technical_Guides/`
+
+---
+
+## Issue Cross-References
+
+Each phase becomes a GitHub issue cross-referenced to #1340.
+
+| Issue | Phase | Title |
+|-------|-------|-------|
+| #TBD-1 | 1.1 | Write benchmark dataset generator script |
+| #TBD-2 | 1.2 | Generate 1B-row synthetic dataset |
+| #TBD-3 | 1.3 | Generate 10B-row synthetic dataset (optional, overnight) |
+| #TBD-4 | 2.* | PostgreSQL 16.3 baseline benchmark |
+| #TBD-5 | 3.* | ClickHouse 24.5 benchmark |
+| #TBD-6 | 4.* | Trino 446 benchmark |
+| #TBD-7 | 5.* | Spark 3.5.2 benchmark |
+| #TBD-8 | 6.* | Aggregate and publish final report |
+
+---
+
+## Verification Gates
+
+- After Phase 1: dataset manifest validates; row counts match expectations
+- After each engine phase: 16 JSON files present + JSON valid + per-cell row count sanity
+- After Phase 6: report file exists + recommendation section cites ADR-735
+
+---
+
+## Grill-Me: 5 Hard Questions
+
+1. **Q: 1B rows on a single host is not 10B. Will the 1TB cell actually stress the engines, or just stress PG's planner?**
+   A: 1B rows is sufficient to differentiate engines on grouped aggregates (W1/W2), but Trino/Spark are designed for distributed shuffle and may show unrealistically poor single-node numbers. Mitigation: report the single-node p95 as a "lower bound" for distributed Trino/Spark and use the engine's published distributed benchmarks (ClickBench) for cross-reference.
+
+2. **Q: Synthetic data with seeded RNG cannot reproduce production skew. Class histograms match but joint distributions (class × level × world) won't.**
+   A: True. Spec §3 accepts this. Mitigation: the 4 workloads target different cardinalities (40 classes, 50 worlds, 300 levels, 90 days), so individual workload results are interpretable even if joint distribution drifts. Document this caveat prominently in the report.
+
+3. **Q: Trino reads Parquet via Hive connector, not Iceberg. Does this miss the Iceberg value-prop (hidden partitioning, time-travel)?**
+   A: Yes. Trino-on-Hive-Parquet is the worst case for Trino; Iceberg would help. Mitigation: keep this benchmark as "baseline Trino" and flag in the report that Iceberg-specific benefits are not measured. A follow-up benchmark (Iceberg+Trino) is out of scope per #1340.
+
+4. **Q: Dropping OS cache between cold runs takes 5-10s per drop × 320 timed runs = 25-50 min just on cache drops.**
+   A: True. Cold-cache runs dominate wall-clock. Mitigation: warm-cache cells run first (cache stays hot throughout); cold-cache cells run last per workload with cache drop between. Saves ~30 min wall-clock.
+
+5. **Q: Spark cold-start (10-30s) will dominate p99 for small queries. Reporting p99 across cold+warm conflates "engine slowness" with "startup overhead".**
+   A: True. Mitigation: report cold-start as separate metric (`cold_start_ms`) per cell. Aggregate p99 excludes the first query's cold-start by dropping the first of 5 timed runs (4 used).
+
+---
+
+## Out-of-Scope Reminders
+
+- No `.env` changes
+- No production DB writes
+- No Calculator/synchronizer/REST module changes
+- No cluster deployment (ClickHouse Keeper, Spark K8s)

--- a/docs/superpowers/plans/2026-06-23-serving-analytics-separation.md
+++ b/docs/superpowers/plans/2026-06-23-serving-analytics-separation.md
@@ -1,0 +1,195 @@
+# Plan: Serving Layer vs Analytics Layer Separation
+
+- Date: 2026-06-23
+- Spec: `docs/superpowers/specs/2026-06-23-serving-analytics-separation.md`
+- Parent issue: #1344
+- Module-rule baseline: `.claude/rules/module-boundaries.md`
+
+---
+
+## Phase 1 — Consumer matrix (investigative)
+
+### Task 1.1: Document consumer matrix
+
+- **Scope**: write `/home/maple/probabilistic-valuation-engine/docs/03_Technical_Guides/analytics-consumer-matrix.md` with the 5-row consumer table from spec §4.1
+- **Inputs**: spec §4.1; ADR-735 §1 volume metrics
+- **ADR section to update**: append reference line in `ADR-735 §5 References`
+- **Verification**:
+  - File exists and contains all 5 consumers (REST, dashboard, analyst, ML, training)
+  - Latency/freshness/consistency/cache/engine columns filled for every row
+
+### Task 1.2: Document data flow decision
+
+- **Scope**: write `/home/maple/probabilistic-valuation-engine/docs/03_Technical_Guides/analytics-data-flow.md` capturing the Kafka-observer-first decision and the rejected alternatives (CDC, direct Iceberg write, batch ETL)
+- **Inputs**: spec §4.3; ADR-013 (Kafka pipeline); ADR-735 §2 non-risk on Calculator
+- **ADR section to update**: append reference line in `ADR-735 §5 References`
+- **Verification**:
+  - File lists chosen approach + 3 rejected alternatives with reason
+  - Diagram matches spec §4.3 ASCII
+
+## Phase 2 — Port contracts (module-core, framework-free)
+
+### Task 2.1: Define `AnalyticsQueryPort`
+
+- **Scope**: create `module-core/.../core/port/out/analytics/AnalyticsQueryPort.kt` with the three typed query methods (`topNByClass`, `levelRangeRollup`, `expectationDrift`)
+- **Inputs**: spec §4.4 signatures
+- **ADR section to update**: append "AnalyticsQueryPort" to `ADR-041 §3.5` outbound ports list
+- **Verification**:
+  ```bash
+  grep -rn "AnalyticsQueryPort" module-core/src/main/java | wc -l    # ≥ 1
+  grep -rE "@(Component|Service|Repository|Configuration)" module-core/src/main/java/.../analytics/ | wc -l   # 0
+  ./gradlew :module-core:compileKotlin
+  ```
+
+### Task 2.2: Define `IcebergSnapshotPort`
+
+- **Scope**: create `module-core/.../core/port/out/analytics/IcebergSnapshotPort.kt` with `listSnapshots`, `timeTravel`
+- **Inputs**: spec §4.4 signatures
+- **ADR section to update**: append "IcebergSnapshotPort" to `ADR-041 §3.5` outbound ports list
+- **Verification**: same checks as Task 2.1, plus `grep` for any `org.apache.iceberg` import in module-core must return 0.
+
+### Task 2.3: Extend ArchUnit rule for analytics purity
+
+- **Scope**: extend `module-app/src/test/java/maple/expectation/architecture/ArchitectureTest.java` rule `app_should_not_depend_on_infra_implementation` to also forbid `module-app` and `module-core` from referencing engine packages (`com.clickhouse`, `org.apache.iceberg`, `io.trino`, `org.apache.spark`)
+- **Inputs**: existing ArchUnit test; engine package names
+- **ADR section to update**: extend `ADR-041 §4.3` test snippet
+- **Verification**:
+  ```bash
+  ./gradlew :module-app:test --tests "maple.expectation.architecture.ArchitectureTest"
+  ```
+
+## Phase 3 — Adapter placement (module-infra, conditional)
+
+### Task 3.1: Conditional adapter stubs
+
+- **Scope**: create `module-infra/.../adapter/outgoing/analytics/ClickHouseAnalyticsQueryAdapter.kt` and `IcebergSnapshotAdapter.kt` and `TrinoQueryAdapter.kt` — each annotated `@ConditionalOnProperty(name = "analytics.engine", havingValue = "<engine>")` and `implements <Port>`. Stub methods throw `UnsupportedOperationException` (this task is investigation-only — no engine wiring).
+- **Inputs**: spec §4.2 adapter placement; ADR-044 (LogicExecutor for try-catch avoidance)
+- **ADR section to update**: append adapter list to `ADR-041 §3.5` secondary-adapter diagram
+- **Verification**:
+  ```bash
+  grep -rn "@ConditionalOnProperty" module-infra/src/main/java/.../analytics/ | wc -l   # 3
+  ./gradlew :module-infra:compileKotlin
+  ./gradlew :module-app:bootRun --args='--spring.profiles.active=test' &
+  sleep 30
+  curl -sf http://localhost:8080/actuator/beans | grep -i analytics   # empty (engine=none default)
+  ```
+
+### Task 3.2: Default config isolation
+
+- **Scope**: ensure `application.yml` (all profiles) has `analytics.engine: none` documented as a comment block; verify no `@Bean` factory in `module-app/.../config/` is annotated unconditionally with analytics types
+- **Inputs**: existing YAML structure; spec §4.2 default
+- **ADR section to update**: none (config only)
+- **Verification**:
+  ```bash
+  grep -rn "analytics.engine" --include="application*.yml" .
+  ./gradlew test  # existing test suite still passes
+  ```
+
+## Phase 4 — Failure isolation & docs
+
+### Task 4.1: Failure isolation matrix
+
+- **Scope**: extend `/home/maple/probabilistic-valuation-engine/docs/03_Technical_Guides/analytics-failure-isolation.md` with the 6-row table from spec §4.5
+- **Inputs**: spec §4.5; ADR-052 (Resilience4j circuit breaker)
+- **ADR section to update**: append reference in `ADR-735 §5 References`
+- **Verification**:
+  - File exists; all 6 failure modes listed; "Serving" column = "Unaffected" or "Existing"
+
+### Task 4.2: Update ADR-735 references
+
+- **Scope**: append new doc references (`analytics-consumer-matrix.md`, `analytics-data-flow.md`, `analytics-failure-isolation.md`) to `ADR-735 §5 References`
+- **Inputs**: Task 1.1, 1.2, 4.1 outputs
+- **ADR section to update**: `ADR-735 §5 References` only
+- **Verification**:
+  ```bash
+  grep -E "analytics-(consumer-matrix|data-flow|failure-isolation)" docs/01_ADR/ADR-735-*.md
+  ```
+
+### Task 4.3: Cross-link from spec & plan
+
+- **Scope**: add "Companion issues" line to spec §7 referencing the issues created from this plan (to-issues stage output)
+- **Inputs**: GitHub issue numbers from to-issues stage
+- **ADR section to update**: none
+- **Verification**: spec §7 lists all 8 created issues
+
+---
+
+## Verification matrix (final)
+
+| Check | Command | Expected |
+|-------|---------|----------|
+| module-core Spring-free | `grep -rE "@(Component|Service|Repository|Configuration)" module-core/src/main/java/ | wc -l` | 0 |
+| module-core engine-free | `grep -rE "com\.clickhouse\|org\.apache\.iceberg\|io\.trino\|org\.apache\.spark" module-core/src/main/java/ | wc -l` | 0 |
+| Port interfaces present | `grep -rn "AnalyticsQueryPort\|IcebergSnapshotPort" module-core/src/main/java` | ≥ 2 files |
+| Adapter stubs conditional | `grep -rn "@ConditionalOnProperty.*analytics.engine" module-infra/src/main/java/.../analytics/` | 3 |
+| Default profile silent | `curl -sf http://localhost:8080/actuator/beans 2>/dev/null | grep -i analytics` (with `analytics.engine=none`) | empty |
+| ArchUnit passes | `./gradlew :module-app:test --tests "maple.expectation.architecture.ArchitectureTest"` | BUILD SUCCESSFUL |
+| Full test suite | `./gradlew test` | BUILD SUCCESSFUL |
+| Calculator untouched | `git diff --stat HEAD -- module-calculator module-synchronizer module-external-api` | empty |
+
+---
+
+## Out of scope (confirm)
+
+- No ClickHouse / Iceberg / Trino / Spark client wiring
+- No new REST endpoint on `/api/v5`
+- No module restructuring
+- No calculator hot-path changes
+- No Kafka topic creation (left to Phase 1 implementation ADR, fires after T1/T2/T3)
+
+---
+
+## Status
+
+Proposed. Architectural-design tasks only. Each task is bounded; no engine implementation.
+
+---
+
+## Grill-me (5 hard questions, patched in place)
+
+### Q1: Why does the port interface live in `module-core` and not in a new `module-analytics-core`?
+
+If `module-core` is the framework-free domain layer for the entire application, adding ports that **only fire under `@ConditionalOnProperty`** arguably pollutes the always-loaded domain with optional capability. A new `module-analytics-core` subpackage (or even module) would signal "this is conditionally loaded" at the build-graph level, not just the bean-graph level.
+
+**Resolution (best practice, accepted)**: keep ports in `module-core/.../core/port/out/analytics/`. Reasons:
+- ADR-041 §3.5 establishes a single hexagonal core; ADR-050's roadmap tracks any future module extraction.
+- Interface definitions carry zero runtime cost — `@ConditionalOnProperty` lives on adapters, not ports.
+- Splitting core fragments the ArchUnit rule set and breaks the "single domain" mental model that ADR-041 explicitly chooses.
+- If Phase 3 ever extracts analytics into a separate service, port relocation is mechanical (move file + module dependency).
+
+### Q2: The Kafka observer requires a *new* Kafka topic — that's not "Calculator untouched" if someone has to create it.
+
+The spec says analytics ingest is "additive," but producing a derived topic (`q_analytics_calc_events`) from `expectation_calc_high` is a new pipeline component owned by... whom? Not Calculator (untouched). Not synchronizer (different domain). That makes it an orphan producer with no team owner.
+
+**Resolution (best practice, accepted)**: ownership belongs to a new Airflow DAG, not a long-running producer. The DAG reads existing `q_expectation_calc_high` on a schedule, re-emits the same payload (or a derived schema) into a topic consumed by ClickHouse `Kafka` engine table. This keeps:
+- Calculator unchanged (still writes `expectation_calc_high`)
+- Synchronizer unchanged (still consumes `expectation_calc_high` for read-model projection)
+- Analytics ingest scheduled, observable, and replay-able via Airflow backfill (matches ADR-046 outbox pattern philosophy)
+
+Update: add explicit `owner: airflow-dag-analytics-ingest` note to spec §4.3. Plan Task 1.2 should mention this DAG location.
+
+### Q3: `AnalyticsQueryPort` returns `ValuationSnapshot`, `RollupResult`, `DriftSeries` — these domain types must already exist in `module-core`. Are they defined today?
+
+If those types don't exist in `module-core`, Task 2.1 will fail at compile time (unresolved reference). Even if stub types are added, they leak analytics-shape concepts into the always-loaded domain.
+
+**Resolution (best practice, accepted)**: define the three return types as records in `module-core/.../core/domain/analytics/` as part of Task 2.1. They are pure data carriers (`ValuationSnapshot(characterId, world, valuation, timestamp)`, `RollupResult(bucket, count, mean, stddev)`, `DriftSeries(timestamp, value)`). No engine dependency. They serve as the **contract language** for analytics queries. If an adapter needs engine-specific projections, it converts at the adapter boundary. This is consistent with ADR-041 §3.4 (port returns domain types, not infrastructure types).
+
+### Q4: `@ConditionalOnProperty` adapters throw `UnsupportedOperationException` at runtime — that means they register as real beans and could be autowired accidentally. Why not omit them entirely until Phase 1 fires?
+
+If a developer injects `AnalyticsQueryPort` in some unrelated code path today, the `@ConditionalOnProperty` bean activates and `UnsupportedOperationException` blows up at runtime — exactly the failure mode the ArchUnit test was supposed to prevent.
+
+**Resolution (best practice, accepted)**: dual-gate the stub adapters. Add `@ConditionalOnProperty(name = "analytics.engine", havingValue = "<engine>")` AND `@Conditional(AnalyticsEnabledCondition.class)` where the condition checks `analytics.enabled=true`. Default config sets `analytics.enabled=false`. Any accidental injection fails at startup with a clear `NoSuchBeanDefinitionException`, not at runtime with a stub exception. Update Task 3.1 verification command to check both annotations.
+
+### Q5: Failure isolation §4.5 lists "MinIO write failure → Calculator fails pipeline (existing)" — but if analytics layer is Kafka-observer, it does NOT write MinIO. The row is wrong.
+
+The row implies analytics writes MinIO. It doesn't. Remove or annotate the row to clarify "analytics does not write MinIO in Phase 1."
+
+**Resolution (best practice, accepted)**: change the failure-isolation row to:
+- MinIO write failure (existing) → Calculator fails pipeline → analytics layer does not write MinIO in Phase 1; no analytics impact
+- This makes the dependency direction explicit (serving owns MinIO writes; analytics is downstream).
+
+Update Task 4.1 input to reflect this correction.
+
+---
+
+**All 5 questions resolved.** Spec §4.3, plan Tasks 1.2, 2.1, 3.1, and 4.1 updated accordingly. No open architectural branches.

--- a/docs/superpowers/specs/2026-06-23-analytics-adr-finalization.md
+++ b/docs/superpowers/specs/2026-06-23-analytics-adr-finalization.md
@@ -1,0 +1,111 @@
+# Spec: Analytics Layer ADR Finalization (#1339)
+
+- Issue: #1339
+- Date: 2026-06-23
+- Parent ADR: `docs/01_ADR/ADR-735-future-analytics-platform-evaluation.md`
+- ADR template: `.claude/rules/adr-conventions.md`
+
+## Goal
+
+Convert ADR-735 from `Status: Proposed` → `Status: Accepted` once 8 sibling investigation issues close with measured evidence. Populate §4 Result/Evidence with numeric measurements, evaluate T1-T8 trigger conditions against today's data, and obtain a second-maintainer review before status flip.
+
+## Non-Goals
+
+- Implementing any analytics platform (PG, ClickHouse, Iceberg, Trino, Spark).
+- Modifying Calculator, external-api, synchronizer, or REST controller modules.
+- Production deployment, sizing, or capacity decisions.
+- Creating new evaluation docs (companion docs already exist or are owned by sibling issues).
+- Reopening the Phase 0/1/2/3 escalation order — it is settled by §2 Decision.
+
+## Background
+
+ADR-735 proposes a phased analytics strategy: PG-only default, escalate to ClickHouse → Iceberg+Trino → Iceberg+Spark as measurable triggers fire. The ADR currently has Status `Proposed` because no measured evidence backs the §4 metrics table; numbers are public benchmarks and estimates.
+
+Issue #1339 is the parent finalization ticket. It is blocked by 8 sibling investigation issues that must close with measurable results before the ADR can be accepted. This spec governs only the finalization mechanics — not the investigation work itself.
+
+## Design (ADR Finalization Workflow)
+
+### Phase A — Evidence aggregation
+
+1. Wait for all 8 sibling investigation issues to close (status `Closed`, not `Reopened`).
+2. Enumerate the 8 issue numbers explicitly in the working evidence sheet before any ADR edit. If count < 8, the ADR cannot be finalized yet — re-open issue #1339 and surface the missing investigations.
+3. For each closed issue, capture: measured numbers, method, timestamp, sample size. Issues that close with narrative but no numeric measurement are treated as unmeasured and block acceptance.
+4. Tabulate evidence against the §4 Result/Evidence table slots.
+
+### Phase B — Decision validation
+
+1. Evaluate T1-T8 trigger conditions against current measurements (today's data, not projected).
+2. For each trigger, record: fired? (yes/no), measured value, threshold, gap to threshold.
+3. Update §2 Decision block with a "Trigger evaluation (2026-MM-DD)" annotation per phase.
+4. **If any trigger has already fired today**, the ADR cannot be blanket-Accepted — escalate to revision (status `Revised` → re-circulate). Acceptance is reserved for ADRs whose decision is unchanged by current measurements.
+
+### Phase C — Metrics table population
+
+1. Replace §4 metrics table estimates with measured numbers where available.
+2. Where measurement is not yet available, mark cell as `n/a — not deployed` and link the blocking investigation issue.
+3. Add an explicit footnote: *"Cells marked `n/a — not deployed` reflect absence of in-environment measurement; estimates from §References are not carried into the Metrics table."*
+4. Update §4 Observed Result bullets to cite measured numbers, not benchmarks.
+
+### Phase D — Status transition
+
+1. Update `Status: Proposed` → `Status: Accepted` with `Date:` stamp.
+2. Update §5 Summary with measured reaffirmation (no wording change to the principle).
+3. Update References section if any new evaluation doc was produced.
+
+### Phase E — Reviewer gate
+
+1. Open PR from `feature/adr-735-accepted` against `develop`.
+2. PR body links issue #1339 and lists the 8 sibling issues as prerequisites.
+3. Require ≥1 approval from a maintainer other than the author.
+4. On approval, merge PR. Status transition is complete.
+
+### Phase F — Rollback path
+
+If any reviewer flags a measurement gap or contradicted evidence:
+1. Revert status to `Proposed` (or `Deprecated` if decision is invalidated).
+2. Open follow-up issue per blocker.
+3. If decision direction is wrong, write superseding ADR (ADR-735a) and add cross-link.
+
+## Acceptance Criteria
+
+- [ ] All 8 sibling investigation issues closed with measured results.
+- [ ] ADR-735 §4 Result/Evidence table populated with measured numbers (cells marked `n/a — not deployed` where applicable, no estimates).
+- [ ] §2 Decision T1-T8 trigger conditions evaluated against current data with measured values.
+- [ ] `Status: Proposed` → `Status: Accepted` with date stamp.
+- [ ] §5 Summary unchanged in principle (only measured reaffirmation added).
+- [ ] Final recommendation reviewed by ≥1 other maintainer (PR approval).
+- [ ] PR merged via `feature/adr-735-accepted` against `develop`.
+- [ ] No implementation work — documentation finalization only.
+
+## Trade-offs
+
+| Choice | Get | Give up |
+| -- | -- | -- |
+| Wait for all 8 sibling issues before flipping status | Clean acceptance gate; no partial evidence | Slowest path; blocks ADR finalization on slowest investigation |
+| Allow `n/a — not deployed` cells | Honest representation of what is measured vs not | Readers may misread blanks as zero |
+| Single PR with all updates | Atomic review; one approval gate | Large diff; harder to roll back specific sections |
+| Reviewer must be a different maintainer | Avoid self-approval | Single-maintainer projects cannot complete this ADR |
+
+### Sensitivity
+
+- **Measurement latency**: each sibling issue's evidence is only as fresh as its measurement date.
+- **Trigger threshold interpretation**: T1-T8 thresholds are subjective (e.g., "p95 > 10s") and may need re-statement.
+- **Reviewer availability**: gate depends on at least one other maintainer being active.
+
+### Risk
+
+- **Medium**: Single-reviewer bottleneck delays acceptance indefinitely if no second maintainer is available. Mitigation: pre-arrange reviewer in issue #1339 before starting.
+- **Low**: §4 table cells marked `n/a` may be misread. Mitigation: explicit column footnote clarifying scope.
+
+### Non-Risk
+
+- Calculator throughput — out of scope, untouched.
+- Implementation work — explicitly out of scope by issue #1339's design.
+
+## References
+
+- Parent ADR: `docs/01_ADR/ADR-735-future-analytics-platform-evaluation.md`
+- Issue: https://github.com/zbnerd/probabilistic-valuation-engine/issues/1339
+- ADR template: `.claude/rules/adr-conventions.md`
+- Workflow rules: `.claude/rules/workflow-rules.md` (Definition of Done, branch + PR)
+- Related ADRs: ADR-013, ADR-039, ADR-041 (cross-referenced in ADR-735 §References)

--- a/docs/superpowers/specs/2026-06-23-class-hierarchy-modeling.md
+++ b/docs/superpowers/specs/2026-06-23-class-hierarchy-modeling.md
@@ -1,0 +1,254 @@
+# Spec: Class Hierarchy Data Modeling
+
+- Date: 2026-06-23
+- Parent Issue: #1343
+- Parent ADR: ADR-735 (Future Analytics Platform Evaluation)
+- Status: Proposed
+
+---
+
+## Goal
+
+Design a portable, cross-store data model for the MapleStory class hierarchy (40+ jobs, 5 advancement tiers) that:
+
+1. Documents the current PG encoding and its denormalization cost.
+2. Proposes a single star-schema dimension (`dim_class`) usable on PostgreSQL (serving), ClickHouse (Phase 1), and Iceberg+Trino (Phase 2).
+3. Captures the 1st-5th advancement hierarchy with a strategy that supports ancestor queries, branch rollups, and class rebalances.
+4. Provides a basis for the "Serving Layer vs Analytics Layer Separation" companion issue.
+
+---
+
+## Non-Goals
+
+- No schema changes to production tables.
+- No modification of existing class encoding in `character_equipment_read_model`.
+- No domain model changes to `module-core`.
+- No new tables in the production schema.
+- No implementation work — this is investigation/specification only.
+
+---
+
+## Background
+
+`probabilistic-valuation-engine` ingests ~595K user snapshots/day and produces ~40M items/day. Character snapshots carry a class dimension (job, tier, job group) that is heavily denormalized into `character_equipment_read_model` for read efficiency.
+
+ADR-735 commits the project to a phased analytics platform escalation:
+
+- **Phase 0 (today):** PG-only serving + materialized views.
+- **Phase 1:** ClickHouse for analytical Top-N and class rollups (trigger: p95 > 10s or Top-N becomes user-facing).
+- **Phase 2:** Iceberg+Trino for ≥30TB historical corpus or time-travel needs.
+- **Phase 3:** Iceberg+Spark for MLlib workloads.
+
+The class dimension is the highest-cardinality analytical group-by (40+ classes × 50 worlds × 10 level buckets = 15K groups at base; explodes with time window and item category). Without a clean dimension model, the same hierarchy must be redefined in each store, and class rebalances will silently desynchronize serving and analytical views.
+
+The MapleStory class taxonomy is a 5-tier tree (Beginner → 1st → 2nd → 3rd → 4th; 5th-job is a 2023 Anima/Nova mechanic layered on top). It includes ~40-50 leaf classes plus intermediate parents, distributed across 9+ job groups (Explorer, Cygnus, Resistance, Nova, Sengoku, Anima, Jianghu, Shine, Arcana).
+
+---
+
+## Design
+
+### 1. Taxonomy
+
+#### 1.1 Job Groups (top-level rollup)
+
+| Group | Examples | Branches |
+|-------|----------|----------|
+| Beginner | Citizen | 1 |
+| Explorer | Warrior, Magician, Archer, Thief, Pirate, Xenon | 30 |
+| Cygnus | Noblesse, Dawn Warrior, Blaze Wizard, Wind Archer, Night Walker, Thunder Breaker | 6 |
+| Resistance | Wild Hunter, Battle Mage, Mechanic | 3 |
+| Nova | Kaiser, Angelic Buster | 2 |
+| Sengoku | Hayato, Kanna | 2 |
+| Anima | Lara, Hoyoung | 2 |
+| Jianghu | Kinesis | 1 |
+| Shine | Sia, Aria | 2 |
+| Arcana | (TBD) | 1-3 |
+| **Total** | | **~52** |
+
+#### 1.2 Advancement Tiers
+
+| Tier | Description | Storage |
+|------|-------------|---------|
+| 0 | Beginner / Citizen | `advancement_tier = 0` |
+| 1 | 1st job | `advancement_tier = 1` |
+| 2 | 2nd job | `advancement_tier = 2` |
+| 3 | 3rd job | `advancement_tier = 3` |
+| 4 | 4th job | `advancement_tier = 4` |
+| 5 | 5th job (Anima/Nova special mechanic) | `advancement_tier = 5` |
+
+#### 1.3 Hierarchy Storage Strategy
+
+| Store | Strategy | Rationale |
+|-------|----------|-----------|
+| PostgreSQL (serving) | Closure table `dim_class_closure(ancestor, descendant, depth)` | O(1) ancestor lookup; cheap subtree query; supports SCD Type 2 |
+| ClickHouse (analytical) | Adjacency list (`parent_class_key`) | Depth bounded at 5; JOIN depth 5 acceptable; no closure table writes |
+| Iceberg (analytical) | Adjacency list | Same as ClickHouse; small dim table, JOIN cost negligible |
+
+Rationale: PG needs fast ancestry for class-rollup queries on the read path; analytical stores trade write amplification for join cost. With max depth 5, the difference is small but the PG read path is hotter.
+
+### 2. Dimensional Model
+
+#### 2.1 `dim_class`
+
+```
+dim_class (
+  class_key           INT           PRIMARY KEY,    -- surrogate
+  class_id            SMALLINT      NOT NULL,        -- source id (NEXON/Mediaroh)
+  class_name_en       VARCHAR(32)   NOT NULL,
+  class_name_kr       VARCHAR(32),
+  job_group_id        SMALLINT      NOT NULL,        -- FK dim_job_group
+  job_group_name      VARCHAR(32),                   -- denormalized for fast rollup
+  advancement_tier    TINYINT       NOT NULL,        -- 0..5
+  parent_class_key    INT           REFERENCES dim_class(class_key),
+  is_5th_job          BOOLEAN,                       -- computed at load
+  is_active           BOOLEAN       NOT NULL,
+  effective_from      DATE          NOT NULL,        -- SCD Type 2
+  effective_to        DATE                            -- NULL = current
+)
+```
+
+#### 2.2 `dim_job_group` (separate small dim)
+
+```
+dim_job_group (
+  job_group_id        SMALLINT      PRIMARY KEY,
+  job_group_name      VARCHAR(32),
+  release_year        SMALLINT,
+  region_origin       VARCHAR(16)                    -- KMS / JMS / GMS / MSEA
+)
+```
+
+#### 2.3 `dim_class_closure` (PG only)
+
+```
+dim_class_closure (
+  ancestor_key        INT           NOT NULL,
+  descendant_key      INT           NOT NULL,
+  depth               TINYINT       NOT NULL,
+  PRIMARY KEY (ancestor_key, descendant_key)
+)
+```
+
+#### 2.4 Backward-Compatible Read Model
+
+`character_equipment_read_model` keeps current columns. New columns (e.g. `class_key`) are **optional** in the spec; the audit will confirm whether surrogate-key migration is in scope for a follow-up issue.
+
+### 3. Cross-Store Compatibility
+
+#### 3.1 PostgreSQL (current)
+
+- `dim_class` + `dim_class_closure` as regular tables.
+- `dim_job_group` as a small reference table.
+- Closure table rebuilt on class rebalance via `INSERT ... ON CONFLICT`.
+- `LowCardinality` equivalent: not applicable (PG has no such type).
+- JOIN cost on `class_key` (INT) is negligible relative to fact scan cost.
+
+#### 3.2 ClickHouse (Phase 1)
+
+- `dim_class` table engine: `MergeTree ORDER BY (class_key)`.
+- `class_id`, `job_group_id` → `LowCardinality(UInt16)`.
+- `class_name_kr` → `LowCardinality(String)`.
+- `class_name_en` → `LowCardinality(String)` (max ~50 distinct values; below 10K cap).
+- `is_5th_job`, `is_active` → `LowCardinality(UInt8)` (0/1).
+- For hot analytical queries: use `dictGet('dim_class', ...)` to skip JOIN.
+- No closure table; use CTE with `JOIN` up to 5 levels.
+
+#### 3.3 Iceberg+Trino (Phase 2)
+
+- `dim_class` as Iceberg table, no partition (≤100 rows, partition overhead exceeds benefit).
+- `PARTITION BY (job_group_id)` is optional — only if dimension grows beyond 10K rows (it won't).
+- Schema evolution: new locale columns (`class_name_ja`) added without rewrite.
+- Trino reads with `SELECT * FROM iceberg.dw.dim_class` — same shape as PG.
+- Fact table partition: `PARTITION BY (year(ts), job_group_id)` aligns with class rollup queries.
+
+### 4. Storage Cost (current PG)
+
+- Denormalized class fields per row: `class_id` (2B SMALLINT) + `class_name` (~16-24B UTF-8 KR/EN) + `job_group_name` (4-8B) + `advancement_tier` (1B) = **~25-35B per row**.
+- 40M items/day × 30B = 1.2GB/day attributable to class fields.
+- Monthly: ~36GB; annual: ~432GB. (~4% of total 10TB/year storage.)
+- Normalizing to `dim_class` + INT FK (4B) saves ~21-31B/row → ~840GB-1.2TB/year savings.
+- Trade-off: one JOIN per analytical query (acceptable for cold analytical path).
+
+### 5. Query Patterns Covered
+
+| Pattern | PG Plan | ClickHouse Plan | Iceberg Plan |
+|---------|---------|-----------------|--------------|
+| Top 100 per class × world | `RANK() OVER (PARTITION BY class_id, world_id)` on indexed scan | `topK(100) BY class_id, world_id` | Trino window function |
+| Class distribution histogram | `GROUP BY class_id` btree | `groupArray(class_name_en)` | `GROUP BY class_id` |
+| Ancestor rollup (e.g. "all Explorers") | `JOIN dim_class_closure ON ancestor_key = explorer_root` | `JOIN dim_class` 5-deep | Trino `UNNEST` on recursive CTE |
+| Subtree at tier N | `WHERE depth = N` on closure | `WHERE advancement_tier = N` | Same |
+
+---
+
+## Acceptance Criteria
+
+- [ ] Current PG class encoding documented: column types, constraints, indexes, NULL policy.
+- [ ] 40+ job class taxonomy enumerated with parent_class_key relationships and tier assignments.
+- [ ] Denormalization cost measured: bytes/row attributable to class fields, projected to annual cost.
+- [ ] Query pattern inventory: top 5 class-based GROUP BY / JOIN patterns with current PG plan costs.
+- [ ] `dim_class` schema designed: columns, types, SCD Type 2 strategy.
+- [ ] `dim_job_group` schema designed.
+- [ ] `dim_class_closure` schema designed (PG only).
+- [ ] Cross-store mapping documented: PG (serving), ClickHouse (Phase 1), Iceberg (Phase 2) with type adaptations.
+- [ ] LowCardinality mapping specified for ClickHouse.
+- [ ] Iceberg partition-key implications documented (fact tables only).
+- [ ] Risk register: 5 risks with mitigations.
+- [ ] No implementation work — investigation only.
+
+---
+
+## Trade-offs
+
+### Sensitivity
+
+- **Class taxonomy churn**: NEXON rebalances a class every 6-18 months; affects SCD Type 2 closure table writes.
+- **LowCardinality cardinality ceiling in CH**: 10K cap; current 50 classes is 0.5% of cap.
+- **Storage cost vs JOIN cost**: denormalization saves ~840GB-1.2TB/year; one extra JOIN per analytical query.
+- **Mixed-branch classes (Xenon)**: cross-tree ancestry breaks simple parent-child.
+- **5th-job explosion**: 2023 mechanic; Kinesis/Hoyoung/Lara split into branches; total leaves grows by 2-3.
+
+### Trade-off
+
+| Choice | Get | Give up |
+|--------|-----|---------|
+| **Closure table in PG** | O(1) ancestor; cheap subtree | Write amplification on rebalance |
+| **Adjacency list in CH/Iceberg** | Simple schema, no separate table | Recursive CTE for ancestor (depth 5 acceptable) |
+| **SCD Type 2 on dim_class** | Time-travel for class rebalances | Storage overhead; multiple active rows per class_id |
+| **Job group as separate dim** | Clean rollup; separable release metadata | Extra JOIN for "Explorer only" queries |
+| **Korean + English names both stored** | Locale-flexible serving | UTF-8 expansion ~3B/row in PG |
+
+### Risk
+
+- **R1 (Medium)**: Class rebalance rewrites closure table; large transactions may lock the table. Mitigation: batch closure writes in <10K-row chunks; defer until Phase 1 since serving reads dominate today.
+- **R2 (Low)**: LowCardinality cardinality ceiling in CH (10K). Mitigation: monitor; alert at 1K; schema change is a 1-hour DDL.
+- **R3 (Low)**: Mixed-branch classes (Xenon) break parent-child expectations. Mitigation: explicit `parent_class_key` may be NULL for hybrid classes; treat as multi-parent in rollups via UNION.
+- **R4 (Low)**: 5th-job mechanic is recent and may evolve. Mitigation: `is_5th_job` boolean + `advancement_tier` allows both legacy and future 5th-job variants.
+- **R5 (Low)**: UTF-8 name storage inflates PG row size. Mitigation: normalize to FK + 4B INT, store names only in `dim_class`.
+
+### Non-Risk
+
+- **Calculator writer hot path**: untouched; class dimension lives in serving + analytical layers, not calculator.
+- **OLTP serving path**: PG remains the sole serving store; dimension normalization is additive.
+- **Module-core domain model**: not affected; class taxonomy lives in read model + analytics dim.
+
+---
+
+## References
+
+- Parent ADR: `docs/01_ADR/ADR-735-future-analytics-platform-evaluation.md` §3 Sensitivity, §4 Metrics
+- Issue: #1343 "[Investigation] Class Hierarchy Data Modeling"
+- Companion issue: "Serving Layer vs Analytics Layer Separation" (referenced in #1343)
+- Public sources:
+  - [MapleStory class taxonomy (Mediaroh / NEXON wiki data)](https://maplestory.fandom.com/wiki/Job)
+  - [ClickHouse LowCardinality type](https://clickhouse.com/docs/en/sql-reference/data-types/lowcardinality)
+  - [Apache Iceberg schema evolution](https://iceberg.apache.org/spec/#schema-evolution)
+  - [Trino Iceberg connector](https://trino.io/docs/current/connector/iceberg.html)
+- Internal:
+  - `module-synchronizer/.../read-model/` (current `character_equipment_read_model` definition)
+  - `module-calculator/.../core/port/inbound/` (class dimension in domain)
+
+---
+
+## Summary
+
+> A single `dim_class` + `dim_job_group` + (PG-only) `dim_class_closure` model, with type adaptations for ClickHouse `LowCardinality` and Iceberg schema evolution, supports the same class hierarchy across all three stores — denormalization today costs ~840GB-1.2TB/year, saved by one JOIN per analytical query.

--- a/docs/superpowers/specs/2026-06-23-historical-analytics-requirements.md
+++ b/docs/superpowers/specs/2026-06-23-historical-analytics-requirements.md
@@ -1,0 +1,199 @@
+# Spec: Historical Analytics Requirements (Issue #1342)
+
+- Status: Proposed
+- Date: 2026-06-23
+- Owner: Architecture Team
+- Parent: ADR-735
+- Issue: #1342
+
+---
+
+## 1. Goal
+
+Produce a concrete, ranked inventory of analytical workloads that the platform must support beyond the current per-character serving path. The inventory is the evidence base for the trigger gates (T1-T8) defined in ADR-735 §2 and feeds the platform-escalation decision.
+
+Success = every potential analytical use case is captured with frequency, latency budget, volume, freshness, consumer, cross-source join requirement, time-travel requirement, retention class, roadmap commitment, and priority tier (P0-P3).
+
+## 2. Non-Goals
+
+- No implementation of any analytical workload
+- No database schema changes
+- No new service deployment
+- No vendor selection (ClickHouse / Iceberg / Trino / Spark)
+- No code in this investigation
+
+## 3. Background
+
+ADR-735 establishes PG-only as the default analytics strategy and defines 8 escalation triggers (T1-T8) tied to measurable conditions. ADR-735 §1 lists candidate workloads (class/world/level rollups, multi-week trend, Top-N, recommendations, ML feature pipelines) but does not enumerate them, rank them, or map them to triggers.
+
+Without this inventory, the trigger gates have no concrete workload to fire on, and platform-escalation decisions become speculative. Issue #1342 closes that gap by requiring the workload inventory before any platform work begins.
+
+## 4. Design
+
+### 4.1 Workload Inventory Template
+
+Every workload entry captures the following 14 fields:
+
+| # | Field | Type | Required |
+|---|-------|------|----------|
+| 1 | ID | `WA-N` slug | yes |
+| 2 | Persona / Story | "As a …, I want …, so that …" | yes |
+| 3 | Question template | concrete parameterized SQL shape | yes |
+| 4 | Cardinality | rows scanned / rows emitted / distinct keys | yes |
+| 5 | Frequency | ad-hoc / hourly / daily / weekly / monthly / on-demand | yes |
+| 6 | Latency budget | p50 / p95 / p99 numeric (ms or s) | yes |
+| 7 | Data volume | GB scanned per run; rows returned | yes |
+| 8 | Freshness | real-time (<5min) / near-RT (<1h) / hourly / daily / weekly | yes |
+| 9 | Consumer | analyst / dashboard / user-facing API / ML feature / partner / regulatory | yes |
+| 10 | Cross-source join | PG-only / PG+MinIO / multi-system | yes |
+| 11 | Time-travel | TT-0 none / TT-1 point-in-time / TT-2 range / TT-3 version-tag / TT-4 branch | yes |
+| 12 | Retention | RET-N none / 30-90d / 1-7y / 7-10y / permanent | yes |
+| 13 | Roadmap commitment | COMMITTED / SPECULATIVE | yes |
+| 14 | Trigger gate hit | T1..T8 from ADR-735 §2 (multi-select) | yes |
+
+### 4.2 Consumer Taxonomy
+
+| Code | Consumer | SLA class | Counted for trigger? |
+|------|----------|-----------|----------------------|
+| C-1 | Analyst ad-hoc | best-effort, human-rate | no (T1 only) |
+| C-2 | Internal dashboard | scheduled, low concurrency | no |
+| C-3 | User-facing API | contractual p95 budget | **yes (T3)** |
+| C-4 | ML feature pipeline | batch, latency-tolerant | **yes (T7)** |
+| C-5 | Partner / external SQL | contractual | **yes (T8)** |
+| C-6 | Regulatory report | scheduled, immutable output | yes (retention-driven) |
+
+### 4.3 Priority Ranking Rubric
+
+Score 0-3 per axis, sum, sort into tiers.
+
+| Axis | 0 | 1 | 2 | 3 |
+|------|---|---|---|---|
+| Roadmap commitment | speculative | desired | planned | committed in next 2Q |
+| Frequency | on-demand | monthly | daily | hourly+ |
+| Consumer breadth | single analyst | team-internal | cross-team | user-facing / external |
+| Trigger gate hit | none | soft (T1) | hard (T2-T4) | mandate (T5-T8) |
+| Decision impact | informational | internal | product feature | contractual SLA |
+
+Tiers:
+- **P0 (12-15)**: ship Phase-0 support now, design for Phase-1 cutover
+- **P1 (8-11)**: design Phase-0, defer platform decision
+- **P2 (4-7)**: document only, revisit in 6 months
+- **P3 (0-3)**: drop or punt to a future ADR
+
+### 4.4 Cross-Source Join Classification
+
+- **CSJ-A (PG-only)**: phase 0 default
+- **CSJ-B (PG + MinIO chunks)**: triggers T6
+- **CSJ-C (multi-system)**: triggers T6 + partner data layer
+
+### 4.5 Time-Travel Taxonomy
+
+- **TT-0**: latest state (PG works)
+- **TT-1**: point-in-time (PG time-bucketed partitioning works)
+- **TT-2**: range scan (PG range partitioning works)
+- **TT-3**: version-tag (Iceberg)
+- **TT-4**: branch / fork (Iceberg)
+
+TT-3+ triggers T5.
+
+### 4.6 Retention Classes
+
+- **RET-N**: ephemeral
+- **RET-1**: operational 30-90d
+- **RET-2**: financial 1-7y
+- **RET-3**: compliance 7-10y
+- **RET-4**: permanent / WORM
+
+RET-3+ implies immutable storage tier; influences T8 partner data contract.
+
+### 4.7 Output Artifacts
+
+1. **Workload matrix** — `docs/03_Technical_Guides/historical-analytics-workloads.md` (Markdown table, one row per workload)
+2. **Priority ranking** — sorted P0-P3 list with score breakdown
+3. **Trigger-gate map** — matrix: workload × T1..T8
+4. **Cross-source map** — workload × CSJ class
+5. **Time-travel map** — workload × TT class
+6. **Retention map** — workload × RET class
+
+### 4.8 Seed Workload List (from ADR-735 §1)
+
+| ID | Workload (short) |
+|----|------------------|
+| WA-1 | Class / world / level-range rollup |
+| WA-2 | Multi-week expectation drift |
+| WA-3 | Top-N leaderboard per class/world |
+| WA-4 | Recommendation system inputs |
+| WA-5 | ML feature pipelines (per-item features) |
+| WA-6 | Item price history (per character) |
+| WA-7 | Ingestion anomaly detection |
+| WA-8 | Cross-class economic comparison |
+| WA-9 | Daily active user / churn signals |
+| WA-10 | Regulatory / data-lineage report |
+
+## 5. Acceptance Criteria
+
+- [ ] Workload inventory contains ≥10 candidate workloads, each with all 14 template fields filled
+- [ ] Frequency, latency, volume, freshness captured per workload
+- [ ] Consumer identified per workload from the C-1..C-6 taxonomy
+- [ ] Cross-source join class (CSJ-A / B / C) per workload
+- [ ] Time-travel class (TT-0..TT-4) per workload
+- [ ] Retention class (RET-N..RET-4) per workload
+- [ ] Roadmap commitment (COMMITTED / SPECULATIVE) per workload
+- [ ] Priority score 0-15 with P0-P3 tier assignment per workload
+- [ ] Trigger-gate map (workload × T1..T8) published
+- [ ] No code, no schema, no deployment — investigation only
+- [ ] Output doc published under `docs/03_Technical_Guides/`
+- [ ] Doc linked from ADR-735 §5 References
+
+## 6. Trade-offs
+
+### Sensitivity
+
+- Roadmap commitment accuracy (depends on PM/roadmap source)
+- Latency budgets for hypothetical user-facing APIs (no contract yet)
+- Regulatory baseline jurisdiction (KR, US, EU may differ)
+- Cardinality estimates (depend on growth projection)
+
+### Trade-off
+
+| Choice | Get | Give up |
+|--------|-----|---------|
+| Capture all 14 fields per workload | Comparable ranking; trigger mapping | Slower interview cycle; harder to keep matrix current |
+| Use 0-3 ordinal scoring | Simple, auditable rubric | Coarse; ties possible |
+| Seed list from ADR-735 | Anchor to existing roadmap signals | May miss workloads not yet named |
+| Output as Markdown table | Versioned in git, diffable | Not directly queryable; copy-paste into BI tools needed |
+
+### Risk
+
+- Latency budgets guessed for non-existent APIs → wrong priority → over-build
+- Roadmap commitment misread (planned ≠ committed) → P0 actually P2
+- Regulatory class overlooked → RET-3 workload shipped on mutable storage
+
+### Non-Risk
+
+- No infra change in this investigation (Phase-0 untouched)
+- No platform commitment (only inventory + ranking)
+
+## 7. Grill-me (self-challenge)
+
+> Five hard questions raised against the spec, with answers baked into the design. No follow-up tickets; the spec is responsible for the resolution.
+
+1. **Q: "Roadmap commitment" is the load-bearing axis — who is the source of truth?**
+   A: The PM owner of analytics. COMMITTED requires a link to a roadmap doc / issue with a target quarter. SPECULATIVE is the default; promotion to COMMITTED is gated on PM sign-off in Phase 3 task 3.4.
+2. **Q: "Latency budget" for workloads that have no API contract yet — is this just guessing?**
+   A: Yes, and that is acceptable. Guessed budgets are tagged `estimated` in the matrix. The first user-facing analytical API contract triggers a re-score for that workload (revisit quarterly).
+3. **Q: "Time-travel" beyond TT-2 (TT-3 version-tag, TT-4 branch) auto-fires T5. Does that mean the inventory implicitly commits to Iceberg?**
+   A: No. T5 firing is a trigger condition, not a commitment. The inventory records that T5 would fire for a workload; ADR-735 owns the platform decision. The two artifacts stay independent.
+4. **Q: "Cross-source join CSJ-B" depends on MinIO chunk shape — but chunks are JSONL.gz per run, not a queryable table. How is the join modeled?**
+   A: CSJ-B is a "join to raw snapshot" workload, executed by either (a) external ETL that writes a derived table to PG, or (b) Phase-2 Iceberg tables that read MinIO directly. The inventory records CSJ-B existence; the join mechanism is decided per-workload when the trigger fires.
+5. **Q: "Retention RET-3 (7-10y)" implies WORM storage. Is that a platform decision this ADR is making?**
+   A: No. Retention is recorded as a requirement. If RET-3+ workloads exist, they generate a separate compliance/storage ADR; ADR-735 stays focused on analytics tier.
+
+## 8. References
+
+- ADR-735 §1 Background (candidate workloads)
+- ADR-735 §2 Decision (trigger gates T1-T8)
+- Issue #1342 acceptance criteria
+- Companion issues: Query Engine Evaluation, PG Scalability Assessment
+- `docs/agents/issue-tracker.md`
+- `docs/agents/triage-labels.md`

--- a/docs/superpowers/specs/2026-06-23-iceberg-feasibility.md
+++ b/docs/superpowers/specs/2026-06-23-iceberg-feasibility.md
@@ -1,0 +1,168 @@
+# Iceberg Feasibility Study
+
+- Status: Proposed
+- Date: 2026-06-23
+- Owner: Architecture Team
+- Parent Issue: #1337
+- Parent ADR: [ADR-735](../01_ADR/ADR-735-future-analytics-platform-evaluation.md)
+- Companion Doc Target: `docs/03_Technical_Guides/iceberg-evaluation.md`
+
+---
+
+## 1. Goal
+
+Determine whether Apache Iceberg v1.7+ is a viable table format for the probabilistic-valuation-engine analytics platform. Deliverable: written feasibility study with concrete GO / NO-GO / DEFER recommendation, validated MinIO + REST catalog integration, and quantified compaction plan for the 340GB/day workload.
+
+Outcome enables ADR-735 Action Item #1 closure and unblocks future Phase 2 trigger decisions.
+
+## 2. Non-Goals
+
+- Migrating Calculator writer hot path to Iceberg
+- Replacing JSONL.gz chunk artifact format
+- Production deployment of Polaris or Nessie catalog
+- Any module code change
+- ClickHouse evaluation (separate ADR-735 Action Item #4)
+- Spark/Iceberg integration (ADR-735 reserves Phase 3 for MLlib workloads)
+
+## 3. Background
+
+`probabilistic-valuation-engine` produces ~595K user snapshots/day (~340GB/day compressed JSONL.gz on MinIO, ~10TB/month, ~120TB/year). ADR-735 commits PG-only as default and escalates in stages: PG → ClickHouse → Iceberg+Trino → Iceberg+Spark. Iceberg+Trino is the Phase 2 candidate.
+
+Phase 1 trigger conditions (any one):
+- T1. Analytical query p95 > 10s on indexed PG (EXPLAIN ANALYZE-verified)
+- T2. Analytical load > 20% of DB CPU during peak hour
+- T3. Top-N leaderboard or class-rollup becomes user-facing API contract
+
+Phase 2 trigger conditions (any one on top of Phase 1):
+- T4. ≥30TB active historical corpus retained for analytics
+- T5. Time-travel / point-in-time read model snapshot needed
+- T6. Cross-source SQL join required (MinIO chunks + PG read model)
+
+This study runs the Iceberg-on-MinIO integration validation **before** any Phase 2 trigger fires, so that when one does fire the decision cycle is weeks instead of months.
+
+## 4. Design
+
+### 4.1 Catalog Choice
+
+Primary: **Apache Polaris 1.0.x** (REST catalog, Apache-governed, multi-engine).
+Fallback: **Project Nessie 0.103+** (if Polaris unstable in test namespace).
+Rejected: Hive Metastore (couples to single ecosystem, breaks ADR-735 engine-agnostic posture).
+
+### 4.2 Test Namespace Layout
+
+| Component | Deployment | Notes |
+|---|---|---|
+| Polaris | Docker compose service in `docker-compose.test.yml` | Postgres backend in same compose file; isolated from serving PG |
+| MinIO | Existing cluster, dedicated `iceberg-pilot` bucket | Bucket lifecycle disabled; no expiration |
+| Trino | Docker compose service | Iceberg connector, reads Polaris-managed table |
+| PyIceberg writer | One-shot script (not a service) | Reads one `character_basic` chunk; writes test table |
+| Serving PG/Kafka | Unchanged, isolated | No pilot writes reach serving path |
+
+### 4.3 Test Table Schema
+
+```sql
+CREATE TABLE landing.character_basic_pilot (
+    character_id BIGINT,
+    ign VARCHAR,
+    ocid VARCHAR,
+    ingest_ts TIMESTAMP,
+    raw_payload BINARY  -- parsed from JSONL.gz
+) PARTITIONED BY days(ingest_ts), bucket(64, character_id);
+```
+
+File format: Parquet v2.
+Sort order: `zorder(character_id, ingest_ts)` to accelerate Top-N and character-time lookups.
+
+### 4.4 Compaction Plan
+
+| Parameter | Value | Source |
+|---|---|---|
+| Target Parquet file size | 256MB | ADR-735 §3 |
+| Action | `rewrite-data-files` | Iceberg spec |
+| Schedule | Nightly cron (initial) | Operational simplicity |
+| Promotion to service | When manifest list > 50MB | ADR-735 risk mitigation |
+| Sort order during rewrite | zorder(character_id, ingest_ts) | Top-N acceleration |
+| Acceptance band | ≥128MB median within 3 runs | Gate metric |
+
+### 4.5 Snapshot Retention
+
+| Snapshot class | Retention | Mechanism |
+|---|---|---|
+| Raw (`landing.*`) | 7 days rolling | `expire_snapshots` with `retain_last` |
+| Serving read-model (`serving.*`) | 365 days | `expire_snapshots` with `retain_last` |
+
+### 4.6 Validation Matrix
+
+| Gate | Verification command | Pass threshold |
+|---|---|---|
+| MinIO version | `mc admin info minio` | RELEASE 2024-05+ |
+| Polaris health | `curl /healthcheck` | 200 within 30s × 5 |
+| Test table create | PyIceberg `create_table` exit 0 | Table appears in Polaris |
+| Chunk ingest | Row count = source chunk row count | Exact match |
+| Compaction | `rewrite-data-files` exit 0 | Parquet median ≥128MB |
+| Manifest growth | Daily `manifest_list_size` measurement | ≤10MB/day for 7 days |
+| Time-travel query | `SELECT ... AS OF TIMESTAMP` in Trino | <30s for 7-day scan |
+| Cross-engine read | Trino reads table written by PyIceberg | Row count matches |
+
+## 5. Acceptance Criteria
+
+- [ ] AC1. MinIO RELEASE ≥ 2024-05 confirmed in cluster, or upgrade plan documented
+- [ ] AC2. Polaris 1.0.x OR Nessie 0.103+ deployed in test namespace; `/healthcheck` 200
+- [ ] AC3. Test table created with `PARTITIONED BY days(ingest_ts), bucket(64, character_id)`
+- [ ] AC4. One `character_basic` chunk ingested; source row count = table row count
+- [ ] AC5. `rewrite-data-files` run nightly; Parquet median file size ≥128MB
+- [ ] AC6. Manifest list size measured 7 consecutive days; growth ≤10MB/day
+- [ ] AC7. 7-day rolling raw snapshot retention validated
+- [ ] AC8. 365-day serving read-model retention policy documented
+- [ ] AC9. Time-travel query on 7-day scan returns within 30s
+- [ ] AC10. Companion doc published at `docs/03_Technical_Guides/iceberg-evaluation.md`
+- [ ] AC11. Recommendation (GO / NO-GO / DEFER) recorded in issue #1337 with conditions/triggers
+- [ ] AC12. ADR-735 Action Item #1 marked complete
+
+## 6. Trade-offs
+
+### Sensitivity
+
+- Daily ingest volume: 340GB/day raw → ~50GB/day columnar if adopted
+- Manifest list growth (drives compaction cost)
+- Catalog availability (single point of failure for read access)
+- Test namespace isolation (shared MinIO/PG = blast radius)
+- Polaris backend choice (Postgres vs. in-memory)
+
+### Trade-off Table
+
+| Choice | Get | Give up |
+|---|---|---|
+| Test namespace isolated from serving | No blast radius; can run anytime | Duplicate Postgres for catalog backend |
+| Polaris primary, Nessie fallback | Apache governance + multi-engine | Two catalog implementations to validate |
+| Nightly cron compaction | Simple ops | Compaction lag risk if cron misses |
+| PyIceberg one-shot writer | Minimal service surface | Not representative of future Java writer |
+| DEFER default recommendation | Honest with ADR-735 phase gating | Slower path if triggers fire mid-pilot |
+
+### Risk
+
+- **RK1 (High)**: MinIO RELEASE < 2024-05 blocks conditional writes → defer recommendation
+- **RK2 (Medium)**: Polaris 1.0.x immaturity → Nessie fallback ready
+- **RK3 (Medium)**: Compaction becomes operational burden before ROI → DEFER triggers documented
+- **RK4 (Medium)**: Recommendation conflict with ClickHouse-first strategy → scope discipline
+- **RK5 (Low)**: Test data bleeds into serving PG via shared catalog → namespace isolation enforced
+
+### Non-Risk
+
+- Calculator throughput regression — out of scope by hard rule
+- OLTP serving path — PG remains sole serving store; pilot is read-only analytics
+- Vendor lock-in — Iceberg is engine-agnostic
+
+## 7. Open Questions
+
+None. All decisions finalized as best practice.
+
+## 8. References
+
+- Parent ADR: `docs/01_ADR/ADR-735-future-analytics-platform-evaluation.md`
+- Parent Issue: https://github.com/zbnerd/probabilistic-valuation-engine/issues/1337
+- Apache Iceberg S3FileIO: https://iceberg.apache.org/javadoc/latest/org/apache/iceberg/aws/s3/S3FileIOProperties.html
+- Apache Polaris: https://polaris.apache.org/
+- Project Nessie: https://projectnessie.org/
+- Trino Iceberg connector: https://trino.io/docs/current/connector/iceberg.html
+- MinIO RELEASE 2024-05 changelog (conditional writes): https://github.com/minio/minio/releases/tag/RELEASE.2024-05-10T01-41-38Z

--- a/docs/superpowers/specs/2026-06-23-minio-compatibility.md
+++ b/docs/superpowers/specs/2026-06-23-minio-compatibility.md
@@ -1,0 +1,161 @@
+# Spec: MinIO Compatibility Validation
+
+- Status: Proposed
+- Date: 2026-06-23
+- Owner: Architecture Team
+- Parent Issue: #1338
+- Parent ADR: ADR-735
+
+---
+
+## 1. Goal
+
+Validate that the existing MinIO deployment supports the full S3 API surface required by the four candidate analytics engines called out in ADR-735 §2:
+
+- Apache Iceberg (S3FileIO)
+- Trino (Hive connector)
+- Spark (S3A connector)
+- ClickHouse (S3 disk type)
+
+Produce a compatibility matrix, capture MinIO version + configuration, and surface gaps as follow-up implementation tickets. Investigation only.
+
+## 2. Non-Goals
+
+- Upgrading MinIO to a newer release (separate ticket)
+- Modifying bucket policies
+- Data migration or backfill
+- Standing up Iceberg/Trino/Spark/ClickHouse in production
+- Modifying Calculator's MinIO writer path (Calculator is untouched per ADR-735 §2)
+
+## 3. Background
+
+ADR-735 §2 escalates the analytics tier through PG → ClickHouse → Iceberg+Trino → Iceberg+Spark. Phase 2 trigger T6 (cross-source SQL join on MinIO + PG) implies Iceberg adoption on top of the existing MinIO bucket.
+
+Per ADR-735 §4 evidence, MinIO RELEASE 2024-05+ is required for safe concurrent writer commits via `If-Match` conditional writes. Today's deployed image is `minio/minio:latest` (rolling tag — actual version unknown until inspected).
+
+MinIO is currently used by Calculator for stateless JSONL.gz chunk artifacts under `data/runs/{runId}/...` and by External API for `snapshots/`. Lifecycle rules are configured for `snapshots/`, `runs/`, `calculator/`, `ocid-mapping/` (2-day expiry, idempotent bootstrap).
+
+## 4. Design
+
+### 4.1 Test Bucket Isolation
+
+All compatibility tests run against a separate bucket `maple-iceberg-test` so the production `maple-expectation` bucket is never polluted.
+
+### 4.2 Test Environment
+
+- Local MinIO from `docker-compose.yml` at `http://localhost:9000`
+- Test bucket created by the test scripts (not the bootstrap script)
+- Operator tools: `mc` (MinIO client) + `aws s3api` (AWS CLI v2)
+
+### 4.3 S3 API Test Matrix
+
+**Tier 1 (Baseline — required by all four engines)**
+
+| API | Test Method | Required For |
+|-----|-------------|--------------|
+| `ListObjectsV2` | `aws s3api list-objects-v2 --bucket ... --max-keys 1000` | All |
+| `GetObject` | `aws s3api get-object` (single + range) | All |
+| `PutObject` (single) | `aws s3api put-object` < 5MB | All |
+| `CopyObject` | `aws s3api copy-object` | Iceberg, ClickHouse |
+| `DeleteObjects` (batch) | `aws s3api delete-objects --delete ...` | Iceberg, Spark |
+| `HeadObject` | `aws s3api head-object` | All |
+| `HeadBucket` | `aws s3api head-bucket` (health check) | All |
+
+**Tier 2 (Correctness — required by ≥1 engine)**
+
+| API | Test Method | Required For |
+|-----|-------------|--------------|
+| `If-Match` conditional PUT | `aws s3api put-object --if-match <etag>` | Iceberg (safe concurrent writer) |
+| `If-None-Match: *` PUT | `aws s3api put-object --if-none-match "*"` | ClickHouse S3PlainRewritable |
+| Object versioning | `aws s3api put-bucket-versioning --versioning-configuration Status=Enabled` | Iceberg (snapshot isolation) |
+| Multipart upload (5MB+ part) | `aws s3api create-multipart-upload` + `upload-part` + `complete` | All engines for >threshold |
+| Multipart copy | `aws s3api upload-part-copy` | Iceberg |
+
+**Tier 3 (Operational)**
+
+| API | Test Method | Required For |
+|-----|-------------|--------------|
+| Lifecycle / ILM | `mc ilm ls local/<bucket>` | All (cost / retention) |
+| Bucket policy review | `mc admin policy info` | Security |
+| Server-side encryption | `aws s3api put-object --server-side-encryption AES256` | Optional; flag as gap |
+
+### 4.4 Version Matrix
+
+| Component | Test Version | Source |
+|-----------|--------------|--------|
+| MinIO server | `mc admin info` output (capture actual) | Live |
+| `mc` client | `latest` (Alpine) | Docker |
+| AWS CLI v2 | `latest` | pip / brew |
+| Apache Iceberg | 1.6.x (latest stable at test time) | Maven Central |
+| Trino | 435+ (Hive connector support) | trino.io |
+| Spark | 3.5.x | spark.apache.org |
+| ClickHouse | 24.x LTS | clickhouse.com |
+
+### 4.5 Compatibility Matrix Output
+
+Produce a single table mapping each engine → required S3 API → MinIO version status (SUPPORTED / PARTIAL / UNSUPPORTED / NOT-TESTED). Document under `docs/03_Technical_Guides/minio-compatibility-report.md`.
+
+### 4.6 Per-Engine Smoke Tests
+
+For each engine, run a 5-minute smoke that exercises the engine against `maple-iceberg-test`:
+
+- Iceberg: write a sample table → read it back → conditional write on metadata.json
+- Trino: create Hive schema backed by S3 → `SELECT` from a parquet file
+- Spark: write a parquet via S3A → read it back
+- ClickHouse: create S3PlainRewritable disk → INSERT → SELECT
+
+Smoke scripts live under `scripts/minio-compat/<engine>-smoke.sh` (committed to repo).
+
+## 5. Acceptance Criteria
+
+- [ ] MinIO version + release date captured (`mc admin info` output saved)
+- [ ] Tier 1 S3 APIs (7 APIs) all tested and pass
+- [ ] Tier 2 conditional writes (`If-Match`, `If-None-Match:*`) tested
+- [ ] Object versioning enabled on `maple-iceberg-test` and verified
+- [ ] Multipart upload threshold + part size documented
+- [ ] Lifecycle policy for `data/runs/{runId}/...` captured (current + recommended)
+- [ ] Bucket policy / IAM reviewed for read-only analyst scenario (gap statement)
+- [ ] Per-engine smoke tests executed; results captured
+- [ ] Compatibility matrix published at `docs/03_Technical_Guides/minio-compatibility-report.md`
+- [ ] Test scripts committed at `scripts/minio-compat/`
+- [ ] Each identified gap → separate implementation issue, cross-referenced to #1338
+
+## 6. Trade-offs
+
+### Sensitivity
+
+- MinIO server version (rolling tag `latest` introduces variability)
+- Iceberg / Trino / Spark / ClickHouse version pinned at test time
+- Local docker-compose MinIO vs production deployment (single-node vs distributed)
+- Test bucket path-style access dependency
+
+### Trade-off
+
+| Choice | Get | Give up |
+|--------|-----|---------|
+| Separate `maple-iceberg-test` bucket | Production `maple-expectation` untouched | Need to bootstrap test bucket manually |
+| Rolling `minio/minio:latest` for tests | Always tests latest compatibility | Reproducibility drift between runs |
+| Per-engine smoke (not full integration) | Quick validation of API surface | Misses engine-specific quirks |
+| Investigation only (no upgrade) | Aligned with parent issue scope | Any gap found → separate ticket |
+
+### Risk
+
+- MinIO version older than 2024-05 → conditional writes unsupported → Iceberg Phase 2 blocked. Mitigation: gap ticket immediately surfaces upgrade need.
+- Single-node MinIO (local compose) hides distributed-mode behavior. Mitigation: flag gap for production-mode validation.
+
+### Non-Risk
+
+- Calculator throughput / writer path (out of scope, untouched)
+- Production bucket data (test bucket is separate)
+
+## 7. References
+
+- Parent issue: #1338
+- Parent ADR: `docs/01_ADR/ADR-735-future-analytics-platform-evaluation.md`
+- Issue: ADR-735 §4 (MinIO 2024-05+ requirement)
+- Source: Apache Iceberg S3FileIO javadoc
+- Source: Trino Hive connector docs
+- Source: Spark S3A docs
+- Source: ClickHouse S3 disk docs
+- Bootstrap script: `docker/minio/bootstrap.sh`
+- Current adapter: `module-infra/.../storage/MinioObjectStorage.kt`

--- a/docs/superpowers/specs/2026-06-23-pg-scalability-assessment.md
+++ b/docs/superpowers/specs/2026-06-23-pg-scalability-assessment.md
@@ -1,0 +1,176 @@
+# Spec — PostgreSQL Scalability Assessment
+
+- Status: Proposed
+- Date: 2026-06-23
+- Issue: #1341
+- Parent ADR: docs/01_ADR/ADR-735-future-analytics-platform-evaluation.md
+
+---
+
+## 1. Goal
+
+Validate or invalidate the trigger conditions **T1** (analytical query p95 > 10s on indexed PG) and **T2** (analytical load > 20% of DB CPU during peak hour) defined in ADR-735 §2. Produce measurable numbers at current and projected scale so the architecture owner can decide whether Phase 1 (ClickHouse adoption) is justified now, deferred, or unnecessary.
+
+This is an **investigation-only** deliverable. No schema change, no new table, no production index modification, no new analytical engine.
+
+## 2. Non-Goals
+
+- Adding new analytical tables or mat views to production PG.
+- Modifying existing indexes in production without ADR.
+- ClickHouse / Iceberg / Spark adoption work.
+- Production schema changes (all experiments run on staging).
+- Building user-facing Top-N endpoints.
+
+## 3. Background
+
+Probabilistic valuation engine ingests 595K user snapshots/day, produces 40M items/day, ~340GB/day raw storage, ~120TB/year projected. Serving layer = PG 16 read models + L1 Caffeine + L2 PG UNLOGGED. Per-character query p95 < 100ms.
+
+ADR-735 commits to a PG-only default for analytics, escalating to ClickHouse when analytical queries exceed 10s p95 (T1) or analytical load exceeds 20% of DB CPU (T2). Both thresholds are asserted without measurement today. This spec captures the measurements.
+
+Schema inventory (read models touched by analytical queries):
+- `character_valuation_views` (hot, primary serving + analytics)
+- `character_equipment_read_model` (ocid + preset_no)
+- `character_basic_read_model` (ocid-keyed)
+- `character_expectation_read_model` (user_ign-keyed, gzip payload)
+- `calculation_jobs`, `calculation_results` (operational, secondary)
+
+## 4. Design
+
+### 4.1 Measurement
+
+**4.1.1 Workload mix.** Capture 24h of `pg_stat_statements` under production load. Group by `queryid`; report top-50 by `total_exec_time` and top-20 by `mean_exec_time`. Output: `pg_stat_top50.csv`.
+
+**4.1.2 Per-character serving latency.** Sample 10K IGN. Run `GET /api/v5/characters/{ign}/expectation` at CONCURRENCY=50, split warm-cache vs cold-L1. Report p50/p95/p99. Output: `perchar_latency.csv`.
+
+**4.1.3 Slow query log.** Set `log_min_duration_statement=1000`, `log_lock_waits=on`, `log_temp_files=0` on staging for 7 days. Aggregate by query fingerprint. Output: `slow_query_aggregate.csv`.
+
+**4.1.4 EXPLAIN ANALYZE on top-5 analytical patterns.** For each of: Top-N per (world, class), world rollup, level-range histogram, time-windowed expectation drift, cross-class percentile — capture `EXPLAIN (ANALYZE, BUFFERS, VERBOSE, TIMING)` at scale. Output: `q{1..5}.txt`.
+
+**4.1.5 Synthetic benchmark.** Replay top-5 patterns at 100M, 250M, 500M, 750M, 1B, 1.5B, 2B rows. Record p50/p95/p99, shared buffers hit/read, temp spill, parallel workers. Output: `analytical_benchmark.csv`.
+
+### 4.2 Index experiments
+
+Test against synthetic 1B-row dataset, baseline = current btree schema.
+
+| # | Index | Hypothesis | Metric |
+|---|-------|------------|--------|
+| I1 | BRIN `(updated_at) pages_per_range=32` | Time-windowed scans drop 5x | p95 of `WHERE updated_at > NOW()-INTERVAL '1 day'` |
+| I2 | Partial `(character_class, world_name, total_cost DESC) WHERE class IN (top-100)` | Hot Top-N 2-5x faster | p95 of Top-100 query |
+| I3 | Covering `(world_name, character_class, total_cost DESC) INCLUDE (user_ign, ocid)` | Index-only scan, 1.5-3x | p95 + buffers hit/read |
+| I4 | RANGE partitioning by `calculated_at` (daily) | Time-windowed prune 5-10x | p95 + disk per query |
+
+Each experiment: `CREATE INDEX …` (or no-op for baseline) → `ANALYZE` → 100 cold runs → report median + p95. Drop index between experiments.
+
+### 4.3 Materialized view strategy
+
+For each pattern from 4.1.4, recommend one of:
+
+- **Hourly** (refresh after calculator batch close): last-1h expectation drift, Top-N per class/world for last hour.
+- **Daily** (Airflow @ 02:00 KST): world rollup, class-level percentile, daily-active histogram.
+- **Weekly**: 7-day drift, cross-class percentile.
+- **On-demand**: ad-hoc analytical questions.
+
+Mat view design constraints: UNIQUE INDEX matching serving predicate (enables `REFRESH CONCURRENTLY`); documented source tables + refresh DAG + last-refresh time + stale tolerance; storage cap at 5% of base table.
+
+Refresh experiment: `REFRESH CONCURRENTLY` vs `REFRESH` (full) at 100M, 500M, 1B rows. Output: `mv_refresh.csv` (duration, lock duration, write amplification).
+
+### 4.4 Storage projection
+
+Project disk usage at 30/90/365 day retention with current row model.
+
+| Input | Value |
+|-------|------:|
+| Items/day | 40M (sensitivity ±20%) |
+| Avg compressed row | ~300 B |
+| btree overhead | 30-50% |
+| WAL/FMV | ~25% |
+| TOAST compression ratio | 2-3x |
+
+Output: `storage_projection.csv` (window, rows, heap_gb, index_gb, wal_gb, total_gb, sensitivity_low, sensitivity_high).
+
+### 4.5 T1/T2 trigger validation
+
+Plot p95 vs row count for each of top-5 patterns using data from 4.1.5. Identify crossover row count where p95 = 10s. Compare to 30/90/365-day row counts from 4.4.
+
+**Verdict per trigger:**
+- T1 VALIDATED if any pattern crossover ≤ 1.2B rows (today's 30-day baseline).
+- T1 NOT YET if crossover 1.2B-4B; PHASE 1 defer justified.
+- T1 INVALID if crossover > 4B for all patterns; T1 threshold too low.
+
+**T2** verdict requires comparison of analytical query CPU share to total DB CPU during production peak hour. Source: `pg_stat_activity` + `pg_stat_database` snapshot at peak.
+
+### 4.6 Findings deliverable
+
+`docs/01_ADR/ADR-1341-pg-scalability-findings.md` with:
+1. Methodology + dataset scale.
+2. Workload mix.
+3. Per-character serving p95/p99 today.
+4. Analytical p95 vs row count + crossover plot.
+5. Index experiment matrix + winner per pattern.
+6. Mat view refresh strategy recommendation.
+7. Storage projection table.
+8. T1/T2 verdict per §4.5.
+9. Recommendation to ADR-735 owner: keep PG-only, defer Phase 1, or escalate.
+
+## 5. Acceptance Criteria
+
+- [ ] `pg_stat_top50.csv` produced from 24h production-load capture (or prod-equivalent replay).
+- [ ] `perchar_latency.csv` with p50/p95/p99 for 10K IGN sample.
+- [ ] EXPLAIN ANALYZE captured for 5 analytical patterns at 1B-row scale.
+- [ ] Index experiments I1-I4 completed; winner per pattern documented.
+- [ ] Mat view refresh strategy: per-pattern cadence (hourly/daily/weekly/on-demand).
+- [ ] `storage_projection.csv` at 30/90/365 day retention with sensitivity bounds.
+- [ ] T1/T2 verdict per §4.5 with crossover row count.
+- [ ] Findings ADR published.
+- [ ] No production schema change.
+- [ ] No new analytical engine adopted.
+
+## 6. Trade-offs
+
+### Sensitivity
+
+- **Production traffic capture vs synthetic replay.** pg_stat from prod is ground truth; synthetic at 1B-row requires staging clone with proportional CPU/IO. Replay may understate planner choices vs real mixed workload.
+- **Hot class/world list volatility.** Partial index (I2) assumes a stable hot set. If top-100 churns weekly, maintenance cost exceeds benefit.
+- **Mat view storage.** 5% cap is heuristic; class-level percentile may exceed under heavy churn.
+- **Synthetic dataset representativeness.** Value distribution in real data skews (most users low-cost, long tail). Synthetic must preserve skew or p95 numbers mislead.
+
+### Trade-off
+
+| Choice | Get | Give up |
+|---|---|---|
+| Synthetic 1B-row benchmark | Reproducible scaling curve; safe to experiment | Slight skew vs real distribution; staging clone cost |
+| pg_stat capture only (no synthetic) | Real numbers | Cannot extrapolate beyond current 30-day volume |
+| Index experiment I2 partial | 2-5x Top-N speedup | Maintenance overhead when hot list shifts |
+| Mat view hourly refresh | Always-fresh leaderboards | Refresh write amplification + 5% storage cost |
+| Defer Phase 1 if T1 not validated | No new infra; zero ops overhead | Risk of late escalation when roadmap commits to user-facing Top-N |
+
+### Risk
+
+- **Medium**: pg_stat_statements not enabled in current PG. If absent, Phase 1 baseline capture fails; require pre-req migration.
+- **Medium**: Synthetic 1B-row staging dataset takes >1TB disk + 24h pg_restore. Capacity planning needed.
+- **Low**: Mat view refresh competing with serving reads during calculator batch close window. Mitigation: refresh only during off-peak (02:00-04:00 KST) and document contention.
+
+### Non-Risk
+
+- Calculator throughput: untouched by this investigation.
+- Serving path: experiments run on staging; prod indexes unchanged.
+- Cost: zero new infra (uses existing staging PG).
+
+## 7. Hard questions (grill-me)
+
+1. **Synthetic representativeness.** 1B-row dataset built from `generate_series` cannot replicate real planner choices over a 90-day mixed workload (writes + reads competing for buffers). If the synthetic p95 is 2x lower than real, the T1 verdict flips. **Mitigation:** cap synthetic-vs-prod p95 delta at 2x; if exceeded, mark T1 verdict "indeterminate" and require prod EXPLAIN capture for top-5 patterns during peak hour.
+2. **Hot list volatility for I2.** Partial index on top-100 (class, world) assumes the hot set is stable. Real workload shows class-meta rebalances every major patch (~quarterly). **Mitigation:** document partial-index maintenance as quarterly ADR; if maintenance cadence slips, partial index silently regresses to btree-equivalent without alerting. Add a check that compares `pg_stat_user_indexes.idx_scan` against expected hot-set traffic.
+3. **Mat view write amplification under 1B rows.** `REFRESH MATERIALIZED VIEW CONCURRENTLY` rewrites the entire mat view; at 1B source rows × 5% size = 50M mat rows, that's non-trivial. **Mitigation:** size each mat view at creation; if any exceeds 5% of base, flag for incremental strategy (delta tables + UNION, or recompute pipeline).
+4. **T2 measurement is sampling-blind.** `pg_stat_activity` sampled every 5 min for 7 days misses sub-minute spikes. If analytical queries burst for 30s during calculator batch close, T2 share could exceed 20% in that window. **Mitigation:** combine sampling with `pg_stat_statements.total_exec_time` aggregation over the same window; report both numbers.
+5. **Scope creep risk.** Spec is investigation-only, but finding "T1 validated" naturally pulls in ClickHouse POC work. **Mitigation:** explicitly out-of-scope per §2; recommendation in findings ADR points to a separate Phase 1 escalation issue, NOT implementation.
+
+## 8. References
+
+- Issue #1341 — [Investigation] PostgreSQL Scalability Assessment
+- ADR-735 — Future Analytics Platform Evaluation (§2 Decision, §3 Sensitivity, §4 Metrics)
+- V111 — character_expectation_read_model
+- V123 — character_equipment_read_model
+- V126 — character_basic_read_model
+- `.claude/rules/data-access.md`
+- `.claude/rules/db-migration.md` (read-only reference; no migration in this scope)
+- Brainstorm: /tmp/brainstorm-1341.md

--- a/docs/superpowers/specs/2026-06-23-query-engine-benchmark.md
+++ b/docs/superpowers/specs/2026-06-23-query-engine-benchmark.md
@@ -1,0 +1,165 @@
+# Spec: Query Engine Benchmark (Issue #1340)
+
+- Status: Proposed
+- Date: 2026-06-23
+- Parent: Issue #1340, ADR-735
+- Owner: Architecture Team
+
+---
+
+## 1. Goal
+
+Produce an evidence-backed comparison of PostgreSQL 16, ClickHouse, Trino, and Spark on the four named analytical workloads defined in ADR-735 §1, at 1TB and 10TB scale. Recommendation per workload must cite falsifiable conditions from ADR-735 §2 (T1: p95 > 10s; T3: user-facing; T4: ≥30TB corpus).
+
+## 2. Non-Goals
+
+- No production cluster sizing decisions
+- No ClickHouse Keeper deployment
+- No Spark cluster deployment
+- No migration of any read traffic
+- No production code changes
+- No new analytical schemas in production PG
+- No changes to Calculator / synchronizer / REST modules
+
+## 3. Background
+
+ADR-735 proposes PG-only as the default analytics tier, escalating to ClickHouse, Iceberg+Trino, and Iceberg+Spark based on measurable trigger conditions. Issue #1340 is the empirical foundation: a controlled benchmark that turns the trigger conditions into numbers.
+
+Without this benchmark, every analytical workload becomes either an expensive PG query competing with serving reads, a one-off Python script over MinIO JSONL.gz, or a deferred decision. The benchmark replaces intuition with measured latency/memory/spill on each candidate.
+
+Today's data profile: 595K users/day × 40M items/day → 340GB/day raw → ~120TB/year. Analytical workloads target class/world/level rollups, Top-N rankings, and multi-week expectation drift.
+
+## 4. Design
+
+### 4.1 Workloads
+
+Same 4 SQL queries are run identically on every engine where syntax permits. Engines use SQL extensions where required (e.g., ClickHouse `quantileExact`, Trino `approx_percentile`).
+
+| ID | Workload | SQL intent |
+|----|----------|------------|
+| W1 | Class statistics | `SELECT class, count(*), avg(level), percentile(0.95) within group (order by item_score), max(item_score) FROM characters GROUP BY class` |
+| W2 | World statistics | `SELECT world, class, count(*) FROM characters GROUP BY world, class` |
+| W3 | Level-range analytics | `SELECT class, count(*) FROM characters WHERE level BETWEEN 200 AND 260 GROUP BY class` |
+| W4 | Historical trend | `SELECT date_trunc('day', snapshot_ts) AS d, class, avg(expectation_0) FROM characters GROUP BY d, class ORDER BY d, class` |
+
+### 4.2 Engines
+
+| ID | Engine | Version | Container image |
+|----|--------|---------|-----------------|
+| E1 | PostgreSQL | 16.3 | `postgres:16.3` |
+| E2 | ClickHouse | 24.5 LTS | `clickhouse/clickhouse-server:24.5` |
+| E3 | Trino | 446 | `trinodb/trino:446` |
+| E4 | Spark | 3.5.2 | `apache/spark:3.5.2` |
+
+### 4.3 Test data
+
+- Generator: standalone Python script (`docs/03_Technical_Guides/_bench/gen_data.py`), numpy + pyarrow.
+- Schema: 12 columns matching production anonymized shape (see brainstorm).
+- Cardinality:
+  - 1B rows ≈ 700GB Parquet compressed (1TB target)
+  - 10B rows ≈ 7TB Parquet compressed (10TB target)
+- Distribution: seeded RNG (seed = 20260623), class/world/level/expectation distributions sampled from production `character_valuation_views` snapshot 2026-06-15.
+- Output formats: Parquet (all engines), CSV (PG bulk-loader fallback).
+- Storage path: `/tmp/benchmark/data/` on host, bind-mounted into each engine container.
+
+### 4.4 Benchmark cell
+
+A cell is (engine, workload, scale, cache-state). 4 × 4 × 2 × 2 = 64 cells. Per cell:
+- 3 warm-up runs (results discarded)
+- 5 timed runs
+- Metrics: p50, p95, p99 latency (ms), peak RSS (MB), disk spill (bytes), result row count
+
+Total timed runs: 64 × 5 = 320. Estimated ~3 hours wall-clock.
+
+### 4.5 Cache states
+
+- **Warm**: warm-up runs populate OS file cache + engine buffer pool; timed runs hit warm cache.
+- **Cold**: between each timed run, `sync && echo 3 > /proc/sys/vm/drop_caches` on host + engine-specific cache reset (`pg_prewarm` reset for PG, `SYSTEM DROP MARK CACHE` for CH, restart coordinator for Trino, no-op for Spark with `spark.sql.inMemoryColumnarStorage.partitions=0`).
+
+### 4.6 Isolation
+
+- Each engine runs in dedicated Docker container, dedicated volume, dedicated DB namespace.
+- One cell at a time, sequential.
+- Localhost-only networking. No external API.
+- Container resource caps: 8 vCPU, 32GB RAM (1TB cells); 16 vCPU, 64GB RAM (10TB cells).
+
+### 4.7 Metrics capture
+
+- Latency: container-side `time` wrapper around query execution.
+- Memory: `docker stats --no-stream --format '{{.MemUsage}}'` sampled at start + every 1s during query; peak recorded.
+- Disk spill:
+  - PG: `pg_stat_database` `blk_write_time` + temp file size from `EXPLAIN ANALYZE`
+  - ClickHouse: `system.metrics` `DiskSpill`
+  - Trino: `QueryStatistics` from `system.runtime.queries`
+  - Spark: `ShuffleSpillMetrics` from event log
+- Output: one JSON file per cell at `/tmp/benchmark/results/{engine}_{workload}_{scale}_{cache}.json`.
+
+### 4.8 Reporting
+
+- Report path: `docs/03_Technical_Guples/query-engine-benchmark.md`.
+- Sections:
+  - Test setup (data, engines, hardware)
+  - Results table per scale (4 tables, one per workload)
+  - Cross-workload summary (engine wins per workload per scale)
+  - Recommendations per workload with falsifiable conditions mapped to ADR-735 §2 triggers
+  - Caveats and limitations
+
+## 5. Acceptance Criteria
+
+- [ ] Test data generator script checked in at `docs/03_Technical_Guides/_bench/gen_data.py`
+- [ ] 1B-row dataset generated at `/tmp/benchmark/data/characters_1b.parquet`
+- [ ] 10B-row dataset generated at `/tmp/benchmark/data/characters_10b.parquet`
+- [ ] All 4 engines load both datasets successfully
+- [ ] All 16 (engine × workload) cells complete at 1TB scale
+- [ ] All 16 cells complete at 10TB scale
+- [ ] Per-cell JSON metrics captured (64 files total)
+- [ ] Report published at `docs/03_Technical_Guides/query-engine-benchmark.md`
+- [ ] Report contains: comparison matrix, winner per workload, falsifiable recommendations mapped to ADR-735 triggers
+- [ ] No production code changes; investigation only
+- [ ] No `.env` modifications; runs in isolated `/tmp/benchmark/` workspace
+
+## 6. Trade-offs
+
+### Sensitivity
+
+- Dataset distribution skew: results valid only for the chosen production snapshot; re-running with different distribution may shift winners.
+- Hardware cap (32GB / 64GB): engines allowed to use all available RAM; results scale with hardware but ratio between engines remains comparable.
+- Cold-cache methodology: dropping OS cache is invasive and may not reflect real cluster conditions.
+- Spark cold-start: Spark's driver startup adds 10-30s baseline; reported separately as "cold start" overhead.
+
+### Trade-off
+
+| Choice | Get | Give up |
+| -- | -- | -- |
+| Single-host benchmark | Reproducible, fast (~3h), no cluster ops | Results don't capture distributed shuffle overhead |
+| Parquet format | All 4 engines read natively | PG bulk load is slower than COPY from CSV |
+| Drop OS cache for cold runs | True cold-cache measurement | Slower total run time |
+| 5 timed runs | Stable percentiles | 5× run time vs single-run |
+| Same SQL text per workload | Like-for-like comparison | Engines with better-suited syntax can't show their advantage |
+
+### Risk
+
+- **Medium**: 10B-row generation may take >2 hours. Mitigation: budget 4 hours, generate overnight.
+- **Medium**: Trino/Spark containers may OOM at 10TB if distributions skew. Mitigation: 64GB cap, generator keeps level distribution bounded.
+- **Low**: Result-row-count mismatch indicates wrong SQL semantics. Mitigation: assert equality across engines per cell.
+- **Low**: PG CSV bulk-load is slow. Mitigation: 8-thread parallel COPY + CSV split.
+
+### Non-Risk
+
+- Production data exposure: generator uses seeded RNG + production distribution parameters only; no actual IGNs leaked.
+- Calculator throughput: out of scope per ADR-735 §2.
+- Cost: benchmark uses local docker, zero cloud spend.
+
+## 7. References
+
+- Issue #1340: https://github.com/zbnerd/probabilistic-valuation-engine/issues/1340
+- ADR-735: `docs/01_ADR/ADR-735-future-analytics-platform-evaluation.md`
+- Brainstorm: `/tmp/brainstorm-1340.md`
+- Plan: `docs/superpowers/plans/2026-06-23-query-engine-benchmark.md`
+- ClickBench leaderboard: https://benchmark.clickhouse.com/
+- Trino Iceberg connector: https://trino.io/docs/current/connector/iceberg.html
+- Spark MLlib: https://spark.apache.org/docs/latest/ml-collaborative-filtering.html
+
+## 8. Summary
+
+> **Benchmark 4 engines × 4 workloads × 2 scales × 2 cache states = 64 cells on synthetic data matching production distribution; produce a per-workload winner with falsifiable ADR-735 trigger conditions; report at `docs/03_Technical_Guides/query-engine-benchmark.md`.**

--- a/docs/superpowers/specs/2026-06-23-serving-analytics-separation.md
+++ b/docs/superpowers/specs/2026-06-23-serving-analytics-separation.md
@@ -1,0 +1,182 @@
+# Spec: Serving Layer vs Analytics Layer Separation
+
+- Date: 2026-06-23
+- Parent Issue: #1344
+- Parent ADR: ADR-735 (Future Analytics Platform Evaluation)
+- Module-boundary rule: `.claude/rules/module-boundaries.md`
+- Architecture rule: ADR-041 (Multi-Module Hexagonal Architecture)
+
+---
+
+## 1. Goal
+
+Define a clean architectural boundary between the **serving layer** (PostgreSQL read model + REST API, p95 < 100ms) and a **future analytics layer** (Phase 1 ClickHouse, Phase 2 Iceberg+Trino, Phase 3 Iceberg+Spark per ADR-735). The investigation must yield:
+
+1. A consumer-by-consumer contract (latency, freshness, consistency, cache, engine)
+2. A data flow design that does **not** touch the Calculator or serving path hot paths
+3. A Hexagonal port/adapter map that keeps `module-core` Spring-free and forces all analytics-engine coupling into `module-infra`
+4. A failure-isolation story: analytics layer down ⇒ serving path SLA unchanged
+
+## 2. Non-Goals
+
+- No implementation of ClickHouse, Iceberg, Trino, or Spark
+- No change to serving p95 < 100ms contract
+- No new Spring beans on the default `bootRun` profile
+- No `module-app`/`module-infra` restructuring (handled in ADR-050 roadmap)
+- No Calculator hot-path changes (ADR-735 §2 non-risk)
+- No new REST endpoint on `/api/v5` (analytics endpoints, if exposed, are a separate future ADR)
+
+## 3. Background
+
+ADR-735 §1 documents the data volume: 595K user snapshots/day, 40M items/day, ~340GB/day internal storage, ~10TB/month, ~120TB/year. The serving path is p95 < 100ms on PG read model + L1 Caffeine + L2 PG UNLOGGED. ADR-735 §2 commits to a **PG default** with trigger conditions (T1–T8) for ClickHouse, Iceberg+Trino, and Iceberg+Spark escalation.
+
+This spec answers the architectural design question that ADR-735 §2 leaves open: **how** do we draw the boundary contract — what port interfaces exist in `module-core`, where do adapters live, and what does the failure-isolation model look like — before any of the trigger conditions T1–T8 fire.
+
+ADR-041 §3.5 establishes the port/adapter convention: inbound port `XxxPort` in `module-core/.../core/port/in/`, outbound port in `module-core/.../core/port/out/`, adapter in `module-infra/.../adapter/outgoing/`. The `module-boundaries.md` rules forbid `module-web` → `module-infra` direct imports and forbid Spring annotations in `module-core`.
+
+## 4. Design
+
+### 4.1 Consumer matrix
+
+| Consumer | Read pattern | Latency budget | Freshness | Consistency | Volume | Engine | Cache |
+|----------|--------------|----------------|-----------|-------------|--------|--------|-------|
+| REST API (`/api/v5/characters/...`) | Single-row point | **p95 < 100ms** | seconds | Strong (PG RC) | 1 row | PG read model | L1 Caffeine + L2 PG UNLOGGED |
+| Internal dashboard | Aggregations, queue depth | p95 < 1s | seconds | Read-committed | window | PG | L1 only |
+| Analyst ad-hoc (class/level rollup) | Wide aggregates, Top-N | p95 < 10s | minutes–hours | Eventual | full history | PG materialized views → CH | none / CH internal |
+| ML feature pipeline | Bulk scans, PIT joins | minutes (batch) | hours | Snapshot isolation | 1B+ rows | Iceberg+Trino | none |
+| Recommendation training | Iterative (ALS) | hours (offline) | daily | Snapshot | corpus | Iceberg+Spark | none |
+
+### 4.2 Module port map (Hexagonal, per ADR-041)
+
+**`module-core/.../core/port/out/`** — new outbound ports (Spring-free, framework-agnostic):
+
+```
+analytics/
+  AnalyticsQueryPort         // typed query methods (Phase 1)
+  IcebergSnapshotPort        // list/read/timeTravel (Phase 2+)
+```
+
+**`module-infra/.../adapter/outgoing/analytics/`** — adapters (Spring-allowed, engine-coupled):
+
+```
+ClickHouseAnalyticsQueryAdapter  implements AnalyticsQueryPort       // @ConditionalOnProperty analytics.engine=clickhouse
+IcebergSnapshotAdapter           implements IcebergSnapshotPort        // @ConditionalOnProperty analytics.engine=iceberg (Phase 2+)
+TrinoQueryAdapter                implements AnalyticsQueryPort         // @ConditionalOnProperty analytics.engine=trino   (Phase 2+)
+```
+
+**`module-app`** — wires the adapter bean only when config property enables it. Default `analytics.engine=none` ⇒ no analytics bean registered ⇒ serving path unchanged.
+
+### 4.3 Data flow (Phase 1, additive)
+
+```text
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                         SERVING PATH (unchanged)                            │
+│                                                                             │
+│  external-api ─► calculator ─► JSONL.gz → MinIO                              │
+│                              └─► PG read model (serving, p95<100ms)         │
+│                              └─► Kafka topic: expectation_calc_high         │
+│                                                                             │
+│  synchronizer ─► character_valuation_views (L2) + L1 Caffeine (REST 8080)  │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+                                          │
+                                          │  (additive observer — does not block serving)
+                                          ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                         ANALYTICS PATH (new, opt-in)                        │
+│                                                                             │
+│  Phase 1: ClickHouse Kafka engine subscribes to q_analytics_calc_events     │
+│           Materialized views in CH for Top-N / class rollups                │
+│                                                                             │
+│  Phase 2: Iceberg+Trino reads from MinIO via S3FileIO (read-only)          │
+│           Polaris catalog on dedicated cluster                              │
+│                                                                             │
+│  Phase 3: Iceberg+Spark for MLlib (ALS, feature pipelines)                  │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+Key constraint: **Calculator and synchronizer are not modified**. Analytics ingest is an observer on existing Kafka topic `expectation_calc_high` (or a new derived `q_analytics_calc_events` topic produced by an Airflow re-emit DAG). This honors ADR-735 §2 "Calculator is not affected."
+
+### 4.4 Port contracts (signatures, no implementation)
+
+```kotlin
+// module-core/.../core/port/out/analytics/AnalyticsQueryPort.kt
+interface AnalyticsQueryPort {
+    fun topNByClass(world: World, characterClass: String, n: Int): List<ValuationSnapshot>
+    fun levelRangeRollup(world: World, characterClass: String, range: IntRange): RollupResult
+    fun expectationDrift(world: World, characterClass: String, window: Duration): DriftSeries
+}
+
+// module-core/.../core/port/out/analytics/IcebergSnapshotPort.kt
+interface IcebergSnapshotPort {
+    fun listSnapshots(table: String): List<SnapshotId>
+    fun timeTravel(table: String, timestamp: Instant): ScanResult
+}
+```
+
+Signatures are framework-free. Engine-specific SQL, JDBC, REST calls, and Iceberg library types live in adapters.
+
+### 4.5 Failure isolation
+
+| Failure | Serving | Analytics | Mitigation |
+|---------|---------|-----------|------------|
+| ClickHouse down | Unaffected | 503 + fallback to PG matview | Resilience4j circuit breaker (ADR-052); 10s timeout |
+| Kafka analytics topic lag | Unaffected | Stale aggregates | Lag SLO + alert; serving does not depend on lag |
+| Airflow DAG failed | Unaffected | Stale CH until next run | Alert; serving reads from PG |
+| Iceberg catalog unreachable | Unaffected | Analytics 503 | Compaction pipeline alarm |
+| MinIO write failure | Calculator fails (existing) | n/a | Existing calculator error handling |
+| PG replica lag | Possible stale serving read (existing) | n/a | L1/L2 hits mask |
+
+Serving path never reads from analytics layer. Analytics layer may fall back to PG materialized views, never to the live serving read path.
+
+### 4.6 Boundary contract principles
+
+1. Analytics layer is **read-only** with respect to serving — never writes back to PG read model
+2. Calculator (port 8082) is **untouched** — analytics ingest is an observer, not a writer
+3. REST API on 8080 reads **only** PG read model; analytics endpoints, if added, use distinct SLA and a separate controller (future ADR)
+4. No analytics adapter is registered without an explicit `analytics.engine` config property
+5. `module-core` adds **only port interfaces**; no engine client classes
+6. `module-web` and `module-app` only depend on `module-core` port interfaces, never on `module-infra` analytics adapters (per `.claude/rules/module-boundaries.md`)
+
+## 5. Acceptance Criteria
+
+- [ ] Consumer matrix documented with latency, freshness, consistency, cache, engine per consumer
+- [ ] `AnalyticsQueryPort` interface defined in `module-core/.../core/port/out/analytics/`
+- [ ] `IcebergSnapshotPort` interface defined in `module-core/.../core/port/out/analytics/`
+- [ ] Adapters scoped to `module-infra/.../adapter/outgoing/analytics/` and gated by `@ConditionalOnProperty`
+- [ ] Data flow diagram: serving writes → analytics ingest (Kafka observer + Airflow reconciliation)
+- [ ] Failure isolation table: every analytics component failure enumerated, serving SLA impact = none
+- [ ] ArchUnit test extended: `module-core` has zero Spring annotations (existing) AND zero references to engine packages (ClickHouse, Iceberg, Trino, Spark)
+- [ ] Default `application.yml` has `analytics.engine=none`; no analytics beans registered
+- [ ] Calculator and synchronizer source files: zero diff
+
+## 6. Trade-offs
+
+| Choice | Get | Give up |
+|--------|-----|---------|
+| Kafka observer (vs CDC vs direct write) | Additive, no app changes, reuses ADR-013 | Schema drift risk; needs topic ownership rules |
+| Port interfaces in `module-core` (vs new `module-analytics`) | Single core, no module restructuring (matches ADR-050 roadmap) | `module-core` is no longer "zero-conditional" — analytics ports exist even when disabled |
+| `@ConditionalOnProperty` adapters (vs always-on with NULL impl) | Zero serving-path impact when disabled; simple to reason about | Two code paths to test; config sprawl |
+| CH first, Iceberg later (per ADR-735 ladder) | Validated trigger conditions; no premature lakehouse | Two migration cycles |
+| No analytics REST endpoint in Phase 0 | Avoids scope creep; preserves serving SLA | Analyst must use CH client directly until Phase 1 endpoint ADR |
+
+**Risk:** If T1 (analytical p95 > 10s) fires before `module-core` ports are merged, we may need a hotfix that bypasses the port. Mitigation: ports are pure interfaces — even a hotfix adapter can implement them without port rework.
+
+**Non-Risk:** Calculator throughput regression — calculator hot path unchanged; Kafka observer is downstream.
+
+## 7. References
+
+- Parent: [ADR-735](docs/01_ADR/ADR-735-future-analytics-platform-evaluation.md)
+- Architecture: [ADR-041](docs/01_ADR/ADR-041-multi-module-hexagonal-architecture-dip.md)
+- Module rules: `.claude/rules/module-boundaries.md`
+- Pipeline: [ADR-013](docs/01_ADR/ADR-013-high-throughput-event-pipeline.md) (Kafka choreography)
+- Resilience: [ADR-052](docs/01_ADR/ADR-052-resilience4j-circuit-breaker.md) (failure isolation primitive)
+- Issue: #1344
+- Companion: #1343 (Class Hierarchy Data Modeling), #1345 (Historical Analytics Requirements)
+
+---
+
+## Status
+
+Proposed (investigation output). No implementation. Architectural-design tasks only.


### PR DESCRIPTION
## Summary
- **CLAUDE.md**: 맨 상단에 선제 참조 지시문 추가 — 외운 지식·LLM 기본 동작보다 CLAUDE.md 와 `.claude/rules/` 를 먼저 참조. "항상" 규칙이 매 세션 자동 로드됨을 명시해 매뉴얼 참조 결정 지연(decision latency) 제거. (Vercel agent.md 실험 기반)
- **analytics 조사 산출물**: ADR-735 (future analytics platform 평가) + 10개 spec/plan (Iceberg/MinIO/PG scalability/query engine/serving 분리/class hierarchy/historical requirements)

## Notes
- `morning_chain_pipeline.py` 는 이미 develop에 PR #1422로 머지됨 → 본 PR에서 제외 (로컬 사본은 develop과 동일)
- analytics spec/plan 은 어제(2026-06-23) 조사 산출물, develop에 미반영 상태였음

## Test plan
- [ ] CLAUDE.md 가 다음 세션 자동 로드 시 지시문 정상 표시
- [ ] docs/01_ADR/ADR-735, docs/superpowers/{specs,plans}/ 링크 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)