### PR TITLE
fix(loop): defer iteration when upstream OCID_LOOKUP not ready (prevent daily loop death)

### DIFF
--- a/docs/01_ADR/ADR-742_loop-upstream-defer.md
+++ b/docs/01_ADR/ADR-742_loop-upstream-defer.md
@@ -1,0 +1,98 @@
+# ADR-742: PhaseLoopController iteration 업스트림 부재 시 defer/retry (루프 사망 방지)
+
+- Status: Accepted
+- Date: 2026-06-28
+- Owner: maple-pipeline
+- Related: PhaseLoopController, ADR-739, ADR-741
+
+---
+
+## 1. Background / Problem
+
+### Background
+
+- `morning_chain` ITEM_EQUIPMENT infinite loop 는 매 iteration 마다 `latestUpstreamRunId` = `getLastCompletedForPhase(OCID_LOOKUP)?.runId` 로 업스트림을 읽어 `runItemEquipmentPhase` 에 전달.
+- `runItemEquipmentPhase` line 267: `require(upstreamRunId != null) { "ITEM_EQUIPMENT requires upstreamRunId" }`.
+
+### Problem
+
+- 매일 03:00 KST `morning_chain` 가 OCID_LOOKUP 을 refresh 하는 동안, OCID_LOOKUP slot 이 non-terminal(in-progress) → `getLastCompletedForPhase(OCID_LOOKUP)` = **null**.
+- 이 창에 loop 의 다음 iteration 이 `submitIteration` → `triggerPhase(ITEM_EQUIPMENT, runId, null, loopId)` → `require` throw `IllegalArgumentException`.
+- `submitIteration` catch block 이 이를 fatal 로 처리 → `status=STOPPING` → `finalize` → **루프 사망**.
+- 실측(500m log, ADR-741): `iter=274` 에서 `[Loop] iteration submit failed: ITEM_EQUIPMENT requires upstreamRunId` → `[Loop] stopped iterations=273`. 273 iteration 정상 후 매일 아침 사망.
+
+### Goal
+
+- loop 가 upstream(OCID_LOOKUP) transient 부재 시 **사망 대신 대기/재시도**. upstream 이 terminal-completed 로 복귀하면 iteration 재개.
+
+---
+
+## 2. Decision
+
+> `submitIteration` catch block 에서, throw 원인이 `upstream == null` 이면 finalize 대신 **backoff 후 재submit** (defer). loop 상태 RUNNING 유지.
+
+```text
+submitIteration(phase, loopId, runId, n):
+  upstream = latestUpstreamRunId(phase)
+  try triggerPhase(phase, runId, upstream, loopId).whenComplete{...}
+  catch ex:
+    if upstream == null && loop still RUNNING:
+        log.info("[Loop] upstream not ready — deferring retry in {N}s")
+        loopExecutor.execute { sleep(N); submitIteration(phase, loopId, runId, n) }
+        return                         // 사망 방지
+    // upstream non-null 인 진짜 실패 → 기존 fatal 경로 유지
+    log.error("[Loop] iteration submit failed ..."); STOPPING; finalize
+```
+
+근거:
+- `require` 가 triggerPhase 내부에서 **slot acquire 이전**에 throw 하므로, 실패 시 slot 미점유 상태 → 동일 runId 로 안전 재submit.
+- 판별 조건 `upstream == null` 로 "업스트림 부재" 와 "진짜 submit 실패" 명확 분리. upstream non-null 실패는 기존대로 사망 유지(과잉 재시도 방지).
+- backoff = `external-api.loop.upstream-retry-interval-seconds` (기본 30s, YAML 외부화). OCID_LOOKUP refresh 가 terminal 되면 다음 retry 에 iteration 정상 진행.
+- loopExecutor 가 virtual-thread → retry sleep 이 carrier pinning 없이 대기(architecture-guardrails §9-10).
+
+---
+
+## 3. Trade-offs
+
+### Sensitivity
+
+* upstream 이 장기 부재 시 loop 가 `upstreamRetryIntervalSeconds` 마다 retry 하며 RUNNING 유지. 30s 마다 info-log 1건 → 노이즈 가능(수용; 사망보다 양호).
+* morning_chain stop_loop 가 STOPPING 전환하면, defer-resubmit 의 `status == RUNNING` guard 가 추가 재submit 차단 → 정상 종료.
+
+### Trade-off
+
+| 선택 | 얻는 것 | 포기한 것 |
+| -- | ---- | ----- |
+| defer/retry (upstream null) | 일일 loop 사망 제거, upstream 복귀 시 자동 재개 | 장기 부재 시 무한 대기 + 주기적 로그 |
+
+### Risk
+
+* defer 중 loop 교체/stop 시 guard(`loopId`/`status`) 누락되면 stale retry 가능 → guard 로 차단(구현).
+
+### Non-Risk
+
+* `runItemEquipmentPhase` require(precondition guard) — 유지. loop controller 가 null 전달을 defer 로 흡수.
+* non-null upstream 실패 경로 — 기존 fatal 유지.
+
+---
+
+## 4. Result / Evidence
+
+### Metrics
+
+| Metric | Value | Notes |
+| ------ | ----: | ----- |
+| 일일 loop 사망(03:00KST) | 매일 → 0 (예상) | upstream defer 로 회피 |
+| iteration submit failed(사망) | 발생 → defer | catch block 분기 |
+
+### Observed Result
+
+* 단위 테스트: `loop defers iteration when upstream not ready` — triggerPhase throw 시 루프 RUNNING 유지, iterationCount=0, lastError=null 검증.
+* 코드 검증: compileKotlin PASS.
+* 런타임: 다음 03:00 KST morning_chain OCID_LOOKUP refresh 창에 `[Loop] upstream not ready — deferring` 로그 + 루프 사망 없이 유지 관측 예정.
+
+---
+
+## 5. Summary
+
+> morning_chain OCID_LOOKUP refresh 창에 loop iteration 이 null upstream 으로 throw → 사망하던 버그 수정. catch block 에서 `upstream == null` 시 backoff retry(defer) 로 루프 RUNNING 유지, non-null 실패는 기존 fatal 유지.

