### PR TITLE
docs: add troubleshooting casebook from ai-traces (problem/cause/fix/alternatives)

### DIFF
--- a/docs/24_Troubleshooting_Casebook/00_index.md
+++ b/docs/24_Troubleshooting_Casebook/00_index.md
@@ -1,0 +1,56 @@
+# 24. 트러블슈팅 케이스북 (Troubleshooting Casebook)
+
+> `docs/ai-traces/` 세션 기록 + 코드베이스 + ADR + git history 에서 추출한
+> **문제 → 원인 → 해결 → 왜 그 방법 / 대안** 사례 모음.
+> 2026-06-09 ~ 2026-06-28 (약 3주, ~110 세션) 운영·개발 중 발생한 실제 장애·버그·설정 결함.
+
+---
+
+## 왜 이 문서인가
+
+ADRsms *결정(Decision)* 을 기록하지만, 그 결정에 이르는 **에러 증상·재현·디버깅 과정** 은 세션 트레이스에만 남는다.
+이 케이스북은 그 "증상 → 원인 → 해결 → 대안 검토" 사이클을 주제별로 재구성해 동일 실수 반복을 막고
+장애 대응 속도를 높인다. 각 사례는 **실측 에러 메시지·세션 ID·commit·ADR** 를 인용한다.
+
+---
+
+## 주제별 색인
+
+| # | 파일 | 주제 | 대표 사례 |
+|---|------|------|-----------|
+| 01 | [01_async_concurrency.md](01_async_concurrency.md) | 비동기·동시성·가상스레드·락 | CF `.get()` pinning, `LockAspect` 예외 언래핑, `BackpressureLimiter`, recursion StackOverflow, coroutines-reactor 누락 |
+| 02 | [02_memory_streaming.md](02_memory_streaming.md) | 메모리·OOM·스트리밍 I/O | OCID 매핑 OOM, GzipJsonl OOM, `catch(Exception)` 가 OOM 삼킴, sync `s3.putObject` 병목, off-heap cache |
+| 03 | [03_pipeline_data_correctness.md](03_pipeline_data_correctness.md) | 파이프라인 데이터 정합성 | chunk-key 불일치, chunk body 스키마 mismatch, 잘못된 upstreamRunId, result writer pipe race, contentLength 음수 |
+| 04 | [04_orchestration_airflow.md](04_orchestration_airflow.md) | 오케스트레이션·Airflow | HttpOperator 409 dead code, task timeout, connection 미등록, in-process cron vs DAG slot race, daily_full 중복 |
+| 05 | [05_loop_lifecycle_observability.md](05_loop_lifecycle_observability.md) | 무한루프 생명주기·관측성 | loop 사망(upstream null), sensor `iterationCount>=1` timeout, log rotate-out 관측 회귀 |
+| 06 | [06_infra_deploy_migration.md](06_infra_deploy_migration.md) | 인프라·배포·마이그레이션 | nohup→docker network duality, MinIO `listByPrefix` 1000 truncation, SA policy, CI MinIO, Nexon pool 튜닝 |
+
+---
+
+## 읽는 법
+
+각 사례 구조:
+- **문제/에러** — 증상 + 실측 에러 메시지/stacktrace
+- **원인** — 근본 원인 (1-2문장)
+- **해결** — 적용한 변경 (commit + ADR)
+- **왜 이 방법 / 대안** — 해당 접근 선택 이유 + 기각한 대안
+
+인용 키:
+- `Session 202606XX-XXXXXX` — `docs/ai-traces/` 세션
+- `commit <sha>` — git
+- `ADR-XXX` — `docs/01_ADR/`
+
+---
+
+## 교차 교훈 (Cross-cutting lessons)
+
+1. **`catch (Exception)` vs `Throwable`** — OOM/StackOverflow(`Error`) 를 삼키면 진짜 원인이 묻힌다. 단일 writer/sink 코루틴은 `Throwable` 잡아야 (사례 02-3).
+2. **`HttpOperator` + 멱등 4xx = 불가능** — `response.raise_for_status()` 가 callback 전에 throw. 멱등 트리거는 `PythonOperator` (사례 04-1).
+3. **in-memory 상태 + 장기 실행 루프 = 사망** — PhaseLoopController in-memory state 가 restart/refresh 창에 날아감. 관측 로그가 없으면 원인 불가 (사례 05).
+4. **동일 cron 중복 DAG = 매일 fail** — control plane 이전 후 legacy scheduler 가 잔존하면 slot 경쟁. 퇴역은 `schedule=None` (사례 04-4, 04-5).
+5. **log rotation 이 진단을 가른다** — 장기 loop lifecycle 은 retention 충분해야 포착 (사례 05-3).
+6. **동기 bridge 가 비동기 체인을 깬다** — core port 가 sync return 이면 모든 caller 가 `.get()` pinning. `*Async` big-bang + CI grep gate (사례 01-1).
+
+---
+
+*생성: 2026-06-28 · 소스: docs/ai-traces (110 sessions) + docs/01_ADR (192) + git log*

--- a/docs/24_Troubleshooting_Casebook/00_index.md
+++ b/docs/24_Troubleshooting_Casebook/00_index.md
@@ -1,56 +1,72 @@
-# 24. 트러블슈팅 케이스북 (Troubleshooting Casebook)
+# 트러블슈팅 케이스북 — 문제를 정의하고 측정하고 구조적으로 해결한 기록
 
-> `docs/ai-traces/` 세션 기록 + 코드베이스 + ADR + git history 에서 추출한
-> **문제 → 원인 → 해결 → 왜 그 방법 / 대안** 사례 모음.
-> 2026-06-09 ~ 2026-06-28 (약 3주, ~110 세션) 운영·개발 중 발생한 실제 장애·버그·설정 결함.
-
----
-
-## 왜 이 문서인가
-
-ADRsms *결정(Decision)* 을 기록하지만, 그 결정에 이르는 **에러 증상·재현·디버깅 과정** 은 세션 트레이스에만 남는다.
-이 케이스북은 그 "증상 → 원인 → 해결 → 대안 검토" 사이클을 주제별로 재구성해 동일 실수 반복을 막고
-장애 대응 속도를 높인다. 각 사례는 **실측 에러 메시지·세션 ID·commit·ADR** 를 인용한다.
+> 단일 노드에서 하루 ~600K 캐릭터의 장비 기대값을 계산하는 비동기 ETL 파이프라인.
+> 3주(2026-06-09 ~ 06-28)간 발생한 실제 장애·버그·회귀를 **증상 → 원인 → 해결 → 왜 그 방법 / 대안** 으로 재구성.
+> 각 사례는 ADR·commit·세션 ID 로 검증 가능한 근거를 인용한다.
 
 ---
 
-## 주제별 색인
+## 시스템 맥락 (왜 이 문제들이 의미 있는가)
 
-| # | 파일 | 주제 | 대표 사례 |
-|---|------|------|-----------|
-| 01 | [01_async_concurrency.md](01_async_concurrency.md) | 비동기·동시성·가상스레드·락 | CF `.get()` pinning, `LockAspect` 예외 언래핑, `BackpressureLimiter`, recursion StackOverflow, coroutines-reactor 누락 |
-| 02 | [02_memory_streaming.md](02_memory_streaming.md) | 메모리·OOM·스트리밍 I/O | OCID 매핑 OOM, GzipJsonl OOM, `catch(Exception)` 가 OOM 삼킴, sync `s3.putObject` 병목, off-heap cache |
-| 03 | [03_pipeline_data_correctness.md](03_pipeline_data_correctness.md) | 파이프라인 데이터 정합성 | chunk-key 불일치, chunk body 스키마 mismatch, 잘못된 upstreamRunId, result writer pipe race, contentLength 음수 |
-| 04 | [04_orchestration_airflow.md](04_orchestration_airflow.md) | 오케스트레이션·Airflow | HttpOperator 409 dead code, task timeout, connection 미등록, in-process cron vs DAG slot race, daily_full 중복 |
-| 05 | [05_loop_lifecycle_observability.md](05_loop_lifecycle_observability.md) | 무한루프 생명주기·관측성 | loop 사망(upstream null), sensor `iterationCount>=1` timeout, log rotate-out 관측 회귀 |
-| 06 | [06_infra_deploy_migration.md](06_infra_deploy_migration.md) | 인프라·배포·마이그레이션 | nohup→docker network duality, MinIO `listByPrefix` 1000 truncation, SA policy, CI MinIO, Nexon pool 튜닝 |
+메이플스토리 전체 랭킹 IGN(~600K) 의 장비 데이터를 매일 03:00 KST 에 수집·계산·동기화하는 파이프라인이다.
+한 패스 = item-equipment IGN 560K 를 ~62분(150 files/s) 에 처리. external-api → calculator → synchronizer → cleanup 4개 Spring Boot 모듈이 Kafka 이벤트로 연쇄 동작하고, Airflow 가 제어한다.
+
+이 규모에서 **"에러 로그 없이 0건 처리"** · **"매일 같은 시각에만 죽는 루프"** · **"버퍼 하나가 1GB heap 을 채운다"** 같은 문제가 실제로 발생했다. 본 케이스북은 그 문제들을 측정 기반으로 해결한 과정이다.
+
+핵심 교훈: 성능 문제는 인프라 수가 아니라 **데이터 흐름·병목·관측성** 에서 발생한다. 숫자가 아니라 그 숫자가 나온 이유를 설명할 수 있어야 한다.
 
 ---
 
-## 읽는 법
+## 큐레이션 — 대표 사례 (impact-first)
 
