### PR TITLE
feat(ops): nohup→docker deploy + autoheal/cadvisor (#1428-1431)

### DIFF
--- a/docker/services/deploy-apps.sh
+++ b/docker/services/deploy-apps.sh
@@ -2,19 +2,22 @@
 # docker/services/deploy-apps.sh
 # Deploy 4 Spring Boot app services + autoheal + cadvisor via docker compose.
 #
-# Resolves the latest :sha-* image tag (:dev mutable tag may be absent),
+# Resolves the newest :sha-* image tag (:dev mutable tag may be absent),
 # runs pre-flight checks (ports free, DNS resolves on maple-network, SA
-# secrets present, rollback jars present, IDLE gate), then composes up the
-# 4 app services + autoheal + cadvisor and polls /actuator/health.
+# secrets present, rollback jars present, IDLE gate), composes up the 4 app
+# services, polls /actuator/health, and ONLY THEN starts autoheal + cadvisor
+# (so autoheal cannot restart an app mid-cold-start).
 #
-# Idempotent: safe to re-run. Re-running will NOT recreate already-running
-# app containers (no config drift on their side).
+# Idempotent: safe to re-run on already-running app containers.
 #
 # Usage: ./docker/services/deploy-apps.sh
 set -euo pipefail
 cd "$(dirname "$0")/../.."  # repo root
 
 MODULES=(external-api calculator synchronizer cleanup)
+# MINIO_ACCESS_KEY string per module. For 3 modules it equals the module name;
+# external-api differs (ext-api). This must match the access key minio-bootstrap
+# baked into MinIO, NOT necessarily the module name.
 declare -A IMAGE_VAR=(
   [external-api]=IMAGE_EXTERNAL_API
   [calculator]=IMAGE_CALCULATOR
@@ -22,14 +25,19 @@ declare -A IMAGE_VAR=(
   [cleanup]=IMAGE_CLEANUP
 )
 
-# (1) Resolve image tag: prefer :dev, fall back to latest :sha-*
+# (1) Resolve image tag: prefer :dev, fall back to NEWEST :sha-* (by build time,
+# not lexicographic order — git short SHAs are not sortable as strings).
 echo "==> Resolving image tags"
 for mod in "${MODULES[@]}"; do
   if docker image inspect "maple/${mod}:dev" >/dev/null 2>&1; then
     img="maple/${mod}:dev"
   else
-    sha_tag=$(docker images --format '{{.Tag}}' "maple/${mod}" 2>/dev/null | grep '^sha-' | sort -r | head -1)
-    if [ -z "$sha_tag" ]; then
+    # Newest sha tag by CreatedAt (IMAGE ID col, format: Tag<TAB>CreatedAt).
+    sha_tag=$(docker images --format '{{.Tag}}\t{{.CreatedAt}}' "maple/${mod}" 2>/dev/null \
+      | awk -F'\t' '$1 ~ /^sha-/ {print}' \
+      | sort -k2,2 -r \
+      | head -1 | cut -f1)
+    if [ -z "${sha_tag:-}" ]; then
       echo "ERROR: no image for maple/${mod} (:dev nor :sha-*) — run docker/services/build.sh" >&2
       exit 1
     fi
@@ -49,17 +57,23 @@ for port in 8081 8082 8083 8084; do
 done
 
 # (3) Pre-flight: DNS resolves from maple-network (Task 0 network reconcile done?)
-echo "==> Pre-flight: DNS from maple-network (postgres/kafka/minio)"
-if ! docker run --rm --network maple-network alpine \
-  sh -c 'nslookup postgres >/dev/null 2>&1 && nslookup kafka >/dev/null 2>&1 && nslookup minio >/dev/null 2>&1' 2>/dev/null; then
-  cat >&2 <<'EOF'
-ERROR: DNS not resolving on maple-network.
-Run network reconcile first (the --alias is REQUIRED: docker network connect
+# Checks all 4 aliases the apps depend on (synchronizer needs redis too).
+echo "==> Pre-flight: DNS from maple-network (postgres/kafka/minio/redis)"
+if ! dns_missing=$(docker run --rm --network maple-network alpine sh -c '
+  for h in postgres kafka minio redis; do
+    nslookup "$h" >/dev/null 2>&1 || echo "$h"
+  done' 2>/dev/null); then
+  dns_missing="<docker run failed — is maple-network present?>"
+fi
+if [ -n "$dns_missing" ]; then
+  cat >&2 <<EOF
+ERROR: DNS not resolving on maple-network for: $(echo "$dns_missing" | tr '\n' ' ')
+Run network reconcile first (--alias is REQUIRED: docker network connect
 connects by container name, but app services reference the compose service
-alias 'postgres'/'kafka'/'minio', which does not transfer without --alias):
+alias, which does not transfer without --alias):
   docker network connect --alias postgres maple-network maple-postgres
-  docker network connect --alias kafka maple-network maple-kafka
-  docker network connect --alias minio maple-network probabilistic-valuation-engine-minio-1
+  docker network connect --alias kafka    maple-network maple-kafka
+  docker network connect --alias minio    maple-network probabilistic-valuation-engine-minio-1
 EOF
   exit 1
 fi
@@ -80,7 +94,8 @@ for mod in "${MODULES[@]}"; do
   fi
 done
 
-# (6) IDLE gate: no non-terminal calculation_jobs
+# (6) IDLE gate: no non-terminal calculation_jobs (distinguish parse-failure /
+# DB-down from a genuinely busy pipeline — do NOT mask DB errors as "not IDLE").
 echo "==> Pre-flight: IDLE gate (calculation_jobs non-terminal)"
 set -a; source .env; set +a
 H=$(echo "$DB_URL" | sed -n 's|.*://\([^:/]*\).*|\1|p')
@@ -88,24 +103,34 @@ P=$(echo "$DB_URL" | sed -n 's|.*://[^:/]*:\([0-9]*\).*|\1|p')
 N=$(echo "$DB_URL" | sed -n 's|.*/\([^?]*\).*|\1|p')
 U=$(echo "$DB_URL" | sed -n 's|.*user=\([^&]*\).*|\1|p')
 W=$(echo "$DB_URL" | sed -n 's|.*password=\([^&]*\).*|\1|p')
-active=$(PGPASSWORD="$W" psql "host=$H port=$P user=$U dbname=$N sslmode=disable" -t -A -c \
-  "SELECT count(*) FROM calculation_jobs WHERE status IN ('API_REQUESTED','RETRYING','CALCULATING');" 2>/dev/null || echo "?")
+if [ -z "$H" ] || [ -z "$U" ] || [ -z "$W" ]; then
+  echo "ERROR: failed to parse DB_URL for IDLE gate (host/user/password empty)" >&2
+  exit 1
+fi
+if ! active=$(PGPASSWORD="$W" psql "host=$H port=$P user=$U dbname=$N sslmode=disable" -t -A -c \
+  "SELECT count(*) FROM calculation_jobs WHERE status IN ('API_REQUESTED','RETRYING','CALCULATING');" 2>&1); then
+  echo "ERROR: IDLE gate DB query failed (DB unreachable?): $active" >&2
+  exit 1
+fi
+case "$active" in
+  ''|*[!0-9]*) echo "ERROR: IDLE gate returned non-numeric result: '$active'" >&2; exit 1 ;;
+esac
 if [ "$active" != "0" ]; then
   echo "ERROR: $active non-terminal calculation_jobs — pipeline not IDLE, abort (wait for drain or stop pipeline)" >&2
   exit 1
 fi
 
-# (7) Start 4 app services (IMAGE_* resolved above overrides services.yml :dev default)
+# (7) Start 4 app services (IMAGE_* overrides services.yml :dev default).
+# autoheal is intentionally NOT started here — it is started in step (9) AFTER
+# health polling, so it cannot restart an app during its cold start.
 echo "==> Starting 4 app services"
 docker compose -f docker-compose.yml -f docker-compose.services.yml up -d \
   external-api calculator synchronizer cleanup
 
-# (8) Start autoheal + cadvisor
-echo "==> Starting autoheal + cadvisor"
-docker compose -f docker-compose.yml up -d autoheal cadvisor
-
-# (9) Wait for app health (max ~120s per service)
+# (8) Wait for app health (max ~120s per service). Spring Boot cold start under
+# -Xmx2g can take 60-90s; if this times out, check `docker logs maple-<mod>`.
 echo "==> Waiting for app health"
+failed=()
 for entry in external-api:8081 calculator:8082 synchronizer:8083 cleanup:8084; do
   name="${entry%%:*}"; port="${entry##*:}"; ok=0
   for _ in $(seq 1 24); do
@@ -114,10 +139,25 @@ for entry in external-api:8081 calculator:8082 synchronizer:8083 cleanup:8084; d
     fi
     sleep 5
   done
-  echo "  $name (port $port): $([ "$ok" -eq 1 ] && echo UP || echo FAILED)"
+  if [ "$ok" -eq 1 ]; then
+    echo "  $name (port $port): UP"
+  else
+    echo "  $name (port $port): FAILED (check docker logs maple-$name)"
+    failed+=("$name")
+  fi
 done
+if [ "${#failed[@]}" -gt 0 ]; then
+  echo "ERROR: health check failed for: ${failed[*]}" >&2
+  echo "  starting autoheal/cadvisor anyway (for diagnostics); exiting non-zero" >&2
+  docker compose -f docker-compose.yml up -d autoheal cadvisor || true
+  exit 1
+fi
+
+# (9) Start autoheal + cadvisor AFTER apps are healthy.
+echo "==> Starting autoheal + cadvisor"
+docker compose -f docker-compose.yml up -d autoheal cadvisor
 
 # (10) Status table
 echo "==> Status"
 docker ps --format 'table {{.Names}}\t{{.Status}}' \
-  | grep -E 'maple-(external-api|calculator|synchronizer|cleanup|autoheal|cadvisor)|NAMES'
+  | grep -E 'maple-(external-api|calculator|synchronizer|cleanup|autoheal|cadvisor)|NAMES' || true

--- a/docker/services/deploy-apps.sh
+++ b/docker/services/deploy-apps.sh
@@ -97,7 +97,12 @@ done
 # (6) IDLE gate: no non-terminal calculation_jobs (distinguish parse-failure /
 # DB-down from a genuinely busy pipeline — do NOT mask DB errors as "not IDLE").
 echo "==> Pre-flight: IDLE gate (calculation_jobs non-terminal)"
-set -a; source .env; set +a
+# Read DB_URL LITERALLY from .env — do NOT `source .env`: .env contains
+# unquoted values with '$' (e.g. DB_ROOT_PASSWORD) which bash would expand
+# (corrupting them) and which `set -u` would reject as unbound. docker compose
+# reads .env with its own parser (no '$' expansion), so it is unaffected; we
+# only need DB_URL here, and DB_URL itself contains no '$'.
+DB_URL=$(grep -E '^DB_URL=' .env | head -1 | sed "s/^DB_URL=//; s/^'//; s/'$//; s/^\"//; s/\"$//")
 H=$(echo "$DB_URL" | sed -n 's|.*://\([^:/]*\).*|\1|p')
 P=$(echo "$DB_URL" | sed -n 's|.*://[^:/]*:\([0-9]*\).*|\1|p')
 N=$(echo "$DB_URL" | sed -n 's|.*/\([^?]*\).*|\1|p')

--- a/docker/services/deploy-apps.sh
+++ b/docker/services/deploy-apps.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# docker/services/deploy-apps.sh
+# Deploy 4 Spring Boot app services + autoheal + cadvisor via docker compose.
+#
+# Resolves the latest :sha-* image tag (:dev mutable tag may be absent),
+# runs pre-flight checks (ports free, DNS resolves on maple-network, SA
+# secrets present, rollback jars present, IDLE gate), then composes up the
+# 4 app services + autoheal + cadvisor and polls /actuator/health.
+#
+# Idempotent: safe to re-run. Re-running will NOT recreate already-running
+# app containers (no config drift on their side).
+#
+# Usage: ./docker/services/deploy-apps.sh
+set -euo pipefail
+cd "$(dirname "$0")/../.."  # repo root
+
+MODULES=(external-api calculator synchronizer cleanup)
+declare -A IMAGE_VAR=(
+  [external-api]=IMAGE_EXTERNAL_API
+  [calculator]=IMAGE_CALCULATOR
+  [synchronizer]=IMAGE_SYNCHRONIZER
+  [cleanup]=IMAGE_CLEANUP
+)
+
+# (1) Resolve image tag: prefer :dev, fall back to latest :sha-*
+echo "==> Resolving image tags"
+for mod in "${MODULES[@]}"; do
+  if docker image inspect "maple/${mod}:dev" >/dev/null 2>&1; then
+    img="maple/${mod}:dev"
+  else
+    sha_tag=$(docker images --format '{{.Tag}}' "maple/${mod}" 2>/dev/null | grep '^sha-' | sort -r | head -1)
+    if [ -z "$sha_tag" ]; then
+      echo "ERROR: no image for maple/${mod} (:dev nor :sha-*) — run docker/services/build.sh" >&2
+      exit 1
+    fi
+    img="maple/${mod}:${sha_tag}"
+  fi
+  export "${IMAGE_VAR[$mod]}=${img}"
+  echo "  ${IMAGE_VAR[$mod]}=${img}"
+done
+
+# (2) Pre-flight: ports 8081-8084 must be free (split-brain prevention)
+echo "==> Pre-flight: ports 8081-8084 free"
+for port in 8081 8082 8083 8084; do
+  if pid=$(lsof -ti:"$port" -sTCP:LISTEN 2>/dev/null) && [ -n "$pid" ]; then
+    echo "ERROR: port $port occupied (pid $pid) — stop nohup modules first" >&2
+    exit 1
+  fi
+done
+
+# (3) Pre-flight: DNS resolves from maple-network (Task 0 network reconcile done?)
+echo "==> Pre-flight: DNS from maple-network (postgres/kafka/minio)"
+if ! docker run --rm --network maple-network alpine \
+  sh -c 'nslookup postgres >/dev/null 2>&1 && nslookup kafka >/dev/null 2>&1 && nslookup minio >/dev/null 2>&1' 2>/dev/null; then
+  cat >&2 <<'EOF'
+ERROR: DNS not resolving on maple-network.
+Run network reconcile first (the --alias is REQUIRED: docker network connect
+connects by container name, but app services reference the compose service
+alias 'postgres'/'kafka'/'minio', which does not transfer without --alias):
+  docker network connect --alias postgres maple-network maple-postgres
+  docker network connect --alias kafka maple-network maple-kafka
+  docker network connect --alias minio maple-network probabilistic-valuation-engine-minio-1
+EOF
+  exit 1
+fi
+
+# (4) Pre-flight: SA secrets present
+echo "==> Pre-flight: SA secrets"
+ls docker/services/secrets/sa-ext-api.key \
+   docker/services/secrets/sa-calculator.key \
+   docker/services/secrets/sa-synchronizer.key \
+   docker/services/secrets/sa-cleanup.key >/dev/null
+
+# (5) Pre-flight: rollback jars present
+echo "==> Pre-flight: rollback jars"
+for mod in "${MODULES[@]}"; do
+  if [ ! -f "module-${mod}/build/libs/module-${mod}-0.0.1-SNAPSHOT.jar" ]; then
+    echo "ERROR: rollback jar missing: module-${mod}/build/libs/module-${mod}-0.0.1-SNAPSHOT.jar" >&2
+    exit 1
+  fi
+done
+
+# (6) IDLE gate: no non-terminal calculation_jobs
+echo "==> Pre-flight: IDLE gate (calculation_jobs non-terminal)"
+set -a; source .env; set +a
+H=$(echo "$DB_URL" | sed -n 's|.*://\([^:/]*\).*|\1|p')
+P=$(echo "$DB_URL" | sed -n 's|.*://[^:/]*:\([0-9]*\).*|\1|p')
+N=$(echo "$DB_URL" | sed -n 's|.*/\([^?]*\).*|\1|p')
+U=$(echo "$DB_URL" | sed -n 's|.*user=\([^&]*\).*|\1|p')
+W=$(echo "$DB_URL" | sed -n 's|.*password=\([^&]*\).*|\1|p')
+active=$(PGPASSWORD="$W" psql "host=$H port=$P user=$U dbname=$N sslmode=disable" -t -A -c \
+  "SELECT count(*) FROM calculation_jobs WHERE status IN ('API_REQUESTED','RETRYING','CALCULATING');" 2>/dev/null || echo "?")
+if [ "$active" != "0" ]; then
+  echo "ERROR: $active non-terminal calculation_jobs — pipeline not IDLE, abort (wait for drain or stop pipeline)" >&2
+  exit 1
+fi
+
+# (7) Start 4 app services (IMAGE_* resolved above overrides services.yml :dev default)
+echo "==> Starting 4 app services"
+docker compose -f docker-compose.yml -f docker-compose.services.yml up -d \
+  external-api calculator synchronizer cleanup
+
+# (8) Start autoheal + cadvisor
+echo "==> Starting autoheal + cadvisor"
+docker compose -f docker-compose.yml up -d autoheal cadvisor
+
+# (9) Wait for app health (max ~120s per service)
+echo "==> Waiting for app health"
+for entry in external-api:8081 calculator:8082 synchronizer:8083 cleanup:8084; do
+  name="${entry%%:*}"; port="${entry##*:}"; ok=0
+  for _ in $(seq 1 24); do
+    if curl -sf "http://localhost:$port/actuator/health" 2>/dev/null | grep -q '"status":"UP"'; then
+      ok=1; break
+    fi
+    sleep 5
+  done
+  echo "  $name (port $port): $([ "$ok" -eq 1 ] && echo UP || echo FAILED)"
+done
+
+# (10) Status table
+echo "==> Status"
+docker ps --format 'table {{.Names}}\t{{.Status}}' \
+  | grep -E 'maple-(external-api|calculator|synchronizer|cleanup|autoheal|cadvisor)|NAMES'

--- a/docs/01_ADR/ADR-737_nohup-to-docker-deployment.md
+++ b/docs/01_ADR/ADR-737_nohup-to-docker-deployment.md
@@ -1,0 +1,94 @@
+# ADR-737: nohup → docker compose 배포 전환
+
+- Status: Accepted
+- Date: 2026-06-26
+- Owner: maple-pipeline
+- Related: #1245, #1428, #1429, #1430, #1431, ADR-731, ADR-733
+
+---
+
+## 1. Background / Problem
+
+### Background
+
+- 4 active 모듈(external-api/calculator/synchronizer/cleanup)을 nohup 호스트 프로세스로 운영. #1245 로 이미지 빌드(`:sha-75cb631`).
+- Endurance Test #2(~71h) 종료 직후, 파이프라인 IDLE(`calculation_jobs` non-terminal=0), 4 포트 FREE.
+
+### Problem
+
+- 운영 통일(autoheal 자동복구, cadvisor 컨테이너 메트릭) 위해 docker 전환 필요.
+- 단, grill(critic opus) + 독립 검증으로 3가지 장애물 발견:
+  1. **network duality** — infra(postgres/kafka/minio)는 `probabilistic-valuation-engine_maple-network`(project=probabilistic-valuation-engine)에, redis만 `maple-network`에 존재. app 서비스(services.yml)가 `maple-network` 선언 → `postgres`/`kafka`/`minio` DNS **SERVFAIL** (실측). 기본 `compose up` 시 app crash-loop.
+  2. **`:dev` 태그 부재** — services.yml 기본값 `maple/{module}:dev` 가 image not found (`:sha-75cb631`만 존재).
+  3. **airflow host-network drift** — compose bridge 선언 vs 실제 host network. recreate 시 healthy webserver 파손 위험.
+- autoheal/cadvisor 정의만 존재, 미가동.
+
+### Goal
+
+- network reconcile + tag 해석으로 4 모듈 docker 배포 정상화. autoheal/cadvisor 가동. runbook 문서화.
+
+---
+
+## 2. Decision
+
+> (1) infra 컨테이너를 `maple-network`에 live 연결(DNS 해석). (2) deploy-apps.sh 가 `:sha-*` 태그 자동 해석(`:dev` 부재 회피). (3) airflow autoheal runtime 은 별도 이관(host-network drift 위험).
+
+```text
+Task0: docker network connect --alias <service> maple-network <infra-ctn>
+       (postgres/kafka/minio — --alias 필수: 컨테이너명 아닌 service alias 로 app 가 참조)
+deploy: IMAGE_<MOD>=maple/<mod>:sha-<latest>  (deploy-apps.sh resolves)
+airflow: 제외 (follow-up — host/bridge network reconcile 선행 필요)
+```
+
+`docker network connect --alias` 는 non-disruptive(재시작 아님). 단 `--alias` 생략 시 service alias(postgres/kafka/minio)가 DNS 미해석 → app crash. prometheus 는 host network + 포트퍼블리시로 mode-agnostic → config 변경 無.
+
+---
+
+## 3. Trade-offs
+
+### Sensitivity
+
+* `maple-network` 연결 영속성 — `restart` 에는 유지되나 `rm + recreate` 시 상실(runbook 기재).
+* `:sha-*` 태그 존재 — 빌드 후 최신 sha 유지 필요.
+* IDLE 시점 — in-flight 손실 방지(hard gate).
+
+### Trade-off
+
+| 선택 | 얻는 것 | 포기한 것 |
+| -- | ---- | ----- |
+| live network connect (infra recreate 아님) | infra 무중단 reconcile | recreate 시 재연결 필요(수동) |
+| airflow autoheal 이관 | 동작 중 airflow 보호 | airflow 자동복구 지연(follow-up) |
+
+### Risk
+
+* network connect 비영속 — runbook 기재로 보완. infra recreate 시 재실행.
+* 카운터 리셋 — 프로세스 전환으로 Prometheus 누적 counter 0 초기화. endurance 데이터는 endurance-report-71h.md 로 보존. post-test 시점 허용.
+
+### Non-Risk
+
+* 데이터 손실 — IDLE 전환(non-terminal job=0, kafka lag=0).
+* prometheus config — host network + 포트퍼블리시로 mode-agnostic, 변경 無.
+* DB 데이터 — PostgreSQL 컨테이너 계속 running, 전환 무관.
+
+---
+
+## 4. Result / Evidence
+
+### Metrics
+
+| Metric | Value | Notes |
+| ------ | ----: | ----- |
+| DNS(postgres from maple-network) | SERVFAIL → 해결 | Task 0 후 |
+| 4 모듈 `/actuator/health` | 4/4 UP | 배포 후 |
+| cadvisor metric 수집 | `container_cpu_usage_seconds_total` series ≥ 1 | 배포 후 |
+
+### Observed Result
+
+* 설정 검증: deploy-apps.sh 구문 PASS, `compose config` PASS.
+* 런타임 검증: 배포 실행 후 본 절에 실측값 기재.
+
+---
+
+## 5. Summary
+
+> infra 를 `maple-network`에 live 연결하고 deploy-apps.sh 가 sha 태그를 해석하여 4 모듈 docker 전환. airflow autoheal 은 network reconcile 선행 필요로 별도 이관. 파이프라인 IDLE 시점 전환으로 데이터 손실 0.

--- a/docs/01_ADR/ADR-737_nohup-to-docker-deployment.md
+++ b/docs/01_ADR/ADR-737_nohup-to-docker-deployment.md
@@ -82,10 +82,17 @@ airflow: 제외 (follow-up — host/bridge network reconcile 선행 필요)
 | 4 모듈 `/actuator/health` | 4/4 UP | 배포 후 |
 | cadvisor metric 수집 | `container_cpu_usage_seconds_total` series ≥ 1 | 배포 후 |
 
-### Observed Result
+### Observed Result (2026-06-26 배포 후 실측)
 
-* 설정 검증: deploy-apps.sh 구문 PASS, `compose config` PASS.
-* 런타임 검증: 배포 실행 후 본 절에 실측값 기재.
+* **배포 성공**: 4 app 컨테이너 healthy + autoheal + cadvisor Up.
+* **network reconcile 검증**: `maple-network` 에서 postgres→10.0.3.2 / kafka→10.0.3.3 / minio→10.0.3.5 / redis→10.0.3.4 해석 (이전 SERVFAIL 해소). 단 `docker network connect --alias <svc>` 필수.
+* **이미지 태그**: `:dev` 부재 → deploy-apps.sh 가 `:sha-75cb631` 자동 해석.
+* **pipeline 흐름**: ext-api run-on-startup → RankingFetch `fetched=270000 page=1350/3000 failed=0` → Kafka chunk-ready publish → calculator 소비 → synchronizer 파티션 할당.
+* **ERROR 로그**: 4 컨테이너 전부 0. **Kafka LAG**: 전 consumer group 0.
+* **cadvisor (#1430)**: prometheus 가 `container_cpu_usage_seconds_total`/`container_memory_usage_bytes` 각 76 series 스크레이프 (config reload 위해 prometheus 재시작 1회).
+* **prometheus app scrape**: external-api/calc/synchronizer `up=1`. cleanup `/actuator/prometheus` 404 (기존 미노출, health UP → 회귀 아님).
+* **재시작 영향**: postgres/kafka/minio 가 compose reconcile 로 recreate (수초, volume 보존, IDLE 허용).
+* **경고**: `.env` DB_ROOT_PASSWORD 의 `$pNDA2` 를 compose interpolation → blank. 단 postgres·app 동일 interpolation → 상호 일관.
 
 ---
 

--- a/docs/21_Operations/docker-deploy-runbook.md
+++ b/docs/21_Operations/docker-deploy-runbook.md
@@ -1,0 +1,130 @@
+# nohup → docker compose 배포 Runbook (#1428 / #1431)
+
+4 active 모듈(external-api:8081 / calculator:8082 / synchronizer:8083 / cleanup:8084)의 nohup ↔ docker 전환 절차. 반복 전환/rollback 시 참조.
+
+## 사전 조건
+
+- **이미지 빌드**: `docker images | grep maple/` → `:sha-XXX` 존재 (build.sh 가 `:dev` + `:sha-` 둘 부여; `:dev` 부재 시 deploy-apps.sh 가 sha 자동 해석).
+- **SA secret**: `ls docker/services/secrets/sa-*.key` → 4종 (ext-api/calculator/synchronizer/cleanup).
+- **rollback jar**: `ls module-*/build/libs/*SNAPSHOT.jar` → 4종 (non-plain).
+- **인프라 running**: `docker ps` → postgres/kafka/redis/minio Up.
+
+## IDLE 정의 (hard gate)
+
+파이프라인 **IDLE** 상태에서만 전환 (in-flight chunk 손실 방지):
+
+- `calculation_jobs` non-terminal(API_REQUESTED / RETRYING / CALCULATING) = 0
+- Kafka consumer LAG = 0
+
+```sql
+SELECT count(*) FROM calculation_jobs
+WHERE status IN ('API_REQUESTED','RETRYING','CALCULATING');
+```
+
+deploy-apps.sh 가 이 값을 pre-flight 로 검사(0 아니면 abort).
+
+## network reconcile (최초 1회 + infra recreate 시마다)
+
+app 컨테이너(services.yml)는 `maple-network` 선언. infra(postgres/kafka/minio)가 동일 network 에 있어야 DNS 해석.
+
+> **현황**: infra 는 project `probabilistic-valuation-engine` 의 `probabilistic-valuation-engine_maple-network` 에 존재, redis 만 `maple-network`. 아래 connect 로 `maple-network` 에 infra 를 추가.
+
+```bash
+# --alias 필수: docker network connect 는 컨테이너명(maple-postgres)으로 연결하지만,
+# app 서비스는 compose service alias(postgres)로 참조 → alias 없으면 DNS 미해석.
+docker network connect --alias postgres maple-network maple-postgres
+docker network connect --alias kafka maple-network maple-kafka
+docker network connect --alias minio maple-network probabilistic-valuation-engine-minio-1
+
+# 검증 (전부 실제 IP 출력되어야 함 — UNRESOLVED/SERVFAIL 이면 실패)
+docker run --rm --network maple-network alpine \
+  sh -c 'for h in postgres kafka minio redis; do nslookup "$h"; done'
+```
+
+> 이미 alias 없이 연결된 경우: `docker network disconnect maple-network <ctn>` 후 위 `--alias` 명령으로 재연결.
+
+**주의 (비영속)**: `docker network connect` 는 `restart: always` 재시작에는 유지되나 **`docker rm` + recreate (예: `compose down && up` 또는 `--force-recreate`) 시 상실**. infra recreate 후 본 절 재실행.
+
+## 전환 절차 (nohup → docker)
+
+1. **IDLE 확인** (위 쿼리 = 0).
+2. **network reconcile 완료** (위 절차, DNS 검증).
+3. **nohup 4 프로세스 stop** (graceful):
+   ```bash
+   for p in 8081 8082 8083 8084; do
+     pid=$(lsof -ti:$p -sTCP:LISTEN 2>/dev/null)
+     [ -n "$pid" ] && kill -TERM "$pid"
+   done
+   # 잔존 시 graceful timeout 후 kill -KILL
+   ```
+4. **포트 free 확인**:
+   ```bash
+   for p in 8081 8082 8083 8084; do
+     pid=$(lsof -ti:$p -sTCP:LISTEN 2>/dev/null); echo "$p: ${pid:-FREE}"
+   done
+   # 전부 FREE 여야 함
+   ```
+5. **배포** (스크립트 권장):
+   ```bash
+   ./docker/services/deploy-apps.sh
+   ```
+   스크립트가 tag 해석 + pre-flight(port/DNS/secret/jar/IDLE) + `compose up` + health 폴링 수행.
+6. **검증** (아래 체크리스트).
+
+## Rollback 절차 (docker → nohup)
+
+1. docker app 서비스 중지:
+   ```bash
+   docker compose -f docker-compose.yml -f docker-compose.services.yml down \
+     external-api calculator synchronizer cleanup
+   ```
+2. 포트 free 확인 (위 4번).
+3. nohup 재시작 (`.env` source 후 모듈별 env):
+   ```bash
+   set -a && source .env && set +a
+   for mod in external-api calculator synchronizer cleanup; do
+     sa=$( [ "$mod" = external-api ] && echo ext-api || echo "$mod" )
+     MINIO_ACCESS_KEY="$sa" \
+     MINIO_SECRET_KEY_FILE="$(pwd)/docker/services/secrets/sa-${sa}.key" \
+     nohup java -jar "module-${mod}/build/libs/module-${mod}-0.0.1-SNAPSHOT.jar" \
+       > "/tmp/${mod}.log" 2>&1 &
+   done
+   # NEXON_API_KEY / KAFKA_BOOTSTRAP_SERVERS / DB_URL / SPRING_PROFILES_ACTIVE 등은
+   # .env 에서 source 되어 전파 (nohup 프로세스가 host .env 환경 사용).
+   ```
+
+## 검증 체크리스트
+
+- [ ] 4 모듈 `/actuator/health` → `{"status":"UP"}` (ports 8081-8084)
+- [ ] `docker ps` → maple-{external-api,calculator,synchronizer,cleanup,autoheal,cadvisor} Up
+- [ ] autoheal: throwaway unhealthy 컨테이너 → 재시작 + app 컨테이너 무영향 (false positive 없음)
+- [ ] cadvisor metric: `curl -s http://localhost:8086/metrics | grep -m1 container_cpu_usage_seconds_total`
+- [ ] Prometheus: `container_cpu_usage_seconds_total` series ≥ 1
+- [ ] Kafka consumer LAG: 처리 가능 범위 (기동 직후 일시 backlog 후 0 수렴 허용)
+- [ ] DB read model row 증가 (manual trigger 후 — 아래)
+- [ ] ERROR 로그 0: `docker logs maple-<module> 2>&1 | grep -c ERROR`
+
+## end-to-end 검증 (manual trigger)
+
+IDLE 상태에서 DB row 증가를 확인하려면 강제 트리거로 파이프라인 전 모듈 흐름(ext-api → kafka → calculator → synchronizer → DB)을 exercise:
+
+```bash
+curl -s -w "\nHTTP %{http_code}\n" "http://localhost:8080/api/v5/characters/진격캐넌/expectation"
+# 202 접수 후 60s 간격으로 read model row 2회 측정 → 증가 확인
+```
+
+## 주의사항
+
+- **Split-brain**: 두 모드가 동시 포트 점유 금지. 반드시 nohup stop → 포트 free 확인 후 docker up.
+- **카운터 리셋**: 프로세스 전환 시 Prometheus 누적 counter 0 초기화. endurance 누적 데이터는 `docs/endurance-test/endurance-report-71h.md` 에 보존. 전환 시점 이후부터 재누적.
+- **다운타임**: IDLE 시점 전환 시 데이터 손실 0. 처리 중 전환 시 in-flight chunk 손실 가능 → 반드시 IDLE 확인.
+- **network 비영속**: infra recreate 시 `docker network connect` 재실행 (위).
+- **이미지 태그**: 기본 `:dev`(services.yml). 부재 시 deploy-apps.sh 가 최신 `:sha-*` 자동 해석. reproducible 고정 필요 시 `IMAGE_<MODULE>=maple/<module>:sha-XXX` env 수동 지정.
+- **cadvisor `/dev/kmsg`**: 일부 호스트에서 device 마운트 실패 시 `docker-compose.yml` cadvisor `devices:` 블록 주석화 후 re-up (본 호스트는 `/dev/kmsg` 존재, 정상).
+- **airflow autoheal**: 본 runbook 미포함. airflow compose 는 bridge 선언이나 실제 host network 로 구동 → recreate 시 topology 변형 위험. host/bridge network reconcile 선행 필요 → 별도 follow-up 이슈.
+
+## 관련
+
+- ADR-731 (autoheal/coolify self-healing), ADR-733 (cadvisor/observability), ADR-737 (본 전환)
+- spec: `docs/superpowers/specs/2026-06-26-nohup-to-docker-deployment-design.md`
+- plan: `docs/superpowers/plans/2026-06-26-nohup-to-docker-deployment.md`

--- a/docs/superpowers/plans/2026-06-26-nohup-to-docker-deployment.md
+++ b/docs/superpowers/plans/2026-06-26-nohup-to-docker-deployment.md
@@ -1,16 +1,27 @@
-# nohup → docker compose 배포 전환 Implementation Plan (#1428–#1431)
+# nohup → docker compose 배포 전환 Implementation Plan (#1428–#1431) — REVISED post-grill
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
 
-**Goal:** 4 active 모듈을 nohup → docker compose 로 전환하고 autoheal/cadvisor 를 가동·검증한 뒤 runbook 으로 문서화.
+**Goal:** 4 active 모듈을 nohup → docker compose 로 전환, autoheal/cadvisor 가동·검증, runbook 문서화.
 
-**Architecture:** 설정 변경은 최소(airflow autoheal 라벨 추가만). prometheus 는 host network + 포트퍼블리시로 mode-agnostic 이라 config 변경 無. idempotent deploy 스크립트가 `compose up` + health 폴링 수행. 파이프라인 IDLE 시점 전환.
-
-**Tech Stack:** docker compose v2, willfarrell/autoheal, gcr.io/cadvisor/cadvisor, Prometheus, Spring Boot Actuator, bash.
+**Architecture:** 사전 network reconcile(infra → `maple-network` 연결) 선행. prometheus 는 host network + 포트퍼블리시로 mode-agnostic → config 변경 無. deploy-apps.sh 가 image tag 자동 해석 + DNS/secret/IDLE pre-flight + health 검증 수행. airflow autoheal runtime 은 별도 follow-up 이슈로 이관(동작 중 infra 보호).
 
 **Spec:** `docs/superpowers/specs/2026-06-26-nohup-to-docker-deployment-design.md`
 
-**Test strategy note:** 본 작업은 config/docs/ops 이며 애플리케이션 코드 변경 無 → unit test 대상 아님. workflow-rules 통합테스트 금지(#207). 검증 = `docker compose config` 구문 검증 + 런타임 health/prometheus/kafka/DB 확인.
+**Tech Stack:** docker compose v2, willfarrell/autoheal, cadvisor, Prometheus, Spring Boot Actuator, bash.
+
+**Test strategy:** config/ops 작업, 앱 코드 변경 無 → unit test 대상 아님. workflow-rules 통합테스트 금지(#207). 검증 = `compose config` 구문 + 런타임 health/prometheus/kafka/DB/manual-trigger.
+
+---
+
+## grill 반영 (REJECT → FIX)
+
+critic(opus) 적대 리뷰 + 독립 검증으로 확인된 BLOCKER:
+
+1. **network duality** — `maple-network`(redis만) vs `probabilistic-valuation-engine_maple-network`(infra 전부). app 컨테이너 `postgres`/`kafka`/`minio` DNS SERVFAIL. → **Task 0** reconcile.
+2. **`:dev` 태그 부재** — 4 모듈 전부 `:sha-75cb631`만 존재, `:dev` 없음. services.yml 기본값 동작 안 함. → deploy-apps.sh 가 sha 태그 자동 해석.
+3. **airflow host-network drift** — compose bridge 선언 vs 실제 host. recreate 시 healthy webserver 파손 위험. → airflow runtime 본 PR 제외, follow-up 이관.
+4. pre-flight 강화(DNS/secret/image/IDLE), IDLE 정의 구체화, manual trigger 검증 의무화, autoheal 유발 테스트, rollback env 완비.
 
 ---
 
@@ -18,21 +29,54 @@
 
 | 파일 | 책임 | 신규/수정 |
 |---|---|---|
-| `docs/01_ADR/ADR-737_nohup-to-docker-deployment.md` | 전환 결정 + trade-offs | 신규 |
-| `docker-compose.airflow.yml` | airflow 3컨테이너 autoheal 라벨 | 수정 |
-| `docker/services/deploy-apps.sh` | idempotent 배포 + health 검증 스크립트 | 신규 |
-| `docs/21_Operations/docker-deploy-runbook.md` | 전환/rollback/검증 체크리스트 | 신규 |
+| `docs/01_ADR/ADR-737_nohup-to-docker-deployment.md` | 전환 결정 + network 현실 반영 | 신규 |
+| `docker/services/deploy-apps.sh` | tag 해석 + pre-flight + 배포 + health 검증 | 신규 |
+| `docs/21_Operations/docker-deploy-runbook.md` | 전환/rollback/검증/IDLE 정의/network 주의 | 신규 |
+
+airflow compose 변경 = 제외(follow-up #1432-airflow-autoheal).
 
 ---
 
-## Task 1: ADR-737 작성 (RPI 선행)
+## Task 0: Network Reconciliation (BLOCKER 선행)
 
-**Files:**
-- Create: `docs/01_ADR/ADR-737_nohup-to-docker-deployment.md`
+**Files:** (none — operational, live `docker network connect`)
 
-- [ ] **Step 1: ADR 파일 작성** (adr-conventions 5섹션 준수)
+- [ ] **Step 1: 현재 network membership 재확인**
 
-내용:
+Run:
+```bash
+docker network inspect maple-network --format '{{range .Containers}}{{.Name}} {{end}}'
+docker network inspect probabilistic-valuation-engine_maple-network --format '{{range .Containers}}{{.Name}} {{end}}'
+```
+Expected: maple-network = `maple-redis`(only); prefixed = postgres/kafka/minio/...
+
+- [ ] **Step 2: infra 컨테이너를 `maple-network`에 연결** (live, non-disruptive)
+
+```bash
+docker network connect maple-network maple-postgres
+docker network connect maple-network maple-kafka
+docker network connect maple-network probabilistic-valuation-engine-minio-1
+```
+(redis는 이미 maple-network에 존재)
+
+Expected: 각 명령 무출력(성공). 이미 연결 시 "already exists" 무해.
+
+- [ ] **Step 3: DNS 해석 검증 (결정적)**
+
+```bash
+docker run --rm --network maple-network alpine sh -c 'nslookup postgres; nslookup kafka; nslookup minio; nslookup redis' 2>&1 | grep -E 'Name:|Address:'
+```
+Expected: postgres/kafka/minio/redis 각 Address 출력(이전 SERVFAIL → 해결).
+
+- [ ] **Step 4: persistence 주의사항** — `docker network connect` 는 `restart: always` 재시작에는 유지되나 `rm + recreate` 시 상실. runbook(Task 4)에 기재: infra recreate 시 재연결 필요.
+
+---
+
+## Task 1: ADR-737 작성 (RPI)
+
+**Files:** Create `docs/01_ADR/ADR-737_nohup-to-docker-deployment.md`
+
+- [ ] **Step 1: ADR 작성** (adr-conventions 5섹션)
 
 ````markdown
 # ADR-737: nohup → docker compose 배포 전환
@@ -47,31 +91,29 @@
 
 ### Background
 
-- 4 active 모듈(external-api/calculator/synchronizer/cleanup)을 nohup 호스트 프로세스로 운영.
-- #1245 로 이미지 빌드 완료(`maple/{module}:dev` + `:sha-75cb631`).
-- `docker-compose.services.yml` 오버레이 구성 완료(healthcheck + autoheal 라벨 + MinIO SA secret).
-- Endurance Test #2(~71h) 종료 직후, 파이프라인 IDLE, 4 포트 FREE.
+- 4 active 모듈을 nohup 호스트 프로세스로 운영. #1245 로 이미지 빌드(`:sha-75cb631`). Endurance Test #2(~71h) 종료 직후, 파이프라인 IDLE.
+- **infra network 드리프트 발견**: infra(postgres/kafka/minio)는 `probabilistic-valuation-engine_maple-network`(project=probabilistic-valuation-engine)에, redis만 `maple-network`에 존재. docker-compose.yml 은 `maple-network` external 선언. app 서비스(services.yml)가 `maple-network` 선언 → postgres/kafka/minio DNS 미해석.
+- `:dev` mutable 태그 부재(build.sh 는 두 태그 부여 의도였으나 현재 `:sha-75cb631`만).
 
 ### Problem
 
-- 운영 통일(autoheal 자동복구, cadvisor 컨테이너 메트릭) 위해 docker 전환 필요.
-- autoheal/cadvisor 정의는 있으나 미가동. airflow 컨테이너 autoheal 라벨 누락.
+- 운영 통일(autoheal, cadvisor) 위해 docker 전환 필요하나, network 드리프트·태그 부재로 기본 `compose up` 시 app 컨테이너 crash-loop.
+- autoheal/cadvisor 정의만 존재, 미가동.
 
 ### Goal
 
-- docker compose 로 4 모듈 실배포. autoheal/cadvisor 가동. runbook 문서화.
+- network reconcile + tag 해석으로 4 모듈 docker 배포 정상화. autoheal/cadvisor 가동. runbook 문서화.
 
 ---
 
 ## 2. Decision
 
-> nohup 호스트 프로세스를 docker compose 로 전환한다. prometheus 는 host network + 포트퍼블리시로 mode-agnostic → scrape config 유지.
+> (1) infra 컨테이너를 `maple-network`에 live 연결(DNS 해석). (2) deploy-apps.sh 가 `:sha-*` 태그 자동 해석(`:dev` 부재 회피). (3) airflow autoheal runtime 은 별도 이관(host-network drift 위험).
 
 ```text
-4 modules: nohup java -jar → docker compose (services.yml overlay)
-autoheal: 정의만 존재 → up -d 가동
-cadvisor: 정의만 존재 → up -d 가동
-airflow 3 containers: autoheal label 추가 후 recreate
+Task0: docker network connect maple-network {postgres,kafka,minio}
+deploy: IMAGE_<MOD>=maple/<mod>:sha-<latest> (deploy-apps.sh resolves)
+airflow: 제외 (follow-up — host/bridge network reconcile 선행 필요)
 ```
 
 ---
@@ -80,25 +122,26 @@ airflow 3 containers: autoheal label 추가 후 recreate
 
 ### Sensitivity
 
-* 배포 시점(파이프라인 IDLE) — chunk 손실 방지
-* 포트 점유 — split-brain 방지 조건
-* `:dev` 태그가 최신 빌드 지칭 여부
+* `maple-network` 연결 영속성 — recreate 시 상실(runbook 기재)
+* `:sha-*` 태그 존재 — 빌드 후 최신 sha 유지
+* IDLE 시점 — in-flight 손실 방지
 
 ### Trade-off
 
 | 선택 | 얻는 것 | 포기한 것 |
 | -- | ---- | ----- |
-| docker 운영 통일 | autoheal 자동복구, cadvisor 메트릭, 통합 관리 | nohup in-process fallback |
+| live network connect (infra recreate 아님) | infra 무중단 reconcile | recreate 시 재연결 필요(수동) |
+| airflow autoheal 이관 | 동작 중 airflow 보호 | airflow 자동복구 지연(follow-up) |
 
 ### Risk
 
-* 배포 실패 시 rollback — runbook 에 `compose down` → nohup 경로 문서화.
-* 카운터 리셋 — Prometheus 누적값 초기화(post-test 허용).
+* network connect 비영속 — runbook 기재로 보완.
+* 카운터 리셋 — Prometheus 누적 초기화(post-test 허용).
 
 ### Non-Risk
 
-* 데이터 손실 — IDLE 시점 전환.
-* prometheus config — mode-agnostic, 변경 無.
+* 데이터 손실 — IDLE 전환(calculation_jobs non-terminal=0, kafka lag=0 확인).
+* prometheus config — host network + 포트퍼블리시로 mode-agnostic, 변경 無.
 
 ---
 
@@ -108,19 +151,20 @@ airflow 3 containers: autoheal label 추가 후 recreate
 
 | Metric | Value | Notes |
 | ------ | ----: | ----- |
+| DNS 해석(postgres from maple-network) | SERVFAIL → 해결 | Task0 후 |
 | 4 모듈 health | 4/4 UP | 배포 후 |
 | cadvisor metric 수집 | container_cpu_usage_seconds_total 조회 성공 | 배포 후 |
 
 ### Observed Result
 
-* 코드/설정 검증: airflow 라벨 추가 + deploy-apps.sh + runbook 작성. `docker compose config` 구문 PASS.
-* 런타임 검증: 배포 실행 후 본 절 실측값 기재.
+* 설정 검증: deploy-apps.sh 구문 PASS, `compose config` PASS.
+* 런타임: 배포 후 실측값 기재.
 
 ---
 
 ## 5. Summary
 
-> 파이프라인 IDLE 시점에 4 모듈을 docker compose 로 전환, autoheal/cadvisor 가동. prometheus mode-agnostic 으로 config 변경 無.
+> infra 를 `maple-network`에 live 연결하고 deploy-apps.sh 가 sha 태그를 해석하여 4 모듈 docker 전환. airflow autoheal 은 network reconcile 선행 필요로 별도 이관.
 ````
 
 - [ ] **Step 2: commit**
@@ -134,243 +178,221 @@ Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
 
 ---
 
-## Task 2: airflow autoheal 라벨 추가 (#1429)
+## Task 2: deploy-apps.sh (tag 해석 + pre-flight + 배포)
 
-**Files:**
-- Modify: `docker-compose.airflow.yml` (airflow-db ~L6, airflow-webserver ~L24, airflow-scheduler ~L55)
-
-- [ ] **Step 1: airflow-db 라벨 추가**
-
-`docker-compose.airflow.yml` 의 `airflow-db` 서비스 — `container_name: maple-airflow-db` 다음 줄에 labels 추가:
-
-```yaml
-    container_name: maple-airflow-db
-    labels:
-      autoheal: "true"
-    restart: always
-```
-
-- [ ] **Step 2: airflow-webserver 라벨 추가**
-
-```yaml
-    container_name: maple-airflow-webserver
-    labels:
-      autoheal: "true"
-    restart: unless-stopped
-```
-
-- [ ] **Step 3: airflow-scheduler 라벨 추가**
-
-```yaml
-    container_name: maple-airflow-scheduler
-    labels:
-      autoheal: "true"
-    restart: unless-stopped
-```
-
-- [ ] **Step 4: 구문 검증**
-
-Run: `docker compose -f docker-compose.yml -f docker-compose.airflow.yml config >/dev/null && echo OK`
-Expected: `OK`
-
-- [ ] **Step 5: 라벨 적용 확인 (dry)**
-
-Run: `docker compose -f docker-compose.yml -f docker-compose.airflow.yml config | grep -A1 autoheal | head -20`
-Expected: 3개 airflow 서비스 + 기존 infra 서비스 autoheal 라벨 출력
-
-- [ ] **Step 6: commit**
-
-```bash
-git add docker-compose.airflow.yml
-git commit -m "feat(airflow): add autoheal labels to 3 airflow containers (#1429)
-
-Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
-```
-
----
-
-## Task 3: deploy-apps.sh 스크립트 (#1428/#1429/#1430)
-
-**Files:**
-- Create: `docker/services/deploy-apps.sh`
+**Files:** Create `docker/services/deploy-apps.sh`
 
 - [ ] **Step 1: 스크립트 작성**
 
 ````bash
 #!/usr/bin/env bash
 # docker/services/deploy-apps.sh
-# Deploy 4 Spring Boot app services + autoheal + cadvisor via docker compose.
-# Idempotent: safe to re-run. Pre-flight checks ports (split-brain prevention)
-# and verifies /actuator/health after start.
-#
-# Usage: ./docker/services/deploy-apps.sh
+# Deploy 4 Spring Boot app services + autoheal + cadvisor.
+# Resolves latest :sha-* image tag (:dev may be absent), runs pre-flight
+# (ports free, DNS resolves, secrets present, jars for rollback, IDLE gate),
+# then compose up + health polling.
 set -euo pipefail
 cd "$(dirname "$0")/../.."  # repo root
 
-# (1) Pre-flight: ports 8081-8084 must be FREE (no nohup split-brain)
-echo "==> Pre-flight: checking ports 8081-8084 are free"
+MODULES=(external-api calculator synchronizer cleanup)
+declare -A IMAGE_VAR=( [external-api]=IMAGE_EXTERNAL_API [calculator]=IMAGE_CALCULATOR [synchronizer]=IMAGE_SYNCHRONIZER [cleanup]=IMAGE_CLEANUP )
+
+# (1) Resolve image tag: prefer :dev, fall back to latest :sha-*
+echo "==> Resolving image tags"
+for mod in "${MODULES[@]}"; do
+  if docker image inspect "maple/${mod}:dev" >/dev/null 2>&1; then
+    img="maple/${mod}:dev"
+  else
+    img=$(docker images --format '{{.Tag}}' "maple/${mod}" | grep '^sha-' | sort -r | head -1)
+    if [ -z "$img" ]; then
+      echo "ERROR: no image for maple/${mod} (:dev nor :sha-*) — run build.sh" >&2; exit 1
+    fi
+    img="maple/${mod}:${img}"
+  fi
+  export "${IMAGE_VAR[$mod]}=${img}"
+  echo "  ${IMAGE_VAR[$mod]}=${img}"
+done
+
+# (2) Pre-flight: ports free (split-brain)
+echo "==> Pre-flight: ports 8081-8084 free"
 for port in 8081 8082 8083 8084; do
   if pid=$(lsof -ti:"$port" -sTCP:LISTEN 2>/dev/null) && [ -n "$pid" ]; then
-    echo "ERROR: port $port occupied (pid $pid) — stop nohup modules first" >&2
-    exit 1
+    echo "ERROR: port $port occupied (pid $pid) — stop nohup first" >&2; exit 1
   fi
 done
 
-# (2) Start 4 app services (maple/{module}:dev is the default tag in services.yml)
+# (3) Pre-flight: DNS resolves from maple-network (network reconcile done?)
+echo "==> Pre-flight: DNS from maple-network"
+if ! docker run --rm --network maple-network alpine sh -c 'nslookup postgres >/dev/null 2>&1 && nslookup kafka >/dev/null 2>&1 && nslookup minio >/dev/null 2>&1' 2>/dev/null; then
+  echo "ERROR: DNS not resolving on maple-network — run Task 0 (docker network connect)" >&2; exit 1
+fi
+
+# (4) Pre-flight: secrets present
+echo "==> Pre-flight: SA secrets"
+ls docker/services/secrets/sa-ext-api.key docker/services/secrets/sa-calculator.key \
+   docker/services/secrets/sa-synchronizer.key docker/services/secrets/sa-cleanup.key >/dev/null
+
+# (5) Pre-flight: rollback jars exist
+echo "==> Pre-flight: rollback jars"
+for mod in "${MODULES[@]}"; do
+  ls "module-${mod}/build/libs/module-${mod}-0.0.1-SNAPSHOT.jar" >/dev/null
+done
+
+# (6) IDLE gate: no non-terminal calculation_jobs
+echo "==> Pre-flight: IDLE gate"
+set -a; source .env; set +a
+H=$(echo "$DB_URL" | sed -n 's|.*://\([^:/]*\).*|\1|p')
+P=$(echo "$DB_URL" | sed -n 's|.*://[^:/]*:\([0-9]*\).*|\1|p')
+N=$(echo "$DB_URL" | sed -n 's|.*/\([^?]*\).*|\1|p')
+U=$(echo "$DB_URL" | sed -n 's|.*user=\([^&]*\).*|\1|p')
+W=$(echo "$DB_URL" | sed -n 's|.*password=\([^&]*\).*|\1|p')
+active=$(PGPASSWORD="$W" psql "host=$H port=$P user=$U dbname=$N sslmode=disable" -t -A -c \
+  "SELECT count(*) FROM calculation_jobs WHERE status IN ('API_REQUESTED','RETRYING','CALCULATING');" 2>/dev/null || echo "?")
+if [ "$active" != "0" ]; then
+  echo "ERROR: $active non-terminal calculation_jobs — pipeline not IDLE, abort" >&2; exit 1
+fi
+
+# (7) Start 4 app services
 echo "==> Starting 4 app services"
 docker compose -f docker-compose.yml -f docker-compose.services.yml up -d \
   external-api calculator synchronizer cleanup
 
-# (3) Recreate airflow containers with autoheal labels
-echo "==> Recreating airflow with autoheal labels"
-docker compose -f docker-compose.yml -f docker-compose.airflow.yml up -d \
-  airflow-webserver airflow-scheduler airflow-db
-
-# (4) Start autoheal + cadvisor
+# (8) Start autoheal + cadvisor
 echo "==> Starting autoheal + cadvisor"
 docker compose -f docker-compose.yml up -d autoheal cadvisor
 
-# (5) Wait for app health (max ~120s per service)
+# (9) Wait for app health (~120s each)
 echo "==> Waiting for app health"
 for entry in external-api:8081 calculator:8082 synchronizer:8083 cleanup:8084; do
-  name="${entry%%:*}"; port="${entry##*:}"
-  ok=0
+  name="${entry%%:*}"; port="${entry##*:}"; ok=0
   for _ in $(seq 1 24); do
-    if curl -sf "http://localhost:$port/actuator/health" 2>/dev/null | grep -q '"status":"UP"'; then
-      ok=1; break
-    fi
+    if curl -sf "http://localhost:$port/actuator/health" 2>/dev/null | grep -q '"status":"UP"'; then ok=1; break; fi
     sleep 5
   done
-  if [ "$ok" -eq 1 ]; then echo "  $name (port $port): UP"; else echo "  $name (port $port): FAILED"; fi
+  echo "  $name (port $port): $([ "$ok" -eq 1 ] && echo UP || echo FAILED)"
 done
 
-# (6) Status table
+# (10) Status
 echo "==> Status"
 docker ps --format 'table {{.Names}}\t{{.Status}}' \
   | grep -E 'maple-(external-api|calculator|synchronizer|cleanup|autoheal|cadvisor)|NAMES'
 ````
 
-- [ ] **Step 2: 실행 권한 부여**
+- [ ] **Step 2: 권한 + 구문 검증**
 
-Run: `chmod +x docker/services/deploy-apps.sh`
-Expected: no output
-
-- [ ] **Step 3: 구문 검증**
-
-Run: `bash -n docker/services/deploy-apps.sh && echo OK`
+```bash
+chmod +x docker/services/deploy-apps.sh
+bash -n docker/services/deploy-apps.sh && echo OK
+```
 Expected: `OK`
 
-- [ ] **Step 4: commit**
+- [ ] **Step 3: commit**
 
 ```bash
 git add docker/services/deploy-apps.sh
-git commit -m "feat(docker): add deploy-apps.sh idempotent deploy script (#1428)
+git commit -m "feat(docker): deploy-apps.sh with tag resolution + pre-flight (#1428)
 
 Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
 ```
 
 ---
 
-## Task 4: runbook 작성 (#1431)
+## Task 3: runbook 작성 (#1431)
 
-**Files:**
-- Create: `docs/21_Operations/docker-deploy-runbook.md`
+**Files:** Create `docs/21_Operations/docker-deploy-runbook.md`
 
-- [ ] **Step 1: runbook 작성**
-
-내용(전환/rollback/검증/주의사항):
+- [ ] **Step 1: runbook 작성** (전환/rollback/검증/IDLE/network 주의 포함)
 
 ````markdown
 # nohup → docker compose 배포 Runbook (#1428/#1431)
 
-4 active 모듈(external-api/calculator/synchronizer/cleanup)의 nohup ↔ docker 전환 절차.
+4 active 모듈(external-api/calculator/synchronizer/cleanup) nohup ↔ docker 전환 절차.
 
 ## 사전 조건
 
-- 파이프라인 **IDLE** 상태 (phase terminal, chunk 처리 중 아님). 처리 중 전환 시 chunk 손실.
-- 이미지 빌드 완료: `docker images | grep maple/` → `:dev` + `:sha-XXX` 존재 확인.
-- SA secret 존재: `ls docker/services/secrets/sa-*.key` → 4종.
-- 인프라 running: `docker ps` → postgres/kafka/redis/minio/prometheus Up.
+- 이미지 빌드: `docker images | grep maple/` → `:sha-XXX` 존재.
+- SA secret: `ls docker/services/secrets/sa-*.key` → 4종.
+- rollback jar: `ls module-*/build/libs/*SNAPSHOT.jar` → 4종.
+- 인프라 running: postgres/kafka/redis/minio Up.
+
+## IDLE 정의 (hard gate)
+
+파이프라인 IDLE 만 전환:
+- `calculation_jobs` non-terminal(API_REQUESTED/RETRYING/CALCULATING) = 0
+- Kafka consumer LAG = 0
+
+```sql
+SELECT count(*) FROM calculation_jobs WHERE status IN ('API_REQUESTED','RETRYING','CALCULATING');
+```
+
+## network reconcile (최초 1회 + infra recreate 시마다)
+
+infra 가 `maple-network`에 연결되어 있어야 app 컨테이너가 postgres/kafka/minio DNS 해석.
+
+```bash
+docker network connect maple-network maple-postgres
+docker network connect maple-network maple-kafka
+docker network connect maple-network probabilistic-valuation-engine-minio-1
+# 검증
+docker run --rm --network maple-network alpine sh -c 'nslookup postgres; nslookup kafka; nslookup minio'
+```
+
+주의: `docker network connect` 는 infra recreate(rm+up) 시 상실. recreate 후 재실행.
 
 ## 전환 절차 (nohup → docker)
 
-1. **phase terminal 확인**
-
+1. **IDLE 확인** (위 쿼리 = 0)
+2. **nohup stop**:
    ```bash
-   curl -s http://localhost:8081/api/internal/run-status | python3 -m json.tool
-   # phase=IDLE 또는 terminal=true 인지 확인
+   for p in 8081 8082 8083 8084; do pid=$(lsof -ti:$p -sTCP:LISTEN 2>/dev/null); [ -n "$pid" ] && kill -TERM "$pid"; done
+   # graceful 대기 후 잔존 시 kill -KILL
    ```
+3. **포트 free 확인**: `for p in 8081 8082 8083 8084; do lsof -ti:$p -sTCP:LISTEN; done` → 전부 공백
+4. **배포**: `./docker/services/deploy-apps.sh`
 
-2. **nohup 4 프로세스 stop**
+## Rollback (docker → nohup)
 
+1. docker app 중지:
    ```bash
-   for p in 8081 8082 8083 8084; do
-     pid=$(lsof -ti:$p -sTCP:LISTEN 2>/dev/null)
-     [ -n "$pid" ] && kill "$pid"
-   done
+   docker compose -f docker-compose.yml -f docker-compose.services.yml down external-api calculator synchronizer cleanup
    ```
-
-3. **포트 free 확인 (split-brain 방지)**
-
-   ```bash
-   for p in 8081 8082 8083 8084; do
-     pid=$(lsof -ti:$p -sTCP:LISTEN 2>/dev/null)
-     echo "$p: ${pid:-FREE}"
-   done
-   # 전부 FREE 여야 함
-   ```
-
-4. **배포 (스크립트 사용 권장)**
-
-   ```bash
-   ./docker/services/deploy-apps.sh
-   # 또는 수동:
-   docker compose -f docker-compose.yml -f docker-compose.services.yml up -d \
-     external-api calculator synchronizer cleanup
-   docker compose -f docker-compose.yml -f docker-compose.airflow.yml up -d \
-     airflow-webserver airflow-scheduler airflow-db
-   docker compose -f docker-compose.yml up -d autoheal cadvisor
-   ```
-
-5. **검증** (아래 체크리스트)
-
-## Rollback 절차 (docker → nohup)
-
-1. docker 서비스 중지
-
-   ```bash
-   docker compose -f docker-compose.yml -f docker-compose.services.yml down \
-     external-api calculator synchronizer cleanup
-   ```
-
-2. 포트 free 확인 (위 3번)
-
-3. nohup 재시작
-
+2. 포트 free 확인
+3. nohup 재시작:
    ```bash
    set -a && source .env && set +a
-   MINIO_ACCESS_KEY=<module> MINIO_SECRET_KEY_FILE=$(pwd)/docker/services/secrets/sa-<module>.key \
-     nohup java -jar module-<module>/build/libs/module-<module>-0.0.1-SNAPSHOT.jar &
-   # 4 모듈 각각
+   for mod in external-api calculator synchronizer cleanup; do
+     MINIO_ACCESS_KEY=$( [ "$mod" = external-api ] && echo ext-api || echo "$mod" ) \
+     MINIO_SECRET_KEY_FILE=$(pwd)/docker/services/secrets/sa-$( [ "$mod" = external-api ] && echo ext-api || echo "$mod" ).key \
+     nohup java -jar module-${mod}/build/libs/module-${mod}-0.0.1-SNAPSHOT.jar > /tmp/${mod}.log 2>&1 &
+   done
+   # external-api 추가: NEXON_API_KEY 는 .env 에서 source 됨
    ```
 
 ## 검증 체크리스트
 
-- [ ] 4 모듈 `/actuator/health` → `{"status":"UP"}` (ports 8081-8084)
-- [ ] `docker ps` → maple-external-api/calculator/synchronizer/cleanup/autoheal/cadvisor Up
-- [ ] autoheal: `docker logs maple-autoheal` → restart 이벤트 (또는 healthy 유지)
-- [ ] cadvisor metric: `curl -s http://localhost:8086/metrics | grep container_cpu_usage_seconds_total | head -1`
-- [ ] Prometheus: `curl -s 'http://localhost:9090/api/v1/query?query=up' | grep -c '"1"'` ≥ 6
-- [ ] Kafka consumer lag: `docker exec maple-kafka kafka-consumer-groups --bootstrap-server localhost:9092 --describe --all-groups` → LAG 처리 가능 범위
-- [ ] DB read model row 증가: `psql ... -c "SELECT count(*) FROM character_basic_read_model"` (재측정 시 증가)
-- [ ] ERROR 로그: `docker logs maple-<module> 2>&1 | grep ERROR | tail` → 0
+- [ ] 4 모듈 `/actuator/health` → UP
+- [ ] `docker ps` → maple-{external-api,calculator,synchronizer,cleanup,autoheal,cadvisor} Up
+- [ ] cadvisor: `curl -s http://localhost:8086/metrics | grep -m1 container_cpu_usage_seconds_total`
+- [ ] Prometheus: `container_cpu_usage_seconds_total` series ≥ 1
+- [ ] Kafka LAG 처리 가능 범위
+- [ ] DB row 증가 (manual trigger 후 — 아래)
+- [ ] ERROR 로그 0
+
+## end-to-end 검증 (manual trigger)
+
+IDLE 상태 DB row 증가 확인 위해 강제 트리거:
+```bash
+curl -s -w "\nHTTP %{http_code}\n" "http://localhost:8080/api/v5/characters/진격캐넌/expectation"
+# 202 접수 후 파이프라인 전 모듈 흐름 → DB row 증가를 60s 간격 2회 측정
+```
 
 ## 주의사항
 
-- **Split-brain**: 두 모드 동시 포트 점유 금지. 반드시 nohup stop → 포트 free 확인 후 docker up.
-- **카운터 리셋**: 프로세스 전환 시 Prometheus 누적 counter 0 초기화. endurance 누적 데이터는 보고서화(endurance-report-71h.md). 전환 시점 이후부터 재누적.
-- **다운타임**: IDLE 시점 전환 시 데이터 손실 0. 처리 중 전환 시 in-flight chunk 손실 가능 → 반드시 IDLE 확인.
-- **이미지 태그**: `:dev` 가 최신 빌드 가리킴. reproducible 배포 시 `IMAGE_<MODULE>=maple/<module>:sha-XXX` env 로 고정.
+- **Split-brain**: 동시 포트 점유 금지. nohup stop → free 확인 → docker up.
+- **카운터 리셋**: 프로세스 전환 시 Prometheus 누적 0 초기화(endurance 데이터는 endurance-report-71h.md 보존).
+- **network 비영속**: infra recreate 시 `docker network connect` 재실행.
+- **cadvisor `/dev/kmsg`**: 일부 호스트에서 마운트 실패 시 `devices:` 블록 주석화 후 re-up(본 호스트는 존재).
+- **airflow autoheal**: 본 runbook 미포함. airflow host/bridge network reconcile 선행 필요 → follow-up 이슈.
 ````
 
 - [ ] **Step 2: commit**
@@ -384,109 +406,123 @@ Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
 
 ---
 
-## Task 5: 운영 배포 실행 (#1428 runtime)
+## Task 4: 운영 배포 실행
 
 **Files:** (none — operational)
 
-- [ ] **Step 1: 사전 상태 재확인**
+- [ ] **Step 1: Task 0 network reconcile 완료 상태 확인**
 
-Run: `for p in 8081 8082 8083 8084; do pid=$(lsof -ti:$p -sTCP:LISTEN 2>/dev/null); echo "$p: ${pid:-FREE}"; done`
-Expected: 전부 `FREE`
+Run: `docker run --rm --network maple-network alpine sh -c 'nslookup postgres|tail -1; nslookup kafka|tail -1'`
+Expected: Address 출력 (SERVFAIL 아니어야 함)
 
-- [ ] **Step 2: 배포 스크립트 실행**
+- [ ] **Step 2: deploy-apps.sh 실행**
 
 Run: `./docker/services/deploy-apps.sh`
-Expected: 4 서비스 `UP` + status 테이블에 6 컨테이너(4 svc + autoheal + cadvisor) 표시
+Expected: pre-flight 전 PASS → 4 서비스 UP → status 테이블 6 컨테이너
 
-- [ ] **Step 3: 실패 시** — runbook rollback 절차 수행 후 원인 조사. 컨테이너 로그: `docker logs maple-<module>`
-
----
-
-## Task 6: 런타임 검증 (acceptance)
-
-**Files:** (none — verification)
-
-- [ ] **Step 1: 4 모듈 health**
-
-Run: `for p in 8081 8082 8083 8084; do echo -n "$p: "; curl -sf http://localhost:$p/actuator/health || echo FAIL; echo; done`
-Expected: 전부 `{"status":"UP",...}`
-
-- [ ] **Step 2: autoheal 동작** (airflow-scheduler unhealthy 자동복구 확인)
-
-Run: `sleep 10 && docker ps --format '{{.Names}} {{.Status}}' | grep airflow-scheduler`
-Expected: `(healthy)` (autoheal 이 restart 후 복구) 또는 재시작 진행 중
-
-Run: `docker logs maple-autoheal 2>&1 | grep -i restart | tail`
-Expected: restart 이벤트 (scheduler) 또는 "no unhealthy" (이미 healthy)
-
-- [ ] **Step 3: cadvisor metric 수집**
-
-Run: `curl -sf http://localhost:8086/metrics | grep -m1 container_cpu_usage_seconds_total`
-Expected: metric 라인 출력
-
-Run: `curl -s --data-urlencode 'query=container_cpu_usage_seconds_total' http://localhost:9090/api/v1/query | python3 -c "import sys,json;d=json.load(sys.stdin);print('series:',len(d['data']['result']))"`
-Expected: `series:` ≥ 1 (prometheus 가 cadvisor scrape 성공)
-
-- [ ] **Step 4: Kafka lag**
-
-Run: `KAFKA_CTN=$(docker ps --format '{{.Names}}' | grep -i kafka | head -1); docker exec "$KAFKA_CTN" kafka-consumer-groups --bootstrap-server localhost:9092 --describe --all-groups 2>&1 | awk 'NF>=9 && $1!="GROUP"{print $1, $6}' | sort -u`
-Expected: LAG 값 처리 가능 범위 (모듈 기동 직후 일시적 backlog 후 0 수렴 허용)
-
-- [ ] **Step 5: DB row 증가 (파이프라인 흐름)**
-
-Run (2회 측정, 간격 60s):
-```bash
-set -a && source .env && set +a
-H=$(echo "$DB_URL" | sed -n 's|.*://\([^:/]*\).*|\1|p')
-P=$(echo "$DB_URL" | sed -n 's|.*://[^:/]*:\([0-9]*\).*|\1|p')
-N=$(echo "$DB_URL" | sed -n 's|.*/\([^?]*\).*|\1|p')
-U=$(echo "$DB_URL" | sed -n 's|.*user=\([^&]*\).*|\1|p')
-W=$(echo "$DB_URL" | sed -n 's|.*password=\([^&]*\).*|\1|p')
-PGPASSWORD="$W" psql "host=$H port=$P user=$U dbname=$N sslmode=disable" -t -A -c "SELECT count(*) FROM character_basic_read_model"
-```
-Expected: 2회째 값 > 1회째 (증가). 단 파이프라인 idle 시 정체 가능 → ext-api manual trigger 로 검증 가능.
-
-- [ ] **Step 6: ERROR 로그 0**
-
-Run: `for m in external-api calculator synchronizer cleanup; do echo -n "$m: "; docker logs maple-$m 2>&1 | grep -c ERROR || echo 0; done`
-Expected: 전부 `0` (또는 기동 boundary error 만 있고 증가 없음)
-
-- [ ] **Step 7: 검증 결과 기록** — ADR-737 §4 Observed Result 에 실측값 반영
+- [ ] **Step 3: 실패 시** — runbook rollback. 로그: `docker logs maple-<module>`. pre-flight 에러 메시지가 원인 지시.
 
 ---
 
-## Task 7: PR + 이슈 종료
+## Task 5: 런타임 검증 (acceptance)
 
 **Files:** (none)
 
-- [ ] **Step 1: develop 동기화 + push**
+- [ ] **Step 1: 4 모듈 health**
+
+Run: `for p in 8081 8082 8083 8084; do echo -n "$p: "; curl -sf http://localhost:$p/actuator/health | grep -o '"status":"UP"'; echo; done`
+Expected: 전부 `"status":"UP"`
+
+- [ ] **Step 2: autoheal 유발 테스트 (#1429 acceptance)**
+
+healthy 컨테이너 하나 강제 unhealthy 후 5초 폴 내 재시작 + 타 컨테이너 영향 없음 확인:
+```bash
+# before StartedAt 기록
+docker inspect maple-cleanup --format '{{.State.StartedAt}}' > /tmp/before
+# 강제 unhealthy: healthcheck 엔드포인트 일시 실패 유도 (컨테이너 재시작 아님 방지 위해 SIGSTOP 후 autoheal 관찰은 위험 → 대안: 별도 throwaway 컨테이너)
+docker run -d --name autoheal-test --label autoheal=true \
+  --health-cmd='exit 1' --health-interval=5s --health-retries=1 \
+  alpine sleep 300
+sleep 20
+docker inspect autoheal-test --format '{{.RestartCount}}'   # ≥1 이면 autoheal 동작
+# 타 컨테이너 영향 없음 확인
+for m in external-api calculator synchronizer cleanup; do
+  echo "$m: $(docker inspect maple-$m --format '{{.State.StartedAt}}')"
+done   # before 와 동일해야(false positive 없음)
+docker rm -f autoheal-test
+```
+Expected: autoheal-test RestartCount ≥ 1; 4 app StartedAt 불변.
+
+- [ ] **Step 3: cadvisor metric 수집 (#1430)**
 
 ```bash
-git push -u origin feature/nohup-to-docker-deploy
+curl -sf http://localhost:8086/metrics | grep -m1 container_cpu_usage_seconds_total
+curl -s --data-urlencode 'query=container_cpu_usage_seconds_total' http://localhost:9090/api/v1/query \
+  | python3 -c "import sys,json;d=json.load(sys.stdin);print('prometheus series:',len(d['data']['result']))"
 ```
+Expected: metric 라인 + prometheus series ≥ 1.
 
-- [ ] **Step 2: PR 생성**
+- [ ] **Step 4: Kafka lag**
 
 ```bash
-gh pr create --base develop --title "feat(ops): nohup→docker deploy + autoheal/cadvisor (#1428-1431)" --body "..."
+KAFKA_CTN=$(docker ps --format '{{.Names}}' | grep -i kafka | head -1)
+docker exec "$KAFKA_CTN" kafka-consumer-groups --bootstrap-server localhost:9092 --describe --all-groups 2>&1 | awk 'NF>=9 && $1!="GROUP"{print $1,$6}' | sort -u
 ```
+Expected: LAG 처리 가능 범위(기동 직후 일시 backlog 후 0 수렴 허용).
 
-body: summary + ADR-737/runbook 링크 + 검증 결과(health/kafka/prometheus/DB/error)
-
-- [ ] **Step 3: 머지 후 이슈 종료**
+- [ ] **Step 5: end-to-end (manual trigger → DB row 증가)**
 
 ```bash
-gh pr merge <N> --merge
-gh issue close 1428 1429 1430 1431
+curl -s -w "\nHTTP %{http_code}\n" "http://localhost:8080/api/v5/characters/진격캐넌/expectation"
+# 60s 대기 후 DB row 2회 측정
 ```
-각 이슈 코멘트에 검증 증거(health UP, cadvisor series 수, kafka lag, DB row, error=0) + runbook 링크.
+Expected: HTTP 202 + 2회째 read model row 증가(파이프라인 전 모듈 흐름 정상).
+
+- [ ] **Step 6: ERROR 로그 0**
+
+```bash
+for m in external-api calculator synchronizer cleanup; do
+  echo -n "$m: "; docker logs maple-$m 2>&1 | grep -c ERROR
+done
+```
+Expected: 전부 0(또는 기동 boundary 만, 증가 없음).
+
+- [ ] **Step 7: ADR-737 §4 Observed Result 실측 반영**
 
 ---
 
-## Self-Review (작성자 자점)
+## Task 6: follow-up 이슈 + PR + 이슈 종료
 
-**Spec coverage:** #1428(전환)=T1/T3/T5, #1429(autoheal)=T2/T5, #1430(cadvisor)=T3/T5/T6-S3, #1431(runbook)=T4. 전 섹션 커버.
+**Files:** (none)
 
-**Placeholder:** 없음 — 모든 스텝에 실제 코드/명령/expected 포함.
+- [ ] **Step 1: airflow autoheal follow-up 이슈 생성**
 
-**Type/name 일관성:** 서비스명·포트·컨테이너명 전 태스크 일치(external-api:8081 등).
+```bash
+gh issue create --title "airflow autoheal 활성화 (host/bridge network reconcile 선행)" --body "..."
+```
+body: #1429 의 airflow 부분. compose bridge 선언 vs 실제 host network 드리프트 → recreate 시 webserver 파손 위험. network reconcile 선행 후 autoheal 라벨 적용 필요.
+
+- [ ] **Step 2: push + PR**
+
+```bash
+git push -u origin feature/nohup-to-docker-deploy
+gh pr create --base develop --title "feat(ops): nohup→docker deploy + autoheal/cadvisor (#1428-1431)" --body "..."
+```
+
+- [ ] **Step 3: 머지 + 이슈 종료**
+
+```bash
+gh pr merge <N> --merge
+gh issue close 1428 1430 1431
+gh issue close 1429   # app-scope 완료 + airflow follow-up 이슈로 이관 명시
+```
+코멘트에 검증 증거 + runbook 링크 + airflow follow-up 이슈 링크.
+
+---
+
+## Self-Review (post-revision)
+
+**Spec coverage:** #1428=T0/T2/T4, #1429(autoheal for apps)=T4/T5-S2(+airflow follow-up), #1430=T4/T5-S3, #1431=T3.
+**grill 반영:** network duality(T0), :dev 부재(T2 tag 해석), airflow(T6 follow-up), pre-flight 강화(T2), IDLE 정의(T3), manual trigger(T5-S5), autoheal 유발(T5-S2), rollback 완비(T3), cadvisor note(T3).
+**Placeholder:** 없음.
+**일관성:** 서비스명·포트·컨테이너명·네트워크명 전 태스크 일치.

--- a/docs/superpowers/plans/2026-06-26-nohup-to-docker-deployment.md
+++ b/docs/superpowers/plans/2026-06-26-nohup-to-docker-deployment.md
@@ -1,0 +1,492 @@
+# nohup → docker compose 배포 전환 Implementation Plan (#1428–#1431)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 4 active 모듈을 nohup → docker compose 로 전환하고 autoheal/cadvisor 를 가동·검증한 뒤 runbook 으로 문서화.
+
+**Architecture:** 설정 변경은 최소(airflow autoheal 라벨 추가만). prometheus 는 host network + 포트퍼블리시로 mode-agnostic 이라 config 변경 無. idempotent deploy 스크립트가 `compose up` + health 폴링 수행. 파이프라인 IDLE 시점 전환.
+
+**Tech Stack:** docker compose v2, willfarrell/autoheal, gcr.io/cadvisor/cadvisor, Prometheus, Spring Boot Actuator, bash.
+
+**Spec:** `docs/superpowers/specs/2026-06-26-nohup-to-docker-deployment-design.md`
+
+**Test strategy note:** 본 작업은 config/docs/ops 이며 애플리케이션 코드 변경 無 → unit test 대상 아님. workflow-rules 통합테스트 금지(#207). 검증 = `docker compose config` 구문 검증 + 런타임 health/prometheus/kafka/DB 확인.
+
+---
+
+## File Structure
+
+| 파일 | 책임 | 신규/수정 |
+|---|---|---|
+| `docs/01_ADR/ADR-737_nohup-to-docker-deployment.md` | 전환 결정 + trade-offs | 신규 |
+| `docker-compose.airflow.yml` | airflow 3컨테이너 autoheal 라벨 | 수정 |
+| `docker/services/deploy-apps.sh` | idempotent 배포 + health 검증 스크립트 | 신규 |
+| `docs/21_Operations/docker-deploy-runbook.md` | 전환/rollback/검증 체크리스트 | 신규 |
+
+---
+
+## Task 1: ADR-737 작성 (RPI 선행)
+
+**Files:**
+- Create: `docs/01_ADR/ADR-737_nohup-to-docker-deployment.md`
+
+- [ ] **Step 1: ADR 파일 작성** (adr-conventions 5섹션 준수)
+
+내용:
+
+````markdown
+# ADR-737: nohup → docker compose 배포 전환
+
+- Status: Accepted
+- Date: 2026-06-26
+- Owner: maple-pipeline
+
+---
+
+## 1. Background / Problem
+
+### Background
+
+- 4 active 모듈(external-api/calculator/synchronizer/cleanup)을 nohup 호스트 프로세스로 운영.
+- #1245 로 이미지 빌드 완료(`maple/{module}:dev` + `:sha-75cb631`).
+- `docker-compose.services.yml` 오버레이 구성 완료(healthcheck + autoheal 라벨 + MinIO SA secret).
+- Endurance Test #2(~71h) 종료 직후, 파이프라인 IDLE, 4 포트 FREE.
+
+### Problem
+
+- 운영 통일(autoheal 자동복구, cadvisor 컨테이너 메트릭) 위해 docker 전환 필요.
+- autoheal/cadvisor 정의는 있으나 미가동. airflow 컨테이너 autoheal 라벨 누락.
+
+### Goal
+
+- docker compose 로 4 모듈 실배포. autoheal/cadvisor 가동. runbook 문서화.
+
+---
+
+## 2. Decision
+
+> nohup 호스트 프로세스를 docker compose 로 전환한다. prometheus 는 host network + 포트퍼블리시로 mode-agnostic → scrape config 유지.
+
+```text
+4 modules: nohup java -jar → docker compose (services.yml overlay)
+autoheal: 정의만 존재 → up -d 가동
+cadvisor: 정의만 존재 → up -d 가동
+airflow 3 containers: autoheal label 추가 후 recreate
+```
+
+---
+
+## 3. Trade-offs
+
+### Sensitivity
+
+* 배포 시점(파이프라인 IDLE) — chunk 손실 방지
+* 포트 점유 — split-brain 방지 조건
+* `:dev` 태그가 최신 빌드 지칭 여부
+
+### Trade-off
+
+| 선택 | 얻는 것 | 포기한 것 |
+| -- | ---- | ----- |
+| docker 운영 통일 | autoheal 자동복구, cadvisor 메트릭, 통합 관리 | nohup in-process fallback |
+
+### Risk
+
+* 배포 실패 시 rollback — runbook 에 `compose down` → nohup 경로 문서화.
+* 카운터 리셋 — Prometheus 누적값 초기화(post-test 허용).
+
+### Non-Risk
+
+* 데이터 손실 — IDLE 시점 전환.
+* prometheus config — mode-agnostic, 변경 無.
+
+---
+
+## 4. Result / Evidence
+
+### Metrics
+
+| Metric | Value | Notes |
+| ------ | ----: | ----- |
+| 4 모듈 health | 4/4 UP | 배포 후 |
+| cadvisor metric 수집 | container_cpu_usage_seconds_total 조회 성공 | 배포 후 |
+
+### Observed Result
+
+* 코드/설정 검증: airflow 라벨 추가 + deploy-apps.sh + runbook 작성. `docker compose config` 구문 PASS.
+* 런타임 검증: 배포 실행 후 본 절 실측값 기재.
+
+---
+
+## 5. Summary
+
+> 파이프라인 IDLE 시점에 4 모듈을 docker compose 로 전환, autoheal/cadvisor 가동. prometheus mode-agnostic 으로 config 변경 無.
+````
+
+- [ ] **Step 2: commit**
+
+```bash
+git add docs/01_ADR/ADR-737_nohup-to-docker-deployment.md
+git commit -m "docs(adr): ADR-737 nohup→docker deployment switch
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: airflow autoheal 라벨 추가 (#1429)
+
+**Files:**
+- Modify: `docker-compose.airflow.yml` (airflow-db ~L6, airflow-webserver ~L24, airflow-scheduler ~L55)
+
+- [ ] **Step 1: airflow-db 라벨 추가**
+
+`docker-compose.airflow.yml` 의 `airflow-db` 서비스 — `container_name: maple-airflow-db` 다음 줄에 labels 추가:
+
+```yaml
+    container_name: maple-airflow-db
+    labels:
+      autoheal: "true"
+    restart: always
+```
+
+- [ ] **Step 2: airflow-webserver 라벨 추가**
+
+```yaml
+    container_name: maple-airflow-webserver
+    labels:
+      autoheal: "true"
+    restart: unless-stopped
+```
+
+- [ ] **Step 3: airflow-scheduler 라벨 추가**
+
+```yaml
+    container_name: maple-airflow-scheduler
+    labels:
+      autoheal: "true"
+    restart: unless-stopped
+```
+
+- [ ] **Step 4: 구문 검증**
+
+Run: `docker compose -f docker-compose.yml -f docker-compose.airflow.yml config >/dev/null && echo OK`
+Expected: `OK`
+
+- [ ] **Step 5: 라벨 적용 확인 (dry)**
+
+Run: `docker compose -f docker-compose.yml -f docker-compose.airflow.yml config | grep -A1 autoheal | head -20`
+Expected: 3개 airflow 서비스 + 기존 infra 서비스 autoheal 라벨 출력
+
+- [ ] **Step 6: commit**
+
+```bash
+git add docker-compose.airflow.yml
+git commit -m "feat(airflow): add autoheal labels to 3 airflow containers (#1429)
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: deploy-apps.sh 스크립트 (#1428/#1429/#1430)
+
+**Files:**
+- Create: `docker/services/deploy-apps.sh`
+
+- [ ] **Step 1: 스크립트 작성**
+
+````bash
+#!/usr/bin/env bash
+# docker/services/deploy-apps.sh
+# Deploy 4 Spring Boot app services + autoheal + cadvisor via docker compose.
+# Idempotent: safe to re-run. Pre-flight checks ports (split-brain prevention)
+# and verifies /actuator/health after start.
+#
+# Usage: ./docker/services/deploy-apps.sh
+set -euo pipefail
+cd "$(dirname "$0")/../.."  # repo root
+
+# (1) Pre-flight: ports 8081-8084 must be FREE (no nohup split-brain)
+echo "==> Pre-flight: checking ports 8081-8084 are free"
+for port in 8081 8082 8083 8084; do
+  if pid=$(lsof -ti:"$port" -sTCP:LISTEN 2>/dev/null) && [ -n "$pid" ]; then
+    echo "ERROR: port $port occupied (pid $pid) — stop nohup modules first" >&2
+    exit 1
+  fi
+done
+
+# (2) Start 4 app services (maple/{module}:dev is the default tag in services.yml)
+echo "==> Starting 4 app services"
+docker compose -f docker-compose.yml -f docker-compose.services.yml up -d \
+  external-api calculator synchronizer cleanup
+
+# (3) Recreate airflow containers with autoheal labels
+echo "==> Recreating airflow with autoheal labels"
+docker compose -f docker-compose.yml -f docker-compose.airflow.yml up -d \
+  airflow-webserver airflow-scheduler airflow-db
+
+# (4) Start autoheal + cadvisor
+echo "==> Starting autoheal + cadvisor"
+docker compose -f docker-compose.yml up -d autoheal cadvisor
+
+# (5) Wait for app health (max ~120s per service)
+echo "==> Waiting for app health"
+for entry in external-api:8081 calculator:8082 synchronizer:8083 cleanup:8084; do
+  name="${entry%%:*}"; port="${entry##*:}"
+  ok=0
+  for _ in $(seq 1 24); do
+    if curl -sf "http://localhost:$port/actuator/health" 2>/dev/null | grep -q '"status":"UP"'; then
+      ok=1; break
+    fi
+    sleep 5
+  done
+  if [ "$ok" -eq 1 ]; then echo "  $name (port $port): UP"; else echo "  $name (port $port): FAILED"; fi
+done
+
+# (6) Status table
+echo "==> Status"
+docker ps --format 'table {{.Names}}\t{{.Status}}' \
+  | grep -E 'maple-(external-api|calculator|synchronizer|cleanup|autoheal|cadvisor)|NAMES'
+````
+
+- [ ] **Step 2: 실행 권한 부여**
+
+Run: `chmod +x docker/services/deploy-apps.sh`
+Expected: no output
+
+- [ ] **Step 3: 구문 검증**
+
+Run: `bash -n docker/services/deploy-apps.sh && echo OK`
+Expected: `OK`
+
+- [ ] **Step 4: commit**
+
+```bash
+git add docker/services/deploy-apps.sh
+git commit -m "feat(docker): add deploy-apps.sh idempotent deploy script (#1428)
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: runbook 작성 (#1431)
+
+**Files:**
+- Create: `docs/21_Operations/docker-deploy-runbook.md`
+
+- [ ] **Step 1: runbook 작성**
+
+내용(전환/rollback/검증/주의사항):
+
+````markdown
+# nohup → docker compose 배포 Runbook (#1428/#1431)
+
+4 active 모듈(external-api/calculator/synchronizer/cleanup)의 nohup ↔ docker 전환 절차.
+
+## 사전 조건
+
+- 파이프라인 **IDLE** 상태 (phase terminal, chunk 처리 중 아님). 처리 중 전환 시 chunk 손실.
+- 이미지 빌드 완료: `docker images | grep maple/` → `:dev` + `:sha-XXX` 존재 확인.
+- SA secret 존재: `ls docker/services/secrets/sa-*.key` → 4종.
+- 인프라 running: `docker ps` → postgres/kafka/redis/minio/prometheus Up.
+
+## 전환 절차 (nohup → docker)
+
+1. **phase terminal 확인**
+
+   ```bash
+   curl -s http://localhost:8081/api/internal/run-status | python3 -m json.tool
+   # phase=IDLE 또는 terminal=true 인지 확인
+   ```
+
+2. **nohup 4 프로세스 stop**
+
+   ```bash
+   for p in 8081 8082 8083 8084; do
+     pid=$(lsof -ti:$p -sTCP:LISTEN 2>/dev/null)
+     [ -n "$pid" ] && kill "$pid"
+   done
+   ```
+
+3. **포트 free 확인 (split-brain 방지)**
+
+   ```bash
+   for p in 8081 8082 8083 8084; do
+     pid=$(lsof -ti:$p -sTCP:LISTEN 2>/dev/null)
+     echo "$p: ${pid:-FREE}"
+   done
+   # 전부 FREE 여야 함
+   ```
+
+4. **배포 (스크립트 사용 권장)**
+
+   ```bash
+   ./docker/services/deploy-apps.sh
+   # 또는 수동:
+   docker compose -f docker-compose.yml -f docker-compose.services.yml up -d \
+     external-api calculator synchronizer cleanup
+   docker compose -f docker-compose.yml -f docker-compose.airflow.yml up -d \
+     airflow-webserver airflow-scheduler airflow-db
+   docker compose -f docker-compose.yml up -d autoheal cadvisor
+   ```
+
+5. **검증** (아래 체크리스트)
+
+## Rollback 절차 (docker → nohup)
+
+1. docker 서비스 중지
+
+   ```bash
+   docker compose -f docker-compose.yml -f docker-compose.services.yml down \
+     external-api calculator synchronizer cleanup
+   ```
+
+2. 포트 free 확인 (위 3번)
+
+3. nohup 재시작
+
+   ```bash
+   set -a && source .env && set +a
+   MINIO_ACCESS_KEY=<module> MINIO_SECRET_KEY_FILE=$(pwd)/docker/services/secrets/sa-<module>.key \
+     nohup java -jar module-<module>/build/libs/module-<module>-0.0.1-SNAPSHOT.jar &
+   # 4 모듈 각각
+   ```
+
+## 검증 체크리스트
+
+- [ ] 4 모듈 `/actuator/health` → `{"status":"UP"}` (ports 8081-8084)
+- [ ] `docker ps` → maple-external-api/calculator/synchronizer/cleanup/autoheal/cadvisor Up
+- [ ] autoheal: `docker logs maple-autoheal` → restart 이벤트 (또는 healthy 유지)
+- [ ] cadvisor metric: `curl -s http://localhost:8086/metrics | grep container_cpu_usage_seconds_total | head -1`
+- [ ] Prometheus: `curl -s 'http://localhost:9090/api/v1/query?query=up' | grep -c '"1"'` ≥ 6
+- [ ] Kafka consumer lag: `docker exec maple-kafka kafka-consumer-groups --bootstrap-server localhost:9092 --describe --all-groups` → LAG 처리 가능 범위
+- [ ] DB read model row 증가: `psql ... -c "SELECT count(*) FROM character_basic_read_model"` (재측정 시 증가)
+- [ ] ERROR 로그: `docker logs maple-<module> 2>&1 | grep ERROR | tail` → 0
+
+## 주의사항
+
+- **Split-brain**: 두 모드 동시 포트 점유 금지. 반드시 nohup stop → 포트 free 확인 후 docker up.
+- **카운터 리셋**: 프로세스 전환 시 Prometheus 누적 counter 0 초기화. endurance 누적 데이터는 보고서화(endurance-report-71h.md). 전환 시점 이후부터 재누적.
+- **다운타임**: IDLE 시점 전환 시 데이터 손실 0. 처리 중 전환 시 in-flight chunk 손실 가능 → 반드시 IDLE 확인.
+- **이미지 태그**: `:dev` 가 최신 빌드 가리킴. reproducible 배포 시 `IMAGE_<MODULE>=maple/<module>:sha-XXX` env 로 고정.
+````
+
+- [ ] **Step 2: commit**
+
+```bash
+git add docs/21_Operations/docker-deploy-runbook.md
+git commit -m "docs(ops): nohup→docker deploy runbook (#1431)
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: 운영 배포 실행 (#1428 runtime)
+
+**Files:** (none — operational)
+
+- [ ] **Step 1: 사전 상태 재확인**
+
+Run: `for p in 8081 8082 8083 8084; do pid=$(lsof -ti:$p -sTCP:LISTEN 2>/dev/null); echo "$p: ${pid:-FREE}"; done`
+Expected: 전부 `FREE`
+
+- [ ] **Step 2: 배포 스크립트 실행**
+
+Run: `./docker/services/deploy-apps.sh`
+Expected: 4 서비스 `UP` + status 테이블에 6 컨테이너(4 svc + autoheal + cadvisor) 표시
+
+- [ ] **Step 3: 실패 시** — runbook rollback 절차 수행 후 원인 조사. 컨테이너 로그: `docker logs maple-<module>`
+
+---
+
+## Task 6: 런타임 검증 (acceptance)
+
+**Files:** (none — verification)
+
+- [ ] **Step 1: 4 모듈 health**
+
+Run: `for p in 8081 8082 8083 8084; do echo -n "$p: "; curl -sf http://localhost:$p/actuator/health || echo FAIL; echo; done`
+Expected: 전부 `{"status":"UP",...}`
+
+- [ ] **Step 2: autoheal 동작** (airflow-scheduler unhealthy 자동복구 확인)
+
+Run: `sleep 10 && docker ps --format '{{.Names}} {{.Status}}' | grep airflow-scheduler`
+Expected: `(healthy)` (autoheal 이 restart 후 복구) 또는 재시작 진행 중
+
+Run: `docker logs maple-autoheal 2>&1 | grep -i restart | tail`
+Expected: restart 이벤트 (scheduler) 또는 "no unhealthy" (이미 healthy)
+
+- [ ] **Step 3: cadvisor metric 수집**
+
+Run: `curl -sf http://localhost:8086/metrics | grep -m1 container_cpu_usage_seconds_total`
+Expected: metric 라인 출력
+
+Run: `curl -s --data-urlencode 'query=container_cpu_usage_seconds_total' http://localhost:9090/api/v1/query | python3 -c "import sys,json;d=json.load(sys.stdin);print('series:',len(d['data']['result']))"`
+Expected: `series:` ≥ 1 (prometheus 가 cadvisor scrape 성공)
+
+- [ ] **Step 4: Kafka lag**
+
+Run: `KAFKA_CTN=$(docker ps --format '{{.Names}}' | grep -i kafka | head -1); docker exec "$KAFKA_CTN" kafka-consumer-groups --bootstrap-server localhost:9092 --describe --all-groups 2>&1 | awk 'NF>=9 && $1!="GROUP"{print $1, $6}' | sort -u`
+Expected: LAG 값 처리 가능 범위 (모듈 기동 직후 일시적 backlog 후 0 수렴 허용)
+
+- [ ] **Step 5: DB row 증가 (파이프라인 흐름)**
+
+Run (2회 측정, 간격 60s):
+```bash
+set -a && source .env && set +a
+H=$(echo "$DB_URL" | sed -n 's|.*://\([^:/]*\).*|\1|p')
+P=$(echo "$DB_URL" | sed -n 's|.*://[^:/]*:\([0-9]*\).*|\1|p')
+N=$(echo "$DB_URL" | sed -n 's|.*/\([^?]*\).*|\1|p')
+U=$(echo "$DB_URL" | sed -n 's|.*user=\([^&]*\).*|\1|p')
+W=$(echo "$DB_URL" | sed -n 's|.*password=\([^&]*\).*|\1|p')
+PGPASSWORD="$W" psql "host=$H port=$P user=$U dbname=$N sslmode=disable" -t -A -c "SELECT count(*) FROM character_basic_read_model"
+```
+Expected: 2회째 값 > 1회째 (증가). 단 파이프라인 idle 시 정체 가능 → ext-api manual trigger 로 검증 가능.
+
+- [ ] **Step 6: ERROR 로그 0**
+
+Run: `for m in external-api calculator synchronizer cleanup; do echo -n "$m: "; docker logs maple-$m 2>&1 | grep -c ERROR || echo 0; done`
+Expected: 전부 `0` (또는 기동 boundary error 만 있고 증가 없음)
+
+- [ ] **Step 7: 검증 결과 기록** — ADR-737 §4 Observed Result 에 실측값 반영
+
+---
+
+## Task 7: PR + 이슈 종료
+
+**Files:** (none)
+
+- [ ] **Step 1: develop 동기화 + push**
+
+```bash
+git push -u origin feature/nohup-to-docker-deploy
+```
+
+- [ ] **Step 2: PR 생성**
+
+```bash
+gh pr create --base develop --title "feat(ops): nohup→docker deploy + autoheal/cadvisor (#1428-1431)" --body "..."
+```
+
+body: summary + ADR-737/runbook 링크 + 검증 결과(health/kafka/prometheus/DB/error)
+
+- [ ] **Step 3: 머지 후 이슈 종료**
+
+```bash
+gh pr merge <N> --merge
+gh issue close 1428 1429 1430 1431
+```
+각 이슈 코멘트에 검증 증거(health UP, cadvisor series 수, kafka lag, DB row, error=0) + runbook 링크.
+
+---
+
+## Self-Review (작성자 자점)
+
+**Spec coverage:** #1428(전환)=T1/T3/T5, #1429(autoheal)=T2/T5, #1430(cadvisor)=T3/T5/T6-S3, #1431(runbook)=T4. 전 섹션 커버.
+
+**Placeholder:** 없음 — 모든 스텝에 실제 코드/명령/expected 포함.
+
+**Type/name 일관성:** 서비스명·포트·컨테이너명 전 태스크 일치(external-api:8081 등).

--- a/docs/superpowers/plans/2026-06-26-nohup-to-docker-deployment.md
+++ b/docs/superpowers/plans/2026-06-26-nohup-to-docker-deployment.md
@@ -53,11 +53,12 @@ Expected: maple-network = `maple-redis`(only); prefixed = postgres/kafka/minio/.
 - [ ] **Step 2: infra 컨테이너를 `maple-network`에 연결** (live, non-disruptive)
 
 ```bash
-docker network connect maple-network maple-postgres
-docker network connect maple-network maple-kafka
-docker network connect maple-network probabilistic-valuation-engine-minio-1
+# --alias 필수: 컨테이너명(maple-postgres)이 아닌 service alias(postgres)로 app 가 참조
+docker network connect --alias postgres maple-network maple-postgres
+docker network connect --alias kafka maple-network maple-kafka
+docker network connect --alias minio maple-network probabilistic-valuation-engine-minio-1
 ```
-(redis는 이미 maple-network에 존재)
+(redis는 이미 maple-network에 존재, alias 보유)
 
 Expected: 각 명령 무출력(성공). 이미 연결 시 "already exists" 무해.
 
@@ -330,9 +331,10 @@ SELECT count(*) FROM calculation_jobs WHERE status IN ('API_REQUESTED','RETRYING
 infra 가 `maple-network`에 연결되어 있어야 app 컨테이너가 postgres/kafka/minio DNS 해석.
 
 ```bash
-docker network connect maple-network maple-postgres
-docker network connect maple-network maple-kafka
-docker network connect maple-network probabilistic-valuation-engine-minio-1
+# --alias 필수 (service alias 전이 안 됨)
+docker network connect --alias postgres maple-network maple-postgres
+docker network connect --alias kafka maple-network maple-kafka
+docker network connect --alias minio maple-network probabilistic-valuation-engine-minio-1
 # 검증
 docker run --rm --network maple-network alpine sh -c 'nslookup postgres; nslookup kafka; nslookup minio'
 ```

--- a/docs/superpowers/specs/2026-06-26-nohup-to-docker-deployment-design.md
+++ b/docs/superpowers/specs/2026-06-26-nohup-to-docker-deployment-design.md
@@ -1,0 +1,136 @@
+# nohup → docker compose 배포 전환 설계 (Issues #1428–#1431)
+
+- Status: Proposed
+- Date: 2026-06-26
+- Owner: maple-pipeline
+- Related: #1245 (이미지 빌드), #1428, #1429, #1430, #1431, ADR-731, ADR-733, ADR-736
+
+---
+
+## 1. Background / Problem
+
+### Background
+
+- 4 active 모듈(`external-api` 8081 / `calculator` 8082 / `synchronizer` 8083 / `cleanup` 8084)은 현재 nohup 호스트 프로세스로 운영 중이었음.
+- 이미지는 #1245 완료로 빌드됨 — `maple/{module}:sha-75cb631` (+ `:dev` mutable alias). `docker/services/build.sh` 가 두 태그 모두 부여.
+- `docker-compose.services.yml` 오버레이에 4 서비스 정의(healthcheck + `autoheal:"true"` 라벨 + MinIO SA secret 마운트) 이미 구성됨.
+- `docker-compose.yml` 에 `autoheal`(willfarrell/autoheal, ADR-731)·`cadvisor`(gcr.io/cadvisor, ADR-733) 정의되어 있으나 **컨테이너 미실행**.
+- `docker/prometheus/prometheus.yml` 에 cadvisor job(`localhost:8086`) + 4 모듈 job(`localhost:PORT`) **이미 존재**.
+- Endurance Test #2 (~71h) 종료 직후. 4 모듈 nohup 프로세스 이미 종료 → 포트 8081–8084 FREE 상태. acceptance #1428 "long-run test 종료 후 전환" 시점 충족.
+
+### Problem
+
+- 운영 통일(autoheal 자동복구, cadvisor 컨테이너 메트릭, 통합 관리)을 위해 nohup → docker 전환이 필요하나 절차 미문서화, autoheal/cadvisor 미가동, airflow 컨테이너 autoheal 라벨 누락.
+- `maple-airflow-scheduler` 가 현재 unhealthy 상태로 방치 중 → autoheal 도입 시 자동 해소 기대.
+
+### Goal
+
+- 4 active 모듈을 docker compose 로 실배포 전환(#1428).
+- autoheal 활성화 + 대상(4 모듈 + airflow) 라벨링(#1429).
+- cadvisor 가동 + 컨테이너 메트릭 Prometheus 수집 확인(#1430).
+- 전환/rollback runbook 문서화(#1431).
+
+---
+
+## 2. Design
+
+### 2.1 핵심 통찰 — 프로메테우스 scrape 는 mode-agnostic
+
+Prometheus 컨테이너는 `network_mode: host` 로 동작. 4 모듈 docker 서비스는 `ports: "808X:808X"` 호스트 포트 퍼블리시.
+
+→ prometheus 가 바라보는 `localhost:8081..8084` 는 **nohup(호스트 프로세스 바인딩) 이나 docker(퍼블리시된 포트) 어느 쪽이든 도달**. 따라서 prometheus config 변경 無. cadvisor job(`localhost:8086`)도 동일. #1430 의 "scrape config 추가"는 이미 완료된 상태 — 부족분은 cadvisor 컨테이너 **실행** 뿐.
+
+### 2.2 이미지 태그 — 별도 핸들링 불필요
+
+`build.sh` 가 `:dev`(mutable) + `:sha-<SHA>`(reproducible) 두 태그 부여. `docker-compose.services.yml` 기본값 `${IMAGE_*:-maple/{module}:dev}` → `:dev` 가 최신 빌드를 가리키므로 **추가 env 설정 없이** `compose up` 만으로 정상 동작.
+
+### 2.3 컴포넌트 변경 (코드/설정)
+
+| 파일 | 변경 | 이슈 |
+|---|---|---|
+| `docker-compose.airflow.yml` | airflow-webserver / airflow-scheduler / airflow-db 에 `labels: autoheal: "true"` 추가 (healthcheck 이미 존재) | #1429 |
+| `docker/services/deploy-apps.sh` (신규) | idempotent 배포 스크립트 — `compose up -d` 4 svc + autoheal + cadvisor → `/actuator/health` UP 폴링 → 상태 테이블 출력 | #1428/#1429/#1430 |
+| `docs/21_Operations/docker-deploy-runbook.md` (신규) | 전환 절차 / rollback / 검증 체크리스트 / 카운터 리셋·다운타임 노트 | #1431 |
+| `docs/01_ADR/ADR-737_nohup-to-docker-deployment.md` (신규) | 전환 결정 + trade-offs | RPI |
+
+### 2.4 운영 전환 절차 (deploy, runtime)
+
+```
+# (1) 사전: phase IDLE 확인 + 포트 free 확인
+# (2) nohup 4 프로세스 stop (현재 이미 종료됨 — skip 가능, runbook에 명시)
+# (3) 배포 (deploy-apps.sh 가 동일 로직 수행; :dev 가 기본 태그라 env 생략 가능)
+docker compose -f docker-compose.yml -f docker-compose.services.yml up -d \
+  external-api calculator synchronizer cleanup
+docker compose -f docker-compose.yml -f docker-compose.airflow.yml up -d \   # airflow 라벨 적용 recreate
+  airflow-webserver airflow-scheduler airflow-db
+docker compose -f docker-compose.yml up -d autoheal cadvisor
+# (4) 검증: /actuator/health 200, kafka lag, prometheus cadvisor 메트릭, DB row 증가, ERROR=0
+```
+
+### 2.5 Split-brain 방지
+
+두 모드가 동시 포트 점유 시 split-brain. runbook 에 `lsof -ti:808X` 로 LISTEN 프로세스 0 확인 후 `compose up` 선행 조건 명시. 현재 4 포트 전부 FREE 검증 완료.
+
+### 2.6 autoheal 적용 범위
+
+| 대상 | 라벨 | healthcheck | 비고 |
+|---|---|---|---|
+| 4 active 모듈 | `autoheal:"true"` (services.yml 기존) | 있음 | unhealthy 시 자동 재시작 |
+| airflow-webserver/scheduler/db | `autoheal:"true"` (본 설계 추가) | 있음 | scheduler 현재 unhealthy → 자동 해소 예상 |
+| cadvisor | 제외 | 없음(설계, ADR-733) | `restart:always` 로 복구 |
+| 인프라(postgres/kafka/redis/...) | 기존 라벨 유지 | 있음 | 변경 없음 |
+
+---
+
+## 3. Trade-offs
+
+### Sensitivity
+
+* 배포 시점(파이프라인 IDLE) — 처리 중 chunk 손실 방지. 현재 IDLE 검증됨.
+* 포트 점유 여부 — split-brain 원천 방지 조건.
+* 이미지 `:dev` 태그가 최신 빌드를 가리키는지 — stale 이미지 배포 위험.
+* MinIO SA secret 파일 존재 — 4종 모두 존재 검증됨(root 소유, mode 0444).
+
+### Trade-off
+
+| 선택 | 얻는 것 | 포기한 것 |
+| -- | ---- | ----- |
+| docker 운영 통일 | autoheal 자동복구, cadvisor 컨테이너 메트릭, 통합 관리 | nohup in-process fallback (호스트 직접 제어 단순성) |
+| `:dev` 태그 default 사용 | deploy env 설정 불필요 | reproducibility 약화 (`:sha-` 태그로 보완 가능, runbook 명시) |
+
+### Risk
+
+* 배포 실패 시 rollback 필요 — runbook 에 `compose down` → nohup 재시작 경로 문서화.
+* 카운터 리셋: 프로세스 전환으로 Prometheus 누적 counter 0 초기화. endurance 데이터는 이미 보고서화(endurance-report-71h.md). post-test 시점이라 허용.
+
+### Non-Risk
+
+* 데이터 손실 — 파이프라인 IDLE 시점 전환, chunk 처리 중 아님.
+* prometheus config 변경 — mode-agnostic 으로 변경 無.
+* DB 데이터 — PostgreSQL 컨테이너는 계속 running, 전환 무관.
+
+---
+
+## 4. Result / Evidence
+
+### Metrics (검증 기준 — 배포 후 수집)
+
+| Metric | 기준 | Notes |
+| ------ | ----: | ----- |
+| 4 모듈 `/actuator/health` | 4/4 = 200 UP | deploy-apps.sh 가 폴링 |
+| autoheal restart (scheduler) | unhealthy → 5s 내 재시작 | AUTOHEAL_INTERVAL=5 |
+| cadvisor metric 수집 | `container_cpu_usage_seconds_total` prometheus 조회 성공 | #1430 |
+| kafka consumer LAG | 처리 가능 범위 (≤ 처리량) | #1428 |
+| DB read model row | 증가 (파이프라인 흐름 정상) | #1428 |
+| ERROR 로그 | 0 | runtime 검증 |
+
+### Observed Result
+
+* 사전 검증(본 설계 시점): 포트 8081–8084 FREE, 이미지 4종 빌드, SA secret 4종 존재, prometheus cadvisor job 존재, 4 서비스 healthcheck+라벨 구성됨.
+* 배포 후 검증: 본 설계 실행(implementation plan) 완료 후 본 절에 실측값 기재.
+
+---
+
+## 5. Summary
+
+> nohup 4 모듈을 docker compose 로 전환. prometheus 는 host network + 포트퍼블리시로 mode-agnostic 이라 config 변경 無. 부족분은 autoheal/cadvisor **실행** + airflow autoheal 라벨 + deploy 스크립트 + runbook + ADR-737. 파이프라인 IDLE 시점 전환으로 데이터 손실 0.

--- a/docs/superpowers/specs/2026-06-26-nohup-to-docker-deployment-design.md
+++ b/docs/superpowers/specs/2026-06-26-nohup-to-docker-deployment-design.md
@@ -1,9 +1,9 @@
 # nohup → docker compose 배포 전환 설계 (Issues #1428–#1431)
 
-- Status: Proposed
+- Status: Revised (post-grill)
 - Date: 2026-06-26
 - Owner: maple-pipeline
-- Related: #1245 (이미지 빌드), #1428, #1429, #1430, #1431, ADR-731, ADR-733, ADR-736
+- Related: #1245 (이미지 빌드), #1428, #1429, #1430, #1431, ADR-731, ADR-733, ADR-736, ADR-737
 
 ---
 
@@ -11,74 +11,75 @@
 
 ### Background
 
-- 4 active 모듈(`external-api` 8081 / `calculator` 8082 / `synchronizer` 8083 / `cleanup` 8084)은 현재 nohup 호스트 프로세스로 운영 중이었음.
-- 이미지는 #1245 완료로 빌드됨 — `maple/{module}:sha-75cb631` (+ `:dev` mutable alias). `docker/services/build.sh` 가 두 태그 모두 부여.
-- `docker-compose.services.yml` 오버레이에 4 서비스 정의(healthcheck + `autoheal:"true"` 라벨 + MinIO SA secret 마운트) 이미 구성됨.
-- `docker-compose.yml` 에 `autoheal`(willfarrell/autoheal, ADR-731)·`cadvisor`(gcr.io/cadvisor, ADR-733) 정의되어 있으나 **컨테이너 미실행**.
-- `docker/prometheus/prometheus.yml` 에 cadvisor job(`localhost:8086`) + 4 모듈 job(`localhost:PORT`) **이미 존재**.
-- Endurance Test #2 (~71h) 종료 직후. 4 모듈 nohup 프로세스 이미 종료 → 포트 8081–8084 FREE 상태. acceptance #1428 "long-run test 종료 후 전환" 시점 충족.
+- 4 active 모듈(`external-api` 8081 / `calculator` 8082 / `synchronizer` 8083 / `cleanup` 8084)은 nohup 호스트 프로세스로 운영.
+- 이미지 #1245 빌드 — `maple/{module}:sha-75cb631` (단 `:dev` mutable 태그는 **부재**, grill 검증).
+- `docker-compose.services.yml` 오버레이에 4 서비스 정의(healthcheck + `autoheal:"true"` 라벨 + MinIO SA secret) 구성됨.
+- `docker-compose.yml` 에 `autoheal`·`cadvisor` 정의되었으나 컨테이너 미실행.
+- `docker/prometheus/prometheus.yml` 에 cadvisor job + 4 모듈 job 존재.
+- Endurance Test #2 (~71h) 종료 직후. 4 nohup 종료 → 포트 8081–8084 FREE. 파이프라인 IDLE(`calculation_jobs` non-terminal=0).
 
-### Problem
+### Problem (grill 로 발견된 추가 장애물)
 
-- 운영 통일(autoheal 자동복구, cadvisor 컨테이너 메트릭, 통합 관리)을 위해 nohup → docker 전환이 필요하나 절차 미문서화, autoheal/cadvisor 미가동, airflow 컨테이너 autoheal 라벨 누락.
-- `maple-airflow-scheduler` 가 현재 unhealthy 상태로 방치 중 → autoheal 도입 시 자동 해소 기대.
+1. **network duality** — infra(postgres/kafka/minio)는 `probabilistic-valuation-engine_maple-network`(project=probabilistic-valuation-engine)에, redis만 `maple-network`에. app 서비스는 `maple-network` 선언 → `postgres`/`kafka`/`minio` DNS **SERVFAIL** (실측 확인). 기본 `compose up` 시 app crash-loop.
+2. **`:dev` 태그 부재** — services.yml 기본값 `maple/{module}:dev` 가 image not found.
+3. **airflow host-network drift** — compose bridge 선언 vs 실제 host network. recreate 시 healthy webserver 파손 위험.
+4. autoheal/cadvisor 미가동, runbook 미문서화.
 
 ### Goal
 
-- 4 active 모듈을 docker compose 로 실배포 전환(#1428).
-- autoheal 활성화 + 대상(4 모듈 + airflow) 라벨링(#1429).
-- cadvisor 가동 + 컨테이너 메트릭 Prometheus 수집 확인(#1430).
-- 전환/rollback runbook 문서화(#1431).
+- network reconcile + tag 해석으로 4 모듈 docker 배포 정상화(#1428).
+- autoheal 가동(4 app 모듈 대상)(#1429). airflow runtime 은 follow-up 이관.
+- cadvisor 가동 + 컨테이너 메트릭 수집(#1430).
+- runbook 문서화(#1431).
 
 ---
 
 ## 2. Design
 
-### 2.1 핵심 통찰 — 프로메테우스 scrape 는 mode-agnostic
+### 2.1 핵심 통찰 — 프로메테우스 scrape 는 mode-agnostic (유효)
 
-Prometheus 컨테이너는 `network_mode: host` 로 동작. 4 모듈 docker 서비스는 `ports: "808X:808X"` 호스트 포트 퍼블리시.
+Prometheus 컨테이너는 `network_mode: host`. 4 모듈 docker 서비스는 `ports: "808X:808X"` 퍼블리시. → `localhost:8081..8084` 가 nohup/docker 양쪽 도달. prometheus config 변경 無. cadvisor job(`localhost:8086`)도 동일. (grill 검증: 이 통찰은 prom→app 한정 유효. **app→infra DNS 는 별도 문제** — §2.2 network reconcile 로 해결.)
 
-→ prometheus 가 바라보는 `localhost:8081..8084` 는 **nohup(호스트 프로세스 바인딩) 이나 docker(퍼블리시된 포트) 어느 쪽이든 도달**. 따라서 prometheus config 변경 無. cadvisor job(`localhost:8086`)도 동일. #1430 의 "scrape config 추가"는 이미 완료된 상태 — 부족분은 cadvisor 컨테이너 **실행** 뿐.
+### 2.2 network reconcile + tag 해석
 
-### 2.2 이미지 태그 — 별도 핸들링 불필요
+**network:** infra 컨테이너를 `maple-network`에 live 연결(`docker network connect`, non-disruptive). redis 는 이미 존재 → 4 infra 모두 maple-network 에서 DNS 해석. 비영속(recreate 시 상실) → runbook 기재.
 
-`build.sh` 가 `:dev`(mutable) + `:sha-<SHA>`(reproducible) 두 태그 부여. `docker-compose.services.yml` 기본값 `${IMAGE_*:-maple/{module}:dev}` → `:dev` 가 최신 빌드를 가리키므로 **추가 env 설정 없이** `compose up` 만으로 정상 동작.
+**tag:** `:dev` 부재 → deploy-apps.sh 가 `:sha-*` 최신 태그 자동 해석, `IMAGE_<MODULE>` env 로 compose 전달.
 
-### 2.3 컴포넌트 변경 (코드/설정)
+### 2.3 컴포넌트 변경
 
 | 파일 | 변경 | 이슈 |
 |---|---|---|
-| `docker-compose.airflow.yml` | airflow-webserver / airflow-scheduler / airflow-db 에 `labels: autoheal: "true"` 추가 (healthcheck 이미 존재) | #1429 |
-| `docker/services/deploy-apps.sh` (신규) | idempotent 배포 스크립트 — `compose up -d` 4 svc + autoheal + cadvisor → `/actuator/health` UP 폴링 → 상태 테이블 출력 | #1428/#1429/#1430 |
-| `docs/21_Operations/docker-deploy-runbook.md` (신규) | 전환 절차 / rollback / 검증 체크리스트 / 카운터 리셋·다운타임 노트 | #1431 |
-| `docs/01_ADR/ADR-737_nohup-to-docker-deployment.md` (신규) | 전환 결정 + trade-offs | RPI |
+| `docker/services/deploy-apps.sh` (신규) | tag 해석 + pre-flight(port/DNS/secret/jar/IDLE) + `compose up` + health 폴링 | #1428/#1429/#1430 |
+| `docs/21_Operations/docker-deploy-runbook.md` (신규) | 전환/rollback/검증/IDLE 정의/network 주의 | #1431 |
+| `docs/01_ADR/ADR-737` (신규) | 전환 결정 + network 현실 반영 | RPI |
+| `docker-compose.airflow.yml` | **변경 제외** — airflow autoheal runtime follow-up 이관 | #1429 partial |
 
-### 2.4 운영 전환 절차 (deploy, runtime)
+**operational(Task 0):** `docker network connect maple-network {maple-postgres, maple-kafka, probabilistic-valuation-engine-minio-1}`.
+
+### 2.4 전환 절차 (runtime)
 
 ```
-# (1) 사전: phase IDLE 확인 + 포트 free 확인
-# (2) nohup 4 프로세스 stop (현재 이미 종료됨 — skip 가능, runbook에 명시)
-# (3) 배포 (deploy-apps.sh 가 동일 로직 수행; :dev 가 기본 태그라 env 생략 가능)
-docker compose -f docker-compose.yml -f docker-compose.services.yml up -d \
-  external-api calculator synchronizer cleanup
-docker compose -f docker-compose.yml -f docker-compose.airflow.yml up -d \   # airflow 라벨 적용 recreate
-  airflow-webserver airflow-scheduler airflow-db
-docker compose -f docker-compose.yml up -d autoheal cadvisor
-# (4) 검증: /actuator/health 200, kafka lag, prometheus cadvisor 메트릭, DB row 증가, ERROR=0
+(0) network reconcile: docker network connect maple-network maple-postgres maple-kafka <minio>
+(1) IDLE gate: calculation_jobs non-terminal = 0
+(2) nohup stop (이미 종료 — skip 가능)
+(3) 포트 free 확인
+(4) ./docker/services/deploy-apps.sh   # tag 해석 + pre-flight + up + health
+(5) 검증: health, autoheal 유발, cadvisor metric, kafka lag, manual trigger→DB row, ERROR=0
 ```
 
 ### 2.5 Split-brain 방지
 
-두 모드가 동시 포트 점유 시 split-brain. runbook 에 `lsof -ti:808X` 로 LISTEN 프로세스 0 확인 후 `compose up` 선행 조건 명시. 현재 4 포트 전부 FREE 검증 완료.
+pre-flight 가 `lsof -ti:808X` 로 LISTEN 0 확인 후 up. 현재 4 포트 FREE.
 
 ### 2.6 autoheal 적용 범위
 
-| 대상 | 라벨 | healthcheck | 비고 |
-|---|---|---|---|
-| 4 active 모듈 | `autoheal:"true"` (services.yml 기존) | 있음 | unhealthy 시 자동 재시작 |
-| airflow-webserver/scheduler/db | `autoheal:"true"` (본 설계 추가) | 있음 | scheduler 현재 unhealthy → 자동 해소 예상 |
-| cadvisor | 제외 | 없음(설계, ADR-733) | `restart:always` 로 복구 |
-| 인프라(postgres/kafka/redis/...) | 기존 라벨 유지 | 있음 | 변경 없음 |
+| 대상 | 상태 | 비고 |
+|---|---|---|
+| 4 active 모듈 | `autoheal:"true"` 라벨 존재(services.yml) | up -d autoheal 로 활성화 |
+| cadvisor | 제외 | healthcheck 無(ADR-733), restart:always 로 복구 |
+| airflow 3컨테이너 | **follow-up 이관** | host/bridge network reconcile 선행 필요, recreate 위험 |
+| 인프라(postgres/kafka/...) | 기존 라벨 유지 | 변경 없음 |
 
 ---
 
@@ -86,51 +87,51 @@ docker compose -f docker-compose.yml up -d autoheal cadvisor
 
 ### Sensitivity
 
-* 배포 시점(파이프라인 IDLE) — 처리 중 chunk 손실 방지. 현재 IDLE 검증됨.
-* 포트 점유 여부 — split-brain 원천 방지 조건.
-* 이미지 `:dev` 태그가 최신 빌드를 가리키는지 — stale 이미지 배포 위험.
-* MinIO SA secret 파일 존재 — 4종 모두 존재 검증됨(root 소유, mode 0444).
+* `maple-network` 연결 영속성 — infra recreate 시 상실(runbook 기재).
+* `:sha-*` 태그 존재 — 빌드 후 최신 유지.
+* IDLE 시점 — in-flight 손실 방지(hard gate).
+* MinIO SA secret 존재 — 4종 검증됨(root 소유, mode 0444, bind-mount 정상).
 
 ### Trade-off
 
 | 선택 | 얻는 것 | 포기한 것 |
 | -- | ---- | ----- |
-| docker 운영 통일 | autoheal 자동복구, cadvisor 컨테이너 메트릭, 통합 관리 | nohup in-process fallback (호스트 직접 제어 단순성) |
-| `:dev` 태그 default 사용 | deploy env 설정 불필요 | reproducibility 약화 (`:sha-` 태그로 보완 가능, runbook 명시) |
+| live network connect (infra recreate 아님) | infra 무중단 reconcile | recreate 시 재연결(수동) |
+| airflow autoheal 이관 | 동작 중 airflow 보호 | airflow 자동복구 지연(follow-up) |
 
 ### Risk
 
-* 배포 실패 시 rollback 필요 — runbook 에 `compose down` → nohup 재시작 경로 문서화.
-* 카운터 리셋: 프로세스 전환으로 Prometheus 누적 counter 0 초기화. endurance 데이터는 이미 보고서화(endurance-report-71h.md). post-test 시점이라 허용.
+* network connect 비영속 — runbook 으로 보완.
+* 카운터 리셋 — Prometheus 누적 초기화(post-test 허용).
 
 ### Non-Risk
 
-* 데이터 손실 — 파이프라인 IDLE 시점 전환, chunk 처리 중 아님.
-* prometheus config 변경 — mode-agnostic 으로 변경 無.
-* DB 데이터 — PostgreSQL 컨테이너는 계속 running, 전환 무관.
+* 데이터 손실 — IDLE 전환(non-terminal job=0, kafka lag=0).
+* prometheus config — mode-agnostic, 변경 無.
+* DB 데이터 — PostgreSQL 컨테이너 계속 running.
 
 ---
 
 ## 4. Result / Evidence
 
-### Metrics (검증 기준 — 배포 후 수집)
+### Metrics (배포 후)
 
 | Metric | 기준 | Notes |
 | ------ | ----: | ----- |
-| 4 모듈 `/actuator/health` | 4/4 = 200 UP | deploy-apps.sh 가 폴링 |
-| autoheal restart (scheduler) | unhealthy → 5s 내 재시작 | AUTOHEAL_INTERVAL=5 |
-| cadvisor metric 수집 | `container_cpu_usage_seconds_total` prometheus 조회 성공 | #1430 |
-| kafka consumer LAG | 처리 가능 범위 (≤ 처리량) | #1428 |
-| DB read model row | 증가 (파이프라인 흐름 정상) | #1428 |
-| ERROR 로그 | 0 | runtime 검증 |
+| DNS(postgres from maple-network) | SERVFAIL → 해결 | Task 0 |
+| 4 모듈 `/actuator/health` | 4/4 UP | deploy-apps.sh 폴링 |
+| autoheal 유발 테스트 | throwaway 컨테이너 재시작 + app 무영향 | #1429 |
+| cadvisor metric 수집 | `container_cpu_usage_seconds_total` series ≥ 1 | #1430 |
+| manual trigger → DB row | 증가 | end-to-end |
+| ERROR 로그 | 0 | runtime |
 
 ### Observed Result
 
-* 사전 검증(본 설계 시점): 포트 8081–8084 FREE, 이미지 4종 빌드, SA secret 4종 존재, prometheus cadvisor job 존재, 4 서비스 healthcheck+라벨 구성됨.
-* 배포 후 검증: 본 설계 실행(implementation plan) 완료 후 본 절에 실측값 기재.
+* 사전 검증: 포트 FREE, 이미지 4종(:sha-75cb631), SA secret 4종, jar 4종, IDLE(non-terminal=0), network duality 실측, :dev 부재 실측.
+* 배포 후: plan 실행 완료 후 실측값 기재.
 
 ---
 
 ## 5. Summary
 
-> nohup 4 모듈을 docker compose 로 전환. prometheus 는 host network + 포트퍼블리시로 mode-agnostic 이라 config 변경 無. 부족분은 autoheal/cadvisor **실행** + airflow autoheal 라벨 + deploy 스크립트 + runbook + ADR-737. 파이프라인 IDLE 시점 전환으로 데이터 손실 0.
+> infra 를 `maple-network`에 live 연결하고 deploy-apps.sh 가 `:sha-*` 태그를 해석하여 4 모듈 docker 전환. airflow autoheal runtime 은 network reconcile 선행 필요로 follow-up 이관. 파이프라인 IDLE 시점 전환으로 데이터 손실 0.


### PR DESCRIPTION
## Summary
- 4 active 모듈(external-api/calculator/synchronizer/cleanup) nohup → docker compose 전환
- autoheal 가동 (4 app 컨테이너 라벨 기존 존재 → up -d autoheal 로 활성화)
- cadvisor 가동 + Prometheus 스크레이프 (#1430)
- runbook + ADR-737 문서화 (#1431)

## Pipeline (brainstorming → spec → plan → grill → implement)
- spec: `docs/superpowers/specs/2026-06-26-nohup-to-docker-deployment-design.md`
- plan: `docs/superpowers/plans/2026-06-26-nohup-to-docker-deployment.md`
- grill(critic opus) REJECT → 3 blocker 발견·수정: network duality, `:dev` 태그 부재, airflow host/bridge drift

## Key artifacts
- `docker/services/deploy-apps.sh`: tag 자동 해석 + pre-flight(port/DNS/secret/jar/IDLE) + health 폴링 + autoheal는 health 이후 기동
- `docs/21_Operations/docker-deploy-runbook.md`: 전환/rollback/검증/IDLE hard gate
- `docs/01_ADR/ADR-737_nohup-to-docker-deployment.md`

## Verification (배포 후 실측)
- 4 app healthy + ERROR=0 + Kafka LAG=0
- pipeline 흐름: ext-api run-on-startup 발화 → RankingFetch → Kafka → calculator 소비 → synchronizer 파티션 할당
- cadvisor: prometheus `container_cpu_usage_seconds_total` 76 series 스크레이프
- autoheal 유발 테스트: unhealthy 컨테이너 재시작 + app 컨테이너 무영향(false positive 없음)
- network reconcile: `maple-network`에서 postgres/kafka/minio/redis DNS 해석 (`--alias` 필수)

## Scope note
- airflow autoheal runtime = 별도 follow-up 이슈 이관 (host/bridge network drift → recreate 위험, 동작 중 infra 보호)

🤖 Generated with [Claude Code](https://claude.com/claude-code)