### PR TITLE
feat(ext-api): add per-endpoint Prometheus counters

### DIFF
--- a/module-external-api/src/main/kotlin/maple/externalapi/metrics/SnapshotFetchMetrics.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/metrics/SnapshotFetchMetrics.kt
@@ -1,5 +1,6 @@
 package maple.externalapi.metrics
 
+import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.DistributionSummary
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Timer
@@ -14,6 +15,8 @@ class SnapshotFetchMetrics(private val registry: MeterRegistry) {
             .record(duration)
         summary("external_api_nexon_response_bytes", endpoint)
             .record(bytes.toDouble())
+        counter("external_api_nexon_total_ms_total", endpoint)
+            .increment(duration.toMillis().toDouble())
     }
 
     fun recordNexonFailure(endpoint: String, duration: Duration) {
@@ -45,6 +48,10 @@ class SnapshotFetchMetrics(private val registry: MeterRegistry) {
         .register(registry)
 
     private fun summary(name: String, endpoint: String): DistributionSummary = DistributionSummary.builder(name)
+        .tag("endpoint", endpoint)
+        .register(registry)
+
+    private fun counter(name: String, endpoint: String): Counter = Counter.builder(name)
         .tag("endpoint", endpoint)
         .register(registry)
 }

--- a/module-external-api/src/main/kotlin/maple/externalapi/metrics/SnapshotVolumeMetrics.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/metrics/SnapshotVolumeMetrics.kt
@@ -5,7 +5,7 @@ import io.micrometer.core.instrument.MeterRegistry
 import org.springframework.stereotype.Component
 
 @Component
-class SnapshotVolumeMetrics(registry: MeterRegistry) {
+class SnapshotVolumeMetrics(private val registry: MeterRegistry) {
 
     private val compressedBytesTotal = registry.counter("external_api_snapshot_compressed_bytes_total")
     private val uncompressedBytesTotal = registry.counter("external_api_snapshot_uncompressed_bytes_total")
@@ -32,5 +32,18 @@ class SnapshotVolumeMetrics(registry: MeterRegistry) {
         if (compressedBytes > 0) {
             compressionRatioSummary.record(uncompressedBytes.toDouble() / compressedBytes.toDouble())
         }
+    }
+
+    /**
+     * Per-endpoint user counter — increments by [count] when a chunk has been
+     * successfully converted and published (snapshotVolume log line is the
+     * success boundary). Lets ops derive per-endpoint user throughput via
+     * `irate(external_api_users_completed_total{endpoint=...}[5m])`.
+     */
+    fun recordUsersCompleted(endpoint: String, count: Long) {
+        io.micrometer.core.instrument.Counter.builder("external_api_users_completed_total")
+            .tag("endpoint", endpoint)
+            .register(registry)
+            .increment(count.toDouble())
     }
 }

--- a/module-external-api/src/main/kotlin/maple/externalapi/snapshot/SnapshotSinkEventPublisher.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/snapshot/SnapshotSinkEventPublisher.kt
@@ -32,6 +32,7 @@ class SnapshotSinkEventPublisher(
         val chunkId = String.format("part-%06d", stats.partIndex)
         val ratio = CompressionUtils.ratioString(stats.uncompressedBytes, stats.compressedBytes)
         volumeMetrics.recordChunk(stats.compressedBytes, stats.uncompressedBytes, stats.recordCount.toLong())
+        volumeMetrics.recordUsersCompleted(endpoint, stats.recordCount.toLong())
         log.info(
             "[snapshotVolume] runId={} chunkId={} compressedBytes={} uncompressedBytes={} jsonRows={} compressionRatio={}",
             runId,


### PR DESCRIPTION
## Summary
- `external_api_nexon_total_ms_total{endpoint=...}` — cumulative ms of successful Nexon fetches per RANKING_FETCH / OCID_LOOKUP / CHARACTER_BASIC / ITEM_EQUIPMENT
- `external_api_users_completed_total{endpoint=...}` — cumulative user count per endpoint, incremented in SnapshotSinkEventPublisher.publishChunkReady (snapshotVolume log = success boundary)
- Enables per-endpoint ms/user and users/s via PromQL
- Fixes `private val registry` in SnapshotVolumeMetrics (was blocking new method)

## Test plan
- [x] `./gradlew :module-external-api:compileKotlin` BUILD SUCCESSFUL
- [ ] Verify both counters appear in /actuator/prometheus after pipeline run
- [ ] Verify per-endpoint breakdown via `irate(external_api_users_completed_total[5m])`

🤖 Generated with [Claude Code](https://claude.com/claude-code)