-각 사례 구조:
-- **문제/에러** — 증상 + 실측 에러 메시지/stacktrace
-- **원인** — 근본 원인 (1-2문장)
-- **해결** — 적용한 변경 (commit + ADR)
-- **왜 이 방법 / 대안** — 해당 접근 선택 이유 + 기각한 대안
+| # | 무엇이 | 규모·영향 | 해결 | 상세 |
+|---|--------|-----------|------|------|
+| 1 | **루프가 매일 03:00 에만 죽음** | 273 iteration 정상 후 사망, ITEM_EQUIPMENT 지속 구동 안 됨 | OCID_LOOKUP refresh 창의 upstream null 을 defer/retry 로 흡수(사망 대신 대기) | [05-1](05_loop_lifecycle_observability.md) |
+| 2 | **관측 로그가 사망 원인을 숨김** | 77K 라인 중 lifecycle 로그 0건 → 진단 불가 | log retention 30m→500m 증설로 사망 stacktrace 포착 | [05-3](05_loop_lifecycle_observability.md) |
+| 3 | **에러 없이 데이터 100% 손실** | calculator/synchronizer 가 모든 chunk silent drop → valuation 0건 | chunk body dual-shape reader 신규 schema 인식 | [03-2](03_pipeline_data_correctness.md) |
+| 4 | **600K IGN 처리 중 OOM, 2.5h run 사망** | 120MB string list 가 1GB heap 점유 | Channel streaming 으로 heap 120MB→~64KB | [02-1](02_memory_streaming.md) |
+| 5 | **OOM 이 `catch(Exception)` 에 삼켜져 진짜 원인 소실** | sink writer silent 사망, 잘못된 에러 노출 | `Throwable` catch 로 Error 노출 + cause chain | [02-3](02_memory_streaming.md) |
+| 6 | **비동기 체인 중 `.get()` 이 가상스레드 pinning** | worker-pool 고갈, 부하테스트 비결정적 저하 | `*Async` big-bang 마이그레이션 + CI grep gate 회귀 차단 | [01-1](01_async_concurrency.md) |
+| 7 | **cleanup 이 ~200GB silent 미삭제** | `listByPrefix` 1000 keys truncation | continuationToken pagination | [06-2](06_infra_deploy_migration.md) |
+| 8 | **매일 아침 두 스케줄러가 같은 slot 경쟁** | morning_chain DAG 매일 fail | legacy in-process cron 제거(단일 오케스트레이터) | [04-4](04_orchestration_airflow.md) |
 
-인용 키:
-- `Session 202606XX-XXXXXX` — `docs/ai-traces/` 세션
-- `commit <sha>` — git
-- `ADR-XXX` — `docs/01_ADR/`
+---
+
+## 주제별 전체 사례
+
+| # | 파일 | 주제 | 사례 수 |
+|---|------|------|--------|
+| 01 | [01_async_concurrency.md](01_async_concurrency.md) | 비동기·동시성·가상스레드·락 | 6 |
+| 02 | [02_memory_streaming.md](02_memory_streaming.md) | 메모리·OOM·스트리밍 I/O | 6 |
+| 03 | [03_pipeline_data_correctness.md](03_pipeline_data_correctness.md) | 파이프라인 데이터 정합성(silent data loss) | 7 |
+| 04 | [04_orchestration_airflow.md](04_orchestration_airflow.md) | 오케스트레이션·Airflow | 7 |
+| 05 | [05_loop_lifecycle_observability.md](05_loop_lifecycle_observability.md) | 무한루프 생명주기·관측성 | 3 |
+| 06 | [06_infra_deploy_migration.md](06_infra_deploy_migration.md) | 인프라·배포·마이그레이션 | 6 |
+
+---
+
+## 읽는 법 / 근거
+
+각 사례 구조: **문제/에러**(증상 + 실측 메시지) → **원인** → **해결**(commit + ADR) → **왜 이 방법 / 대안**(기각안 포함).
+
+근거 인용:
+- `commit <sha>` — git history (모든 인용 commit 실존 검증됨)
+- `ADR-XXX` — `docs/01_ADR/` (모든 인용 ADR 실존 검증됨)
+- `Session 202606XX-XXXXXX` — `docs/ai-traces/` 세션 기록
+
+기술적 깊이는 의도적이다 — 포트폴리오 독자에게 "디버깅을 얼마나 깊이 했는지" 가 credibility 의 핵심이기 때문. impact 는 상단 callout, 근거는 본문.
 
 ---
 
 ## 교차 교훈 (Cross-cutting lessons)
 
-1. **`catch (Exception)` vs `Throwable`** — OOM/StackOverflow(`Error`) 를 삼키면 진짜 원인이 묻힌다. 단일 writer/sink 코루틴은 `Throwable` 잡아야 (사례 02-3).
-2. **`HttpOperator` + 멱등 4xx = 불가능** — `response.raise_for_status()` 가 callback 전에 throw. 멱등 트리거는 `PythonOperator` (사례 04-1).
-3. **in-memory 상태 + 장기 실행 루프 = 사망** — PhaseLoopController in-memory state 가 restart/refresh 창에 날아감. 관측 로그가 없으면 원인 불가 (사례 05).
-4. **동일 cron 중복 DAG = 매일 fail** — control plane 이전 후 legacy scheduler 가 잔존하면 slot 경쟁. 퇴역은 `schedule=None` (사례 04-4, 04-5).
-5. **log rotation 이 진단을 가른다** — 장기 loop lifecycle 은 retention 충분해야 포착 (사례 05-3).
-6. **동기 bridge 가 비동기 체인을 깬다** — core port 가 sync return 이면 모든 caller 가 `.get()` pinning. `*Async` big-bang + CI grep gate (사례 01-1).
+1. **관측성 회귀가 진짜 버그를 은폐한다** — 로그가 증거를 숨기면 "코드는 정상인데 죽는다" 가 된다. retention 먼저 의심(사례 05).
+2. **`catch (Exception)` 이 `Error` 를 삼킨다** — OOM/StackOverflow 는 `Error`. 단일 writer/sink 코루틴은 `Throwable` 잡아야(사례 02-3).
+3. **"에러 없이 0건" 이 가장 교활하다** — silent data loss. reader schema dual-shape 검증 필수(사례 03).
+4. **control plane 이전 후 legacy 가 잔존하면 매일 fail** — 동일 cron/slot 중복. 퇴역은 `schedule=None`(사례 04).
+5. **동기 bridge 가 비동기 체인을 깬다** — core port sync return → 모든 caller `.get()` pinning. `*Async` + CI grep gate(사례 01-1).
+6. **측정 없는 최적화는 미신** — 이론상 완벽해도 실제 회귀. heap 이 effective gate 인 경우가 많다(사례 02-5).
 
 ---
 
-*생성: 2026-06-28 · 소스: docs/ai-traces (110 sessions) + docs/01_ADR (192) + git log*
+*생성: 2026-06-28 · 소스: docs/ai-traces (110 sessions) + docs/01_ADR (171) + git log · fact 검증: commit 26/26·ADR 16/16 실존 확인*