--- a/module-external-api/src/main/kotlin/maple/externalapi/loop/PhaseLoopController.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/loop/PhaseLoopController.kt
@@ -13,8 +13,11 @@ import maple.externalapi.scheduler.ExternalApiScheduler
 import maple.externalapi.scheduler.PhaseStopSignal
 import maple.externalapi.scheduler.phase.RunIdGenerator
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.core.task.AsyncTaskExecutor
 import org.springframework.stereotype.Component
+
+private const val MILLIS_PER_SECOND = 1000L
 
 /**
  * Owns per-phase infinite-loop state. One loop per phase; phases in
@@ -38,6 +41,8 @@ class PhaseLoopController(
     private val runIdGenerator: RunIdGenerator,
     private val stopSignal: PhaseStopSignal,
     private val loopExecutor: AsyncTaskExecutor,
+    @Value("\${external-api.loop.upstream-retry-interval-seconds:30}")
+    private val upstreamRetryIntervalSeconds: Int = 30,
     private val clock: Clock = Clock.systemUTC(),
 ) {
 
@@ -123,12 +128,43 @@ class PhaseLoopController(
             externalApiScheduler.triggerPhase(phase, runId, upstream, loopId)
                 .whenComplete { _, ex -> handleIterationEnd(phase, loopId, runId, ex, n) }
         } catch (ex: Throwable) {
+            // Upstream (OCID_LOOKUP) is transiently absent — the morning_chain
+            // 03:00 KST run refreshes OCID_LOOKUP, leaving its slot non-terminal
+            // so latestUpstreamRunId() returns null. runItemEquipmentPhase
+            // rejects a null upstream synchronously (require, before slot
+            // acquire), which previously killed the loop via the fatal path
+            // below. Defer instead: re-submit on the loopExecutor after a short
+            // backoff (virtual-thread sleep, no carrier pinning). The loop stays
+            // RUNNING and resumes once OCID_LOOKUP reaches a terminal state.
+            // See ADR-742.
+            val state = loops[phase]?.get()
+            if (upstream == null && state != null && state.loopId == loopId && state.status == LoopStatus.RUNNING) {
+                log.info(
+                    "[Loop] upstream not ready phase={} loopId={} iter={} deferring retry in {}s",
+                    phase, loopId, n, upstreamRetryIntervalSeconds,
+                )
+                val delayMillis = upstreamRetryIntervalSeconds.toLong() * MILLIS_PER_SECOND
+                loopExecutor.execute {
+                    sleepInterruptibly(delayMillis)
+                    submitIteration(phase, loopId, runId, n)
+                }
+                return
+            }
             log.error("[Loop] iteration submit failed phase={} loopId={} iter={}", phase, loopId, n, ex)
-            val state = loops[phase]?.get() ?: return
-            if (state.loopId != loopId) return
-            state.lastError = ex.message
-            state.status = LoopStatus.STOPPING
+            val current = state ?: return
+            if (current.loopId != loopId) return
+            current.lastError = ex.message
+            current.status = LoopStatus.STOPPING
             finalize(phase, loopId)
+        }
+    }
+
+    private fun sleepInterruptibly(millis: Long) {
+        if (millis <= 0) return
+        try {
+            Thread.sleep(millis)
+        } catch (ie: InterruptedException) {
+            Thread.currentThread().interrupt()
         }
     }
 

--- a/module-external-api/src/test/kotlin/maple/externalapi/loop/PhaseLoopControllerTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/loop/PhaseLoopControllerTest.kt
@@ -19,7 +19,9 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.atLeast
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -36,12 +38,16 @@ class PhaseLoopControllerTest {
     // Runs the first submission inline, drops the rest.
     private val oneShotInlineExecutor = OneShotInlineExecutor()
 
-    private fun controller(executor: AsyncTaskExecutor = noopExecutor) = PhaseLoopController(
+    private fun controller(
+        executor: AsyncTaskExecutor = noopExecutor,
+        upstreamRetryIntervalSeconds: Int = 30,
+    ) = PhaseLoopController(
         externalApiScheduler = scheduler,
         runStatusTracker = runStatusTracker,
         runIdGenerator = runIdGenerator,
         stopSignal = stopSignal,
         loopExecutor = executor,
+        upstreamRetryIntervalSeconds = upstreamRetryIntervalSeconds,
     )
 
     @Test
@@ -250,6 +256,28 @@ class PhaseLoopControllerTest {
         assertEquals(1, state.iterationCount)
         assertNotNull(state.lastError)
         assertTrue(state.lastError!!.contains("slot occupied"))
+    }
+
+    @Test
+    fun `loop defers iteration when upstream OCID_LOOKUP is not ready instead of dying`() {
+        // No OCID_LOOKUP completed run → latestUpstreamRunId() returns null. The
+        // real scheduler's runItemEquipmentPhase rejects null upstream
+        // synchronously (require, before slot acquire); mirror that throw here.
+        whenever(scheduler.triggerPhase(eq(PipelinePhase.ITEM_EQUIPMENT), any(), isNull(), anyOrNull()))
+            .thenThrow(IllegalArgumentException("ITEM_EQUIPMENT requires upstreamRunId"))
+
+        // interval 0 → defer retry is instant; OneShotInlineExecutor runs the
+        // first deferred resubmit inline then drops the next (bounded, no spin).
+        val state = controller(OneShotInlineExecutor(), upstreamRetryIntervalSeconds = 0)
+            .startLoop(PipelinePhase.ITEM_EQUIPMENT)
+
+        // Loop stays RUNNING (deferred) — never finalized/dies.
+        assertEquals(LoopStatus.RUNNING, state.status)
+        assertNull(state.lastError)
+        assertEquals(0, state.iterationCount)
+        // triggerPhase was attempted (defer path still submits), loop survived.
+        verify(scheduler, atLeast(1))
+            .triggerPhase(eq(PipelinePhase.ITEM_EQUIPMENT), any(), isNull(), anyOrNull())
     }
 
     private class OneShotInlineExecutor : AsyncTaskExecutor {


### PR DESCRIPTION
## Problem
Every 03:00 KST, morning_chain refreshes OCID_LOOKUP. During that window `latestUpstreamRunId` returns null → next loop iteration's `triggerPhase(ITEM_EQUIPMENT, null, …)` throws `IllegalArgumentException: ITEM_EQUIPMENT requires upstreamRunId` (runItemEquipmentPhase `require`, before slot acquire). The submitIteration catch block treated it as fatal → **loop died daily**. Confirmed via 500m logs (ADR-741): `[Loop] iteration submit failed` iter 274 → `[Loop] stopped iterations=273`.

## Fix
In `submitIteration`'s catch: when the throw coincides with a **null upstream** (transient OCID_LOOKUP refresh) and the loop is still RUNNING, **defer** — re-submit on loopExecutor after a backoff (`external-api.loop.upstream-retry-interval-seconds`, default 30s; virtual-thread sleep) — instead of finalizing. Loop stays RUNNING, resumes when OCID_LOOKUP reaches terminal. Non-null-upstream failures keep the existing fatal path (no over-retry).

`require` throws before slot acquire, so the failed iteration holds no slot → re-submitting the same runId is safe.

## Verification
- [x] `./gradlew :module-external-api:compileKotlin` OK
- [x] `PhaseLoopControllerTest` 16/16 pass (0 failures), incl. new `loop defers iteration when upstream OCID_LOOKUP is not ready instead of dying`
- [ ] Runtime: next 03:00 KST morning_chain OCID_LOOKUP refresh window → `[Loop] upstream not ready — deferring` log, loop survives

ADR-742.

🤖 Generated with [Claude Code](https://claude.com/claude-code)