### PR TITLE
docs(incident): root-cause framing + incident timeline (MTTD/MTTC/MTTR)

### DIFF
--- a/docs/23_Incident_Response_Journey/2026-07-03-airflow-db-container-compromise.md
+++ b/docs/23_Incident_Response_Journey/2026-07-03-airflow-db-container-compromise.md
@@ -55,6 +55,46 @@ was found** (with the caveat that "not found by a basic check" is weaker than
 
 ## 2. Timeline
 
+### 2.1 Incident timeline at a glance (UTC)
+
+| Time (UTC) | Event | Basis | Confidence |
+|------------|-------|-------|------------|
+| ≤ 2026-07-02 | First compromise (estimated) | prior session already observed 655–780% CPU and **misdiagnosed** it as a parallel-worker leak (PR #1454) | ESTIMATE — DB auth logs lost, exact entry unknown |
+| 2026-07-02 23:42 | Parallel-disable "fix" committed (wrong diagnosis) | git `655c4fcc1` | FACT |
+| 2026-07-03 00:14 | `/tmp/kunt` dropper (re-infection) | file mtime `00:14:16Z` | FACT |
+| 2026-07-03 00:20–00:21 | `/tmp/postgresql` miner + `/tmp/systemd` watchdog dropped | file mtimes | FACT |
+| ~2026-07-03 00:30 | 655% re-observed **despite** `max_parallel_workers=0` → forensics begun | session record | ESTIMATE (±10 min) |
+| ~2026-07-03 00:5x | `docker stop` isolation → CPU→0, C2 cut | session record | FACT (time ±) |
+| 2026-07-03 01:25 | Volume destroyed + `127.0.0.1` bind + strong password redeploy | container `Created 01:25:10Z` | FACT |
+
+> **Timezone note.** The `/tmp/kunt` mtime `00:14 UTC` equals `09:14 KST`. A
+> superficial "00:14 → 09:00" reading is a timezone artifact, not a 9-hour gap —
+> this-session detection followed the dropper by ~16 minutes. The genuine dwell
+> time came from the prior session's misdiagnosis (see MTTD below).
+
+### 2.2 Four-phase breakdown
+
+| Phase | Time (UTC) | Basis |
+|-------|------------|-------|
+| **Occurrence** (estimated) | ≤ 2026-07-02 | compromise predated this session; exact first entry unknown |
+| **Detection** (correct identification) | ~2026-07-03 00:30 | 655% persisted with parallel disabled → forensics |
+| **Containment** | ~2026-07-03 00:5x | container stopped, C2 severed |
+| **Recovery** | 2026-07-03 01:25 | clean volume + localhost bind + strong pw |
+
+### 2.3 Detection metrics (MTTD / MTTC / MTTR)
+
+- **MTTD (this-session re-infection → detection):** ~16 min. Lucky — the box was
+  being actively benchmarked when the dropper ran, so the CPU spike was caught
+  immediately.
+- **MTTD (true: first compromise → correct identification):** ~18–24 h. Dominated
+  by the prior session's parallel-worker-leak misdiagnosis, which let the miner
+  run for a day while the "fix" (`max_parallel_workers=0`) had no effect. **This
+  is the real detection gap and the main lesson.**
+- **MTTC (detection → containment):** ~30 min (forensics → `docker stop`).
+- **MTTR (containment → recovery):** ~30 min (volume nuke → clean redeploy + verify).
+
+### 2.4 Narrative
+
 ### T0 — Symptom (FACT)
 - `maple-airflow-db` CPU steady at **655–780%** (`docker stats`).
 - `pg_stat_activity` showed only idle Airflow queries — nothing active enough to

--- a/docs/23_Incident_Response_Journey/2026-07-03-airflow-db-container-compromise.md
+++ b/docs/23_Incident_Response_Journey/2026-07-03-airflow-db-container-compromise.md
@@ -235,11 +235,34 @@ Not definitively confirmed. Ranked by likelihood with the supporting facts.
 
 ## 7. Root Cause Analysis
 
-### Direct Cause
-Internet-exposed PostgreSQL (`5432 → 0.0.0.0` on a public-IP host) with a weak
-superuser account enabled `COPY … TO PROGRAM` — a built-in superuser facility
-that executes an arbitrary shell command. That is remote code execution by an
-external attacker, who used it to drop and run the miner.
+> **Root cause = internet exposure combined with weak/default authentication.**
+> Neither alone would have sufficed: a `0.0.0.0` bind with strong credentials, or
+> `admin`/`admin` reachable only on `localhost`, would each have resisted this
+> attack. The compromise required *both* conditions at once.
+
+**Internet-exposed administrative services (`0.0.0.0` bind) combined with
+weak/default credentials enabled unauthorized access to the Airflow environment.**
+
+### Causal chain
+
+`0.0.0.0` bind → reachable from the internet → weak/default account
+(`admin`/`admin`, `airflow:airflow`) → attacker authenticates →
+`COPY … TO PROGRAM` (superuser shell exec) → `/tmp/kunt` dropper → miner →
+CPU ~700%.
+
+### Exposure (necessary condition — not the root cause on its own)
+
+- `5432 → 0.0.0.0` on a public-IP host; Airflow UI on host-network `0.0.0.0:8180`;
+  plus many sibling services (redis, kafka, minio, grafana, app modules) bound
+  the same way.
+- Exposure enabled *reachability*; it did not itself grant access.
+
+### Authentication failure (the other half of the root cause)
+
+- Default / weak credentials: Airflow `admin`/`admin`; postgres superuser with a
+  brute-forceable default password.
+- Superuser privilege: `airflow` role `rolsuper = t` → `COPY … TO PROGRAM`
+  became remote code execution, not merely data access.
 
 ### Contributing Factors
 - **Weak / default credentials** — the pipeline-test skill provisions


### PR DESCRIPTION
## Summary
Two refinements to the 2026-07-03 incident report, both per review:

**1. Root-cause framing (§7)** — `0.0.0.0` bind is the **exposure** (necessary condition), not the root cause alone. The compromise required **internet exposure + weak/default authentication together**. Adds causal chain + splits Exposure vs Authentication-failure halves.

**2. Incident timeline (§2.1–2.3)** — at-a-glance UTC timeline (event / basis / confidence), four-phase breakdown (Occurrence → Detection → Containment → Recovery), and MTTD/MTTC/MTTR.

### Key correction (timezone artifact)
`/tmp/kunt` mtime `00:14 UTC` = `09:14 KST`. The apparent "9-hour detection gap" is a TZ illusion — this-session detection followed the dropper by **~16 min**. The genuine dwell time was **~18–24h**, caused by the prior session's parallel-worker-leak **misdiagnosis** (PR #1454), which is the real MTTD lesson.

## Changes (doc only)
- §2: timeline table + four-phase + detection metrics + TZ note
- §7: combined-root-cause framing replacing the blunt "Direct Cause"

## Test plan
- [x] only the report file changed
- [x] timestamps sourced from file mtimes + git history; ESTIMATE tagged where not precisely logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)