--- a/docs/24_Troubleshooting_Casebook/01_async_concurrency.md
+++ b/docs/24_Troubleshooting_Casebook/01_async_concurrency.md
@@ -1,0 +1,64 @@
+# 01. 비동기·동시성·가상스레드·락
+
+> CompletableFuture 체이닝, virtual-thread pinning, 분산락 예외 전파, backpressure, 코루틴 의존성.
+> 비동기 계약을 깨뜨리는 패턴들이 만든 장애들.
+
+---
+
+## 1-1. 비동기 CF 체인 중 `.get()`/`.join()` blocking → 가상스레드 carrier pinning
+
+- **Session:** 20260618-121324-3985962 (+ 20260618-150610, 20260618-231729, 20260617-053345)
+- **문제/에러:** `LogicExecutor.execute`/`Lock.execute`/`SingleFlight`/`TieredCache` 가 동기 `T` 반환. caller 가 `ThrowingSupplier { task.get() }` 로 언래핑. PGMQ worker·controller·scheduler 가 체인 중 block → 가상스레드 carrier pinning(`synchronized`+blocking), worker-pool 고갈, backpressure 무력화, 부하테스트 비결정적 저하(wait-bound). `module-infra`/`module-external-api` 에서 24 CRITICAL + 6 HIGH call-site.
+- **원인:** core port 가 동기 반환 계약 → 모든 caller 가 blocking bridge 강제. 비동기 경로 도달 불가.
+- **해결:** `*Async` API big-bang 마이그레이션(`executeAsync`/`executeWithLockAsync`/`getAsync`/`putAsync`), ~15 caller 파일. `PgmqWorker.processAsync`/`ProcessOutcome`(Ack|Nack|DeadLetter) sealed class. `InternalApiController` `.join()` 제거(fire-and-forget). `ChunkFileManager`/`Sink.closeAsync` 의 `all.get(10min)` 제거. 회귀 방지 CI grep gate(`runBlocking`/`.join(`/`.get(`/`Thread.sleep(` 금지). ADR `external-api-worker-cf-chaining`, `blocking-async-contract-cf-chain`.
+- **왜 이 방법 / 대안:** 동기 반환 삭제 선택 — API surface 축소, 오용이 compile error, grep gate 가 회귀 차단. big-bang 은 port-별 shim 을 두면 `.get()` 이 여전히 leak 되기 때문. **기각:** port-별 호환 shim(footgun 잔존), ADR-010 outbox timing 별도 추적(Non-Risk 선언).
+
+---
+
+## 1-2. `LockAspect.handleLockFailure` 가 `DistributedLockException` 삼킴 → fail-open 미작동
+
+- **Session:** 20260618-121324-3985962
+- **문제/에러:** `executeWithLockAsync` + `cf.get()` 마이그레이션 후, AOP failure handler 의 `if (e is DistributedLockException)` 가 매치 안 됨. `cf.get()` 이 원본 `DistributedLockException` 을 `ExecutionException` 으로 wrap → caller 가 `InternalSystemException` 수신, 의도한 `proceedWithoutLock` fallback 미발동. 부수: `PostgresAdvisoryLockStrategyAsyncTest` `InvalidUseOfMatchersException`, 운영 `whenComplete` NPE(mock 이 `*Async` method 에 null 반환).
+- **원인:** (1) AOP handler 가 `ExecutionException.cause` 언래핑 누락; (2) test mock 이 신규 async signature 에 맞춰지지 않아 null 반환 → 운영 `whenComplete` continuation NPE.
+- **해결:** `LockAspect.kt` 가 `is DistributedLockException` 체크 전 `ExecutionException.cause` 언래핑(commit `08c972ba0`). `PostgresAdvisoryLockStrategyAsyncTest` Mockito matcher 수정(`abce52060`), `*Async` Lock API 용 unit-test mock 갱신(`ab1c151a0`). `PostgresLockStrategy.unlockInternal` 상단 session-registry cleanup 추가(`*Async` path leak 방지).
+- **왜 이 방법 / 대안:** JDK wrap 예외 언래핑이 fail-open semantics 보존하는 최소 fix. **기각:** `cf.get()` → 비throwing `cf.handle` 전환(모든 caller error path 재작성 필요, 마이그레이션 중 너무 침습적). 락 모델은 ADR-057(Redisson)/ADR-318(PostgreSQL advisory).
+
+---
+
+## 1-3. `BackpressureLimiter` cancel-safety 결함 + `runBlocking` 잔초 (전 모듈)
+
+- **Session:** 20260619-050643-2314642 (2,411 tool calls), 20260619-061917-2513672
+- **문제/에러:** 코드베이스 전수 audit(`docs/05_Reports/2026-06-18-blocking-audit.md`) 이 module-synchronizer/consumer/ranking, ext-api/snapshot/urgent, infra/pgmq/worker, infra/lock 의 blocking primitive 적발. `BackpressureLimiter` cancel-safety 구멍, hot path `runBlocking` leak, `OrderedLockExecutor`/`PostgresAdvisoryLockStrategy` commonPool 사용.
+- **원인:** 가상스레드 executor 위 mixed blocking primitive; 락 예외 `ExecutionException` wrap 미언래핑; async lock 에 commonPool 사용.
+- **해결:** `BackpressureLimiter` cancel-safety + consumer/ranking `runBlocking` 정리(commit `8b56bdce9`). 락 직렬 fix(`776db9a23`, `65ca65872`, `185c1dcdd`) — `PostgresAdvisoryLockStrategy` 에 `defaultAsyncExecutor` 주입(commonPool 제거), `LockAspect` `ExecutionException.cause` 언래핑. 회귀 방지 CI grep gate(`2edf07dc6`, `a801ba601`). ADR-393, ADR-blocking-async-contract-cf-chain, blocking-audit report.
+- **왜 이 방법 / 대안:** CI grep gate(모듈별 `BlockingPrimitiveGateTest`)가 no-regression 계약을 저비용으로 시행. runtime instrumentation 대신 광역 파일 커버리지 우선.
+
+---
+
+## 1-4. `OcidLookupPhase` 무한 재귀 → `StackOverflowError`
+
+- **Session:** 20260610-084740-679261
+- **문제/에러:** rate-limiter bucket 이 refill window 보다 빨리 drain 될 때 `StackOverflowError`. 리팩터 `0344c62b7` 가 `while { ... continue }` 를 `private suspend fun processBatch(...)` 자기호출로 변환. `permits==0` 일 때 재귀 — coroutine suspension point 없이 stack frame 적재 → overflow.
+- **원인:** 재귀 호출에 suspension point 없어 stack 적재. `acquirePermits` 가 동기라 yield 없으면 dispatcher 굶주림.
+- **해결:** `processBatch` body 를 `while (current < igns.size)` 로 되돌리고 `permits==0` 시 `yield()`(`delay(100)` 아님). `suspend fun` signature 유지(`ExternalApiScheduler` 의 `runBlocking { ocidLookupPhase.execute(...) }` 호환). commit `0a8ef7bab`. 검증: 599,800 IGN @ ~402 files/s, 0 StackOverflowError.
+- **왜 이 방법 / 대안:** `yield()` 가 tight-spin/재귀 대신 coroutine suspend. 반복문은 #1128 의 recursion 패턴 되돌리되 suspend contract 유지.
+
+---
+
+## 1-5. Calculator Kafka listener 사망 (`NoClassDefFoundError`) — coroutines-reactor 의존성 삭제
+
+- **Session:** 20260611-021434-6530
+- **문제/에러:** Calculator `@KafkaListener`(`KafkaSnapshotChunkReadyConsumer.consume/consumeUrgent`) `suspend fun` 선언이 첫 메시지에 `NoClassDefFoundError` → `calculator-snapshot-chunk-processor` listener 자가 정지.
+- **원인:** commit `9fbea109f` 가 "version catalog 미해결" 로 `libs.kotlinx.coroutines.reactor` 삭제. Spring Kafka `KotlinAwareInvocableHandlerMethod` 가 `suspend`→reactive bridge 를 `kotlinx.coroutines.reactor.MonoKt` 로. OCID→char-basic 경로가 Kafka chunk 발행전까지 latent.
+- **해결:** 의존성 1.9.0 복구(타 coroutines module 일치). commit `4e5459a57`.
+- **왜 이 방법 / 대안:** 대안 없음 — suspend→reactive bridge 는 Spring Kafka hard requirement. 원 삭제는 false-positive version-catalog 정리; 최소 복구가 listener 재활성화.
+
+---
+
+## 1-6. RankingFetch backpressure 우회 — submission CF 미대기, sink 조기 close
+
+- **Session:** 20260610-143941-1012841, 20260610-154158-1084574
+- **문제/에러:** page-1 record 가 `sink.close()` 이후 submit 됨 — `thenAcceptAsync + inner whenComplete`(fire-and-forget) 로 submission CF 가 outer chain 에서 미대기; submission error 삼킴.
+- **원인:** async composition 이 `sink.close()` 를 submission 보다 앞서게 race. #1217 의 backpressure 가 실제 미작동.
+- **해결:** `thenComposeAsync + outer whenComplete` 로 submission chain+대기; error 가 outer handle 로 전파→실패 기록. commit `1c54202ac`. 동 세션 post-merge test fixture 5건(KeyTypes, JavaTimeModule, FQN event class) 수리.
+- **왜 이 방법 / 대안:** `thenCompose` 가 future chain(backpressure 보존) vs `thenAccept` fire-and-forget(ordering 상실).

--- a/docs/24_Troubleshooting_Casebook/01_async_concurrency.md
+++ b/docs/24_Troubleshooting_Casebook/01_async_concurrency.md
@@ -3,6 +3,8 @@
 > CompletableFuture 체이닝, virtual-thread pinning, 분산락 예외 전파, backpressure, 코루틴 의존성.
 > 비동기 계약을 깨뜨리는 패턴들이 만든 장애들.
 
+**영향(Impact):** 비동기 체인 중 동기 `.get()`/`.join()` 이 가상스레드 carrier 를 pinning → worker-pool 고갈, 부하테스트 비결정적 저하. ~15 caller 파일·24 CRITICAL call-site.
+
 ---
 
 ## 1-1. 비동기 CF 체인 중 `.get()`/`.join()` blocking → 가상스레드 carrier pinning

