### PR TITLE
fix(infra): disable airflow-db parallel query (worker leak)

### DIFF
--- a/docker-compose.airflow.yml
+++ b/docker-compose.airflow.yml
@@ -4,6 +4,15 @@ services:
   airflow-db:
     image: postgres:17-alpine
     container_name: maple-airflow-db
+    # Disable parallel query: airflow-db is metadata-only (tiny tables) and
+    # postgres parallel workers leak here (orphaned live workers spin ~700%
+    # CPU, recur after restart, not in pg_stat_activity). max_parallel_workers=0
+    # prevents spawns → leak source removed. Survives container/volume recreate
+    # (ALTER SYSTEM in postgresql.auto.conf does not). See project_airflow_db_parallel_leak.
+    command: >
+      postgres
+      -c max_parallel_workers=0
+      -c max_parallel_workers_per_gather=0
     labels:
       autoheal: "true"
     restart: always


### PR DESCRIPTION
## Summary
- airflow-db (postgres metadata) leaks parallel workers → orphaned live workers spin ~700% CPU, recur after restart, invisible in pg_stat_activity.
- Spawners: airflow scheduler/webserver + synchronizer OcidLookupRunConsumer. airflow-db is metadata-only (tiny tables) — parallel query gives no benefit.
- Fix: `command: postgres -c max_parallel_workers=0 -c max_parallel_workers_per_gather=0` in docker-compose.airflow.yml. Survives container/volume recreate (ALTER SYSTEM in postgresql.auto.conf does not).

## Verification
- [x] YAML valid (`docker compose config`)
- [x] force-recreate airflow-db → settings=0 from command line
- [x] CPU 669% → 0.04%, healthy

## Notes
- Infra bug (postgres runtime), not app code. No code changes.
- Separate from ext-api writer gzip-CPU ceiling (PR #1453).

🤖 Generated with [Claude Code](https://claude.com/claude-code)