### PR TITLE
fix(ext-api): normalize endpoint case in recordUsersCompleted

### DIFF
--- a/module-external-api/src/main/kotlin/maple/externalapi/snapshot/SnapshotSinkEventPublisher.kt
+++ b/module-external-api/src/main/kotlin/maple/externalapi/snapshot/SnapshotSinkEventPublisher.kt
@@ -32,7 +32,13 @@ class SnapshotSinkEventPublisher(
         val chunkId = String.format("part-%06d", stats.partIndex)
         val ratio = CompressionUtils.ratioString(stats.uncompressedBytes, stats.compressedBytes)
         volumeMetrics.recordChunk(stats.compressedBytes, stats.uncompressedBytes, stats.recordCount.toLong())
-        volumeMetrics.recordUsersCompleted(endpoint, stats.recordCount.toLong())
+        // Endpoint factory passes lowercase ("ranking-overall"); Micrometer tags
+        // emitted by recordNexonBodyReceived use ExternalApiEndpoint.name which is
+        // uppercase ("RANKING_OVERALL"). Normalize once here so the two counters
+        // share one tag value, which makes `users_completed_total / nexon_total_ms_total`
+        // math work per endpoint.
+        val metricEndpoint = endpoint.uppercase().replace('-', '_')
+        volumeMetrics.recordUsersCompleted(metricEndpoint, stats.recordCount.toLong())
         log.info(
             "[snapshotVolume] runId={} chunkId={} compressedBytes={} uncompressedBytes={} jsonRows={} compressionRatio={}",
             runId,


### PR DESCRIPTION
## Summary
PR #1460 introduced two per-endpoint counters but they emitted with mismatched `endpoint` tag case:
- `external_api_nexon_total_ms_total{endpoint="RANKING_OVERALL"}` (from ExternalApiEndpoint.name)
- `external_api_users_completed_total{endpoint="ranking-overall"}` (from EndpointSinkFactory literal)

Result: per-endpoint math like `rate(nexon_ms)/rate(users_completed)` produced no data because numerator/denominator pairs had different tag values.

## Fix
Normalize at the metric call boundary in `SnapshotSinkEventPublisher.publishChunkReady`:
```kotlin
val metricEndpoint = endpoint.uppercase().replace('-', '_')  // "ranking-overall" → "RANKING_OVERALL"
volumeMetrics.recordUsersCompleted(metricEndpoint, stats.recordCount.toLong())
```

Chunking config keys and storage subdirectory paths still use the lowercase form (untouched).

## Test plan
- [x] `./gradlew :module-external-api:compileKotlin` BUILD SUCCESSFUL
- [ ] Run pipeline; confirm both counters emit with `endpoint="RANKING_OVERALL"` etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)