--- a/docs/24_Troubleshooting_Casebook/02_memory_streaming.md
+++ b/docs/24_Troubleshooting_Casebook/02_memory_streaming.md
@@ -1,0 +1,64 @@
+# 02. 메모리·OOM·스트리밍 I/O
+
+> 대용량 IGN(~600K) 처리 중 heap 압박·OOM·스트리밍 writer race.
+> "buffer 전체를 heap 에 올린다" 와 "동기 put 으로 writer thread 를 막는다" 패턴이 만든 장애.
+
+---
+
+## 2-1. OCID 매핑 writer OOM — 120MB buffered string list (600K 엔트리)
+
+- **Session:** 20260611-054924-211160, 20260611-152120-705286 (`/diagnose ext-api oom`)
+- **문제/에러:** OCID run 25분 지점 `OutOfMemoryError`, 2.5h run 사망. `results: MutableList<String>` 증가로 heap plateau. 각 `{"userIgn","ocid"}` JSON(~200B)을 단일 in-memory list(~120MB/600K) 적재 후 run 끝에 1회 `objectStorage.put(key, ByteArray)` flush. 1GB heap ceiling(in-flight batch state + item-equipment loop 공유).
+- **원인:** 전체 매핑을 heap list 적재 후 일괄 flush.
+- **해결:** 매핑을 `Channel` 로 stream → 단일 writer 코루틴이 gzip + `ObjectStorage.putStream` write. heap = pipe buffer(~64KB) + GZIP 내부 buffer; 120MB list 제거. commit `4fa308f19` (#1234).
+- **왜 이 방법 / 대안:** `OcidCacheProvider` reader 불변 — `listByPrefix + maxByOrNull(lastModified)` 로 latest object 취하므로 동일 key streaming write 가 동일 artifact 생성. **기각:** 출력을 multi-key chunking(reader 의 latest-object contract 복잡화).
+
+---
+
+## 2-2. `GzipJsonlChunkWriter` OOM — chunk 당 in-memory `ByteArrayOutputStream`
+
+- **Session:** 20260611-054924-211160, 20260611-152120-705286
+- **문제/에러:** `GzipJsonlChunkWriter.close` line 55 에서 `OutOfMemoryError`, char-basic 사망(~10:27/12:10/12:44). 128MB uncompressed chunk 당 ~256MB peak heap.
+- **원인:** chunk 를 `ByteArrayOutputStream` 적재 후 `ObjectStorage.put`(buffer + `toByteArray()` copy + deflater state) → writer-thread heap 1GB 초과.
+- **해결:** `GZIPOutputStream` 으로 temp file write, close 시 `ObjectStorage.putStream` stream. heap = deflater window(~32KB), chunk 크기 무관. 회귀 test(160K record/~40MB round-trip OOM 없음). commit `810b3ca41`.
+- **왜 이 방법 / 대안:** trade-off: chunk rotation 시 brief disk 이중 사용. 후속 `3dbc18ce4` 가 `putFile(key, path)` 추가(double spool 제거 — `putStream` 이 두 backend 모두 2차 temp spool → item-equipment 143→50 files/s 저하). 추가 `94cdd5685` 가 upload 를 `S3TransferManager` fire-and-forget(sinkSubmitMs 917→near-0).
+
+---
+
+## 2-3. `ChunkedSnapshotSink` 가 OOM/`Error` 삼킴 — `catch (Exception)` 구멍
+
+- **Session:** 20260611-152120-705286
+- **문제/에러:** `daily_collection` DAG 1h19m 후 `IllegalStateException("sink writer thread is not alive")` FAILED — 원본 `OutOfMemoryError` 소실. heap 25분간 928MB/1GB plateau.
+- **원인:** `ChunkedSnapshotSink.runWriterLoop` 의 `catch (ex: Exception)` — `OutOfMemoryError`/`StackOverflowError`/`VirtualMachineError` 는 `Error`라 catch 미발동, thread silent 사망, 다음 `submit()` 은 `writerFuture.isDone` 만 관측.
+- **해결:** catch 를 `Throwable` 로 확장 — writer 장애 시 `writerError` 기록 + `accepting=false` 전환; 다음 `submit()` 이 `"sink closed due to writer error: <원본 message>"` throw(cause chain). `ChunkedSnapshotSinkTest` 로 contract pin. commit `d0747c10b` (#1235).
+- **왜 이 방법 / 대안:** `Throwable` catch 는 일반적이지 않으나 여기서는 의도적 — sink writer 단일 코루틴의 silent 사망은 Error 노출보다 엄격히 더 나쁨. test 가 fix 없이 fail(OOM 소실)되어 진단 contract lock.
+
+---
+
+## 2-4. 동기 `s3.putObject` 가 writer thread 5-10s/chunk block → fetcher 기아
+
+- **Session:** 20260614-020255-3566982 (+ 20260614-075928, 20260614-150517)
+- **문제/에러:** item-equipment ~50 files/s 로 저하(baseline 150 의 1/3). sinkQueue 3000 cap 포화, `sinkSubmitMs` avg 917ms(max 2270ms). fetcher 가상스레드가 fetch 보다 queue 공간 대기에 시간 소비.
+- **원인:** `GzipJsonlChunkWriter.close()` 가 ~128MB chunk 동기 `s3.putObject`; ~50 files/s 시 writer thread chunk 당 5-10s block → upstream fetcher 굶주림.
+- **해결:** `ObjectStorage.putFileAsync(key, path)` → `CompletableFuture<PutResult>`. MinIO 구현 `S3TransferManager.upload()` (5MB multipart part, 50-thread pool, 128MB 에서 5-10x 빠름). `ChunkFileManager` 가 in-flight future 추적, `awaitAllUploads(timeoutMs)` 를 manifest write 전 호출(manifest 가 누락 chunk 참조 방지); timeout/실패 시 loud fail + `cleanupOnFailure` + `publishRunFailed`. commit `94cdd5685` (#1283). ADR-730.
+- **왜 이 방법 / 대안:** LocalFs backend 는 `completedFuture(putFile(...))` 반환(writer API backend 간 대칭). **기각:** 동기 put 유지 + sink queue 확장(벽 이동만). ADR-717 이 "pool 압력 떨어지면 `.join()`/batch wait 가 다음 병목" 이라 예고 — 본 사례가 그 병목 해소.
+
+---
+
+## 2-5. item-equipment throughput 3중 병목 — 102 files/s (150 baseline)
+
+- **Session:** 20260616-094101-1480103 (+ 20260616-005215, 20260616-135046)
+- **문제/에러:** item-equipment 102 files/s 고착(baseline 150). (1) chunk-ready publish race: writer 가 `future.join()` block 으로 "PUT 후 publish" 정렬 → 90s 당 1133 chunk 실패. (2) in-flight cap 100 이 250-permit rate limiter throttle(per-batch wave 2.5s vs 1.6s). (3) `MinioObjectStorage` temp-file double spool — chunk 당 4 disk 왕복 → `/tmp` I/O 경합. (4) Calculator `CurrentRunIdHolder` in-memory `ConcurrentHashMap`(restart 유실 + multi-instance drift).
+- **원인:** 동기 ordering primitive, concurrency knob 불일치, 동기 `S3Client.putObject` chunked-stream 불가로 redundant disk spool, stateful in-memory run registry.
+- **해결:** (1) `future.whenComplete` 비동기 ordering — 0 race error, writer ~50ms 복귀. (2) `application.yml` in-flight 100→250. (3) stream→`ByteArray` drain + `RequestBody.fromByteArray`(1 왕복, disk 무). (4) `CurrentRunIdHolder` ext-api `/run-status` poll → stale-chunk skip reason `calculator_chunks_skipped_total{reason="stale_run"}` 이관. commit `ecee74549` (#1294). heap `-Xmx` 1g→2g(`a76ff88dd`, #1293) — GC 압박이 실제 effective gate 였음.
+- **왜 이 방법 / 대안:** in-memory `ByteArray` 가 동기 경로 유일 옵션(동기 `S3Client.putObject` 는 length-1 chunked-stream API 무). 완전 async(S3TransferManager, ADR-730) 는 연기. **기각:** in-flight 정렬 없이 pool 인상(pending connection 압력, ADR-717). 검증: ext-api 102→150 files/s, calc 186→362 users/s. **heap 이 effective gate** 였음 — "throughput 영향 없었음, Heap이 effective gate".
+
+---
+
+## 2-6. Calculator off-heap OCID cache + Netty/Kafka direct-buffer 튜닝
+
+- **Session:** 20260619-174026-4166158 (18,587 tool calls, 설계 doc 5건), 20260622-174152-1947951, 20260623-005012-3020198
+- **문제/에러:** hot-path OCID cache 가 on-heap(300K char 부하 시 heap 압박); Netty/Kafka direct-buffer pool undertune → `DirectBuffer` allocation stall. spec 작업 중 producer-only 인 `consumer buffer.memory` config 와 Chronicle Map version pin(초기 3.23.5→3.26.8 정정) 적발.
+- **원인:** 기본 heap cache + 미구성 pool sizing, 고처리량 볼륨.
+- **해결:** `chronicle-map 3.26.8` dep(`cca3dfba9`/`54021fca2`), `OffHeapSerializedBackend` 도입(`c0a163928`), Netty/Kafka direct buffer pool 튜닝(producer-only Kafka, `30c601724`/`4be816e99`), Prometheus `offheap-alerts.yml`+`cache-backend-alerts.yml`. metric naming `calculator_cache_*` 정렬.
+- **왜 이 방법 / 대안:** off-heap cache 가 GC 압박 회피를 allocation overhead 와 교환. **기각:** heap 확장(300K char 부하 시 heap 압박이 GC 지배). `-P` override 용 lazy `providers.gradleProperty`.

--- a/docs/24_Troubleshooting_Casebook/02_memory_streaming.md
+++ b/docs/24_Troubleshooting_Casebook/02_memory_streaming.md
@@ -3,6 +3,8 @@
 > 대용량 IGN(~600K) 처리 중 heap 압박·OOM·스트리밍 writer race.
 > "buffer 전체를 heap 에 올린다" 와 "동기 put 으로 writer thread 를 막는다" 패턴이 만든 장애.
 
+**영향(Impact):** 600K IGN 처리 중 120MB buffer 가 1GB heap 점유 → 2.5h run 사망; `catch(Exception)` 이 OOM 삼켜 진짜 원인 소실; 동기 `s3.putObject` 가 writer thread 5-10s/chunk block → fetcher 기아(150→50 files/s).
+
 ---
 
 ## 2-1. OCID 매핑 writer OOM — 120MB buffered string list (600K 엔트리)

--- a/docs/24_Troubleshooting_Casebook/03_pipeline_data_correctness.md
+++ b/docs/24_Troubleshooting_Casebook/03_pipeline_data_correctness.md
@@ -1,0 +1,74 @@
+# 03. 파이프라인 데이터 정합성
+
+> chunk key/body 불일치, 잘못된 upstream runId, result writer pipe race.
+> "에러 없이 0건 처리" — silent data loss 패턴들이 만든 장애. 로그에 에러가 없어도 데이터가 안 흐르는 가장 교활한 버그 유형.
+
+---
+
+## 3-1. producer/consumer chunk-key layout 불일치 — `OcidLookupPhase` chunk 못 찾음
+
+- **Session:** 20260611-054924-211160
+- **문제/에러:** raw-path→MinIO 마이그레이션 Task 7 후, producer 가 `runs/$runId/ranking-overall/part-N.jsonl.gz` 에 write 하는데 consumer(`OcidLookupPhase`) 는 `runs/$runId/ranking-overall/chunks/...` read → phase 가 data 없이 silent 통과.
+- **원인:** `ChunkFileManager`(producer) 가 구 local-FS layout 의 `/chunks/` subdir 누락.
+- **해결:** producer key 에 `ranking-overall/chunks/` convention 복구(producer-consumer 합의). commit `2d9222680`.
+- **왜 이 방법 / 대안:** consumer 기존 contract 에 producer 맞춤(`OcidLookupPhase`/reader 무변경). ADR-725 "single ObjectStorage interface" non-risk(hot-path layout 은 cutover 중 변경 금지)와 교차검증.
+
+---
+
+## 3-2. chunk body schema mismatch — calculator/synchronizer 가 record 100% silent drop
+
+- **Session:** 20260611-054924-211160
+- **문제/에러:** Calculator `SnapshotChunkProcessor.parseLines` "460 records read, 0 success, 0 items, 0 results" — 모든 item-equipment chunk silent drop. Sync `DefaultChunkFileReader.parseBasicLine` 도 char-basic chunk 100% "chunk processing failed" filter.
+- **원인:** reader 가 `node.path("status").asText()=="SUCCESS"` + `node.path("body")` 확인, but 신규 chunk format 은 base64 `bodyBytes` + `httpStatus` 운반; 구 field 둘 다 `MissingNode`.
+- **해결:** 양 module 에 `extractBody(node)` helper 추가(inline `body` JSON 또는 base64 `bodyBytes`→JSON); `status=="SUCCESS"` **또는** `httpStatus==200` 일 때 SUCCESS 처리. commit `254441e65` (#1233).
+- **왜 이 방법 / 대안:** dual-shape reader(breaking format migration 회피) — 기존 artifact 계속 parse. inline comment 로 dual shape 문서화(향후 refactor 가 한쪽 branch drop 방지). **기각:** 단일 format 강제(cutover 중 in-flight MinIO object 무효화).
+
+---
+
+## 3-3. ITEM_EQUIPMENT 가 매 run silent skip — 잘못된 `upstreamRunId` source
+
+- **Session:** 20260621-041954-715366
+- **문제/에러:** ITEM_EQUIPMENT 가 ~1초 만에 0 record exit. `ocid-mapping-{runId}.jsonl.gz` S3 lookup `NoSuchKey`, cache 공란. 0 record 진단 중 ext-api `[PROBE-ext]` 로그로 발견. chain 도입 후 모든 `run-on-startup` trigger 에서 silent broken.
+- **원인:** `triggerDailyRefresh` 가 `cbRunId`(CHARACTER_BASIC) 를 ITEM_EQUIPMENT 의 `upstreamRunId` 로 전달. `runItemEquipmentPhase` → `ocidCacheProvider.loadFromRun(upstreamRunId)` 가 `ocid-mapping-{cbRunId}.jsonl.gz` 탐색 — but OCID mapping 은 **OCID_LOOKUP** 이 write.
+- **해결:** ITEM_EQUIPMENT 에 OCID_LOOKUP runId 전달(`loadFromRun` 이 올바른 mapping file 해석). commit `e4dc0dcdd`. ADR-729(OCID read-through cache 설계, write-key contract 준수).
+- **왜 이 방법 / 대안:** 최소 정정 — upstream-runId 를 artifact 소유 phase 에 정렬. **기각:** phase 간 ocid-mapping join(phase semantics 결합, per-run isolation 파손).
+
+---
+
+## 3-4. Calculator result writer 빈 gzip 파일 — pipe race ("Read end dead")
+
+- **Session:** 20260622-060636-122097
+- **문제/에러:** `CalculationResultWriter` 가 모든 ITEM_EQUIPMENT chunk 에 0-row `result-part-*.jsonl.gz` 생성. Sync `results=0`; DAG `wait_for_item_equipment_cycle` 미충족 → **valuation data 0건**. 로그: `IOException: Read end dead` + `NullPointerException: Deflater has been closed` @ `CalculationResultWriter.kt:140`; `calculator_chunks_processed_total=0`, run 당 ~14,921 ERROR. 검증: 깨진 파일 0 bytes, fix 후 674,986 bytes/30,507 rows.
+- **원인:** `PipedInputStream`/`PipedOutputStream` + `putStreamMultipart` 경로가 AWS SDK async reader 와 race. producer 코루틴 exit 후 `PipedInputStream` "Read end dead"(`readSide.isAlive()` check) throw + `Deflater` 이미 close → truncated/empty gzip. `composed.whenComplete { pipeInput.close() }` 도 SDK drain mid-read 중 발생 가능.
+- **해결:** pipe 경로를 temp-file drain + `putFileAsync` 로 교체(OcidLookupPhase 검증패턴 `c7b20f4c3` 미러). producer 코루틴이 `Flow<CalculationResult>` → `GZIPOutputStream` → `Files.createTempFile` drain, close 후 `putFileAsync`(MinIO S3TransferManager multipart | LocalFs atomic move) upload. temp file `whenComplete` 안전망 삭제. `CompletableFuture<WriteResult>` 반환 불변. **ADR-730**.
+- **왜 이 방법 / 대안:** 대안 "pipe + putStreamMultipart 유지" = disk write 0 but data-loss race 잔존. temp-file approach 가 correctness + 실제 byte count 를 chunk 당 1회 disk write 와 교환(chunk ≤500 record/128MB). memory 는 구 pipe 보다 엄격히 우수(temp file = disk, heap 아님) — OOM risk 무도입; LocalFs `putFile` atomic rename.
+
+---
+
+## 3-5. OCID_LOOKUP upload 회귀 — streaming-gzip 변경 후 `contentLength must not be negative`
+
+- **Session:** 20260620-053408-1772825 (+ 20260621-041954)
+- **문제/에러:** OCID_LOOKUP 즉시 `contentLength must not be negative` 실패(PR #1318 streaming writer 회귀). 3 중 bug: (a) `MinioObjectStorage.putStreamMultipart: b.contentLength(-1L)` → `IllegalArgumentException`(SDK `Validate.isNotNegativeOrNull`); (b) executor 누락 → NPE; (c) 3-4 와 동일 pipe race.
+- **원인:** `putStreamMultipart` 가 `contentLength(-1)`(unknown length 에 invalid signal — `null` 이어야) + executor 없이 호출. SDK 가 background thread 에서 `InputStream` read 시 non-null `Executor` 필요; pipe pattern 이 async reader 와 추가 race.
+- **해결:** `MinioObjectStorage`: `contentLength(-1L)` 제거(null 이 unknown-length 정확 신호), 공유 virtual-thread `streamReadExecutor` 추가. `OcidLookupPhase`: pipe+`putStreamMultipart` → temp file+`putFileAsync`; writer 가 `Files.createTempFile` drain, S3TransferManager multipart upload, `finally` cleanup. 검증: 594,928 mapping upload(18 MiB gz), 400 files/s. 이 fix 가 later calc(3-4) template.
+- **왜 이 방법 / 대안:** pure streaming 유지는 pipe race 하 불가; temp-file+multipart 가 검증된 ext-api 패턴. **기각:** per-record content-length probing(어차피 전 stream buffer 필요).
+
+---
+
+## 3-6. Phase DAG upstream sensor 교착 — daily chain 완료 후 standalone trigger timeout
+
+- **Session:** 20260623-042836-3612963 (+ 20260623-081233, -085126, -100348)
+- **문제/에러:** `item_equipment_pipeline` run 2개가 daily chain success 후 `wait_upstream_terminal_character_basic` 에 4h stuck. ext-api 가 run 완료 시 `current=null` 반환 → sensor strict-progression gate(`current_idx > target_idx`) 불충족 → timeout 까지 poll. 선행 break: PR #1329 `daily_full_pipeline` wrapper 가 `TriggerDagRunOperator` 로 즉시 발화 → ext-api `400 MISSING_UPSTREAM` 거절(phase in-flight).
+- **원인:** phase DAG 내부 wait sensor 가 `trigger_once` *이후* 실행 → trigger 가 wait 보다 선키; but gate 는 `current.phase` strict advance 만 고려. run 완료 시 `current` null → gate 통과 불가.
+- **해결:** 2-part. (a) commit `3e81c8f73`: `phase_pipeline_factory` 에 `make_wait_phase_terminal_sensor(phase)`; `make_phase_dag` 가 `upstream_phase` param 획득(3 branch 전부 trigger 전 upstream terminal 대기). phase-progression gating(xcom/runId correlation 불필요). test 12건. (b) commit `f203688b4`: 2차 통과 조건 — `current==null` **and** `lastCompletedByPhase[phase].terminal=true` 시 upstream terminal 처리. **ADR-734**.
+- **왜 이 방법 / 대안:** ADR-734 trade-off 기각: operator-JSON scope parsing(mode-on-conf 제거), `stop_loop_pipeline` 즉시정지(30min drain latency). 선택 설계가 ext-api 를 유일 loop-state owner 로 유지 + 기존 `PhaseLoopController` 재사용; 제약: loop 가 ext-api restart 시 사망(#1291 §13 pre-existing, → 사례 05-1 참조).
+
+---
+
+## 3-7. item-equipment loop 가 daily runId 덮어씀 — Airflow sensor runId 불일치 FAILED
+
+- **Session:** 20260613-053448-2564568 (+ 20260612-013142 "current 가 old run 가리키는 문제")
+- **문제/에러:** `daily_collection_pipeline` Airflow sensor 2h 재시도 후 FAILED(06-12→06-13 연속 3회 실패), `ALREADY_RUNNING`/runId mismatch — daily run healthy 임에도.
+- **원인:** PR #1278 이 loop 에 `startItemEquipmentCycle` 추가, 매 item-equipment cycle 마다 `currentRun` 무조건 덮어씀; pipeline 중간에 daily run runId clobber → sensor expected runId 불일치.
+- **해결:** `currentRun` 이 null 또는 이미 terminal 일 때만 `startItemEquipmentCycle` 호출; per-cycle runId 는 log-correlation handle 로 강등, `/run-status` 는 daily runId 유지. commit `7a3841168`. 관련 `cbff899cc`: loop `startRun` hardcode `RANKING_FETCH` → `startItemEquipmentCycle(runId)` 로 initial phase `ITEM_EQUIPMENT` 설정.
+- **왜 이 방법 / 대안:** **기각:** run-status 를 두 concurrent run(daily+loop cycle) 추적으로 재설계 — daily run 을 single source of truth 유지, loop runId 를 correlation 전용 강등(Airflow sensor 계약 = daily trigger 당 1 runId).

--- a/docs/24_Troubleshooting_Casebook/03_pipeline_data_correctness.md
+++ b/docs/24_Troubleshooting_Casebook/03_pipeline_data_correctness.md
@@ -3,6 +3,8 @@
 > chunk key/body 불일치, 잘못된 upstream runId, result writer pipe race.
 > "에러 없이 0건 처리" — silent data loss 패턴들이 만든 장애. 로그에 에러가 없어도 데이터가 안 흐르는 가장 교활한 버그 유형.
 
+**영향(Impact):** chunk key/body schema 불일치·잘못된 upstreamRunId 로 calculator/synchronizer 가 모든 chunk silent drop → **valuation data 0건**. 에러 로그 없이 0건 처리(가장 교활한 장애 유형).
+
 ---
 
 ## 3-1. producer/consumer chunk-key layout 불일치 — `OcidLookupPhase` chunk 못 찾음

--- a/docs/24_Troubleshooting_Casebook/04_orchestration_airflow.md
+++ b/docs/24_Troubleshooting_Casebook/04_orchestration_airflow.md
@@ -3,6 +3,8 @@
 > Airflow control plane 도입 과정의 함정: HttpOperator 4xx 계약, task timeout, connection 미등록,
 > in-process cron vs DAG slot race, legacy DAG 중복. control plane 이전 후 legacy 가 잔존하면 매일 fail 하는 패턴.
 
+**영향(Impact):** Airflow HttpOperator 가 409 CONFLICT 에 도달 불가 → 멱등 트리거 2h×3 scheduled run fail; in-process cron 과 morning_chain DAG 가 동일 03:00 KST slot 경쟁 → ITEM_EQUIPMENT loop 사망 + DAG 매일 fail.
+
 ---
 
 ## 4-1. Airflow `HttpOperator.response_check` 가 409 에 도달 불가 — 멱등 트리거 2h 재시도 fail

--- a/docs/24_Troubleshooting_Casebook/04_orchestration_airflow.md
+++ b/docs/24_Troubleshooting_Casebook/04_orchestration_airflow.md
@@ -1,0 +1,74 @@
+# 04. 오케스트레이션·Airflow
+
+> Airflow control plane 도입 과정의 함정: HttpOperator 4xx 계약, task timeout, connection 미등록,
+> in-process cron vs DAG slot race, legacy DAG 중복. control plane 이전 후 legacy 가 잔존하면 매일 fail 하는 패턴.
+
+---
+
+## 4-1. Airflow `HttpOperator.response_check` 가 409 에 도달 불가 — 멱등 트리거 2h 재시도 fail
+
+- **Session:** 20260613-053448-2564568, 20260613-165731-3106593, 20260614-075928-3864474 (+ 0614-124902)
+- **문제/에러:** `daily_collection_pipeline.trigger_daily_collection` 매 재시도 `AirflowException: 409:`. DAG 는 409 CONFLICT(이미 run 활성) 를 멱등 success 로 처리 설계 — but `response_check` callback 미실행. 3 scheduled run(06-12, 06-13) 120 재시도 × 60s = 2h fail.
+- **원인:** `HttpHook.run()` → `run_and_check()` → `check_response()` → `response.raise_for_status()` 가 operator 의 `response_check` invoke *전* 4xx 에 `AirflowException` raise. 409 수용 custom `is_accepted_response` 전부 dead code.
+- **해결:** `HttpOperator` → `PythonOperator` + `requests.post()` 직접 전환 — 4xx flow 를 우리 code 가 제어(200/202 → runId via xcom; 409 → status 의 active run; else raise). poll task → `PythonSensor(mode="reschedule")`(4h 대기 중 worker slot 해방). hardcode `host.docker.internal` → `BaseHook.get_connection("external_api")`. per-task retry budget(DAG-wide `retries=120` 대신). commit `05e0939a3` (#1284/#1286). ADR-726.
+- **왜 이 방법 / 대안:** `PythonOperator` 가 4xx branch 도달 유일 경로 — hook `raise_for_status` disable 플래그 무. trade-off: HttpOperator retry/timeout/logging template 상실(inline 재구현). **기각:** blanket infinite timeout(실제 hang mask).
+
+---
+
+## 4-2. Airflow task timeout < 실제 pipeline runtime — 실행 중 SIGTERM
+
+- **Session:** 20260613-053448-2564568, 20260614-075928-3864474
+- **문제/에러:** 정상 daily pipeline(ranking 4m → ocid 25m → char-basic 40m → item-equipment 35m ≈ 1.75h)이 runId guard fix 후에도 DAG FAILED — sensor 가 2h `execution_timeout` 에 재시도 고갈.
+- **원인:** timeout budget(2h)이 Nexon API rate-limit 지연/GC pause spike 여유 무; runId fix 는 정확했으나 DAG 가 여전히 timeout.
+- **해결:** `wait_for_completion` 2h→4h, `wait_ie_cycle` 1h→2h 인상. commit `3043ba80a` (#1282).
+- **왜 이 방법 / 대안:** 측정 runtime 대비 여유 budget — 단일 operator 프로젝트는 fast-fail 보다 Nexon 변동 흡수 선호. ADR-726 이 DAG-wide retry 대체 per-task retry-budget policy 통할.
+
+---
+
+## 4-3. Airflow cleanup DAG connection 미등록 — DAG 등록 단계 fail
+
+- **Session:** 20260617-053345-4091260 (+ 20260617-084647)
+- **문제/에러:** cleanup DAG 가 필수 Airflow Connection 미등록으로 fail; downstream cleanup task 가 ext-api endpoint 미해석.
+- **원인:** connection provisioning 이 DAG bootstrap 외부; `BaseHook.get_connection`(ADR-726) 마이그레이션이 hardcode host 가 숨기던 missing-connection failure mode 노출.
+- **해결:** `external_api` Connection 멱등 등록 script(delete-first 중복 방지 → add). commit `4b5944b31` (#1297). 관련 `6a081b12e`: prometheus+airflow host network 전환(docker-bridge hairpin bypass).
+- **왜 이 방법 / 대안:** 멱등 ensure-script 를 수동 `airflow connections` CLI 대신 — redeploy 생존. host-network bypass 를 DNS/bridge 디버그 대신(bridge hairpin 은 알려진 docker 제약; ADR-738 port-publish 정책화). **기각:** `host.docker.internal` 의존(host 간 불안정).
+
+---
+
+## 4-4. in-process daily cron vs morning_chain DAG 동시 발화 — ITEM_EQUIPMENT slot race
+
+- **Session:** 20260626-010319-1175180
+- **문제/에러:** 06-26 03:00 KST 두 오케스트레이터 동시 발화. `ExternalApiScheduler.scheduledDailyRefresh()`(`@Scheduled` cron)가 ITEM_EQUIPMENT once-run 으로 slot 선점 후, morning_chain `trigger_loop_infinite` → `acquirePhaseSlot` `IllegalStateException("ITEM_EQUIPMENT slot occupied")` → `submitIteration` catch → `finalize(STOPPED)` → loop 사망 + morning_chain sensor 실패 → DAG failed.
+- **원인:** 신규 `morning_chain_pipeline` DAG 도입 후에도 구버전 in-process `@Scheduled(cron="0 0 3 * * *")` 활성 잔존. 두 경로 동일 03:00 KST·동일 phase slot 경쟁.
+- **해결:** `@Scheduled scheduledDailyRefresh()` method + `external-api.schedule.daily-cron` YAML config 제거. 수동 트리거용 `triggerDailyRefresh(airflowRunId)` endpoint 유지. morning_chain DAG 를 유일 오케스트레이터 확정. **ADR-736**, commit `85229a4e7` (#1433).
+- **왜 이 방법 / 대안:** in-process cron 이 사실상 Airflow backup fallback 이었으나 이미 control plane 으로 Airflow 채택 → net-new SPOF risk 아님. **기각:** 두 오케스트레이터 유지 + phase slot 분리(경쟁 회피 비용·복잡도 상습 증가).
+
+---
+
+## 4-5. `daily_full_pipeline` vs `morning_chain` 동일 cron — legacy 중복 매일 전체 fail
+
+- **Session:** 20260627-150059-3412697
+- **문제/에러:** `daily_full_pipeline`(`0 18 * * *`)과 `morning_chain_pipeline`(동일 cron)이 같은 phase slot 경쟁. morning_chain 선점 → daily_full `trigger_character_basic` 매일 timeout, item_equipment/cleanup `upstream_failed`. 06-25, 06-26 연속 daily_full 전체 fail.
+- **원인:** daily_full 은 morning_chain(ocid 추가 + infinite item-equipment loop = 상위 호환)의 중복 legacy. 같은 03:00 KST cron slot 경쟁.
+- **해결:** `daily_full_pipeline` schedule 을 `None` 으로 퇴역(repo 컨벤션, `daily_collection` 동일 패턴). DEPRECATED docstring 로 morning_chain 정규 후계 DAG 명시. 정의 보존(수동 trigger 가능). cleanup 은 `daily_cleanup_pipeline`(`0 */6 * * *`) 독자 스케줄로 무관. **ADR-740**, commit `1ec76cc4b` (#1442).
+- **왜 이 방법 / 대안:** 역참조 없음(어느 DAG 도 daily_full 미 trigger). `schedule=None`(정의 보존)은 reversible + repo 컨벤션 일관. **기각:** 파일 완전 삭제(수동 finite once-mode 풀체인 fallback 상실 위험).
+
+---
+
+## 4-6. airflow metadata DB 단결 — host-network scheduler 의 `airflow-db` DNS 미해석
+
+- **Session:** 20260626-013345-1258594
+- **문제/에러:** host-network 구동 airflow scheduler/webserver 가 bridge 망 `airflow-db` Docker DNS 해석 불가 → `socket.gaierror` → metadata DB 단절 → scheduler "No alive jobs found" unhealthy. airflow autoheal 미가동.
+- **원인:** compose 는 bridge 선언이나 runtime host override. `SQL_ALCHEMY_CONN` `@airflow-db:5432`(Docker DNS)인데 host-network 프로세스는 bridge DNS 접근 불가.
+- **해결:** host-network 유지 + airflow-db `5433:5432` port publish(5432 는 maple-postgres 점유, 5433 실측 FREE). `SQL_ALCHEMY_CONN` `@localhost:5433` 변경. compose `network_mode: host` 명시 + autoheal label + scheduler healthcheck `start_period: 120s`. 검증: scheduler `SELECT count(*) FROM dag`=8(단결→해결), app `/actuator/health`=200. **ADR-738**, commits `2022abcf8`/`37d4e106a`/`2601122c1` (#1435/#1437).
+- **왜 이 방법 / 대안:** bridge 통일(최초 구상)은 grill(critic opus) 검증에서 2 BLOCKER — loki/grafana/promtail strand + connection-recreate race. host 유지 + port publish 가 app connections·DAG 코드 불변(Simplicity First), 관측 스택 이동 無. bridge 통일 기각.
+
+---
+
+## 4-7. scheduler healthcheck single-quote 버그 — `'$$(hostname -f)'` 항상 false-unhealthy
+
+- **Session:** 20260626-013345-1258594
+- **문제/에러:** airflow scheduler 배포 후 계속 unhealthy. healthcheck `airflow jobs check --job-type SchedulerJob --hostname '$$(hostname -f)'` 항상 매칭 실패.
+- **원인:** CMD-SHELL healthcheck 에서 `'$$(hostname -f)'` single-quote 가 sh expansion 차단 → `$(hostname -f)` 가 리터럴 문자열 비교 → 실제 FQDN 불일치 → 항상 false-unhealthy. ADR-738 작업 중 잠재 bug 발견.
+- **해결:** single-quote 제거 → `$$(hostname -f)` 로 sh 가 FQDN 확장. 45s 내 `healthy` 전환. commit `2601122c1` (#1437).
+- **왜 이 방법 / 대안:** 1문자 변경으로 sh 확장 복원. 동시 `start_period: 120s` 추가(autoheal 기동 중 restart-loop 방지; 첫 unhealthy 감지 120s 지연을 자동복구 안정성과 교환).

--- a/docs/24_Troubleshooting_Casebook/05_loop_lifecycle_observability.md
+++ b/docs/24_Troubleshooting_Casebook/05_loop_lifecycle_observability.md
@@ -3,6 +3,8 @@
 > `morning_chain` 의 ITEM_EQUIPMENT infinite loop 가 매일 사망하던 연쇄 사건.
 > 3개 사례(05-3 → 05-2 → 05-1)가 인과로 연결된 한 사가(episode). log retention(05-3) 없이는 05-1 진단 불가.
 
+**영향(Impact):** ITEM_EQUIPMENT infinite loop 가 매일 03:00 KST 273 iteration 정상 후 사망 → 장비 데이터 지속 갱신 안 됨; lifecycle 로그 rotate-out 으로 사망 stacktrace 관측 불가(정적 분석으론 원인 불가).
+
 ---
 
 ## 5-1. Loop 사망 — `ITEM_EQUIPMENT requires upstreamRunId` (OCID_LOOKUP refresh 창)

--- a/docs/24_Troubleshooting_Casebook/05_loop_lifecycle_observability.md
+++ b/docs/24_Troubleshooting_Casebook/05_loop_lifecycle_observability.md
@@ -1,0 +1,52 @@
+# 05. 무한루프 생명주기·관측성
+
+> `morning_chain` 의 ITEM_EQUIPMENT infinite loop 가 매일 사망하던 연쇄 사건.
+> 3개 사례(05-3 → 05-2 → 05-1)가 인과로 연결된 한 사가(episode). log retention(05-3) 없이는 05-1 진단 불가.
+
+---
+
+## 5-1. Loop 사망 — `ITEM_EQUIPMENT requires upstreamRunId` (OCID_LOOKUP refresh 창)
+
+- **Session:** 20260628-071021-1933904 (진단은 20260627-150059-3412697 의 500m log 관찰로 확보)
+- **문제/에러:** 매 03:00 KST `morning_chain` infinite loop 가 273 iteration 정상 후 사망. 500m-retention 로그(ADR-741 도입 후 첫 포착) 실측: `iter=274` 에서 `[Loop] iteration submit failed: ITEM_EQUIPMENT requires upstreamRunId` → `[Loop] stopped iterations=273`. ITEM_EQUIPMENT 매일 아침 사망 → 지속 구동 안 됨. (사용자 프롬프트: "루프가 왜안돌지")
+- **원인:** 03:00 KST morning_chain 가 OCID_LOOKUP refresh 중 OCID_LOOKUP slot non-terminal → `getLastCompletedForPhase(OCID_LOOKUP)` = null. 이 창에 다음 iteration `triggerPhase(ITEM_EQUIPMENT, runId, null, loopId)` → `runItemEquipmentPhase` 의 `require(upstreamRunId != null)` 가 slot acquire *이전* throw. `submitIteration` catch block 이 fatal(STOPPING→finalize) 처리.
+- **해결:** `submitIteration` catch 분기 — throw 원인이 `upstream == null` & loop 아직 RUNNING 이면 finalize 대신 backoff 후 re-submit(defer). backoff = `external-api.loop.upstream-retry-interval-seconds`(기본 30s, YAML 외부화). non-null upstream 실패는 기존 fatal 경로 유지. `PhaseLoopControllerTest.loop defers iteration when upstream not ready` 추가. **ADR-742**, commit `3d1264d43` (#1444).
+- **왜 이 방법 / 대안:** `require` 가 slot acquire 이전 throw 라 실패 시 slot 미점유 → 동일 runId 안전 재submit. 분기 `upstream == null` 로 transient 업스트림 부재와 진짜 submit 실패 분리(후자 defer 시 과잉 재시도). loopExecutor virtual-thread → backoff sleep carrier pinning 無(architecture-guardrails §9-10). **기각:** OCID_LOOKUP refresh 시 loop 를 외부에서 pause(coupling 증가·morning_chain stop_loop 와 상태 충돌).
+
+---
+
+## 5-2. morning_chain loop-started sensor 항상 10분 timeout (`iterationCount>=1`)
+
+- **Session:** 20260626-110222-2915509
+- **문제/에러:** 2026-06-24 morning_chain run 본체 success 임에도 tail sensor `wait_first_iteration_started` 만 failed. sensor 성공 조건 `status==RUNNING and iterationCount>=1`, `timeout=10min`. ITEM_EQUIPMENT 1 iteration = IGN ~560K 풀패스 = 실측 ~3735s(≈62분, 150 files/s) → `iterationCount>=1` 도달 전 timeout.
+- **원인:** `iterationCount` 는 iteration *완료* 시에만 증가(`PhaseLoopController.handleIterationEnd`). sensor 주석 intent 는 "iteration begun" 이나 구현은 "completed" → intent↔코드 불일치.
+- **해결:** `iterationCount>=1` 조건 제거, `status == "RUNNING"` 단일 조건. `LoopStatus.RUNNING` enum 정의("at least one iteration submitted; loop active")가 `startLoop` 동기 iteration 1 submit 시 전환 → trigger 후 수초 내 가시화. **ADR-739**, commit `dd992209c` (#1441).
+- **왜 이 방법 / 대안:** loop 시작 직후 실패 시 false-positive 가능성 수용 — sensor 역할(시작 확인) 범위 밖, 실패는 별도 모니터링·다음 run 영역. **기각:** timeout 연장(62분 분기당 1회인 DAG 에 비효율, 근본 intent 불일치 해소 못함).
+
+---
+
+## 5-3. infinite-loop lifecycle 로그 rotate-out — 사망 원인 진단 불가 (관측성 회귀)
+
+- **Session:** 20260627-150059-3412697
+- **문제/에러:** morning_chain infinite loop 가 1패스 후 사망(지속 안 됨) 원인 조사 시 `[Loop] startLoop`/`iteration done/failed/stopped` lifecycle 로그가 전부 rotate-out → 사망 사유 관측 불가. 실측: ext-api 77K 라인 중 "loop" 키워드 **0건**. 정적 분석상 continuation 코드 정상이라 런타임 로그가 유일한 단서.
+- **원인:** docker daemon default log config(`json-file`, `max-size=10m`, `max-file=3` = 30m cap). item-equipment phase 가 수초마다 progress 로그 → 30m 빠르게 rotate → 장시간 loop lifecycle 로그 소거.
+- **해결:** 4 app module compose 에 `logging` block 추가: `max-size=50m`, `max-file=10`(= 500m/container, ~10일 retention). infra 는 base compose 유지. **ADR-741**, commit `a23aeac67` (#1443). 이 500m retention 가 ADR-742(05-1) 의 iter=274 stacktrace 포착 가능케 함 — 두 ADR 인과 연결.
+- **왜 이 방법 / 대안:** 디스크 여유 237G 대비 4×500m=2GB 미미. ext-api 활동 로그 ~50MB/일 추정 10일 보존. json-file driver 유지(rotation 정책만 변경)로 로그 형식·앱 동작 영향 無. container recreate 필요하나 loop 이미 사망 상태라 state 손실 無.
+
+---
+
+## 에피소드 요약: 한 사건의 3단계
+
+```
+05-3 (log rotate)  →  관측 불가 상태로 loop 사망 원인 은폐
+       │
+       ▼  (ADR-741: 500m retention)
+05-2 (sensor)      →  morning_chain 본체 success 조차 DAG fail (tail sensor)
+       │              (ADR-739: iterationCount→status) — 별개 버그, 같은 run 노이즈
+       ▼
+05-1 (loop death)  →  진짜 원인 포착: OCID_LOOKUP refresh 창 upstream null → 사망
+                      (ADR-742: catch block defer) — 근본 fix
+```
+
+**교훈:** 관측성 회귀(05-3)가 먼저 해결되어야 진짜 버그(05-1)가 보인다.
+"코드는 정상인데 죽는다" = 로그가 증거를 숨기고 있을 가능성 먼저 의심.

--- a/docs/24_Troubleshooting_Casebook/06_infra_deploy_migration.md
+++ b/docs/24_Troubleshooting_Casebook/06_infra_deploy_migration.md
@@ -3,6 +3,8 @@
 > nohup→docker 전환, MinIO 운영(network/SA/CI), Nexon HTTP pool 튜닝, orphan cleanup.
 > 배포 모델 전환 중 드러난 network duality·권한·CI 드리프트.
 
+**영향(Impact):** nohup→docker 전환 시 network duality 로 4 app 컨테이너 crash-loop; cleanup 의 `listByPrefix` truncation 으로 ~200GB silent 미삭제; 4 SA policy `DeleteObject` 누락으로 marker `AccessDenied`.
+
 ---
 
 ## 6-1. nohup→docker 전환 시 app crash-loop — infra DNS `SERVFAIL` + `:dev` 태그 부재

--- a/docs/24_Troubleshooting_Casebook/06_infra_deploy_migration.md
+++ b/docs/24_Troubleshooting_Casebook/06_infra_deploy_migration.md
@@ -1,0 +1,64 @@
+# 06. 인프라·배포·마이그레이션
+
+> nohup→docker 전환, MinIO 운영(network/SA/CI), Nexon HTTP pool 튜닝, orphan cleanup.
+> 배포 모델 전환 중 드러난 network duality·권한·CI 드리프트.
+
+---
+
+## 6-1. nohup→docker 전환 시 app crash-loop — infra DNS `SERVFAIL` + `:dev` 태그 부재
+
+- **Session:** 20260626-013345-1258594 (및 20260626-065852)
+- **문제/에러:** 4 모듈(external-api/calculator/synchronizer/cleanup)을 nohup→docker compose 전환 시 app 컨테이너가 `postgres`/`kafka`/`minio` DNS `SERVFAIL` 로 crash-loop. `services.yml` 기본 `maple/{module}:dev` 가 image not found.
+- **원인:** network duality — infra(postgres/kafka/minio)는 `probabilistic-valuation-engine_maple-network`(project=probabilistic-valuation-engine), redis 만 `maple-network`. app `services.yml` 이 `maple-network` 선언 → infra service alias 미해석. grill(critic opus)+독자 검증으로 3 장애물(network duality / `:dev` 부재 / airflow host-network drift) 동시 발견.
+- **해결:** (1) infra 컨테이너를 `docker network connect --alias <service> maple-network <ctn>` 로 live 연결(non-disruptive, `--alias` 필수 — 생략 시 service alias 미해석). (2) `deploy-apps.sh` 가 `:sha-*` 최신 태그 자동 해석(`:dev` 회피), `.env` `$` expansion 회피용 grep DB_URL. (3) airflow autoheal 은 host/bridge reconcile 선행 필요로 별도 이관(→ 사례 04-6). 검증: 4 모듈 `/actuator/health` 4/4 UP, ERROR 0, Kafka LAG 0, cadvisor 76 series. **ADR-737**, commits `b395132eb`/`ea2f42057` (#1428-1431/#1434).
+- **왜 이 방법 / 대안:** live network connect 는 infra 무중단 reconcile(recreate 아님) — 영속성 부족(infra recreate 시 재연결)을 runbook 으로 보완. airflow 를 같이 전환 시 동작 중 webserver healthy 파손 위험 → 분리. `.env DB_ROOT_PASSWORD` 의 `$pNDA2` compose interpolation blank 를 postgres·app 동일 interpolation 으로 상호 일치(non-issue). **기각:** `:dev` 태그 강제 빌드(reproducibility ↓).
+
+---
+
+## 6-2. MinIO `listByPrefix` 1000 keys truncation — cleanup 이 ~200GB silent 미삭제
+
+- **Session:** 20260615-010251-1114908
+- **문제/에러:** `module-cleanup` `RunCleanupService` 가 object key 에서 runId 추출, but 70+ run × 수백 chunk 시 첫 2 runId 만 visible. cleanup "no runs to delete" 보고 — but ~200GB stale data 가 MinIO 잔존.
+- **원인:** `listObjectsV2` 가 기본 1000 keys/page; 구현이 `continuationToken` 없이 1회 호출 → page 1 이후 silent drop.
+- **해결:** `nextContinuationToken()` null 까지 loop, 기존 `deleteByPrefix` 의 pagination 패턴과 일치. commit `4002effd7` (#1285). 검증: `POST /api/internal/cleanup/runs` 가 `runsDeleted=5, bytesDeleted=14,151,671,872`(~14GB) 보고(이전 0).
+- **왜 이 방법 / 대안:** 기존 `deleteByPrefix` pagination 재사용(고수준 SDK paginator 도입 대신 일관성). ADR 없음(bugfix 수준).
+
+---
+
+## 6-3. MinIO 4 SA policy 에 `DeleteObject` 누락 — `_RUNNING`/`_SUCCESS` marker `AccessDenied`
+
+- **Session:** 20260615-010251-1114908 (+ 0615-074305, -165301)
+- **문제/에러:** cleanup 이 `_RUNNING`/`_SUCCESS` lifecycle marker delete 시 `AccessDenied`. audit 결과 4 service-account prefix-policy 격리(ext-api/cleanup/calculator+read-api)가 `s3:ListBucket`/`s3:PutObject` 부여 but marker 관리에 필요한 `s3:DeleteObject` 누락.
+- **원인:** per-SA prefix-policy 가 lifecycle marker 도입 *전* 정의; marker delete 권한이 policy set 에 누락.
+- **해결:** 4 SA policy audit + `runs/_RUNNING`/`_SUCCESS`/`calculator/runs/*` prefix 에 `s3:DeleteObject` 추가. commit `2e779d0c5`. 4-SA ephemeral-CI 격리 설계(#1288, `f09fc9d03`) 연동.
+- **왜 이 방법 / 대안:** SA 는 runtime-scoped("영구 보관 이유 无") → per-prefix least-privilege + ephemeral CI key. **기격:** single privileged cleanup SA(격리 목적 위반).
+
+---
+
+## 6-4. Nexon HTTP pool / rate-limiter mis-tune — fetch ~215/s cap (300/s 미도달)
+
+- **Session:** 20260617-053345-4091260 (+ 20260616-094101)
+- **문제/에러:** fetch 병목 — wave 가 직렬로 돌아 batch duration 2배. connection pending 압력; 300/s rate 미도달.
+- **원인:** pool(150) + in-flight(100) cap 이 250/s rate limiter throttle; in-container `minio-bootstrap` MINIO_ENDPOINT misconfig; rate-limiter non-greedy refill.
+- **해결:** `NEXON_HTTP_MAX_CONNECTIONS` 150→250(`a260709e9`), rate limiter greedy refill + pool tune(`998c0bf60`), in-container `minio-bootstrap` MINIO_ENDPOINT override(`939121ac4`, #1298). ADR-729.
+- **왜 이 방법 / 대안:** ADR-717 이 pool 150/rate 250 를 안정 band 로 측정; 06-17 발견("throughput 영향 無 — Heap이 effective gate")이 heap bump(1g→2g, #1293) 후 다음 gate 가 pool 임을 보여 150→250 정당화. **기각:** pool 500(과잉 provisioning — pending 압력 재발, 비례 throughput gain 無). greedy refill 을 tail-latency fairness 축소와 burst throughput 지속 교환.
+
+---
+
+## 6-5. MinIO CI integration hard-fail (2026-06-19 이후 매 run) — service container 건강 미달
+
+- **Session:** 20260622-021100-3692459, 20260622-050451-4148311
+- **문제/에러:** `minio-it` CI job 이 2026-06-19 이후 매 run "Initialize containers" fail. 중첩: (a) `minio/minio:latest` 가 default CMD 미탑재 → 인수 없으면 help print 후 exit; (b) GH Actions service-container 가 image ENTRYPOINT/CMD override 불가; (c) job-level `env:` 가 `steps.*` context 참조(job-level 금지 — secrets/vars/github/inputs/matrix/needs/strategy 만 허용) → `workflow file issue`(0s run); (d) `mc admin user list --json` 이 구 grep 이 기대한 `accessKey` field 미노출, `mc admin user info` root 에 `Access Denied`.
+- **원인:** image/CLI 동작 drift + GH Actions context 규칙. 각 fix 가 다음 bug 노출로 중첩.
+- **해결:** (2026-06-22 commits) `0110f7453` MinIO 를 detached background container(service 아님)로 explicit `server /data --console-address :9001` launch, liveness endpoint 200 까지 poll; `8d86a5412` invalid `steps.*` ref 제거; `c512beb20` `minio/mc` entrypoint override(`/bin/sh`); `313c93a4e` SA 를 `mc admin user list` 대신 `mc stat local/maple-expectation`(bucket visible) 로 verify.
+- **왜 이 방법 / 대안:** bucket-stat check 를 `mc` JSON schema 역추적 대신 — Run-IT step 이 SA credential 직접 사용 = authoritative correctness signal; bucket 존재가 충분 전제. service container 는 GH Actions 가 entrypoint override 불가로 폐기.
+
+---
+
+## 6-6. orphan temp-file leak — ext-api snapshot path 에 cleanup hook 부재
+
+- **Session:** 20260619-061917-2513672, 20260619-075233-2762017
+- **문제/에러:** `ChunkFileManager` 가 chunk sink 실패/restart 후 orphan temp file 잔존 → disk leak.
+- **원인:** temp file sweep lifecycle hook 부재; 실패 시 partial file 잔존.
+- **해결:** `OrphanTempFileCleanupHook` 도입(commit `a38e6a3d3`) — **per-file fail-soft delete**(한 bad file 이 sweep 중단시키지 않음); `runWithDeadline` timeout path WARN, 실패 시 ERROR(`55e467713`); INFO summary log `scanned/deleted/bytes_freed/failed`. commit `66f16f9ed` `loopExecutor` 전환(`TaskExecutionAutoConfiguration` 가 custom `Executor` bean 존재 시 suppress).
+- **왜 이 방법 / 대안:** fail-soft 로 cleanup 자체가 실패 source 가 아닌 self-healing 되게; deadline + level-differentiated logging 으로 timeout 이 data error 로 위장 방지.


### PR DESCRIPTION
## Summary
Synthesize `docs/ai-traces/` (110 sessions, 2026-06-09..06-28) + 192 ADRs + git history into a themed **troubleshooting casebook**. Each case: error symptom → root cause → fix (commit/ADR) → why that approach over alternatives.

4 parallel agents mined the traces by date range; findings deduped + grouped into 6 themes.

## Structure (`docs/24_Troubleshooting_Casebook/`)
- `00_index.md` — theme map + 6 cross-cutting lessons
- `01_async_concurrency.md` — CF `.get()` pinning, lock exception unwrap, recursion StackOverflow, coroutines-reactor dep
- `02_memory_streaming.md` — OCID/Gzip OOM, `catch(Exception)` swallowing `Error`, sync s3.putObject stall, off-heap cache
- `03_pipeline_data_correctness.md` — chunk key/body mismatch, wrong upstreamRunId, result-writer pipe race
- `04_orchestration_airflow.md` — HttpOperator 409 dead code, task timeouts, cron/DAG slot race, daily_full duplicate
- `05_loop_lifecycle_observability.md` — loop death (upstream null), sensor timeout, log rotate-out (this week's 3-ADR episode)
- `06_infra_deploy_migration.md` — nohup→docker network duality, MinIO ops, CI MinIO, Nexon pool tuning

## Verification
- [x] 7 files, 448 lines, all internal links resolve
- [x] Each case cites session ID + commit + ADR

🤖 Generated with [Claude Code](https://claude.com/claude-code)