### PR TITLE
perf(ext-api): default gzip chunk writer to BEST_SPEED

### DIFF
--- a/module-external-api/src/main/kotlin/maple/externalapi/snapshot/ChunkFileManager.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/snapshot/ChunkFileManager.kt
@@ -8,6 +8,7 @@ import java.time.Clock
 import java.time.Instant
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
+import java.util.zip.Deflater
 
 /**
  * Owns every object-storage concern of a snapshot-sink run:
@@ -40,6 +41,7 @@ class ChunkFileManager(
     private val objectMapper: ObjectMapper,
     private val clock: Clock = Clock.systemUTC(),
     private val objectStorage: ObjectStorage,
+    private val compressionLevel: Int = Deflater.BEST_SPEED,
 ) {
     private val log = LoggerFactory.getLogger(ChunkFileManager::class.java)
 
@@ -228,6 +230,7 @@ class ChunkFileManager(
             objectMapper = objectMapper,
             objectStorage = objectStorage,
             clock = clock,
+            compressionLevel = compressionLevel,
         )
     }
 

--- a/module-external-api/src/main/kotlin/maple/externalapi/snapshot/GzipJsonlChunkWriter.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/snapshot/GzipJsonlChunkWriter.kt
@@ -11,6 +11,7 @@ import java.time.Clock
 import java.time.Instant
 import java.util.UUID
 import java.util.concurrent.CompletableFuture
+import java.util.zip.Deflater
 import java.util.zip.GZIPOutputStream
 
 data class ChunkStats(
@@ -68,6 +69,16 @@ class GzipJsonlChunkWriter(
     private val objectMapper: ObjectMapper,
     private val objectStorage: ObjectStorage,
     private val clock: Clock = Clock.systemUTC(),
+    /**
+     * Deflater compression level for the gzip stream. Defaults to
+     * [Deflater.BEST_SPEED] (level 1): the writer thread is a single-threaded
+     * CPU-bound gzip stage on the snapshot hot path, and large payloads
+     * (item-equipment ~218KB avg) make level-6 deflate the throughput ceiling.
+     * Level 1 is ~2-3x faster for ~15% larger output; downstream consumers
+     * (calculator/synchronizer) read gzip transparently regardless of level.
+     * See [docs/05_Reports/05_06_Load_Tests/ENDURANCE_THROUGHPUT_CEILING_20260702.md].
+     */
+    private val compressionLevel: Int = Deflater.BEST_SPEED,
 ) {
     private val tempFile: Path = Files.createTempFile(
         "gzip-chunk-${UUID.randomUUID()}-part-${partIndex.toString().padStart(6, '0')}-",
@@ -78,7 +89,14 @@ class GzipJsonlChunkWriter(
         StandardOpenOption.WRITE,
         StandardOpenOption.TRUNCATE_EXISTING,
     )
-    private val gzipped = GZIPOutputStream(fileOut)
+    // GZIPOutputStream has no level constructor; subclass to set the
+    // underlying Deflater's level (protected `def` field) after the gzip
+    // header is written. setLevel applies to all subsequent deflate calls.
+    private val gzipped: GZIPOutputStream = object : GZIPOutputStream(fileOut) {
+        init {
+            def.setLevel(compressionLevel)
+        }
+    }
     private var recordCount: Int = 0
     private var uncompressedBytes: Long = 0
     private val startedAt: Instant = Instant.now(clock)

--- a/module-external-api/src/test/kotlin/maple/externalapi/snapshot/GzipJsonlChunkWriterTest.kt
+++ b/module-external-api/src/test/kotlin/maple/externalapi/snapshot/GzipJsonlChunkWriterTest.kt
@@ -179,4 +179,98 @@ class GzipJsonlChunkWriterTest {
         val lines = raw.lines().filter { it.isNotBlank() }
         assertThat(lines).hasSize(recordCount)
     }
+
+    /**
+     * Microbench: gzip level 6 vs 1 on `appendPreSerialized` (the writer hot path),
+     * on a ~218KB compressible body matching the real item-equipment payload size
+     * (avg 218KB, 98% >100KB — the ceiling cause). Measures three axes:
+     *   - rate (rec/s, MB/s deflate)
+     *   - per-record latency (mean, p50, p95, p99)
+     *   - compression ratio (uncompressed/compressed from ChunkStats)
+     *
+     * Body is SYNTHETIC (real size + real code path, synthetic repetitive content).
+     * Real item-equip ratio @ level 6 is ~11.5:1 (endurance report); synthetic is
+     * approximate. The level 6→1 RATE ratio is data-robust (~3x) regardless.
+     *
+     * Writes results to /tmp/gzip_bench_result.txt (System.out forbidden in tests).
+     * Run: ./gradlew :module-external-api:test --tests '*GzipJsonlChunkWriterTest.bench*'
+     */
+    @Test
+    fun `bench gzip level 6 vs 1 latency rate compression`() {
+        val body = synthItemEquipBody(218 * 1024)
+        val storage = mock<ObjectStorage>()
+        whenever(storage.putFileAsync(any<String>(), any<Path>()))
+            .thenReturn(java.util.concurrent.CompletableFuture.completedFuture(PutResult("k", 1L, null)))
+        val n = 400
+
+        data class Result(
+            val level: Int, val recPerSec: Double, val mbPerSec: Double,
+            val meanUs: Double, val p50Us: Double, val p95Us: Double, val p99Us: Double,
+            val ratio: Double,
+        )
+
+        fun bench(level: Int): Result {
+            // warmup (separate writer, discarded)
+            GzipJsonlChunkWriter(
+                chunkKey = "runs/warmup/item-equipment/part-1.jsonl.gz",
+                partIndex = 1, maxRecords = Int.MAX_VALUE,
+                maxUncompressedBytes = 100L * 1024 * 1024 * 1024,
+                objectMapper = objectMapper, objectStorage = storage,
+                clock = Clock.systemUTC(), compressionLevel = level,
+            ).close()
+            // measured
+            val w = GzipJsonlChunkWriter(
+                chunkKey = "runs/bench/item-equipment/part-1.jsonl.gz",
+                partIndex = 1, maxRecords = Int.MAX_VALUE,
+                maxUncompressedBytes = 100L * 1024 * 1024 * 1024,
+                objectMapper = objectMapper, objectStorage = storage,
+                clock = Clock.systemUTC(), compressionLevel = level,
+            )
+            val rec = SnapshotChunkRecord.PreSerialized(
+                key = "k", endpoint = "item-equipment", keyType = "OCID",
+                httpStatus = 200, fetchedAt = Instant.EPOCH, bodyBytes = body,
+            )
+            val lats = LongArray(n)
+            val t0 = System.nanoTime()
+            repeat(n) { i ->
+                val s = System.nanoTime()
+                w.appendPreSerialized(rec)
+                lats[i] = System.nanoTime() - s
+            }
+            val secs = (System.nanoTime() - t0) / 1e9
+            val stats = w.close()
+            lats.sort()
+            fun pct(p: Double) = lats[minOf(n - 1, (n * p).toInt())].toDouble()
+            val ratio = if (stats.compressedBytes > 0) stats.uncompressedBytes.toDouble() / stats.compressedBytes else 0.0
+            return Result(
+                level, n / secs, n * body.size / secs / 1e6,
+                lats.average() / 1000.0, pct(0.5) / 1000.0, pct(0.95) / 1000.0, pct(0.99) / 1000.0, ratio,
+            )
+        }
+
+        val r6 = bench(6)
+        val r1 = bench(1)
+        val msg = buildString {
+            appendLine("gzip level 6 vs 1 — synthetic 218KB item-equip-sized body (hot path: appendPreSerialized)")
+            appendLine("             rate(rec/s)  rate(MB/s)  lat-mean  p50   p95   p99     ratio")
+            appendLine(String.format("level 6   :  %8.0f    %7.1f    %6.0f  %5.0f %5.0f %5.0f   %5.1f:1", r6.recPerSec, r6.mbPerSec, r6.meanUs, r6.p50Us, r6.p95Us, r6.p99Us, r6.ratio))
+            appendLine(String.format("level 1   :  %8.0f    %7.1f    %6.0f  %5.0f %5.0f %5.0f   %5.1f:1", r1.recPerSec, r1.mbPerSec, r1.meanUs, r1.p50Us, r1.p95Us, r1.p99Us, r1.ratio))
+            appendLine(String.format("delta     :  %.2fx rate, %.2fx lower mean latency, ratio %.1f:1->%.1f:1", r1.recPerSec / r6.recPerSec, r6.meanUs / r1.meanUs, r6.ratio, r1.ratio))
+            appendLine("body=$body bytes (synthetic). real item-equip ratio @ level 6 ~ 11.5:1 (endurance report)")
+        }
+        java.io.File("/tmp/gzip_bench_result.txt").writeText(msg)
+        // Guard: level 1 must be materially faster than level 6 on the writer
+        // hot path. Fails (surfacing the full comparison table in `msg`) if
+        // someone reverts the default to level 6 or breaks the level wiring.
+        assertThat(r1.recPerSec).`as`(msg).isGreaterThanOrEqualTo(r6.recPerSec * 1.5)
+    }
+
+    /** Synthesize a ~[targetBytes] compressible body resembling item-equipment JSON (~10:1 ratio). */
+    private fun synthItemEquipBody(targetBytes: Int): ByteArray {
+        val baos = java.io.ByteArrayOutputStream(targetBytes + 1024)
+        val frag = ("""{"item_name":"잔혀된검","slot":"장비","ocid":"abc123","stats":{""" +
+            """"str":999,"dex":888,"int":777,"luk":666,"hp":99999,"mp":99999,"attack":1234,"potential":"LEGENDARY","sockets":3}}""").toByteArray()
+        while (baos.size() < targetBytes) baos.write(frag)
+        return baos.toByteArray()
+    }
 }


### PR DESCRIPTION
## Summary
- Snapshot writer thread is single-threaded gzip on the hot path; item-equipment payloads are large (avg 218KB, 98% >100KB), making level-6 deflate the throughput ceiling.
- Live diagnosis: writer ~60% CPU-bound on gzip (H1), queue pinned at cap (2914-2933/3000), producers blocked ~2s avg to enqueue, drain ~26-49/s. PUT already async (94cdd5685); disk/Nexon/CPU-contention ruled out.
- Fix: subclass `GZIPOutputStream` to set Deflater level (no level ctor available); default `compressionLevel = BEST_SPEED` in `GzipJsonlChunkWriter`, threaded through `ChunkFileManager`. Factories unchanged (use default).
- Bench (appendPreSerialized, 218KB body): **3.0x rate** (166→498 rec/s), **3.0x lower mean latency**, ~15-20% larger output (real 11.5:1 → ~9-10:1). Downstream reads gzip transparently.
- Extrapolated drain ~78-147/s clears the Nexon supply ceiling (~40-150/s) → writer no longer binding → queue drains, backpressure gone.

## Hypothesis (per /diagnose)
Writer gzip-CPU-bound (H1), confirmed via `top -H` instantaneous (~60% one core, user-CPU = deflate, iowait ~9%). Earlier 18% was cumulative-since-start. The endurance report's "writer 71/s + sequential PUT" diagnosis was mathematically impossible (80h avg 132/s; PUT async).

## Test plan
- [x] `./gradlew :module-external-api:test --tests '*GzipJsonlChunkWriterTest'` — all pass (bench guard + 2 existing)
- [x] Bench asserts level 1 >= 1.5x level 6 (regression guard)
- [ ] Live A/B (rebuild ext-api image + re-seed OCID ~35min) — optional, bench is decisive
- [ ] Verify calculator/synchronizer decompress level-1 chunks end-to-end (gzip transparent, but confirm on next pipeline run)

## Files
- `GzipJsonlChunkWriter.kt` — `compressionLevel` param + leveled subclass, default `BEST_SPEED`
- `ChunkFileManager.kt` — pass-through param (default `BEST_SPEED`)
- `GzipJsonlChunkWriterTest.kt` — added 3-axis bench (rate/latency/ratio) as regression guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)