### PR TITLE
fix(module-cleanup): bind KAFKA_BOOTSTRAP_SERVERS env to spring.kafka.bootstrap-servers

### DIFF
--- a/module-cleanup/src/main/resources/application.yml
+++ b/module-cleanup/src/main/resources/application.yml
@@ -6,6 +6,8 @@ spring:
     name: cleanup
   profiles:
     active: local
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
 
 cleanup:
   dry-run: false


### PR DESCRIPTION
## Summary
- module-cleanup's @KafkaListener (cleanup-inbox group) had no `spring.kafka.bootstrap-servers` binding in application.yml, so it fell back to Spring Boot's default of `localhost:9092`. Inside the docker container, `localhost` resolves to the container itself, not the host's Kafka broker at `kafka:29092` → consumer has been disconnected since boot.
- Effect: `cleanup-inbox` Kafka lag accumulated to 38K+ and `POST /api/internal/cleanup/inbox` returned `drained=0` because no events ever entered the in-memory queue.
- `/cleanup/runs` and `/cleanup/calculator-runs` were unaffected (they scan MinIO directly).

## Test plan
- [x] Compile: `./gradlew :module-cleanup:compileKotlin` PASS
- [x] Rebuild + restart container
- [x] Logs: `bootstrap.servers = [kafka:29092]`, `Subscribed to topic(s): synchronizer.chunk.consumed`
- [x] Kafka lag: 38044 → 0
- [x] Drain API: `{"drained": 8, "deleted": 16, "failed": 0}`
- [ ] CI / full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)